### PR TITLE
Implement autocommand support

### DIFF
--- a/autoload/ale/engine.vim
+++ b/autoload/ale/engine.vim
@@ -108,6 +108,9 @@ function! s:HandleExit(job) abort
         call ale#sign#SetSigns(l:buffer, g:ale_buffer_loclist_map[l:buffer])
     endif
 
+    " Call user autocommands. This allows users to hook into ALE's lint cycle.
+    doautocmd User ALELint
+
     " Mark line 200, column 17 with a squiggly line or something
     " matchadd('ALEError', '\%200l\%17v')
 endfunction

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -605,12 +605,20 @@ ale#statusline#Status()                               *ale#statusline#Status()*
   Return a formatted string that can be added to the statusline.
   The output's format is defined in |`g:ale_statusline_format`|.
   To enable it, the following should be present in your |statusline| settings: >
-  %{ale#statusline#status()}
+  %{ale#statusline#Status()}
 
 
 g:ale#util#stdin_wrapper                             *g:ale#util#stdin_wrapper*
   This variable names a wrapper script for sending stdin input to programs
   which cannot accept input via stdin. See |ale#linter#Define()| for more.
+
+
+ALELint                                                               *ALELint*
+  This |User| autocommand is triggered by ALE every time it completes a lint
+  operation. It can be used to update statuslines, send notifications, or
+  complete any other operation that needs to be done after a lint run.
+  It can be used simply:
+  autocmd User ALELint echom "ALE run!"
 
 
 ===============================================================================


### PR DESCRIPTION
This pull adds a simple autocommand, `ALELint`, called by the core after all linters have been executed. This is useful for third-party integrations.