### PR TITLE
Add golang support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ name. That seems to be the fairest way to arrange this table.
 | Cython (pyrex filetype) | [cython](http://cython.org/) |
 | D | [dmd](https://dlang.org/dmd-linux.html)^ |
 | Fortran | [gcc](https://gcc.gnu.org/) |
+| Go | [gofmt -e](https://golang.org/cmd/gofmt/), [go vet](https://golang.org/cmd/vet/), [golint](https://godoc.org/github.com/golang/lint) |
 | Haskell | [ghc](https://www.haskell.org/ghc/) |
 | HTML | [HTMLHint](http://htmlhint.com/), [tidy](http://www.html-tidy.org/) |
 | JavaScript | [eslint](http://eslint.org/), [jscs](http://jscs.info/), [jshint](http://jshint.com/) |

--- a/ale_linters/go/gofmt.vim
+++ b/ale_linters/go/gofmt.vim
@@ -7,41 +7,11 @@ endif
 
 let g:loaded_ale_linters_go_gofmt = 1
 
-function! ale_linters#go#gofmt#Handle(buffer, lines)
-    " Matches patterns line the following:
-    "
-    " file1.go:5:2: expected declaration, found 'STRING' "log"
-    " file2.go:17:2: expected declaration, found 'go'
-    let l:pattern = '^.*:\(\d\+\):\(\d\+\): \(.\+\)$'
-    let l:output = []
-
-    for l:line in a:lines
-        let l:match = matchlist(l:line, l:pattern)
-
-        if len(l:match) == 0
-            continue
-        endif
-
-        " vcol is Needed to indicate that the column is a character.
-        call add(l:output, {
-        \   'bufnr': a:buffer,
-        \   'lnum': l:match[1] + 0,
-        \   'vcol': 0,
-        \   'col': l:match[2] + 0,
-        \   'text': l:match[3],
-        \   'type': 'E',
-        \   'nr': -1,
-        \})
-    endfor
-
-    return l:output
-endfunction
-
 call ale#linter#Define('go', {
 \   'name': 'gofmt',
 \   'output_stream': 'stderr',
 \   'executable': 'gofmt',
 \   'command': g:ale#util#stdin_wrapper . ' .go gofmt -e',
-\   'callback': 'ale_linters#go#gofmt#Handle',
+\   'callback': 'ale#handlers#HandleUnixFormatAsError',
 \})
 

--- a/ale_linters/go/gofmt.vim
+++ b/ale_linters/go/gofmt.vim
@@ -1,0 +1,47 @@
+" Author: neersighted <bjorn@neersighted.com>
+" Description: gofmt for Go files
+
+if exists('g:loaded_ale_linters_go_gofmt')
+    finish
+endif
+
+let g:loaded_ale_linters_go_gofmt = 1
+
+function! ale_linters#go#gofmt#Handle(buffer, lines)
+    " Matches patterns line the following:
+    "
+    " file1.go:5:2: expected declaration, found 'STRING' "log"
+    " file2.go:17:2: expected declaration, found 'go'
+    let l:pattern = '^.*:\(\d\+\):\(\d\+\): \(.\+\)$'
+    let l:output = []
+
+    for l:line in a:lines
+        let l:match = matchlist(l:line, l:pattern)
+
+        if len(l:match) == 0
+            continue
+        endif
+
+        " vcol is Needed to indicate that the column is a character.
+        call add(l:output, {
+        \   'bufnr': a:buffer,
+        \   'lnum': l:match[1] + 0,
+        \   'vcol': 0,
+        \   'col': l:match[2] + 0,
+        \   'text': l:match[3],
+        \   'type': 'E',
+        \   'nr': -1,
+        \})
+    endfor
+
+    return l:output
+endfunction
+
+call ale#linter#Define('go', {
+\   'name': 'gofmt',
+\   'output_stream': 'stderr',
+\   'executable': 'gofmt',
+\   'command': g:ale#util#stdin_wrapper . ' .go gofmt -e',
+\   'callback': 'ale_linters#go#gofmt#Handle',
+\})
+

--- a/ale_linters/go/golint.vim
+++ b/ale_linters/go/golint.vim
@@ -7,39 +7,9 @@ endif
 
 let g:loaded_ale_linters_go_golint = 1
 
-function! ale_linters#go#golint#Handle(buffer, lines)
-    " Matches patterns line the following:
-    "
-    " file1.go:53:10: if block ends with a return statement, so drop this else and outdent its block (move short variable declaration to its own line if necessary)
-    " file2.go:67:14: should omit type [][]byte from declaration of var matches; it will be inferred from the right-hand side
-    let l:pattern = '^.*:\(\d\+\):\(\d\+\): \(.\+\)$'
-    let l:output = []
-
-    for l:line in a:lines
-        let l:match = matchlist(l:line, l:pattern)
-
-        if len(l:match) == 0
-            continue
-        endif
-
-        " vcol is Needed to indicate that the column is a character.
-        call add(l:output, {
-        \   'bufnr': a:buffer,
-        \   'lnum': l:match[1] + 0,
-        \   'vcol': 0,
-        \   'col': l:match[2] + 0,
-        \   'text': l:match[3],
-        \   'type': 'W',
-        \   'nr': -1,
-        \})
-    endfor
-
-    return l:output
-endfunction
-
 call ale#linter#Define('go', {
 \   'name': 'golint',
 \   'executable': 'golint',
 \   'command': g:ale#util#stdin_wrapper . ' .go golint',
-\   'callback': 'ale_linters#go#golint#Handle',
+\   'callback': 'ale#handlers#HandleUnixFormatAsWarning',
 \})

--- a/ale_linters/go/golint.vim
+++ b/ale_linters/go/golint.vim
@@ -1,0 +1,45 @@
+" Author: neersighted <bjorn@neersighted.com>
+" Description: golint for Go files
+
+if exists('g:loaded_ale_linters_go_golint')
+    finish
+endif
+
+let g:loaded_ale_linters_go_golint = 1
+
+function! ale_linters#go#golint#Handle(buffer, lines)
+    " Matches patterns line the following:
+    "
+    " file1.go:53:10: if block ends with a return statement, so drop this else and outdent its block (move short variable declaration to its own line if necessary)
+    " file2.go:67:14: should omit type [][]byte from declaration of var matches; it will be inferred from the right-hand side
+    let l:pattern = '^.*:\(\d\+\):\(\d\+\): \(.\+\)$'
+    let l:output = []
+
+    for l:line in a:lines
+        let l:match = matchlist(l:line, l:pattern)
+
+        if len(l:match) == 0
+            continue
+        endif
+
+        " vcol is Needed to indicate that the column is a character.
+        call add(l:output, {
+        \   'bufnr': a:buffer,
+        \   'lnum': l:match[1] + 0,
+        \   'vcol': 0,
+        \   'col': l:match[2] + 0,
+        \   'text': l:match[3],
+        \   'type': 'W',
+        \   'nr': -1,
+        \})
+    endfor
+
+    return l:output
+endfunction
+
+call ale#linter#Define('go', {
+\   'name': 'golint',
+\   'executable': 'golint',
+\   'command': g:ale#util#stdin_wrapper . ' .go golint',
+\   'callback': 'ale_linters#go#golint#Handle',
+\})

--- a/ale_linters/go/govet.vim
+++ b/ale_linters/go/govet.vim
@@ -1,0 +1,46 @@
+" Author: neersighted <bjorn@neersighted.com>
+" Description: go vet for Go files
+
+if exists('g:loaded_ale_linters_go_govet')
+    finish
+endif
+
+let g:loaded_ale_linters_go_govet = 1
+
+function! ale_linters#go#govet#Handle(buffer, lines)
+    " Matches patterns line the following:
+    "
+    " file.go:27: missing argument for Printf("%s"): format reads arg 2, have only 1 args
+    let l:pattern = '^.*:\(\d\+\): \(.\+\)$'
+    let l:output = []
+
+    for l:line in a:lines
+        let l:match = matchlist(l:line, l:pattern)
+
+        if len(l:match) == 0
+            continue
+        endif
+
+        " vcol is Needed to indicate that the column is a character.
+        call add(l:output, {
+        \   'bufnr': a:buffer,
+        \   'lnum': l:match[1] + 0,
+        \   'vcol': 0,
+        \   'col': 0,
+        \   'text': l:match[2],
+        \   'type': 'W',
+        \   'nr': -1,
+        \})
+    endfor
+
+    return l:output
+endfunction
+
+call ale#linter#Define('go', {
+\   'name': 'go vet',
+\   'output_stream': 'stderr',
+\   'executable': 'go',
+\   'command': g:ale#util#stdin_wrapper . ' .go go vet',
+\   'callback': 'ale_linters#go#govet#Handle',
+\})
+

--- a/ale_linters/go/govet.vim
+++ b/ale_linters/go/govet.vim
@@ -7,40 +7,11 @@ endif
 
 let g:loaded_ale_linters_go_govet = 1
 
-function! ale_linters#go#govet#Handle(buffer, lines)
-    " Matches patterns line the following:
-    "
-    " file.go:27: missing argument for Printf("%s"): format reads arg 2, have only 1 args
-    let l:pattern = '^.*:\(\d\+\): \(.\+\)$'
-    let l:output = []
-
-    for l:line in a:lines
-        let l:match = matchlist(l:line, l:pattern)
-
-        if len(l:match) == 0
-            continue
-        endif
-
-        " vcol is Needed to indicate that the column is a character.
-        call add(l:output, {
-        \   'bufnr': a:buffer,
-        \   'lnum': l:match[1] + 0,
-        \   'vcol': 0,
-        \   'col': 0,
-        \   'text': l:match[2],
-        \   'type': 'W',
-        \   'nr': -1,
-        \})
-    endfor
-
-    return l:output
-endfunction
-
 call ale#linter#Define('go', {
 \   'name': 'go vet',
 \   'output_stream': 'stderr',
 \   'executable': 'go',
 \   'command': g:ale#util#stdin_wrapper . ' .go go vet',
-\   'callback': 'ale_linters#go#govet#Handle',
+\   'callback': 'ale#handlers#HandleUnixFormatAsError',
 \})
 

--- a/autoload/ale/handlers.vim
+++ b/autoload/ale/handlers.vim
@@ -4,13 +4,15 @@ scriptencoding utf-8
 "   linter which outputs warnings and errors in a format accepted by one of
 "   these functions can simply use one of these pre-defined error handlers.
 
+let s:path_pattern = '[a-zA-Z]\?\\\?:\?[[:alnum:]/\.-]\+'
+
 function! s:HandleUnixFormat(buffer, lines, type) abort
     " Matches patterns line the following:
     "
     " file.go:27: missing argument for Printf("%s"): format reads arg 2, have only 1 args
     " file.go:53:10: if block ends with a return statement, so drop this else and outdent its block (move short variable declaration to its own line if necessary)
     " file.go:5:2: expected declaration, found 'STRING' "log"
-    let l:pattern = '^[^:]\+:\(\d\+\):\?\(\d\+\)\?: \(.\+\)$'
+    let l:pattern = '^' . s:path_pattern . ':\(\d\+\):\?\(\d\+\)\?: \(.\+\)$'
     let l:output = []
 
     for l:line in a:lines

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -55,6 +55,7 @@ The following languages and tools are supported.
 * Cython (pyrex filetype): 'cython'
 * D: 'dmd'
 * Fortran: 'gcc'
+* Go: 'gofmt -e', 'go vet', 'golint'
 * Haskell: 'ghc'
 * HTML: 'HTMLHint', 'tidy'
 * JavaScript: 'eslint', 'jscs', 'jshint'


### PR DESCRIPTION
Add support for `gofmt -e` (for syntax checks), `go vet` for static analysis, and `golint` for style checks.

Closes #84