### PR TITLE
Add ale_lint_in_normal_mode option

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ vimrc file for all given linters is as follows:
 | `g:ale_lint_on_enter` | lint when opening a file  | `1` |
 | `g:ale_lint_on_save` | lint when saving a file  | `0` |
 | `g:ale_lint_on_text_changed` | lint while typing  | `1` |
+| `g:ale_lint_in_normal_mode` | lint when leaving insert mode and changing text in normal mode  | `1` |
 | `g:ale_set_loclist` | set the loclist with errors | `1` |
 | `g:ale_set_signs` | set gutter signs with error markers | `has('signs')` |
 | `g:ale_sign_column_always` | always show the sign gutter | `0` |

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -211,6 +211,15 @@ g:ale_lint_on_save                                         *g:ale_lint_on_save*
   desired.
 
 
+g:ale_lint_in_normal_mode                                   *g:ale_lint_in_normal_mode*
+
+  Type: |Number|
+  Default: `1`
+
+  This option will make ALE run the linters when leaving insert mode or when
+  making changes to the text in normal mode.
+
+
 g:ale_set_loclist                                           *g:ale_set_loclist*
 
   Type: |Number|

--- a/plugin/ale.vim
+++ b/plugin/ale.vim
@@ -70,6 +70,20 @@ if g:ale_lint_on_save
     augroup END
 endif
 
+" This flag can be set to 1 to enable linting when leaving insert mode.
+let g:ale_lint_in_normal_mode = get(g:, 'ale_lint_in_normal_mode', 0)
+if g:ale_lint_in_normal_mode
+    augroup ALERunOnInsertLeaveGroup
+        autocmd!
+        autocmd InsertLeave * call ale#Queue(0)
+    augroup END
+
+    augroup ALERunOnTextChangedNormalGroup
+        autocmd!
+        autocmd TextChanged * call ale#Queue(g:ale_lint_delay)
+    augroup END
+endif
+
 " This flag can be set to 0 to disable setting the loclist.
 let g:ale_set_loclist = get(g:, 'ale_set_loclist', 1)
 


### PR DESCRIPTION
This PR implements an option to lint when exiting insert mode and making changes in normal mode.

(I found continuous linting in insert mode a little off putting and this seems like a happy medium without having to wait until a save.)