### PR TITLE
Option to keep sign column always open

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Each directory within corresponds to a particular filetype in Vim, and each file
 in each directory corresponds to the name of a particular linter.
 
 ### Always showing gutter
-To prevent left gutter to disappear when there is no errors set
+You can keep the sign gutter open at all times by setting the g:ale_sign_column_always to 1
 
 ```vim
 let g:ale_sign_column_always = 1

--- a/README.md
+++ b/README.md
@@ -82,6 +82,14 @@ This plugin will look for linters in the [`ale_linters`](ale_linters) directory.
 Each directory within corresponds to a particular filetype in Vim, and each file
 in each directory corresponds to the name of a particular linter.
 
+### Always showing gutter
+To prevent left gutter to disappear when there is no errors set
+
+```vim
+let g:ale_sign_column_always = 1
+```
+
+
 ## Installation
 
 To install this plugin, you should use one of the following methods.

--- a/plugin/ale/aaflags.vim
+++ b/plugin/ale/aaflags.vim
@@ -45,3 +45,8 @@ endif
 if !exists('g:ale_warn_about_trailing_whitespace')
     let g:ale_warn_about_trailing_whitespace = 1
 endif
+
+" This flag can be set to 1 to keep sign gutter always open
+if !exists('g:ale_sign_column_always')
+    let g:ale_sign_column_always = 0
+endif

--- a/plugin/ale/sign.vim
+++ b/plugin/ale/sign.vim
@@ -4,8 +4,6 @@ endif
 
 let g:loaded_ale_sign = 1
 
-let g:ale_sign_column_always = 0
-
 if !hlexists('ALEErrorSign')
     highlight link ALErrorSign error
 endif

--- a/plugin/ale/sign.vim
+++ b/plugin/ale/sign.vim
@@ -4,6 +4,8 @@ endif
 
 let g:loaded_ale_sign = 1
 
+let g:ale_sign_column_always = 0
+
 if !hlexists('ALEErrorSign')
     highlight link ALErrorSign error
 endif
@@ -50,6 +52,8 @@ function! ale#sign#SetSigns(buffer, loclist)
         endif
     endfor
 
+    call ale#sign#InsertDummy(len(signlist))
+
     for i in range(0, len(signlist) - 1)
         let obj = signlist[i]
         let name = obj['type'] ==# 'W' ? 'ALEWarningSign' : 'ALEErrorSign'
@@ -62,3 +66,12 @@ function! ale#sign#SetSigns(buffer, loclist)
         exec sign_line
     endfor
 endfunction
+
+" Show signd gutter if there is no signs and g:ale_sign_column_alwas is set to 1
+function! ale#sign#InsertDummy(no_signs)
+    if g:ale_sign_column_always == 1 && a:no_signs == 0
+        sign define ale_keep_open_dummy
+        execute 'sign place 9999 line=1 name=ale_keep_open_dummy buffer=' . bufnr('')
+    endif
+endfunction
+

--- a/plugin/ale/zmain.vim
+++ b/plugin/ale/zmain.vim
@@ -297,6 +297,8 @@ function! ALELint(delay)
     if a:delay > 0
         let s:lint_timer = timer_start(a:delay, function('s:TimerHandler'))
     else
+        " Show empty gutter if g:ale_sign_column_always = 1
+        call ale#sign#InsertDummy(0)
         call s:TimerHandler()
     endif
 endfunction


### PR DESCRIPTION
Add option to keep sign column open event when there is no signs to show.

I found this works better for me since It stops sign columns from constantly pushing text left and right.