### PR TITLE
Factor out list support, and implement opening/closing

### DIFF
--- a/autoload/ale/engine.vim
+++ b/autoload/ale/engine.vim
@@ -105,16 +105,16 @@ function! s:HandleExit(job) abort
     " for efficient lookup of the messages in the cursor handler.
     call sort(g:ale_buffer_loclist_map[l:buffer], 'ale#util#LocItemCompare')
 
-    if g:ale_set_loclist
-        call setloclist(0, g:ale_buffer_loclist_map[l:buffer])
+    if g:ale_set_quickfix || g:ale_set_loclist
+        call ale#list#SetLists(g:ale_buffer_loclist_map[l:buffer])
     endif
 
     if g:ale_set_signs
         call ale#sign#SetSigns(l:buffer, g:ale_buffer_loclist_map[l:buffer])
     endif
 
+    " Don't load/run if not already loaded.
     if exists('*ale#statusline#Update')
-        " Don't load/run if not already loaded.
         call ale#statusline#Update(l:buffer, g:ale_buffer_loclist_map[l:buffer])
     endif
 

--- a/autoload/ale/list.vim
+++ b/autoload/ale/list.vim
@@ -1,0 +1,37 @@
+" Author: Bjorn Neergaard <bjorn@neersighted.com>
+" Description: Manages the loclist and quickfix lists
+
+function! ale#list#SetLists(loclist) abort
+    " Set either the quickfix list, or the loclist.
+    if g:ale_set_quickfix
+        call setqflist(a:loclist)
+    elseif g:ale_set_loclist
+        call setloclist(0, a:loclist)
+    endif
+
+    " If we don't auto-open lists, bail out here.
+    if !g:ale_open_list
+        return
+    endif
+
+    " If we have errors in our list, open the list.
+    if len(a:loclist) > 0
+        let l:winnr = winnr()
+        if g:ale_set_quickfix
+            copen
+        elseif g:ale_set_loclist
+            lopen
+        end
+        " If focus changed, restore it (jump to the last window).
+        if l:winnr !=# winnr()
+            wincmd p
+        endif
+    " Only close if the list is totally empty (relying on Vim's state, not our
+    " own). This keeps us from closing the window when other plugins have
+    " populated it.
+    elseif g:ale_set_quickfix && len(getqflist()) == 0
+        cclose
+    elseif g:ale_set_loclist && len(getloclist(0)) == 0
+        lclose
+    endif
+endfunction

--- a/plugin/ale.vim
+++ b/plugin/ale.vim
@@ -70,8 +70,13 @@ if g:ale_lint_on_save
     augroup END
 endif
 
-" This flag can be set to 0 to disable setting the loclist.
+" These flags dictates if ale uses the quickfix or the loclist (loclist is the
+" default, quickfix overrides loclist).
+let g:ale_set_quickfix = get(g:, 'ale_set_quickfix', 0)
 let g:ale_set_loclist = get(g:, 'ale_set_loclist', 1)
+
+" This flag dictates if ale open the configured list (quickfix or loclist).
+let g:ale_open_list = get(g:, 'ale_open_list', 0)
 
 " This flag can be set to 0 to disable setting signs.
 " This is enabled by default only if the 'signs' feature exists.
@@ -86,7 +91,7 @@ let g:ale_sign_warning = get(g:, 'ale_sign_warning', '--')
 " The dummy sign will use the ID exactly equal to the offset.
 let g:ale_sign_offset = get(g:, 'ale_sign_offset', 1000000)
 
-" This flag can be set to 1 to keep sign gutter always open
+" This flag can be set to 1 to keep sign gutter always open.
 let g:ale_sign_column_always = get(g:, 'ale_sign_column_always', 0)
 
 " String format for the echoed message
@@ -94,7 +99,7 @@ let g:ale_sign_column_always = get(g:, 'ale_sign_column_always', 0)
 " It can contain 2 handlers: %linter%, %severity%
 let g:ale_echo_msg_format = get(g:, 'ale_echo_msg_format', '%s')
 
-" Strings used for severity in the echoed message
+" Strings used for severity in the echoed message.
 let g:ale_echo_msg_error_str = get(g:, 'ale_echo_msg_error_str', 'Error')
 let g:ale_echo_msg_warning_str = get(g:, 'ale_echo_msg_warning_str', 'Warning')
 


### PR DESCRIPTION
This PR factors out the loclist logic to be more generic and support the
quickfix list (as well as moving it to its own file). It also implements
the opening and closing of said lists, with logic to ensure we don't
close the list when another plugin is using it.

I am not sure what the best way to address preferences is, as I wanted
to maintain backward compaibility. I think the implementation here is
acceptable, but @w0rp's opinion may differ.

The settings still need to be documented, but I will follow up on that
after the settings interface is finalized.

Closes #136, #45
