### PR TITLE
Use gcc format for vint output

### DIFF
--- a/ale_linters/vim/vint.vim
+++ b/ale_linters/vim/vint.vim
@@ -1,4 +1,5 @@
 " Author: w0rp <devw0rp@gmail.com>
+" Modified by: KabbAmine <amine.kabb@gmail.com>
 " Description: This file adds support for checking Vim code with Vint.
 
 if exists('g:loaded_ale_linters_vim_vint')
@@ -7,40 +8,11 @@ endif
 
 let g:loaded_ale_linters_vim_vint = 1
 
-function! ale_linters#vim#vint#Handle(buffer, lines)
-    " Matches patterns line the following:
-    "
-    " /home/w0rp/.vim/vimrc:198:30: Prefer single quoted strings (see Google VimScript Style Guide (Strings))
-    let pattern = '^.*:\(\d\+\):\(\d\+\): \(.\+\)$'
-    let output = []
-
-    for line in a:lines
-        let l:match = matchlist(line, pattern)
-
-        if len(l:match) == 0
-            continue
-        endif
-
-        let text = l:match[3]
-
-        " vcol is Needed to indicate that the column is a character.
-        call add(output, {
-        \   'bufnr': a:buffer,
-        \   'lnum': l:match[1] + 0,
-        \   'vcol': 0,
-        \   'col': l:match[2] + 0,
-        \   'text': text,
-        \   'type': 'W',
-        \   'nr': -1,
-        \})
-    endfor
-
-    return output
-endfunction
+let s:format = '-f "{file_path}:{line_number}:{column_number}: {severity}: {description} (see {reference})'
 
 call ALEAddLinter('vim', {
 \   'name': 'vint',
 \   'executable': 'vint',
-\   'command': g:ale#util#stdin_wrapper . ' .vim vint -w --no-color',
-\   'callback': 'ale_linters#haskell#ghc#Handle',
+\   'command': g:ale#util#stdin_wrapper . ' .vim vint -w --no-color ' . s:format,
+\   'callback': 'ale#handlers#HandleGCCFormat',
 \})


### PR DESCRIPTION
Vint allows to use a custom output format so I made it gcc compatible.

The advantages:

- Less code (We are lazy, everybody knows that)
- The warnings and errors are differentiated now

Also, even if the errors were reported correctly the callback function was wrong (`ale_linters#haskell#ghc#Handle` instead of `ale_linters#vim#vint#Handle`)