### PR TITLE
Minor fixes:

### DIFF
--- a/ale_linters/json/jsonlint.vim
+++ b/ale_linters/json/jsonlint.vim
@@ -10,7 +10,7 @@ function! ale_linters#json#jsonlint#Handle(buffer, lines)
     " Matches patterns like the following:
     " line 2, col 15, found: 'STRING' - expected: 'EOF', '}', ',', ']'.
 
-    let pattern = 'line \(\d\+\), col \(\d*\), \(.\+\)'
+    let pattern = '^line \(\d\+\), col \(\d*\), \(.\+\)$'
     let output = []
 
     for line in a:lines

--- a/ale_linters/php/php.vim
+++ b/ale_linters/php/php.vim
@@ -11,7 +11,7 @@ function! ale_linters#php#php#Handle(buffer, lines)
     " Matches patterns like the following:
     "
     " Parse error: parse error in - on line 7
-    let pattern = 'Parse error: \(.\+\) on line \(\d\+\)'
+    let pattern = 'Parse error:\s\+\(.\+\) on line \(\d\+\)'
     let output = []
 
     for line in a:lines

--- a/plugin/ale/cursor.vim
+++ b/plugin/ale/cursor.vim
@@ -68,14 +68,14 @@ function! ale#cursor#TruncatedEcho(message)
 
     " We need to turn T for truncated messages on for shortmess,
     " and then then we need to reset the option back to what it was.
-    let shortmess_options = &shortmess
+    let shortmess_options = getbufvar('%', '&shortmess')
 
     try
         " Echo the message truncated to fit without creating a prompt.
-        set shortmess+=T
+        setlocal shortmess+=T
         exec "norm :echomsg message\n"
     finally
-        let &shortmess = shortmess_options
+        call setbufvar('%', '&shortmess', shortmess_options)
     endtry
 endfunction
 

--- a/plugin/ale/statusline.vim
+++ b/plugin/ale/statusline.vim
@@ -24,11 +24,11 @@ function! ALEGetStatusLine() abort
 
     let errors = errors ? printf(g:ale_statusline_format[0], errors) : ''
     let warnings = warnings ? printf(g:ale_statusline_format[1], warnings) : ''
-    let noErrors = g:ale_statusline_format[2]
+    let no_errors = g:ale_statusline_format[2]
 
     " Different formats if no errors or no warnings
     if empty(errors) && empty(warnings)
-        let res = noErrors
+        let res = no_errors
     elseif !empty(errors) && !empty(warnings)
         let res = printf('%s %s', errors, warnings)
     else


### PR DESCRIPTION
- Ensure that php linter pattern does not include spaces:
    PHP can return errors with extra spaces like the following:
    `PHP Parse error:  syntax error, unexpected end of file in t.php on line 4`

- Set option locally to buffer

- Rename `noErrors` variable according to the project's naming convention

- Make the jsonlint pattern a little better