### PR TITLE
Remove many redundant handlers

### DIFF
--- a/ale_linters/haskell/ghc.vim
+++ b/ale_linters/haskell/ghc.vim
@@ -7,63 +7,12 @@ endif
 
 let g:loaded_ale_linters_haskell_ghc = 1
 
-function! ale_linters#haskell#ghc#Handle(buffer, lines)
-    " Look for lines like the following.
-    "
-    " /dev/stdin:28:26: Not in scope: `>>>>>'
-    let l:pattern = '^[^:]\+:\(\d\+\):\(\d\+\): \(.\+\)$'
-    let l:output = []
-
-    " For some reason the output coming out of the GHC through the wrapper
-    " script breaks the lines up in strange ways. So we have to join some
-    " lines back together again.
-    let l:corrected_lines = []
-
-    for l:line in a:lines
-        if len(matchlist(l:line, l:pattern)) > 0
-            call add(l:corrected_lines, l:line)
-            if l:line !~# ': error:$'
-                call add(l:corrected_lines, '')
-            endif
-        elseif l:line ==# ''
-            call add(l:corrected_lines, l:line)
-        else
-            if len(l:corrected_lines) > 0
-                if l:corrected_lines[-1] =~# ': error:$'
-                    let l:line = substitute(l:line, '\v^\s+', ' ', '')
-                endif
-                let l:corrected_lines[-1] .= l:line
-            endif
-        endif
-    endfor
-
-    for l:line in l:corrected_lines
-        let l:match = matchlist(l:line, l:pattern)
-
-        if len(l:match) == 0
-            continue
-        endif
-
-        call add(l:output, {
-        \   'bufnr': a:buffer,
-        \   'lnum': l:match[1] + 0,
-        \   'vcol': 0,
-        \   'col': l:match[2] + 0,
-        \   'text': l:match[3],
-        \   'type': 'E',
-        \   'nr': -1,
-        \})
-    endfor
-
-    return l:output
-endfunction
-
 call ale#linter#Define('haskell', {
 \   'name': 'ghc',
 \   'output_stream': 'stderr',
 \   'executable': 'ghc',
 \   'command': g:ale#util#stdin_wrapper . ' .hs ghc -fno-code -v0',
-\   'callback': 'ale_linters#haskell#ghc#Handle',
+\   'callback': 'ale#handlers#HandleUnixFormatAsError',
 \})
 
 call ale#linter#Define('haskell', {
@@ -71,5 +20,5 @@ call ale#linter#Define('haskell', {
 \   'output_stream': 'stderr',
 \   'executable': 'stack',
 \   'command': g:ale#util#stdin_wrapper . ' .hs stack ghc -- -fno-code -v0',
-\   'callback': 'ale_linters#haskell#ghc#Handle',
+\   'callback': 'ale#handlers#HandleUnixFormatAsError',
 \})

--- a/ale_linters/html/htmlhint.vim
+++ b/ale_linters/html/htmlhint.vim
@@ -7,42 +7,9 @@ endif
 
 let g:loaded_ale_linters_html_htmlhint = 1
 
-function! ale_linters#html#htmlhint#Handle(buffer, lines) abort
-    " Matches patterns lines like the following:
-    "stdin:7:10: <title></title> must not be empty. [error/title-require]
-
-    let l:pattern = '^stdin:\(\d\+\):\(\d\+\): \(.\+\)$'
-    let l:output = []
-
-    for l:line in a:lines
-        let l:match = matchlist(l:line, l:pattern)
-
-        if len(l:match) == 0
-            continue
-        endif
-
-        let l:line = l:match[1] + 0
-        let l:col = l:match[2] + 0
-        let l:text = l:match[3]
-
-        " vcol is Needed to indicate that the column is a character.
-        call add(l:output, {
-        \   'bufnr': a:buffer,
-        \   'lnum': l:line,
-        \   'vcol': 0,
-        \   'col': l:col,
-        \   'text': l:text,
-        \   'type': 'E',
-        \   'nr': -1,
-        \})
-    endfor
-
-    return l:output
-endfunction
-
 call ale#linter#Define('html', {
 \   'name': 'htmlhint',
 \   'executable': 'htmlhint',
 \   'command': 'htmlhint --format=unix stdin',
-\   'callback': 'ale_linters#html#htmlhint#Handle',
+\   'callback': 'ale#handlers#HandleUnixFormatAsError',
 \})

--- a/ale_linters/javascript/jscs.vim
+++ b/ale_linters/javascript/jscs.vim
@@ -7,52 +7,16 @@ endif
 
 let g:loaded_ale_linters_javascript_jscs = 1
 
-function! ale_linters#javascript#jscs#Handle(buffer, lines)
-    " Matches patterns line the following:
-    "
-    " input:57:8: Unexpected token (57:8)
-    let l:pattern = '^.\+:\(\d\+\):\(\d\+\): \(.\+\)'
-    let l:output = []
-
-    for l:line in a:lines
-        let l:match = matchlist(l:line, l:pattern)
-
-        if len(l:match) == 0
-            continue
-        endif
-
-        let l:text = l:match[3]
-        let l:marker_parts = l:match[4]
-
-        if len(l:marker_parts) == 2
-            let l:text = l:text . ' (' . l:marker_parts[1] . ')'
-        endif
-
-        " vcol is Needed to indicate that the column is a character.
-        call add(l:output, {
-        \   'bufnr': a:buffer,
-        \   'lnum': l:match[1] + 0,
-        \   'vcol': 0,
-        \   'col': l:match[2] + 0,
-        \   'text': l:text,
-        \   'type': 'E',
-        \   'nr': -1,
-        \})
-    endfor
-
-    return l:output
-endfunction
-
 call ale#linter#Define('javascript', {
 \   'name': 'jscs',
 \   'executable': 'jscs',
 \   'command': 'jscs -r unix -n -',
-\   'callback': 'ale_linters#javascript#jscs#Handle',
+\   'callback': 'ale#handlers#HandleUnixFormatAsError',
 \})
 
 call ale#linter#Define('javascript.jsx', {
 \   'name': 'jscs',
 \   'executable': 'jscs',
 \   'command': 'jscs -r unix -n -',
-\   'callback': 'ale_linters#javascript#jscs#Handle',
+\   'callback': 'ale#handlers#HandleUnixFormatAsError',
 \})

--- a/ale_linters/javascript/jshint.vim
+++ b/ale_linters/javascript/jshint.vim
@@ -31,55 +31,16 @@ function! ale_linters#javascript#jshint#GetCommand(buffer)
     return l:command
 endfunction
 
-function! ale_linters#javascript#jshint#Handle(buffer, lines)
-    " Matches patterns line the following:
-    "
-    " stdin:57:9: Missing name in function declaration.
-    " stdin:60:5: Attempting to override 'test2' which is a constant.
-    " stdin:57:10: 'test' is defined but never used.
-    " stdin:57:1: 'function' is defined but never used.
-    let l:pattern = '^.\+:\(\d\+\):\(\d\+\): \(.\+\)'
-    let l:output = []
-
-    for l:line in a:lines
-        let l:match = matchlist(l:line, l:pattern)
-
-        if len(l:match) == 0
-            continue
-        endif
-
-        let l:text = l:match[3]
-        let l:marker_parts = l:match[4]
-
-        if len(l:marker_parts) == 2
-            let l:text = l:text . ' (' . l:marker_parts[1] . ')'
-        endif
-
-        " vcol is Needed to indicate that the column is a character.
-        call add(l:output, {
-        \   'bufnr': a:buffer,
-        \   'lnum': l:match[1] + 0,
-        \   'vcol': 0,
-        \   'col': l:match[2] + 0,
-        \   'text': l:text,
-        \   'type': 'E',
-        \   'nr': -1,
-        \})
-    endfor
-
-    return l:output
-endfunction
-
 call ale#linter#Define('javascript', {
 \   'name': 'jshint',
 \   'executable': g:ale_javascript_jshint_executable,
 \   'command_callback': 'ale_linters#javascript#jshint#GetCommand',
-\   'callback': 'ale_linters#javascript#jshint#Handle',
+\   'callback': 'ale#handlers#HandleUnixFormatAsError',
 \})
 
 call ale#linter#Define('javascript.jsx', {
 \   'name': 'jshint',
 \   'executable': g:ale_javascript_jshint_executable,
 \   'command_callback': 'ale_linters#javascript#jshint#GetCommand',
-\   'callback': 'ale_linters#javascript#jshint#Handle',
+\   'callback': 'ale#handlers#HandleUnixFormatAsError',
 \})

--- a/ale_linters/php/phpcs.vim
+++ b/ale_linters/php/phpcs.vim
@@ -42,7 +42,7 @@ function! ale_linters#php#phpcs#Handle(buffer, lines)
         \   'vcol': 0,
         \   'col': l:match[2] + 0,
         \   'text': l:text,
-        \   'type': l:type ==# 'warning' ? 'W' : 'E',
+        \   'type': l:type ==# 'error' ? 'E' : 'W',
         \   'nr': -1,
         \})
     endfor

--- a/ale_linters/pug/puglint.vim
+++ b/ale_linters/pug/puglint.vim
@@ -7,38 +7,10 @@ endif
 
 let g:loaded_ale_linters_pug_puglint = 1
 
-function! ale_linters#pug#puglint#Handle(buffer, lines)
-    " Matches patterns like the following:
-    "
-    " temp.jade:6:1 The end of the string reached with no closing bracket ) found.
-    let l:pattern = '^.\+:\(\d\+\):\(\d\+\) \(.\+\)$'
-    let l:output = []
-
-    for l:line in a:lines
-        let l:match = matchlist(l:line, l:pattern)
-
-        if len(l:match) == 0
-            continue
-        endif
-
-        call add(l:output, {
-        \   'bufnr': a:buffer,
-        \   'lnum': l:match[1] + 0,
-        \   'vcol': 0,
-        \   'col': l:match[2] + 0,
-        \   'text': l:match[3],
-        \   'type': 'E',
-        \   'nr': -1,
-        \})
-    endfor
-
-    return l:output
-endfunction
-
 call ale#linter#Define('pug', {
 \   'name': 'puglint',
 \   'executable': 'pug-lint',
 \   'output_stream': 'stderr',
 \   'command': g:ale#util#stdin_wrapper . ' .pug pug-lint -r inline',
-\   'callback': 'ale_linters#pug#puglint#Handle',
+\   'callback': 'ale#handlers#HandleUnixFormatAsError',
 \})

--- a/ale_linters/pyrex/cython.vim
+++ b/ale_linters/pyrex/cython.vim
@@ -1,39 +1,6 @@
 " Author: w0rp <devw0rp@gmail.com>
 " Description: cython syntax checking for cython files.
 
-function! ale_linters#pyrex#cython#Handle(buffer, lines)
-    " Matches patterns line the following:
-    "
-    " test.pyx:13:25: Expected ':', found 'NEWLINE'
-    let l:pattern = '^.\+:\(\d\+\):\(\d\+\): \(.\+\)$'
-    let l:output = []
-
-    for l:line in a:lines
-        let l:match = matchlist(l:line, l:pattern)
-
-        if len(l:match) == 0
-            continue
-        endif
-
-        if l:match[3] =~# 'is not a valid module name$'
-            " Skip invalid module name errors.
-            continue
-        endif
-
-        call add(l:output, {
-        \   'bufnr': a:buffer,
-        \   'lnum': l:match[1] + 0,
-        \   'vcol': 0,
-        \   'col': l:match[2] + 0,
-        \   'text': l:match[3],
-        \   'type': 'E',
-        \   'nr': -1,
-        \})
-    endfor
-
-    return l:output
-endfunction
-
 call ale#linter#Define('pyrex', {
 \   'name': 'cython',
 \   'output_stream': 'stderr',
@@ -41,5 +8,5 @@ call ale#linter#Define('pyrex', {
 \   'command': g:ale#util#stdin_wrapper
 \       . ' .pyx cython --warning-extra -o '
 \       . g:ale#util#nul_file,
-\   'callback': 'ale_linters#pyrex#cython#Handle',
+\   'callback': 'ale#handlers#HandleUnixFormatAsError',
 \})

--- a/ale_linters/verilog/iverilog.vim
+++ b/ale_linters/verilog/iverilog.vim
@@ -25,7 +25,7 @@ function! ale_linters#verilog#iverilog#Handle(buffer, lines)
         endif
 
         let l:line = l:match[1] + 0
-        let l:type = l:match[2] ==# 'error' ? 'E' : 'W'
+        let l:type = l:match[2] =~# 'error' ? 'E' : 'W'
         let l:text = l:match[2] ==# 'syntax error' ? 'syntax error' : l:match[4]
 
         call add(l:output, {

--- a/ale_linters/verilog/iverilog.vim
+++ b/ale_linters/verilog/iverilog.vim
@@ -25,7 +25,7 @@ function! ale_linters#verilog#iverilog#Handle(buffer, lines)
         endif
 
         let l:line = l:match[1] + 0
-        let l:type = l:match[2] ==# 'warning' ? 'W' : 'E'
+        let l:type = l:match[2] ==# 'error' ? 'E' : 'W'
         let l:text = l:match[2] ==# 'syntax error' ? 'syntax error' : l:match[4]
 
         call add(l:output, {

--- a/ale_linters/yaml/yamllint.vim
+++ b/ale_linters/yaml/yamllint.vim
@@ -32,7 +32,7 @@ function! ale_linters#yaml#yamllint#Handle(buffer, lines)
         \   'vcol': 0,
         \   'col': l:col,
         \   'text': l:text,
-        \   'type': l:type ==# 'warning' ? 'W' : 'E',
+        \   'type': l:type ==# 'error' ? 'E' : 'W',
         \   'nr': -1,
         \})
     endfor


### PR DESCRIPTION
Some of these are debatable, as there is some special behavior we want to save. All of these work on my system, but some more testing might be required.

To preserve the special cases, and to simplify some of the Unix-compatible handlers I left untouched, some method for extending handlers or inheriting from handlers is desirable.

This is just a rough draft, let me know what you think.