### PR TITLE
Explicit scope (aka vint -s)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ cache: pip
 install:
   - "pip install vim-vint==0.3.9"
 script:
-  - "vint ."
+  - "vint -s ."

--- a/ale_linters/coffee/coffeelint.vim
+++ b/ale_linters/coffee/coffeelint.vim
@@ -12,36 +12,36 @@ function! ale_linters#coffee#coffeelint#Handle(buffer, lines)
     "
     " path,lineNumber,lineNumberEnd,level,message
     " stdin,14,,error,Throwing strings is forbidden
-    " 
+    "
     " Note that we currently ignore lineNumberEnd for multiline errors
-    let pattern = 'stdin,\(\d\+\),\(\d*\),\(.\+\),\(.\+\)'
-    let output = []
+    let l:pattern = 'stdin,\(\d\+\),\(\d*\),\(.\+\),\(.\+\)'
+    let l:output = []
 
-    for line in a:lines
-        let l:match = matchlist(line, pattern)
+    for l:line in a:lines
+        let l:match = matchlist(l:line, l:pattern)
 
         if len(l:match) == 0
             continue
         endif
 
-        let line = l:match[1] + 0
-        let column = 1
-        let type = l:match[3] ==# 'error' ? 'E' : 'W'
-        let text = l:match[4]
+        let l:line = l:match[1] + 0
+        let l:column = 1
+        let l:type = l:match[3] ==# 'error' ? 'E' : 'W'
+        let l:text = l:match[4]
 
         " vcol is needed to indicate that the column is a character
-        call add(output, {
+        call add(l:output, {
         \   'bufnr': a:buffer,
-        \   'lnum': line,
+        \   'lnum': l:line,
         \   'vcol': 0,
-        \   'col': column,
-        \   'text': text,
-        \   'type': type,
+        \   'col': l:column,
+        \   'text': l:text,
+        \   'type': l:type,
         \   'nr': -1,
         \})
     endfor
 
-    return output
+    return l:output
 endfunction
 
 call ale#linter#Define('coffee', {

--- a/ale_linters/d/dmd.vim
+++ b/ale_linters/d/dmd.vim
@@ -9,56 +9,56 @@ let g:loaded_ale_linters_d_dmd = 1
 
 " A function for finding the dmd-wrapper script in the Vim runtime paths
 function! s:FindWrapperScript()
-    for parent in split(&runtimepath, ',')
+    for l:parent in split(&runtimepath, ',')
         " Expand the path to deal with ~ issues.
-        let path = expand(parent . '/' . 'dmd-wrapper')
+        let l:path = expand(l:parent . '/' . 'dmd-wrapper')
 
-        if filereadable(path)
-            return path
+        if filereadable(l:path)
+            return l:path
         endif
     endfor
 endfunction
 
 function! ale_linters#d#dmd#GetCommand(buffer)
-    let wrapper_script = s:FindWrapperScript()
+    let l:wrapper_script = s:FindWrapperScript()
 
-    let command = wrapper_script . ' -o- -vcolumns -c'
+    let l:command = l:wrapper_script . ' -o- -vcolumns -c'
 
-    return command
+    return l:command
 endfunction
 
 function! ale_linters#d#dmd#Handle(buffer, lines)
     " Matches patterns lines like the following:
     "
     " /tmp/tmp.G1L5xIizvB.d(8,8): Error: module weak_reference is in file 'dstruct/weak_reference.d' which cannot be read
-    let pattern = '^[^(]\+(\([0-9]\+\),\([0-9]\+\)): \([^:]\+\): \(.\+\)'
-    let output = []
+    let l:pattern = '^[^(]\+(\([0-9]\+\),\([0-9]\+\)): \([^:]\+\): \(.\+\)'
+    let l:output = []
 
-    for line in a:lines
-        let l:match = matchlist(line, pattern)
+    for l:line in a:lines
+        let l:match = matchlist(l:line, l:pattern)
 
         if len(l:match) == 0
             break
         endif
 
-        let line = l:match[1] + 0
-        let column = l:match[2] + 0
-        let type = l:match[3]
-        let text = l:match[4]
+        let l:line = l:match[1] + 0
+        let l:column = l:match[2] + 0
+        let l:type = l:match[3]
+        let l:text = l:match[4]
 
         " vcol is Needed to indicate that the column is a character.
-        call add(output, {
+        call add(l:output, {
         \   'bufnr': bufnr('%'),
-        \   'lnum': line,
+        \   'lnum': l:line,
         \   'vcol': 0,
-        \   'col': column,
-        \   'text': text,
-        \   'type': type ==# 'Warning' ? 'W' : 'E',
+        \   'col': l:column,
+        \   'text': l:text,
+        \   'type': l:type ==# 'Warning' ? 'W' : 'E',
         \   'nr': -1,
         \})
     endfor
 
-    return output
+    return l:output
 endfunction
 
 call ale#linter#Define('d', {

--- a/ale_linters/fortran/gcc.vim
+++ b/ale_linters/fortran/gcc.vim
@@ -18,33 +18,33 @@ function! ale_linters#fortran#gcc#Handle(buffer, lines)
     "
     " :21.34:
     " Error: Expected comma in I/O list at (1)
-    let line_marker_pattern = '^:\(\d\+\)\.\(\d\+\):$'
-    let message_pattern = '^\(Error\|Warning\): \(.\+\)$'
-    let looking_for_message = 0
-    let last_loclist_obj = {}
+    let l:line_marker_pattern = '^:\(\d\+\)\.\(\d\+\):$'
+    let l:message_pattern = '^\(Error\|Warning\): \(.\+\)$'
+    let l:looking_for_message = 0
+    let l:last_loclist_obj = {}
 
-    let output = []
+    let l:output = []
 
-    for line in a:lines
-        if looking_for_message
-            let l:match = matchlist(line, message_pattern)
+    for l:line in a:lines
+        if l:looking_for_message
+            let l:match = matchlist(l:line, l:message_pattern)
         else
-            let l:match = matchlist(line, line_marker_pattern)
+            let l:match = matchlist(l:line, l:line_marker_pattern)
         endif
 
         if len(l:match) == 0
             continue
         endif
 
-        if looking_for_message
-            let looking_for_message = 0
+        if l:looking_for_message
+            let l:looking_for_message = 0
 
             " Now we have the text, we can set it and add the error.
-            let last_loclist_obj.text = l:match[2]
-            let last_loclist_obj.type = l:match[1] ==# 'Warning' ? 'W' : 'E'
-            call add(output, last_loclist_obj)
+            let l:last_loclist_obj.text = l:match[2]
+            let l:last_loclist_obj.type = l:match[1] ==# 'Warning' ? 'W' : 'E'
+            call add(l:output, l:last_loclist_obj)
         else
-            let last_loclist_obj = {
+            let l:last_loclist_obj = {
             \   'bufnr': a:buffer,
             \   'lnum': l:match[1] + 0,
             \   'vcol': 0,
@@ -53,11 +53,11 @@ function! ale_linters#fortran#gcc#Handle(buffer, lines)
             \}
 
             " Start looking for the message and error type.
-            let looking_for_message = 1
+            let l:looking_for_message = 1
         endif
     endfor
 
-    return output
+    return l:output
 endfunction
 
 call ale#linter#Define('fortran', {

--- a/ale_linters/haskell/ghc.vim
+++ b/ale_linters/haskell/ghc.vim
@@ -11,40 +11,40 @@ function! ale_linters#haskell#ghc#Handle(buffer, lines)
     " Look for lines like the following.
     "
     " /dev/stdin:28:26: Not in scope: `>>>>>'
-    let pattern = '^[^:]\+:\(\d\+\):\(\d\+\): \(.\+\)$'
-    let output = []
+    let l:pattern = '^[^:]\+:\(\d\+\):\(\d\+\): \(.\+\)$'
+    let l:output = []
 
     " For some reason the output coming out of the GHC through the wrapper
     " script breaks the lines up in strange ways. So we have to join some
     " lines back together again.
-    let corrected_lines = []
+    let l:corrected_lines = []
 
-    for line in a:lines
-        if len(matchlist(line, pattern)) > 0
-            call add(corrected_lines, line)
-            if line !~# ': error:$'
-                call add(corrected_lines, '')
+    for l:line in a:lines
+        if len(matchlist(l:line, l:pattern)) > 0
+            call add(l:corrected_lines, l:line)
+            if l:line !~# ': error:$'
+                call add(l:corrected_lines, '')
             endif
-        elseif line ==# ''
-            call add(corrected_lines, line)
+        elseif l:line ==# ''
+            call add(l:corrected_lines, l:line)
         else
-            if len(corrected_lines) > 0
-                if corrected_lines[-1] =~# ': error:$'
-                    let line = substitute(line, '\v^\s+', ' ', '')
+            if len(l:corrected_lines) > 0
+                if l:corrected_lines[-1] =~# ': error:$'
+                    let l:line = substitute(l:line, '\v^\s+', ' ', '')
                 endif
-                let corrected_lines[-1] .= line
+                let l:corrected_lines[-1] .= l:line
             endif
         endif
     endfor
 
-    for line in corrected_lines
-        let l:match = matchlist(line, pattern)
+    for l:line in l:corrected_lines
+        let l:match = matchlist(l:line, l:pattern)
 
         if len(l:match) == 0
             continue
         endif
 
-        call add(output, {
+        call add(l:output, {
         \   'bufnr': a:buffer,
         \   'lnum': l:match[1] + 0,
         \   'vcol': 0,
@@ -55,7 +55,7 @@ function! ale_linters#haskell#ghc#Handle(buffer, lines)
         \})
     endfor
 
-    return output
+    return l:output
 endfunction
 
 call ale#linter#Define('haskell', {

--- a/ale_linters/html/htmlhint.vim
+++ b/ale_linters/html/htmlhint.vim
@@ -11,33 +11,33 @@ function! ale_linters#html#htmlhint#Handle(buffer, lines) abort
     " Matches patterns lines like the following:
     "stdin:7:10: <title></title> must not be empty. [error/title-require]
 
-    let pattern = '^stdin:\(\d\+\):\(\d\+\): \(.\+\)$'
-    let output = []
+    let l:pattern = '^stdin:\(\d\+\):\(\d\+\): \(.\+\)$'
+    let l:output = []
 
-    for line in a:lines
-        let match = matchlist(line, pattern)
+    for l:line in a:lines
+        let l:match = matchlist(l:line, l:pattern)
 
-        if len(match) == 0
+        if len(l:match) == 0
             continue
         endif
 
-        let line = match[1] + 0
-        let col = match[2] + 0
-        let text = match[3]
+        let l:line = l:match[1] + 0
+        let l:col = l:match[2] + 0
+        let l:text = l:match[3]
 
         " vcol is Needed to indicate that the column is a character.
-        call add(output, {
+        call add(l:output, {
         \   'bufnr': a:buffer,
-        \   'lnum': line,
+        \   'lnum': l:line,
         \   'vcol': 0,
-        \   'col': col,
-        \   'text': text,
+        \   'col': l:col,
+        \   'text': l:text,
         \   'type': 'E',
         \   'nr': -1,
         \})
     endfor
 
-    return output
+    return l:output
 endfunction
 
 call ale#linter#Define('html', {

--- a/ale_linters/html/tidy.vim
+++ b/ale_linters/html/tidy.vim
@@ -12,10 +12,9 @@ let g:ale_html_tidy_executable = get(g:, 'ale_html_tidy_executable', 'tidy')
 let g:ale_html_tidy_args = get(g:, 'ale_html_tidy_args', '-q -e -language en')
 
 function! ale_linters#html#tidy#GetCommand(buffer) abort
-
     " Specify file encoding in options
     " (Idea taken from https://github.com/scrooloose/syntastic/blob/master/syntax_checkers/html/tidy.vim)
-    let file_encoding = get({
+    let l:file_encoding = get({
     \   'ascii':        '-ascii',
     \   'big5':         '-big5',
     \   'cp1252':       '-win1252',
@@ -33,7 +32,7 @@ function! ale_linters#html#tidy#GetCommand(buffer) abort
     return printf('%s %s %s -',
     \   g:ale_html_tidy_executable,
     \   g:ale_html_tidy_args,
-    \   file_encoding
+    \   l:file_encoding
     \ )
 endfunction
 
@@ -41,34 +40,34 @@ function! ale_linters#html#tidy#Handle(buffer, lines) abort
     " Matches patterns lines like the following:
     " line 7 column 5 - Warning: missing </title> before </head>
 
-    let pattern = '^line \(\d\+\) column \(\d\+\) - \(Warning\|Error\): \(.\+\)$'
-    let output = []
+    let l:pattern = '^line \(\d\+\) column \(\d\+\) - \(Warning\|Error\): \(.\+\)$'
+    let l:output = []
 
-    for line in a:lines
-        let match = matchlist(line, pattern)
+    for l:line in a:lines
+        let l:match = matchlist(l:line, l:pattern)
 
-        if len(match) == 0
+        if len(l:match) == 0
             continue
         endif
 
-        let line = match[1] + 0
-        let col = match[2] + 0
-        let type = match[3] ==# 'Error' ? 'E' : 'W'
-        let text = match[4]
+        let l:line = l:match[1] + 0
+        let l:col = l:match[2] + 0
+        let l:type = l:match[3] ==# 'Error' ? 'E' : 'W'
+        let l:text = l:match[4]
 
         " vcol is Needed to indicate that the column is a character.
-        call add(output, {
+        call add(l:output, {
         \   'bufnr': a:buffer,
-        \   'lnum': line,
+        \   'lnum': l:line,
         \   'vcol': 0,
-        \   'col': col,
-        \   'text': text,
-        \   'type': type,
+        \   'col': l:col,
+        \   'text': l:text,
+        \   'type': l:type,
         \   'nr': -1,
         \})
     endfor
 
-    return output
+    return l:output
 endfunction
 
 call ale#linter#Define('html', {

--- a/ale_linters/javascript/eslint.vim
+++ b/ale_linters/javascript/eslint.vim
@@ -15,38 +15,38 @@ function! ale_linters#javascript#eslint#Handle(buffer, lines)
     "
     " /path/to/some-filename.js:47:14: Missing trailing comma. [Warning/comma-dangle]
     " /path/to/some-filename.js:56:41: Missing semicolon. [Error/semi]
-    let pattern = '^.*:\(\d\+\):\(\d\+\): \(.\+\) \[\(.\+\)\]$'
-    let output = []
+    let l:pattern = '^.*:\(\d\+\):\(\d\+\): \(.\+\) \[\(.\+\)\]$'
+    let l:output = []
 
-    for line in a:lines
-        let l:match = matchlist(line, pattern)
+    for l:line in a:lines
+        let l:match = matchlist(l:line, l:pattern)
 
         if len(l:match) == 0
             continue
         endif
 
-        let text = l:match[3]
-        let marker = l:match[4]
-        let marker_parts = split(marker, '/')
-        let type = marker_parts[0]
+        let l:text = l:match[3]
+        let l:marker = l:match[4]
+        let l:marker_parts = split(l:marker, '/')
+        let l:type = l:marker_parts[0]
 
-        if len(marker_parts) == 2
-            let text = text . ' (' . marker_parts[1] . ')'
+        if len(l:marker_parts) == 2
+            let l:text = l:text . ' (' . l:marker_parts[1] . ')'
         endif
 
         " vcol is Needed to indicate that the column is a character.
-        call add(output, {
+        call add(l:output, {
         \   'bufnr': a:buffer,
         \   'lnum': l:match[1] + 0,
         \   'vcol': 0,
         \   'col': l:match[2] + 0,
-        \   'text': text,
-        \   'type': type ==# 'Warning' ? 'W' : 'E',
+        \   'text': l:text,
+        \   'type': l:type ==# 'Warning' ? 'W' : 'E',
         \   'nr': -1,
         \})
     endfor
 
-    return output
+    return l:output
 endfunction
 
 call ale#linter#Define('javascript', {

--- a/ale_linters/javascript/jscs.vim
+++ b/ale_linters/javascript/jscs.vim
@@ -11,36 +11,36 @@ function! ale_linters#javascript#jscs#Handle(buffer, lines)
     " Matches patterns line the following:
     "
     " input:57:8: Unexpected token (57:8)
-    let pattern = '^.\+:\(\d\+\):\(\d\+\): \(.\+\)'
-    let output = []
+    let l:pattern = '^.\+:\(\d\+\):\(\d\+\): \(.\+\)'
+    let l:output = []
 
-    for line in a:lines
-        let l:match = matchlist(line, pattern)
+    for l:line in a:lines
+        let l:match = matchlist(l:line, l:pattern)
 
         if len(l:match) == 0
             continue
         endif
 
-        let text = l:match[3]
-        let marker_parts = l:match[4]
+        let l:text = l:match[3]
+        let l:marker_parts = l:match[4]
 
-        if len(marker_parts) == 2
-            let text = text . ' (' . marker_parts[1] . ')'
+        if len(l:marker_parts) == 2
+            let l:text = l:text . ' (' . l:marker_parts[1] . ')'
         endif
 
         " vcol is Needed to indicate that the column is a character.
-        call add(output, {
+        call add(l:output, {
         \   'bufnr': a:buffer,
         \   'lnum': l:match[1] + 0,
         \   'vcol': 0,
         \   'col': l:match[2] + 0,
-        \   'text': text,
+        \   'text': l:text,
         \   'type': 'E',
         \   'nr': -1,
         \})
     endfor
 
-    return output
+    return l:output
 endfunction
 
 call ale#linter#Define('javascript', {

--- a/ale_linters/javascript/jshint.vim
+++ b/ale_linters/javascript/jshint.vim
@@ -14,21 +14,21 @@ function! ale_linters#javascript#jshint#GetCommand(buffer)
     " Set this to the location of the jshint configuration file to
     " use a fixed location for .jshintrc
     if exists('g:ale_jshint_config_loc')
-        let jshint_config = g:ale_jshint_config_loc
+        let l:jshint_config = g:ale_jshint_config_loc
     else
         " Look for the JSHint config in parent directories.
-        let jshint_config = ale#util#FindNearestFile(a:buffer, '.jshintrc')
+        let l:jshint_config = ale#util#FindNearestFile(a:buffer, '.jshintrc')
     endif
 
-    let command = g:ale_javascript_jshint_executable . ' --reporter unix'
+    let l:command = g:ale_javascript_jshint_executable . ' --reporter unix'
 
-    if !empty(jshint_config)
-        let command .= ' --config ' . fnameescape(jshint_config)
+    if !empty(l:jshint_config)
+        let l:command .= ' --config ' . fnameescape(l:jshint_config)
     endif
 
-    let command .= ' -'
+    let l:command .= ' -'
 
-    return command
+    return l:command
 endfunction
 
 function! ale_linters#javascript#jshint#Handle(buffer, lines)
@@ -38,36 +38,36 @@ function! ale_linters#javascript#jshint#Handle(buffer, lines)
     " stdin:60:5: Attempting to override 'test2' which is a constant.
     " stdin:57:10: 'test' is defined but never used.
     " stdin:57:1: 'function' is defined but never used.
-    let pattern = '^.\+:\(\d\+\):\(\d\+\): \(.\+\)'
-    let output = []
+    let l:pattern = '^.\+:\(\d\+\):\(\d\+\): \(.\+\)'
+    let l:output = []
 
-    for line in a:lines
-        let l:match = matchlist(line, pattern)
+    for l:line in a:lines
+        let l:match = matchlist(l:line, l:pattern)
 
         if len(l:match) == 0
             continue
         endif
 
-        let text = l:match[3]
-        let marker_parts = l:match[4]
+        let l:text = l:match[3]
+        let l:marker_parts = l:match[4]
 
-        if len(marker_parts) == 2
-            let text = text . ' (' . marker_parts[1] . ')'
+        if len(l:marker_parts) == 2
+            let l:text = l:text . ' (' . l:marker_parts[1] . ')'
         endif
 
         " vcol is Needed to indicate that the column is a character.
-        call add(output, {
+        call add(l:output, {
         \   'bufnr': a:buffer,
         \   'lnum': l:match[1] + 0,
         \   'vcol': 0,
         \   'col': l:match[2] + 0,
-        \   'text': text,
+        \   'text': l:text,
         \   'type': 'E',
         \   'nr': -1,
         \})
     endfor
 
-    return output
+    return l:output
 endfunction
 
 call ale#linter#Define('javascript', {

--- a/ale_linters/json/jsonlint.vim
+++ b/ale_linters/json/jsonlint.vim
@@ -10,29 +10,29 @@ function! ale_linters#json#jsonlint#Handle(buffer, lines)
     " Matches patterns like the following:
     " line 2, col 15, found: 'STRING' - expected: 'EOF', '}', ',', ']'.
 
-    let pattern = '^line \(\d\+\), col \(\d*\), \(.\+\)$'
-    let output = []
+    let l:pattern = '^line \(\d\+\), col \(\d*\), \(.\+\)$'
+    let l:output = []
 
-    for line in a:lines
-        let match = matchlist(line, pattern)
+    for l:line in a:lines
+        let l:match = matchlist(l:line, l:pattern)
 
         if len(l:match) == 0
             continue
         endif
 
         " vcol is needed to indicate that the column is a character
-        call add(output, {
+        call add(l:output, {
         \   'bufnr': a:buffer,
-        \   'lnum': match[1] + 0,
+        \   'lnum': l:match[1] + 0,
         \   'vcol': 0,
-        \   'col': match[2] + 0,
-        \   'text': match[3],
+        \   'col': l:match[2] + 0,
+        \   'text': l:match[3],
         \   'type': 'E',
         \   'nr': -1,
         \})
     endfor
 
-    return output
+    return l:output
 endfunction
 
 call ale#linter#Define('json', {

--- a/ale_linters/perl/perl.vim
+++ b/ale_linters/perl/perl.vim
@@ -7,34 +7,34 @@ endif
 
 let g:loaded_ale_linters_perl_perl = 1
 function! ale_linters#perl#perl#Handle(buffer, lines)
-    let pattern = '\(.\+\) at \(.\+\) line \(\d\+\)'
-    let output = []
+    let l:pattern = '\(.\+\) at \(.\+\) line \(\d\+\)'
+    let l:output = []
 
-    for line in a:lines
-        let l:match = matchlist(line, pattern)
+    for l:line in a:lines
+        let l:match = matchlist(l:line, l:pattern)
 
         if len(l:match) == 0
             continue
         endif
 
-        let line = l:match[3]
-        let column = 1
-        let text = l:match[1]
-        let type = 'E'
+        let l:line = l:match[3]
+        let l:column = 1
+        let l:text = l:match[1]
+        let l:type = 'E'
 
         " vcol is Needed to indicate that the column is a character.
-        call add(output, {
+        call add(l:output, {
         \   'bufnr': a:buffer,
-        \   'lnum': line,
+        \   'lnum': l:line,
         \   'vcol': 0,
-        \   'col': column,
-        \   'text': text,
-        \   'type': type,
+        \   'col': l:column,
+        \   'text': l:text,
+        \   'type': l:type,
         \   'nr': -1,
         \})
     endfor
 
-    return output
+    return l:output
 endfunction
 
 call ale#linter#Define('perl', {

--- a/ale_linters/perl/perlcritic.vim
+++ b/ale_linters/perl/perlcritic.vim
@@ -7,34 +7,34 @@ endif
 
 let g:loaded_ale_linters_perl_perlcritic = 1
 function! ale_linters#perl#perlcritic#Handle(buffer, lines)
-    let pattern = '\(.\+\) at \(.\+\) line \(\d\+\)'
-    let output = []
+    let l:pattern = '\(.\+\) at \(.\+\) line \(\d\+\)'
+    let l:output = []
 
-    for line in a:lines
-        let l:match = matchlist(line, pattern)
+    for l:line in a:lines
+        let l:match = matchlist(l:line, l:pattern)
 
         if len(l:match) == 0
             continue
         endif
 
-        let line = l:match[3]
-        let column = 1
-        let text = l:match[1]
-        let type = 'E'
+        let l:line = l:match[3]
+        let l:column = 1
+        let l:text = l:match[1]
+        let l:type = 'E'
 
         " vcol is Needed to indicate that the column is a character.
-        call add(output, {
+        call add(l:output, {
         \   'bufnr': a:buffer,
-        \   'lnum': line,
+        \   'lnum': l:line,
         \   'vcol': 0,
-        \   'col': column,
-        \   'text': text,
-        \   'type': type,
+        \   'col': l:column,
+        \   'text': l:text,
+        \   'type': l:type,
         \   'nr': -1,
         \})
     endfor
 
-    return output
+    return l:output
 endfunction
 
 call ale#linter#Define('perl', {

--- a/ale_linters/php/php.vim
+++ b/ale_linters/php/php.vim
@@ -11,18 +11,18 @@ function! ale_linters#php#php#Handle(buffer, lines)
     " Matches patterns like the following:
     "
     " Parse error: parse error in - on line 7
-    let pattern = 'Parse error:\s\+\(.\+\) on line \(\d\+\)'
-    let output = []
+    let l:pattern = 'Parse error:\s\+\(.\+\) on line \(\d\+\)'
+    let l:output = []
 
-    for line in a:lines
-        let l:match = matchlist(line, pattern)
+    for l:line in a:lines
+        let l:match = matchlist(l:line, l:pattern)
 
         if len(l:match) == 0
             continue
         endif
 
         " vcol is needed to indicate that the column is a character.
-        call add(output, {
+        call add(l:output, {
         \   'bufnr': a:buffer,
         \   'lnum': l:match[2] + 0,
         \   'vcol': 0,
@@ -33,7 +33,7 @@ function! ale_linters#php#php#Handle(buffer, lines)
         \})
     endfor
 
-    return output
+    return l:output
 endfunction
 
 call ale#linter#Define('php', {

--- a/ale_linters/php/phpcs.vim
+++ b/ale_linters/php/phpcs.vim
@@ -8,46 +8,46 @@ endif
 let g:loaded_ale_linters_php_phpcs = 1
 
 function! ale_linters#php#phpcs#GetCommand(buffer)
-    let command = 'phpcs -s --report=emacs --stdin-path=%s'
+    let l:command = 'phpcs -s --report=emacs --stdin-path=%s'
 
     " This option can be set to change the standard used by phpcs
     if exists('g:ale_php_phpcs_standard')
-        let command .= ' --standard=' . g:ale_php_phpcs_standard
+        let l:command .= ' --standard=' . g:ale_php_phpcs_standard
     endif
 
-    return command
+    return l:command
 endfunction
 
 function! ale_linters#php#phpcs#Handle(buffer, lines)
     " Matches against lines like the following:
     "
     " /path/to/some-filename.php:18:3: error - Line indented incorrectly; expected 4 spaces, found 2 (Generic.WhiteSpace.ScopeIndent.IncorrectExact)
-    let pattern = '^.*:\(\d\+\):\(\d\+\): \(.\+\) - \(.\+\) \(\(.\+\)\)$'
-    let output = []
+    let l:pattern = '^.*:\(\d\+\):\(\d\+\): \(.\+\) - \(.\+\) \(\(.\+\)\)$'
+    let l:output = []
 
-    for line in a:lines
-        let l:match = matchlist(line, pattern)
+    for l:line in a:lines
+        let l:match = matchlist(l:line, l:pattern)
 
         if len(l:match) == 0
             continue
         endif
 
-        let text = l:match[4]
-        let type = l:match[3]
+        let l:text = l:match[4]
+        let l:type = l:match[3]
 
         " vcol is Needed to indicate that the column is a character.
-        call add(output, {
+        call add(l:output, {
         \   'bufnr': a:buffer,
         \   'lnum': l:match[1] + 0,
         \   'vcol': 0,
         \   'col': l:match[2] + 0,
-        \   'text': text,
-        \   'type': type ==# 'warning' ? 'W' : 'E',
+        \   'text': l:text,
+        \   'type': l:type ==# 'warning' ? 'W' : 'E',
         \   'nr': -1,
         \})
     endfor
 
-    return output
+    return l:output
 endfunction
 
 call ale#linter#Define('php', {

--- a/ale_linters/pug/puglint.vim
+++ b/ale_linters/pug/puglint.vim
@@ -11,17 +11,17 @@ function! ale_linters#pug#puglint#Handle(buffer, lines)
     " Matches patterns like the following:
     "
     " temp.jade:6:1 The end of the string reached with no closing bracket ) found.
-    let pattern = '^.\+:\(\d\+\):\(\d\+\) \(.\+\)$'
-    let output = []
+    let l:pattern = '^.\+:\(\d\+\):\(\d\+\) \(.\+\)$'
+    let l:output = []
 
-    for line in a:lines
-        let l:match = matchlist(line, pattern)
+    for l:line in a:lines
+        let l:match = matchlist(l:line, l:pattern)
 
         if len(l:match) == 0
             continue
         endif
 
-        call add(output, {
+        call add(l:output, {
         \   'bufnr': a:buffer,
         \   'lnum': l:match[1] + 0,
         \   'vcol': 0,
@@ -32,7 +32,7 @@ function! ale_linters#pug#puglint#Handle(buffer, lines)
         \})
     endfor
 
-    return output
+    return l:output
 endfunction
 
 call ale#linter#Define('pug', {

--- a/ale_linters/pyrex/cython.vim
+++ b/ale_linters/pyrex/cython.vim
@@ -5,11 +5,11 @@ function! ale_linters#pyrex#cython#Handle(buffer, lines)
     " Matches patterns line the following:
     "
     " test.pyx:13:25: Expected ':', found 'NEWLINE'
-    let pattern = '^.\+:\(\d\+\):\(\d\+\): \(.\+\)$'
-    let output = []
+    let l:pattern = '^.\+:\(\d\+\):\(\d\+\): \(.\+\)$'
+    let l:output = []
 
-    for line in a:lines
-        let l:match = matchlist(line, pattern)
+    for l:line in a:lines
+        let l:match = matchlist(l:line, l:pattern)
 
         if len(l:match) == 0
             continue
@@ -20,7 +20,7 @@ function! ale_linters#pyrex#cython#Handle(buffer, lines)
             continue
         endif
 
-        call add(output, {
+        call add(l:output, {
         \   'bufnr': a:buffer,
         \   'lnum': l:match[1] + 0,
         \   'vcol': 0,
@@ -31,7 +31,7 @@ function! ale_linters#pyrex#cython#Handle(buffer, lines)
         \})
     endfor
 
-    return output
+    return l:output
 endfunction
 
 call ale#linter#Define('pyrex', {

--- a/ale_linters/python/flake8.vim
+++ b/ale_linters/python/flake8.vim
@@ -11,40 +11,40 @@ function! ale_linters#python#flake8#Handle(buffer, lines)
     " Matches patterns line the following:
     "
     " stdin:6:6: E111 indentation is not a multiple of four
-    let pattern = '^stdin:\(\d\+\):\(\d\+\): \([^ ]\+\) \(.\+\)$'
-    let output = []
+    let l:pattern = '^stdin:\(\d\+\):\(\d\+\): \([^ ]\+\) \(.\+\)$'
+    let l:output = []
 
-    for line in a:lines
-        let l:match = matchlist(line, pattern)
+    for l:line in a:lines
+        let l:match = matchlist(l:line, l:pattern)
 
         if len(l:match) == 0
             continue
         endif
 
-        let line = l:match[1] + 0
-        let column = l:match[2] + 0
-        let code = l:match[3]
-        let text = code . ': ' . l:match[4]
-        let type = code[0] ==# 'E' ? 'E' : 'W'
+        let l:line = l:match[1] + 0
+        let l:column = l:match[2] + 0
+        let l:code = l:match[3]
+        let l:text = l:code . ': ' . l:match[4]
+        let l:type = l:code[0] ==# 'E' ? 'E' : 'W'
 
-        if code ==# 'W291' && !g:ale_warn_about_trailing_whitespace
+        if l:code ==# 'W291' && !g:ale_warn_about_trailing_whitespace
             " Skip warnings for trailing whitespace if the option is off.
             continue
         endif
 
         " vcol is Needed to indicate that the column is a character.
-        call add(output, {
+        call add(l:output, {
         \   'bufnr': a:buffer,
-        \   'lnum': line,
+        \   'lnum': l:line,
         \   'vcol': 0,
-        \   'col': column,
-        \   'text': text,
-        \   'type': type,
+        \   'col': l:column,
+        \   'text': l:text,
+        \   'type': l:type,
         \   'nr': -1,
         \})
     endfor
 
-    return output
+    return l:output
 endfunction
 
 call ale#linter#Define('python', {

--- a/ale_linters/ruby/rubocop.vim
+++ b/ale_linters/ruby/rubocop.vim
@@ -12,32 +12,32 @@ function! ale_linters#ruby#rubocop#Handle(buffer, lines)
     "
     " <path>/_:47:14: 83:29: C: Prefer single-quoted strings when you don't
     " need string interpolation or special symbols.
-    let pattern = '\v_:(\d+):(\d+): (.): (.+)'
-    let output = []
+    let l:pattern = '\v_:(\d+):(\d+): (.): (.+)'
+    let l:output = []
 
-    for line in a:lines
-        let l:match = matchlist(line, pattern)
+    for l:line in a:lines
+        let l:match = matchlist(l:line, l:pattern)
 
         if len(l:match) == 0
             continue
         endif
 
-        let text = l:match[4]
-        let type = l:match[3]
+        let l:text = l:match[4]
+        let l:type = l:match[3]
 
         " vcol is Needed to indicate that the column is a character.
-        call add(output, {
+        call add(l:output, {
         \   'bufnr': a:buffer,
         \   'lnum': l:match[1] + 0,
         \   'vcol': 0,
         \   'col': l:match[2] + 0,
-        \   'text': text,
-        \   'type': type ==# 'C' ? 'E' : 'W',
+        \   'text': l:text,
+        \   'type': l:type ==# 'C' ? 'E' : 'W',
         \   'nr': -1,
         \})
     endfor
 
-    return output
+    return l:output
 endfunction
 
 call ale#linter#Define('ruby', {

--- a/ale_linters/scala/scalac.vim
+++ b/ale_linters/scala/scalac.vim
@@ -12,41 +12,41 @@ function! ale_linters#scala#scalac#Handle(buffer, lines)
     " Matches patterns line the following:
     "
     " /var/folders/5q/20rgxx3x1s34g3m14n5bq0x80000gn/T/vv6pSsy/0:26: error: expected class or object definition
-    let pattern = '^.\+:\(\d\+\): \(\w\+\): \(.\+\)'
-    let output = []
-    let ln = 0
+    let l:pattern = '^.\+:\(\d\+\): \(\w\+\): \(.\+\)'
+    let l:output = []
+    let l:ln = 0
 
-    for line in a:lines
-        let ln = ln + 1
-        let l:match = matchlist(line, pattern)
+    for l:line in a:lines
+        let l:ln = l:ln + 1
+        let l:match = matchlist(l:line, l:pattern)
 
         if len(l:match) == 0
             continue
         endif
 
-        let text = l:match[3]
-        let type = l:match[2] ==# 'error' ? 'E' : 'W'
-        let col = 0
-        if ln + 1 < len(a:lines)
-            let col = stridx(a:lines[ln + 1], '^')
-            if col == -1
-                let col = 0
+        let l:text = l:match[3]
+        let l:type = l:match[2] ==# 'error' ? 'E' : 'W'
+        let l:col = 0
+        if l:ln + 1 < len(a:lines)
+            let l:col = stridx(a:lines[l:ln + 1], '^')
+            if l:col == -1
+                let l:col = 0
             endif
         endif
 
         " vcol is Needed to indicate that the column is a character.
-        call add(output, {
+        call add(l:output, {
         \   'bufnr': a:buffer,
         \   'lnum': l:match[1] + 0,
         \   'vcol': 0,
-        \   'col': col + 1,
-        \   'text': text,
-        \   'type': type,
+        \   'col': l:col + 1,
+        \   'text': l:text,
+        \   'type': l:type,
         \   'nr': -1,
         \})
     endfor
 
-    return output
+    return l:output
 endfunction
 
 call ale#linter#Define('scala', {

--- a/ale_linters/scss/scsslint.vim
+++ b/ale_linters/scss/scsslint.vim
@@ -11,11 +11,11 @@ function! ale_linters#scss#scsslint#Handle(buffer, lines)
     " Matches patterns like the following:
     "
     " test.scss:2:1 [W] Indentation: Line should be indented 2 spaces, but was indented 4 spaces
-    let pattern = '^.*:\(\d\+\):\(\d*\) \[\([^\]]\+\)\] \(.\+\)$'
-    let output = []
+    let l:pattern = '^.*:\(\d\+\):\(\d*\) \[\([^\]]\+\)\] \(.\+\)$'
+    let l:output = []
 
-    for line in a:lines
-        let l:match = matchlist(line, pattern)
+    for l:line in a:lines
+        let l:match = matchlist(l:line, l:pattern)
 
         if len(l:match) == 0
             continue
@@ -27,7 +27,7 @@ function! ale_linters#scss#scsslint#Handle(buffer, lines)
         endif
 
         " vcol is needed to indicate that the column is a character
-        call add(output, {
+        call add(l:output, {
         \   'bufnr': a:buffer,
         \   'lnum': l:match[1] + 0,
         \   'vcol': 0,
@@ -38,7 +38,7 @@ function! ale_linters#scss#scsslint#Handle(buffer, lines)
         \})
     endfor
 
-    return output
+    return l:output
 endfunction
 
 call ale#linter#Define('scss', {

--- a/ale_linters/sh/shell.vim
+++ b/ale_linters/sh/shell.vim
@@ -18,16 +18,16 @@ if !exists('g:ale_linters_sh_shell_default_shell')
 endif
 
 function! ale_linters#sh#shell#GetExecutable(buffer)
-    let banglines = getbufline(a:buffer, 1)
+    let l:banglines = getbufline(a:buffer, 1)
 
     " Take the shell executable from the hashbang, if we can.
-    if len(banglines) == 1 && banglines[0] =~# '^#!'
+    if len(l:banglines) == 1 && l:banglines[0] =~# '^#!'
         " Remove options like -e, etc.
-        let line = substitute(banglines[0], '--\?[a-zA-Z0-9]\+', '', 'g')
+        let l:line = substitute(l:banglines[0], '--\?[a-zA-Z0-9]\+', '', 'g')
 
-        for possible_shell in ['bash', 'tcsh', 'csh', 'zsh', 'sh']
-            if line =~# possible_shell . '\s*$'
-                return possible_shell
+        for l:possible_shell in ['bash', 'tcsh', 'csh', 'zsh', 'sh']
+            if l:line =~# l:possible_shell . '\s*$'
+                return l:possible_shell
             endif
         endfor
     endif
@@ -44,34 +44,34 @@ function! ale_linters#sh#shell#Handle(buffer, lines)
     "
     " bash: line 13: syntax error near unexpected token `d'
     " sh: 11: Syntax error: "(" unexpected
-    let pattern = '^[^:]\+: \%(\w\+ \|\)\(\d\+\): \(.\+\)'
-    let output = []
+    let l:pattern = '^[^:]\+: \%(\w\+ \|\)\(\d\+\): \(.\+\)'
+    let l:output = []
 
-    for line in a:lines
-        let l:match = matchlist(line, pattern)
+    for l:line in a:lines
+        let l:match = matchlist(l:line, l:pattern)
 
         if len(l:match) == 0
             continue
         endif
 
-        let line = l:match[1] + 0
-        let column = 1
-        let text = l:match[2]
-        let type = 'E'
+        let l:line = l:match[1] + 0
+        let l:column = 1
+        let l:text = l:match[2]
+        let l:type = 'E'
 
         " vcol is Needed to indicate that the column is a character.
-        call add(output, {
+        call add(l:output, {
         \   'bufnr': a:buffer,
-        \   'lnum': line,
+        \   'lnum': l:line,
         \   'vcol': 0,
-        \   'col': column,
-        \   'text': text,
-        \   'type': type,
+        \   'col': l:column,
+        \   'text': l:text,
+        \   'type': l:type,
         \   'nr': -1,
         \})
     endfor
 
-    return output
+    return l:output
 endfunction
 
 call ale#linter#Define('sh', {

--- a/ale_linters/typescript/tslint.vim
+++ b/ale_linters/typescript/tslint.vim
@@ -13,34 +13,34 @@ function! ale_linters#typescript#tslint#Handle(buffer, lines)
     " hello.ts[7, 41]: trailing whitespace
     " hello.ts[5, 1]: Forbidden 'var' keyword, use 'let' or 'const' instead
     "
-    let pattern = '.\+.ts\[\(\d\+\), \(\d\+\)\]: \(.\+\)'
-    let output = []
+    let l:pattern = '.\+.ts\[\(\d\+\), \(\d\+\)\]: \(.\+\)'
+    let l:output = []
 
-    for line in a:lines
-        let l:match = matchlist(line, pattern)
+    for l:line in a:lines
+        let l:match = matchlist(l:line, l:pattern)
 
         if len(l:match) == 0
             continue
         endif
 
-        let line = l:match[1] + 0
-        let column = l:match[2] + 0
-        let type = 'E'
-        let text = l:match[3]
+        let l:line = l:match[1] + 0
+        let l:column = l:match[2] + 0
+        let l:type = 'E'
+        let l:text = l:match[3]
 
         " vcol is Needed to indicate that the column is a character.
-        call add(output, {
+        call add(l:output, {
         \   'bufnr': a:buffer,
-        \   'lnum': line,
+        \   'lnum': l:line,
         \   'vcol': 0,
-        \   'col': column,
-        \   'text': text,
-        \   'type': type,
+        \   'col': l:column,
+        \   'text': l:text,
+        \   'type': l:type,
         \   'nr': -1,
         \})
     endfor
 
-    return output
+    return l:output
 endfunction
 
 call ale#linter#Define('typescript', {

--- a/ale_linters/verilog/iverilog.vim
+++ b/ale_linters/verilog/iverilog.vim
@@ -14,32 +14,32 @@ function! ale_linters#verilog#iverilog#Handle(buffer, lines)
     " tb_me_top.v:17: syntax error
     " memory_single_port.v:2: syntax error
     " tb_me_top.v:17: error: Invalid module instantiation
-    let pattern = '^[^:]\+:\(\d\+\): \(warning\|error\|syntax error\)\(: \(.\+\)\)\?'
-    let output = []
+    let l:pattern = '^[^:]\+:\(\d\+\): \(warning\|error\|syntax error\)\(: \(.\+\)\)\?'
+    let l:output = []
 
-    for line in a:lines
-        let l:match = matchlist(line, pattern)
+    for l:line in a:lines
+        let l:match = matchlist(l:line, l:pattern)
 
         if len(l:match) == 0
             continue
         endif
 
-        let line = l:match[1] + 0
-        let type = l:match[2] ==# 'warning' ? 'W' : 'E'
-        let text = l:match[2] ==# 'syntax error' ? 'syntax error' : l:match[4]
+        let l:line = l:match[1] + 0
+        let l:type = l:match[2] ==# 'warning' ? 'W' : 'E'
+        let l:text = l:match[2] ==# 'syntax error' ? 'syntax error' : l:match[4]
 
-        call add(output, {
+        call add(l:output, {
         \   'bufnr': a:buffer,
-        \   'lnum': line,
+        \   'lnum': l:line,
         \   'vcol': 0,
         \   'col': 1,
-        \   'text': text,
-        \   'type': type,
+        \   'text': l:text,
+        \   'type': l:type,
         \   'nr': -1,
         \})
     endfor
 
-    return output
+    return l:output
 endfunction
 
 call ale#linter#Define('verilog', {

--- a/ale_linters/verilog/verilator.vim
+++ b/ale_linters/verilog/verilator.vim
@@ -16,32 +16,32 @@ function! ale_linters#verilog#verilator#Handle(buffer, lines)
     " %Warning-UNDRIVEN: test.v:3: Signal is not driven: clk
     " %Warning-UNUSED: test.v:4: Signal is not used: dout
     " %Warning-BLKSEQ: test.v:10: Blocking assignments (=) in sequential (flop or latch) block; suggest delayed assignments (<=).
-    let pattern = '^%\(Warning\|Error\)[^:]*:[^:]\+:\(\d\+\): \(.\+\)$'
-    let output = []
+    let l:pattern = '^%\(Warning\|Error\)[^:]*:[^:]\+:\(\d\+\): \(.\+\)$'
+    let l:output = []
 
-    for line in a:lines
-        let l:match = matchlist(line, pattern)
+    for l:line in a:lines
+        let l:match = matchlist(l:line, l:pattern)
 
         if len(l:match) == 0
             continue
         endif
 
-        let line = l:match[2] + 0
-        let type = l:match[1] ==# 'Error' ? 'E' : 'W'
-        let text = l:match[3]
+        let l:line = l:match[2] + 0
+        let l:type = l:match[1] ==# 'Error' ? 'E' : 'W'
+        let l:text = l:match[3]
 
-        call add(output, {
+        call add(l:output, {
         \   'bufnr': a:buffer,
-        \   'lnum': line,
+        \   'lnum': l:line,
         \   'vcol': 0,
         \   'col': 1,
-        \   'text': text,
-        \   'type': type,
+        \   'text': l:text,
+        \   'type': l:type,
         \   'nr': -1,
         \})
     endfor
 
-    return output
+    return l:output
 endfunction
 
 call ale#linter#Define('verilog', {

--- a/ale_linters/yaml/yamllint.vim
+++ b/ale_linters/yaml/yamllint.vim
@@ -10,34 +10,34 @@ function! ale_linters#yaml#yamllint#Handle(buffer, lines)
     " Matches patterns line the following:
     " something.yaml:1:1: [warning] missing document start "---" (document-start)
     " something.yml:2:1: [error] syntax error: expected the node content, but found '<stream end>'
-    let pattern = '^.*:\(\d\+\):\(\d\+\): \[\(error\|warning\)\] \(.\+\)$'
-    let output = []
+    let l:pattern = '^.*:\(\d\+\):\(\d\+\): \[\(error\|warning\)\] \(.\+\)$'
+    let l:output = []
 
-    for line in a:lines
-        let l:match = matchlist(line, pattern)
+    for l:line in a:lines
+        let l:match = matchlist(l:line, l:pattern)
 
         if len(l:match) == 0
             continue
         endif
 
-        let line = match[1] + 0
-        let col = match[2] + 0
-        let type = match[3]
-        let text = match[4]
+        let l:line = l:match[1] + 0
+        let l:col = l:match[2] + 0
+        let l:type = l:match[3]
+        let l:text = l:match[4]
 
         " vcol is Needed to indicate that the column is a character.
-        call add(output, {
+        call add(l:output, {
         \   'bufnr': a:buffer,
-        \   'lnum': line,
+        \   'lnum': l:line,
         \   'vcol': 0,
-        \   'col': col,
-        \   'text': text,
-        \   'type': type ==# 'warning' ? 'W' : 'E',
+        \   'col': l:col,
+        \   'text': l:text,
+        \   'type': l:type ==# 'warning' ? 'W' : 'E',
         \   'nr': -1,
         \})
     endfor
 
-    return output
+    return l:output
 endfunction
 
 call ale#linter#Define('yaml', {

--- a/autoload/ale.vim
+++ b/autoload/ale.vim
@@ -10,8 +10,8 @@ function! ale#Queue(delay) abort
         let s:lint_timer = -1
     endif
 
-    let linters = ale#linter#Get(&filetype)
-    if len(linters) == 0
+    let l:linters = ale#linter#Get(&filetype)
+    if len(l:linters) == 0
         " There are no linters to lint with, so stop here.
         return
     endif
@@ -24,18 +24,18 @@ function! ale#Queue(delay) abort
 endfunction
 
 function! ale#Lint(...) abort
-    let buffer = bufnr('%')
-    let linters = ale#linter#Get(&filetype)
+    let l:buffer = bufnr('%')
+    let l:linters = ale#linter#Get(&filetype)
 
     " Set a variable telling us to clear the loclist later.
-    let g:ale_buffer_should_reset_map[buffer] = 1
+    let g:ale_buffer_should_reset_map[l:buffer] = 1
 
-    for linter in linters
+    for l:linter in l:linters
         " Check if a given linter has a program which can be executed.
-        if has_key(linter, 'executable_callback')
-            let l:executable = ale#util#GetFunction(linter.executable_callback)(buffer)
+        if has_key(l:linter, 'executable_callback')
+            let l:executable = ale#util#GetFunction(l:linter.executable_callback)(l:buffer)
         else
-            let l:executable = linter.executable
+            let l:executable = l:linter.executable
         endif
 
         if !executable(l:executable)
@@ -43,6 +43,6 @@ function! ale#Lint(...) abort
             continue
         endif
 
-        call ale#engine#Invoke(buffer, linter)
+        call ale#engine#Invoke(l:buffer, l:linter)
     endfor
 endfunction

--- a/autoload/ale/handlers.vim
+++ b/autoload/ale/handlers.vim
@@ -10,17 +10,17 @@ function! ale#handlers#HandleGCCFormat(buffer, lines) abort
     " <stdin>:8:5: warning: conversion lacks type at end of format [-Wformat=]
     " <stdin>:10:27: error: invalid operands to binary - (have ‘int’ and ‘char *’)
     " -:189:7: note: $/${} is unnecessary on arithmetic variables. [SC2004]
-    let pattern = '^.\+:\(\d\+\):\(\d\+\): \([^:]\+\): \(.\+\)$'
-    let output = []
+    let l:pattern = '^.\+:\(\d\+\):\(\d\+\): \([^:]\+\): \(.\+\)$'
+    let l:output = []
 
-    for line in a:lines
-        let l:match = matchlist(line, pattern)
+    for l:line in a:lines
+        let l:match = matchlist(l:line, l:pattern)
 
         if len(l:match) == 0
             continue
         endif
 
-        call add(output, {
+        call add(l:output, {
         \   'bufnr': a:buffer,
         \   'lnum': l:match[1] + 0,
         \   'vcol': 0,
@@ -31,7 +31,7 @@ function! ale#handlers#HandleGCCFormat(buffer, lines) abort
         \})
     endfor
 
-    return output
+    return l:output
 endfunction
 
 function! ale#handlers#HandleCSSLintFormat(buffer, lines) abort
@@ -42,35 +42,35 @@ function! ale#handlers#HandleCSSLintFormat(buffer, lines) abort
     "
     " These errors can be very massive, so the type will be moved to the front
     " so you can actually read the error type.
-    let pattern = '^.*: line \(\d\+\), col \(\d\+\), \(Error\|Warning\) - \(.\+\) (\([^)]\+\))$'
-    let output = []
+    let l:pattern = '^.*: line \(\d\+\), col \(\d\+\), \(Error\|Warning\) - \(.\+\) (\([^)]\+\))$'
+    let l:output = []
 
-    for line in a:lines
-        let l:match = matchlist(line, pattern)
+    for l:line in a:lines
+        let l:match = matchlist(l:line, l:pattern)
 
         if len(l:match) == 0
             continue
         endif
 
-        let text = l:match[4]
-        let type = l:match[3]
-        let errorGroup = l:match[5]
+        let l:text = l:match[4]
+        let l:type = l:match[3]
+        let l:errorGroup = l:match[5]
 
         " Put the error group at the front, so we can see what kind of error
         " it is on small echo lines.
-        let text = '(' . errorGroup . ') ' . text
+        let l:text = '(' . l:errorGroup . ') ' . l:text
 
         " vcol is Needed to indicate that the column is a character.
-        call add(output, {
+        call add(l:output, {
         \   'bufnr': a:buffer,
         \   'lnum': l:match[1] + 0,
         \   'vcol': 0,
         \   'col': l:match[2] + 0,
-        \   'text': text,
-        \   'type': type ==# 'Warning' ? 'W' : 'E',
+        \   'text': l:text,
+        \   'type': l:type ==# 'Warning' ? 'W' : 'E',
         \   'nr': -1,
         \})
     endfor
 
-    return output
+    return l:output
 endfunction

--- a/autoload/ale/linter.vim
+++ b/autoload/ale/linter.vim
@@ -9,32 +9,32 @@ function! ale#linter#Define(filetype, linter) abort
         let s:linters[a:filetype] = []
     endif
 
-    let new_linter = {
+    let l:new_linter = {
     \   'name': a:linter.name,
     \   'callback': a:linter.callback,
     \}
 
     if has_key(a:linter, 'executable_callback')
-        let new_linter.executable_callback = a:linter.executable_callback
+        let l:new_linter.executable_callback = a:linter.executable_callback
     else
-        let new_linter.executable = a:linter.executable
+        let l:new_linter.executable = a:linter.executable
     endif
 
     if has_key(a:linter, 'command_callback')
-        let new_linter.command_callback = a:linter.command_callback
+        let l:new_linter.command_callback = a:linter.command_callback
     else
-        let new_linter.command = a:linter.command
+        let l:new_linter.command = a:linter.command
     endif
 
     if has_key(a:linter, 'output_stream')
-        let new_linter.output_stream = a:linter.output_stream
+        let l:new_linter.output_stream = a:linter.output_stream
     else
-        let new_linter.output_stream = 'stdout'
+        let l:new_linter.output_stream = 'stdout'
     endif
 
     " TODO: Assert the value of the output_stream to be something sensible.
 
-    call add(s:linters[a:filetype], new_linter)
+    call add(s:linters[a:filetype], l:new_linter)
 endfunction
 
 function! ale#linter#Get(filetype) abort
@@ -50,8 +50,8 @@ function! ale#linter#Get(filetype) abort
 
     if has_key(g:ale_linters, a:filetype)
         " Filter loaded linters according to list of linters specified in option.
-        for linter in g:ale_linters[a:filetype]
-            execute 'runtime! ale_linters/' . a:filetype . '/' . linter . '.vim'
+        for l:linter in g:ale_linters[a:filetype]
+            execute 'runtime! ale_linters/' . a:filetype . '/' . l:linter . '.vim'
         endfor
     else
         execute 'runtime! ale_linters/' . a:filetype . '/*.vim'

--- a/autoload/ale/sign.vim
+++ b/autoload/ale/sign.vim
@@ -39,64 +39,64 @@ function! ale#sign#FindCurrentSigns(buffer) abort
     " Matches output like :
     " line=4  id=1  name=ALEErrorSign
     " строка=1  id=1000001  имя=ALEErrorSign
-    let pattern = 'id=\(\d\+\).*=ALE\(Warning\|Error\)Sign'
+    let l:pattern = 'id=\(\d\+\).*=ALE\(Warning\|Error\)Sign'
 
-    redir => output
+    redir => l:output
        silent exec 'sign place buffer=' . a:buffer
     redir END
 
-    let id_list = []
+    let l:id_list = []
 
-    for line in split(output, "\n")
-        let match = matchlist(line, pattern)
+    for l:line in split(l:output, "\n")
+        let l:match = matchlist(l:line, l:pattern)
 
-        if len(match) > 0
-            call add(id_list, match[1] + 0)
+        if len(l:match) > 0
+            call add(l:id_list, l:match[1] + 0)
         endif
     endfor
 
-    return id_list
+    return l:id_list
 endfunction
 
 " Given a loclist, combine the loclist into a list of signs such that only
 " one sign appears per line. Error lines will take precedence.
 " The loclist will have been previously sorted.
 function! ale#sign#CombineSigns(loclist) abort
-    let signlist = []
+    let l:signlist = []
 
-    for obj in a:loclist
-        let should_append = 1
+    for l:obj in a:loclist
+        let l:should_append = 1
 
-        if obj.lnum < 1
+        if l:obj.lnum < 1
             " Skip warnings and errors at line 0, etc.
             continue
         endif
 
-        if len(signlist) > 0 && signlist[-1].lnum == obj.lnum
+        if len(l:signlist) > 0 && l:signlist[-1].lnum == l:obj.lnum
             " We can't add the same line twice, because signs must be
             " unique per line.
-            let should_append = 0
+            let l:should_append = 0
 
-            if signlist[-1].type ==# 'W' && obj.type ==# 'E'
+            if l:signlist[-1].type ==# 'W' && l:obj.type ==# 'E'
                 " If we had a warning previously, but now have an error,
                 " we replace the object to set an error instead.
-                let signlist[-1] = obj
+                let l:signlist[-1] = l:obj
             endif
         endif
 
-        if should_append
-            call add(signlist, obj)
+        if l:should_append
+            call add(l:signlist, l:obj)
         endif
     endfor
 
-    return signlist
+    return l:signlist
 endfunction
 
 " This function will set the signs which show up on the left.
 function! ale#sign#SetSigns(buffer, loclist) abort
-    let signlist = ale#sign#CombineSigns(a:loclist)
+    let l:signlist = ale#sign#CombineSigns(a:loclist)
 
-    if len(signlist) > 0 || g:ale_sign_column_always
+    if len(l:signlist) > 0 || g:ale_sign_column_always
         if !get(g:ale_buffer_sign_dummy_map, a:buffer, 0)
             " Insert a dummy sign if one is missing.
             execute 'sign place ' .  g:ale_sign_offset
@@ -108,27 +108,27 @@ function! ale#sign#SetSigns(buffer, loclist) abort
     endif
 
     " Find the current signs with the markers we use.
-    let current_id_list = ale#sign#FindCurrentSigns(a:buffer)
+    let l:current_id_list = ale#sign#FindCurrentSigns(a:buffer)
 
     " Remove those markers.
-    for current_id in current_id_list
-        exec 'sign unplace ' . current_id . ' buffer=' . a:buffer
+    for l:current_id in l:current_id_list
+        exec 'sign unplace ' . l:current_id . ' buffer=' . a:buffer
     endfor
 
     " Now set all of the signs.
-    for i in range(0, len(signlist) - 1)
-        let obj = signlist[i]
-        let name = obj['type'] ==# 'W' ? 'ALEWarningSign' : 'ALEErrorSign'
+    for l:index in range(0, len(l:signlist) - 1)
+        let l:sign = l:signlist[l:index]
+        let l:type = l:sign['type'] ==# 'W' ? 'ALEWarningSign' : 'ALEErrorSign'
 
-        let sign_line = 'sign place ' . (i + g:ale_sign_offset + 1)
-            \. ' line=' . obj['lnum']
-            \. ' name=' . name
+        let l:sign_line = 'sign place ' . (l:index + g:ale_sign_offset + 1)
+            \. ' line=' . l:sign['lnum']
+            \. ' name=' . l:type
             \. ' buffer=' . a:buffer
 
-        exec sign_line
+        exec l:sign_line
     endfor
 
-    if !g:ale_sign_column_always && len(signlist) > 0
+    if !g:ale_sign_column_always && len(l:signlist) > 0
         if get(g:ale_buffer_sign_dummy_map, a:buffer, 0)
             execute 'sign unplace ' . g:ale_sign_offset . ' buffer=' . a:buffer
 

--- a/autoload/ale/statusline.vim
+++ b/autoload/ale/statusline.vim
@@ -5,35 +5,35 @@ function! ale#statusline#Status() abort
     " Returns a formatted string that can be integrated in the
     " statusline
 
-    let buf = bufnr('%')
-    let bufLoclist = g:ale_buffer_loclist_map
+    let l:buffer = bufnr('%')
+    let l:loclist = g:ale_buffer_loclist_map
 
-    if !has_key(bufLoclist, buf)
+    if !has_key(l:loclist, l:buffer)
         return ''
     endif
 
-    let errors = 0
-    let warnings = 0
-    for e in bufLoclist[buf]
-        if e.type ==# 'E'
-            let errors += 1
+    let l:errors = 0
+    let l:warnings = 0
+    for l:entry in l:loclist[l:buffer]
+        if l:entry.type ==# 'E'
+            let l:errors += 1
         else
-            let warnings += 1
+            let l:warnings += 1
         endif
     endfor
 
-    let errors = errors ? printf(g:ale_statusline_format[0], errors) : ''
-    let warnings = warnings ? printf(g:ale_statusline_format[1], warnings) : ''
-    let no_errors = g:ale_statusline_format[2]
+    let l:errors = l:errors ? printf(g:ale_statusline_format[0], l:errors) : ''
+    let l:warnings = l:warnings ? printf(g:ale_statusline_format[1], l:warnings) : ''
+    let l:no_errors = g:ale_statusline_format[2]
 
     " Different formats if no errors or no warnings
-    if empty(errors) && empty(warnings)
-        let res = no_errors
-    elseif !empty(errors) && !empty(warnings)
-        let res = printf('%s %s', errors, warnings)
+    if empty(l:errors) && empty(l:warnings)
+        let l:res = l:no_errors
+    elseif !empty(l:errors) && !empty(l:warnings)
+        let l:res = printf('%s %s', l:errors, l:warnings)
     else
-        let res = empty(errors) ? warnings : errors
+        let l:res = empty(l:errors) ? l:warnings : l:errors
     endif
 
-    return res
+    return l:res
 endfunction

--- a/autoload/ale/util.vim
+++ b/autoload/ale/util.vim
@@ -2,16 +2,16 @@
 " Description: Contains miscellaneous functions
 
 function! s:FindWrapperScript() abort
-    for parent in split(&runtimepath, ',')
+    for l:parent in split(&runtimepath, ',')
         " Expand the path to deal with ~ issues.
-        let path = expand(parent . '/' . 'stdin-wrapper')
+        let l:path = expand(l:parent . '/' . 'stdin-wrapper')
 
-        if filereadable(path)
+        if filereadable(l:path)
             if has('win32')
-                return path . '.exe'
+                return l:path . '.exe'
             endif
 
-            return path
+            return l:path
         endif
     endfor
 endfunction


### PR DESCRIPTION
This pull adjusts the code to make use of explicit scope, as advised by `vint -s`.

* [x] ale core
* [x] ale linters