### PR TITLE
Add custom color support for sign column (different color without err…

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ vimrc file for all given linters is as follows:
 | `g:ale_sign_offset` | an offset for sign ids | `1000000` |
 | `g:ale_echo_cursor` | echo errors when the cursor is over them | `1` |
 | `g:ale_warn_about_trailing_whitespace` | enable trailing whitespace warnings for some linters | `1` |
+| `g:ale_sign_term_color` | color of the sign bar in term | `lightgrey` |
+| `g:ale_sign_term_color_no_error` | color of the sign bar in term when no errors are found (only visible with g:ale_sign_column_always=1) | `green` |
+| `g:ale_sign_gui_color` | color of the sign bar in GUI | `lightgrey` |
+| `g:ale_sign_gui_color_no_error` | color of the sign bar in GUI when no errors are found (only visible with g:ale_sign_column_always=1) | `green` |
 
 ### Selecting Particular Linters
 

--- a/plugin/ale/sign.vim
+++ b/plugin/ale/sign.vim
@@ -33,6 +33,12 @@ let g:ale_sign_warning = get(g:, 'ale_sign_warning', '--')
 " The dummy sign will use the ID exactly equal to the offset.
 let g:ale_sign_offset = get(g:, 'ale_sign_offset', 1000000)
 
+" sign bar color
+let g:ale_sign_term_color = get(g:, 'ale_sign_term_color', 'lightgrey')
+let g:ale_sign_term_color_no_error = get(g:, 'ale_sign_term_color_no_error', 'green')
+let g:ale_sign_gui_color = get(g:, 'ale_sign_gui_color', 'lightgrey')
+let g:ale_sign_gui_color_no_error = get(g:, 'ale_sign_gui_color_no_error', 'green')
+
 " Signs show up on the left for error markers.
 execute 'sign define ALEErrorSign text=' . g:ale_sign_error
 \   . ' texthl=ALEErrorSign'
@@ -120,6 +126,13 @@ function! ale#sign#SetSigns(buffer, loclist)
         exec 'sign unplace ' . current_id . ' buffer=' . a:buffer
     endfor
 
+	" set colot of SignColumn
+	if len(signlist) > 0
+		execute ':highlight SignColumn ctermbg=' . g:ale_sign_term_color . ' guibg=' .g:ale_sign_gui_color
+	else
+		execute ':highlight SignColumn ctermbg=' . g:ale_sign_gui_color_no_error . ' guibg=' . g:ale_sign_gui_color_no_error
+	endif
+
     " Now set all of the signs.
     for i in range(0, len(signlist) - 1)
         let obj = signlist[i]
@@ -134,6 +147,7 @@ function! ale#sign#SetSigns(buffer, loclist)
     endfor
 
     if !g:ale_sign_column_always && len(signlist) > 0
+    " if len(signlist) > 0
         if get(g:ale_buffer_sign_dummy_map, a:buffer, 0)
             execute 'sign unplace ' . g:ale_sign_offset . ' buffer=' . a:buffer
 


### PR DESCRIPTION
With this patch the sign bar changes it's background color when no errors were found to provide instant visual feedback that file a is linting even when sign column is configured to stay open all the time.

Please note: these are my first few lines of vim code, it seems to work but i have real clue if this won't break anything else i did not notice.

Possible improvement: 
Get current configured color of the SignColumn as default instead of hardcoded value