### PR TITLE
Add system to alias linter folders, and register multiple filetypes

### DIFF
--- a/ale_linters/javascript/eslint.vim
+++ b/ale_linters/javascript/eslint.vim
@@ -49,14 +49,7 @@ function! ale_linters#javascript#eslint#Handle(buffer, lines)
     return l:output
 endfunction
 
-call ale#linter#Define('javascript', {
-\   'name': 'eslint',
-\   'executable': g:ale_javascript_eslint_executable,
-\   'command': g:ale_javascript_eslint_executable . ' -f unix --stdin --stdin-filename %s',
-\   'callback': 'ale_linters#javascript#eslint#Handle',
-\})
-
-call ale#linter#Define('javascript.jsx', {
+call ale#linter#Define('javascript', 'javascript.jsx', {
 \   'name': 'eslint',
 \   'executable': g:ale_javascript_eslint_executable,
 \   'command': g:ale_javascript_eslint_executable . ' -f unix --stdin --stdin-filename %s',

--- a/ale_linters/javascript/jscs.vim
+++ b/ale_linters/javascript/jscs.vim
@@ -43,14 +43,7 @@ function! ale_linters#javascript#jscs#Handle(buffer, lines)
     return l:output
 endfunction
 
-call ale#linter#Define('javascript', {
-\   'name': 'jscs',
-\   'executable': 'jscs',
-\   'command': 'jscs -r unix -n -',
-\   'callback': 'ale_linters#javascript#jscs#Handle',
-\})
-
-call ale#linter#Define('javascript.jsx', {
+call ale#linter#Define('javascript', 'javascript.jsx', {
 \   'name': 'jscs',
 \   'executable': 'jscs',
 \   'command': 'jscs -r unix -n -',

--- a/ale_linters/javascript/jshint.vim
+++ b/ale_linters/javascript/jshint.vim
@@ -70,14 +70,7 @@ function! ale_linters#javascript#jshint#Handle(buffer, lines)
     return l:output
 endfunction
 
-call ale#linter#Define('javascript', {
-\   'name': 'jshint',
-\   'executable': g:ale_javascript_jshint_executable,
-\   'command_callback': 'ale_linters#javascript#jshint#GetCommand',
-\   'callback': 'ale_linters#javascript#jshint#Handle',
-\})
-
-call ale#linter#Define('javascript.jsx', {
+call ale#linter#Define('javascript', 'javascript.jsx', {
 \   'name': 'jshint',
 \   'executable': g:ale_javascript_jshint_executable,
 \   'command_callback': 'ale_linters#javascript#jshint#GetCommand',

--- a/ale_linters/sh/shell.vim
+++ b/ale_linters/sh/shell.vim
@@ -74,7 +74,7 @@ function! ale_linters#sh#shell#Handle(buffer, lines)
     return l:output
 endfunction
 
-call ale#linter#Define('sh', {
+call ale#linter#Define('sh', 'zsh', 'csh', {
 \   'name': 'shell',
 \   'output_stream': 'stderr',
 \   'executable_callback': 'ale_linters#sh#shell#GetExecutable',

--- a/autoload/ale/linter.vim
+++ b/autoload/ale/linter.vim
@@ -3,11 +3,6 @@
 "   Retrieves linters as requested by the engine, loading them if needed.
 
 let s:linters = {}
-let s:folder_aliases = {
-    \ 'javascript.jsx': 'javascript',
-    \ 'csh': 'sh',
-    \ 'zsh': 'sh'
-\}
 
 function! ale#linter#Define(...) abort
     let l:linter = a:000[-1]
@@ -57,9 +52,9 @@ function! ale#linter#Get(filetype) abort
         return s:linters[a:filetype]
     endif
 
-    if has_key(s:folder_aliases, a:filetype)
-        " We have an alias for this filetype, so just load that.
-        let l:folder = s:folder_aliases[a:filetype]
+    if has_key(g:ale_load_overrides, a:filetype)
+        " We've been told to load a different folder for this filetype.
+        let l:folder = g:ale_load_overrides[a:filetype]
     else
         let l:folder = a:filetype
     endif

--- a/autoload/ale/linter.vim
+++ b/autoload/ale/linter.vim
@@ -3,38 +3,47 @@
 "   Retrieves linters as requested by the engine, loading them if needed.
 
 let s:linters = {}
+let s:folder_aliases = {
+    \ 'javascript.jsx': 'javascript',
+    \ 'csh': 'sh',
+    \ 'zsh': 'sh'
+\}
 
-function! ale#linter#Define(filetype, linter) abort
-    if !has_key(s:linters, a:filetype)
-        let s:linters[a:filetype] = []
-    endif
+function! ale#linter#Define(...) abort
+    let l:linter = a:000[-1]
+    let l:filetypes = a:000[:-2]
 
     let l:new_linter = {
-    \   'name': a:linter.name,
-    \   'callback': a:linter.callback,
+    \   'name': l:linter.name,
+    \   'callback': l:linter.callback,
     \}
 
-    if has_key(a:linter, 'executable_callback')
-        let l:new_linter.executable_callback = a:linter.executable_callback
+    if has_key(l:linter, 'executable_callback')
+        let l:new_linter.executable_callback = l:linter.executable_callback
     else
-        let l:new_linter.executable = a:linter.executable
+        let l:new_linter.executable = l:linter.executable
     endif
 
-    if has_key(a:linter, 'command_callback')
-        let l:new_linter.command_callback = a:linter.command_callback
+    if has_key(l:linter, 'command_callback')
+        let l:new_linter.command_callback = l:linter.command_callback
     else
-        let l:new_linter.command = a:linter.command
+        let l:new_linter.command = l:linter.command
     endif
 
-    if has_key(a:linter, 'output_stream')
-        let l:new_linter.output_stream = a:linter.output_stream
+    if has_key(l:linter, 'output_stream')
+        let l:new_linter.output_stream = l:linter.output_stream
     else
         let l:new_linter.output_stream = 'stdout'
     endif
 
     " TODO: Assert the value of the output_stream to be something sensible.
 
-    call add(s:linters[a:filetype], l:new_linter)
+    for l:filetype in l:filetypes
+        if !has_key(s:linters, l:filetype)
+            let s:linters[l:filetype] = []
+        endif
+        call add(s:linters[l:filetype], l:new_linter)
+    endfor
 endfunction
 
 function! ale#linter#Get(filetype) abort
@@ -48,13 +57,20 @@ function! ale#linter#Get(filetype) abort
         return s:linters[a:filetype]
     endif
 
+    if has_key(s:folder_aliases, a:filetype)
+        " We have an alias for this filetype, so just load that.
+        let l:folder = s:folder_aliases[a:filetype]
+    else
+        let l:folder = a:filetype
+    endif
+
     if has_key(g:ale_linters, a:filetype)
         " Filter loaded linters according to list of linters specified in option.
         for l:linter in g:ale_linters[a:filetype]
-            execute 'runtime! ale_linters/' . a:filetype . '/' . l:linter . '.vim'
+            execute 'runtime! ale_linters/' . l:folder . '/' . l:linter . '.vim'
         endfor
     else
-        execute 'runtime! ale_linters/' . a:filetype . '/*.vim'
+        execute 'runtime! ale_linters/' . l:folder . '/*.vim'
     endif
 
     if !has_key(s:linters, a:filetype)

--- a/plugin/ale.vim
+++ b/plugin/ale.vim
@@ -33,6 +33,14 @@ let g:ale_buffer_sign_dummy_map = {}
 " This list configures which linters are enabled for which languages.
 let g:ale_linters = get(g:, 'ale_linters', {})
 
+" This list allows the user to override what selection of linters is loaded
+" for a filetype. The defaults are extended, instead of clobbered.
+let g:ale_load_overrides = extend({
+    \ 'javascript.jsx': 'javascript',
+    \ 'csh': 'sh',
+    \ 'zsh': 'sh'
+\}, get(g:, 'ale_load_overrides', {}))
+
 " This flag can be set with a number of milliseconds for delaying the
 " execution of a linter when text is changed. The timeout will be set and
 " cleared each time text is changed, so repeated edits won't trigger the


### PR DESCRIPTION
Closes #87

This change is backwards compatible, as ale#linter#Define() takes
variable arguments, with the linter being the last. It still needs to be
documented, however. Not sure how to describe vargs in vimscript terms.