### PR TITLE
Edit Vundle installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,11 +104,8 @@ git clone https://github.com/w0rp/ale.git
 
 ### Installation with Vundle
 
-You can install this plugin using [Vundle](https://github.com/VundleVim/Vundle.vim)
-by using the github repository URL for cloning the repository.
-
 ```vim
-Plugin 'https://github.com/w0rp/ale.git'
+Plugin 'w0rp/ale'
 ```
 
 See the Vundle documentation for more information.


### PR DESCRIPTION
Full GitHub URL is not required for Vundle (and vim-plug), as GitHub is automatically assumed.