### PR TITLE
Use vim-testbed to run Vader tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,14 @@
 ---
+sudo: required
+services:
+    - docker
 language: python
 python: 2.7
 cache: pip
-install:
-  - "pip install vim-vint==0.3.9"
-script:
-  - "vint -s ."
+install: |
+    pip install vim-vint==0.3.9
+script: |
+    EXIT=0
+    vint -s || EXIT=$?
+    make test || EXIT=$?
+    exit $EXIT

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,5 @@ sudo: required
 services:
     - docker
 language: python
-python: 2.7
-cache: pip
-install: |
-    pip install vim-vint==0.3.9
 script: |
     make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,4 @@ cache: pip
 install: |
     pip install vim-vint==0.3.9
 script: |
-    EXIT=0
-    vint -s || EXIT=$?
-    make test || EXIT=$?
-    exit $EXIT
+    make test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM tweekmonster/vim-testbed:latest
+
+RUN install_vim -tag v8.0.0000 -build \
+                -tag v8.0.0027 -build
+
+ENV PACKAGES="\
+    git \
+"
+RUN apk --update add $PACKAGES && \
+    rm -rf /var/cache/apk/* /tmp/* /var/tmp/*
+
+RUN git clone https://github.com/junegunn/vader.vim vader && \
+    cd vader && git checkout c6243dd81c98350df4dec608fa972df98fa2a3af

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,13 @@ RUN install_vim -tag v8.0.0000 -build \
 
 ENV PACKAGES="\
     git \
+    python=2.7.12-r0 \
+    py-pip=8.1.2-r0 \
 "
 RUN apk --update add $PACKAGES && \
     rm -rf /var/cache/apk/* /tmp/* /var/tmp/*
+
+RUN pip install vim-vint==0.3.9
 
 RUN git clone https://github.com/junegunn/vader.vim vader && \
     cd vader && git checkout c6243dd81c98350df4dec608fa972df98fa2a3af

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,11 @@ test-setup:
 test: test-setup
 	vims=$$(docker run --rm $(IMAGE) ls /vim-build/bin | grep -E '^n?vim'); \
 	if [ -z "$$vims" ]; then echo "No Vims found!"; exit 1; fi; \
+	EXIT=0; \
 	for vim in $$vims; do \
-	  $(DOCKER) $$vim '+Vader! test/*'; \
-	done
+	  $(DOCKER) $$vim '+Vader! test/*' || EXIT=$$?; \
+	done; \
+	$(DOCKER) vint -s /testplugin || EXIT=$$?; \
+	exit $$EXIT;
 
 .PHONY: test-setup test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+IMAGE ?= w0rp/ale
+DOCKER = docker run -a stderr --rm -v $(PWD):/testplugin -v $(PWD)/test:/home "$(IMAGE)"
+
+test-setup:
+	docker images -q $(IMAGE) || docker pull $(IMAGE)
+
+test: test-setup
+	vims=$$(docker run --rm $(IMAGE) ls /vim-build/bin | grep -E '^n?vim'); \
+	if [ -z "$$vims" ]; then echo "No Vims found!"; exit 1; fi; \
+	for vim in $$vims; do \
+	  $(DOCKER) $$vim '+Vader! test/*'; \
+	done
+
+.PHONY: test-setup test

--- a/test/example.vader
+++ b/test/example.vader
@@ -1,0 +1,9 @@
+Given (Hello):
+  Hello
+
+Do (yyp):
+  yyp
+
+Expect (Hello\nHello):
+  Hello
+  Hello

--- a/test/vimrc
+++ b/test/vimrc
@@ -1,0 +1,21 @@
+" Load builtin plugins
+" We need this because run_vim.sh sets -i NONE
+set rtp=/home/vim,$VIM/vimfiles,$VIMRUNTIME,$VIM/vimfiles/after,/home/vim/after
+set rtp+=/vader
+
+" The following is just an example
+filetype plugin indent on
+syntax on
+set nocompatible
+set tabstop=4
+set softtabstop=4
+set shiftwidth=4
+set expandtab
+set backspace=2
+set nofoldenable
+set foldmethod=syntax
+set foldlevelstart=10
+set foldnestmax=10
+set ttimeoutlen=0
+
+let mapleader=','


### PR DESCRIPTION
In addition to the current `vint` script currently on Travis, I added infrastructure for automated testing with Vader inside a Docker container with multiple vim builds that are cached on Docker Hub.

Most of what I wrote is copied from https://github.com/tweekmonster/vim-testbed/tree/master/example, except I created a [new Docker image](https://hub.docker.com/r/prashcr/vim8s/) based on vim-testbed containing vim v8.0.0000 and v8.0.0027.

It was quite a lot for me to wrap my head around at first as well, but I'm convinced the benefits are worth it.  I understand the Makefile and Docker Hub image can be a bit daunting. However, from a tester's perspective, all they need to know is that
1. tests go in `test/`
2. they can modify the `vimrc` there which is used in tests

As this is quite a lot already for one PR so I only included a very basic Vader test as an example.

### Versus our current approach
* Our current approach limits us to whatever version of vim is installed on Ubuntu 12.04, which happens to be v7.3.429 and is useless for testing a vim 8 plugin. The only alternate solution is to build vim from source for every Travis build, but this is messy and takes minutes.
* OS-agnostic testing of multiple vim versions
* Travis builds in seconds, not minutes, allowing for quicker iterations during development
* Contributors just need to link their Github to Travis and push to their fork to run tests, no need to install vint or vader
* Eventual Neovim support https://github.com/tweekmonster/vim-testbed/issues/1

#59

@KabbAmine Try running adding your Vader tests to this and let me know how it goes.