### PR TITLE
Edit Vundle installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ You can install this plugin using [Vundle](https://github.com/VundleVim/Vundle.v
 by using the github repository URL for cloning the repository.
 
 ```vim
-Plugin 'https://github.com/w0rp/ale.git'
+Plugin 'w0rp/ale'
 ```
 
 See the Vundle documentation for more information.


### PR DESCRIPTION
Full GitHub URL isn't required for Vundle (and vim-plug), they automatically assume GitHub.