### PR TITLE
Add ansible-lint support and factor out PEP8 handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,11 @@ name. That seems to be the fairest way to arrange this table.
 
 | Language | Tools |
 | -------- | ----- |
+| Ansible | [ansible-lint](https://github.com/willthames/ansible-lint) |
 | Bash | [-n flag](https://www.gnu.org/software/bash/manual/bash.html#index-set), [shellcheck](https://www.shellcheck.net/) |
 | Bourne Shell | [-n flag](http://linux.die.net/man/1/sh), [shellcheck](https://www.shellcheck.net/) |
 | C | [cppcheck](http://cppcheck.sourceforge.net), [gcc](https://gcc.gnu.org/)|
-| C++ (filetype cpp)| [cppcheck] (http://cppcheck.sourceforge.net), [gcc](https://gcc.gnu.org/)|
+| C++ (filetype cpp) | [cppcheck] (http://cppcheck.sourceforge.net), [gcc](https://gcc.gnu.org/)|
 | CoffeeScript | [coffee](http://coffeescript.org/), [coffeelint](https://www.npmjs.com/package/coffeelint) |
 | CSS | [csslint](http://csslint.net/) |
 | Cython (pyrex filetype) | [cython](http://cython.org/) |

--- a/ale_linters/ansible/ansible-lint.vim
+++ b/ale_linters/ansible/ansible-lint.vim
@@ -1,0 +1,15 @@
+" Author: w0rp <devw0rp@gmail.com>
+" Description: ansible-lint for ansible-yaml files
+
+if exists('g:loaded_ale_linters_ansible_ansiblelint')
+    finish
+endif
+
+let g:loaded_ale_linters_ansible_ansiblelint = 1
+
+call ale#linter#Define('ansible', {
+\   'name': 'ansible',
+\   'executable': 'ansible',
+\   'command': g:ale#util#stdin_wrapper . ' .yml ansible-lint -p',
+\   'callback': 'ale#handlers#HandlePEP8Format',
+\})

--- a/ale_linters/ansible/ansible-lint.vim
+++ b/ale_linters/ansible/ansible-lint.vim
@@ -1,4 +1,4 @@
-" Author: w0rp <devw0rp@gmail.com>
+" Author: Bjorn Neergaard <bjorn@neersighted.com>
 " Description: ansible-lint for ansible-yaml files
 
 if exists('g:loaded_ale_linters_ansible_ansiblelint')

--- a/ale_linters/python/flake8.vim
+++ b/ale_linters/python/flake8.vim
@@ -7,49 +7,9 @@ endif
 
 let g:loaded_ale_linters_python_flake8 = 1
 
-function! ale_linters#python#flake8#Handle(buffer, lines)
-    " Matches patterns line the following:
-    "
-    " stdin:6:6: E111 indentation is not a multiple of four
-    let l:pattern = '^stdin:\(\d\+\):\(\d\+\): \([^ ]\+\) \(.\+\)$'
-    let l:output = []
-
-    for l:line in a:lines
-        let l:match = matchlist(l:line, l:pattern)
-
-        if len(l:match) == 0
-            continue
-        endif
-
-        let l:line = l:match[1] + 0
-        let l:column = l:match[2] + 0
-        let l:code = l:match[3]
-        let l:text = l:code . ': ' . l:match[4]
-        let l:type = l:code[0] ==# 'E' ? 'E' : 'W'
-
-        if (l:code ==# 'W291' || l:code ==# 'W293') && !g:ale_warn_about_trailing_whitespace
-            " Skip warnings for trailing whitespace if the option is off.
-            continue
-        endif
-
-        " vcol is Needed to indicate that the column is a character.
-        call add(l:output, {
-        \   'bufnr': a:buffer,
-        \   'lnum': l:line,
-        \   'vcol': 0,
-        \   'col': l:column,
-        \   'text': l:text,
-        \   'type': l:type,
-        \   'nr': -1,
-        \})
-    endfor
-
-    return l:output
-endfunction
-
 call ale#linter#Define('python', {
 \   'name': 'flake8',
 \   'executable': 'flake8',
 \   'command': 'flake8 -',
-\   'callback': 'ale_linters#python#flake8#Handle',
+\   'callback': 'ale#handlers#HandlePEP8Format',
 \})

--- a/autoload/ale/handlers.vim
+++ b/autoload/ale/handlers.vim
@@ -103,6 +103,43 @@ function! ale#handlers#HandleCppCheckFormat(buffer, lines) abort
 
 endfunction
 
+function! ale#handlers#HandlePEP8Format(buffer, lines)
+    " Matches patterns line the following:
+    "
+    " Matches patterns line the following:
+    "
+    " stdin:6:6: E111 indentation is not a multiple of four
+    " test.yml:35: [EANSIBLE0002] Trailing whitespace
+    let l:pattern = '^' . s:path_pattern . ':\(\d\+\):\?\(\d\+\)\?: \[\?\(\([[:alpha:]]\)[[:alnum:]]\+\)\]\? \(.*\)$'
+    let l:output = []
+
+    for l:line in a:lines
+        let l:match = matchlist(l:line, l:pattern)
+
+        if len(l:match) == 0
+            continue
+        endif
+
+        let l:code = l:match[3]
+        if (l:code ==# 'W291' || l:code ==# 'W293' || l:code ==# 'EANSIBLE002')
+                    \ && !g:ale_warn_about_trailing_whitespace
+            " Skip warnings for trailing whitespace if the option is off.
+            continue
+        endif
+
+        call add(l:output, {
+        \   'bufnr': a:buffer,
+        \   'lnum': l:match[1] + 0,
+        \   'vcol': 0,
+        \   'col': l:match[2] + 0,
+        \   'text': l:code . ': ' . l:match[5],
+        \   'type': l:match[4] ==# 'E' ? 'E' : 'W',
+        \   'nr': -1,
+        \})
+    endfor
+
+    return l:output
+endfunction
 
 function! ale#handlers#HandleCSSLintFormat(buffer, lines) abort
     " Matches patterns line the following:

--- a/autoload/ale/handlers.vim
+++ b/autoload/ale/handlers.vim
@@ -99,11 +99,11 @@ function! ale#handlers#HandleCppCheckFormat(buffer, lines) abort
         \   'nr': -1,
         \})
     endfor
-    return l:output
 
+    return l:output
 endfunction
 
-function! ale#handlers#HandlePEP8Format(buffer, lines)
+function! ale#handlers#HandlePEP8Format(buffer, lines) abort
     " Matches patterns line the following:
     "
     " Matches patterns line the following:

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -50,6 +50,7 @@ ALE supports the following key features:
 
 The following languages and tools are supported.
 
+* Ansible: 'ansible-lint'
 * Bash: 'shell' (-n flag), 'shellcheck'
 * Bourne Shell: 'shell' (-n flag), 'shellcheck'
 * C: 'cppcheck', 'gcc'

--- a/test/test_common_handlers.vader
+++ b/test/test_common_handlers.vader
@@ -26,6 +26,34 @@ Then (The loclist should be correct):
   \ },
   \], g:loclist
 
+Execute (Run HandlePEP8Format):
+  let g:loclist = ale#handlers#HandlePEP8Format(42, [
+  \ "stdin:6:6: E111 indentation is not a multiple of four",
+  \ "test.yml:35: [EANSIBLE0002] Trailing whitespace",
+  \])
+
+Then (The loclist should be correct):
+  AssertEqual [
+  \ {
+  \   'bufnr': 42,
+  \   'vcol': 0,
+  \   'nr': -1,
+  \   'lnum': 6,
+  \   'col': 6,
+  \   'type': 'E',
+  \   'text': 'E111: indentation is not a multiple of four',
+  \ },
+  \ {
+  \   'bufnr': 42,
+  \   'vcol': 0,
+  \   'nr': -1,
+  \   'lnum': 35,
+  \   'col': 0,
+  \   'type': 'E',
+  \   'text': "EANSIBLE0002: Trailing whitespace",
+  \ },
+  \], g:loclist
+
 Execute (Run HandleGCCFormat):
   let g:loclist = ale#handlers#HandleGCCFormat(42, [
   \ '<stdin>:8:5: warning: conversion lacks type at end of format [-Wformat=]',


### PR DESCRIPTION
Still need to implement aliasing. @w0rp, what would be the most elegant way to set this up? (ansible-lint for ansible, yamllint for yaml, both for ansible.yaml).

Closes #128