### PR TITLE
Remove 'attach to STDERR' param in docker run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 IMAGE ?= w0rp/ale
-DOCKER = docker run -a stderr --rm -v $(PWD):/testplugin -v $(PWD)/test:/home -v ${PWD}:/home/ale "$(IMAGE)"
+DOCKER = docker run --rm -v $(PWD):/testplugin -v $(PWD)/test:/home -v ${PWD}:/home/ale "$(IMAGE)"
 
 test-setup:
 	docker images -q $(IMAGE) || docker pull $(IMAGE)


### PR DESCRIPTION
Just saw the commit with style issues, glad to see it's (almost) working as intended!

The Makefile I copied from came with an 'attach to STDERR' param to `docker run`. Which I now understand to mean "ignore everything else except STDERR". Not sure why this was there in the first place.

```
-a stderr
```

So when vint has a fatal error (e.g. can't find directory or unparseable .vintrc.yaml) then it outputs to STDERR but normal linting output goes to STDOUT.

I just removed the option, and now the lint output should show up in the Travis log, as it's currently missing.