### PR TITLE
Add support for javascript.jsx filetype

### DIFF
--- a/ale_linters/javascript/eslint.vim
+++ b/ale_linters/javascript/eslint.vim
@@ -48,3 +48,10 @@ call ALEAddLinter('javascript', {
 \   'command': 'eslint -f unix --stdin',
 \   'callback': 'ale_linters#javascript#eslint#Handle',
 \})
+
+call ALEAddLinter('javascript.jsx', {
+\   'name': 'eslint',
+\   'executable': 'eslint',
+\   'command': 'eslint -f unix --stdin',
+\   'callback': 'ale_linters#javascript#eslint#Handle',
+\})

--- a/ale_linters/javascript/jscs.vim
+++ b/ale_linters/javascript/jscs.vim
@@ -48,3 +48,10 @@ call ALEAddLinter('javascript', {
 \   'command': 'jscs -r unix -n -',
 \   'callback': 'ale_linters#javascript#jscs#Handle',
 \})
+
+call ALEAddLinter('javascript.jsx', {
+\   'name': 'jscs',
+\   'executable': 'jscs',
+\   'command': 'jscs -r unix -n -',
+\   'callback': 'ale_linters#javascript#jscs#Handle',
+\})

--- a/ale_linters/javascript/jshint.vim
+++ b/ale_linters/javascript/jshint.vim
@@ -56,3 +56,10 @@ call ALEAddLinter('javascript', {
 \   'command': 'jshint --reporter unix --config ' . g:ale_jshint_config_loc . ' -',
 \   'callback': 'ale_linters#javascript#jshint#Handle',
 \})
+
+call ALEAddLinter('javascript.jsx', {
+\   'name': 'jshint',
+\   'executable': 'jshint',
+\   'command': 'jshint --reporter unix --config ' . g:ale_jshint_config_loc . ' -',
+\   'callback': 'ale_linters#javascript#jshint#Handle',
+\})


### PR DESCRIPTION
As first thnx a lot for the plugin, works really well!!

When working with [React](https://facebook.github.io/react/) it almost a standard to use the [vim-jsx](https://github.com/mxw/vim-jsx) plugin which adds a `javascript.jsx` filetype for `javascript`.

This was not handled by `ale` by default, with this PR it works.