### PR TITLE
Add support for dot-seperate linters, improve linter tests

### DIFF
--- a/ale_linters/ansible/ansible-lint.vim
+++ b/ale_linters/ansible/ansible-lint.vim
@@ -1,12 +1,6 @@
 " Author: Bjorn Neergaard <bjorn@neersighted.com>
 " Description: ansible-lint for ansible-yaml files
 
-if exists('g:loaded_ale_linters_ansible_ansiblelint')
-    finish
-endif
-
-let g:loaded_ale_linters_ansible_ansiblelint = 1
-
 call ale#linter#Define('ansible', {
 \   'name': 'ansible',
 \   'executable': 'ansible',

--- a/ale_linters/c/cppcheck.vim
+++ b/ale_linters/c/cppcheck.vim
@@ -1,12 +1,6 @@
 " Author: Bart Libert <bart.libert@gmail.com>
 " Description: cppcheck linter for c files
 
-if exists('g:loaded_ale_linters_c_cppcheck')
-    finish
-endif
-
-let g:loaded_ale_linters_c_cppcheck = 1
-
 " Set this option to change the cppcheck options
 if !exists('g:ale_c_cppcheck_options')
     let g:ale_c_cppcheck_options = '--enable=style'

--- a/ale_linters/c/gcc.vim
+++ b/ale_linters/c/gcc.vim
@@ -1,12 +1,6 @@
 " Author: w0rp <devw0rp@gmail.com>
 " Description: gcc linter for c files
 
-if exists('g:loaded_ale_linters_c_gcc')
-    finish
-endif
-
-let g:loaded_ale_linters_c_gcc = 1
-
 " Set this option to change the GCC options for warnings for C.
 if !exists('g:ale_c_gcc_options')
     " let g:ale_c_gcc_options = '-Wall'

--- a/ale_linters/coffee/coffee.vim
+++ b/ale_linters/coffee/coffee.vim
@@ -1,12 +1,6 @@
 " Author: KabbAmine - https://github.com/KabbAmine
 " Description: Coffee for checking coffee files
 
-if exists('g:loaded_ale_linters_coffee_coffee')
-    finish
-endif
-
-let g:loaded_ale_linters_coffee_coffee = 1
-
 call ale#linter#Define('coffee', {
 \   'name': 'coffee',
 \   'executable': 'coffee',
@@ -14,4 +8,3 @@ call ale#linter#Define('coffee', {
 \   'output_stream': 'stderr',
 \   'callback': 'ale#handlers#HandleGCCFormat',
 \})
-

--- a/ale_linters/coffee/coffeelint.vim
+++ b/ale_linters/coffee/coffeelint.vim
@@ -1,12 +1,6 @@
 " Author: Prashanth Chandra https://github.com/prashcr
 " Description: coffeelint linter for coffeescript files
 
-if exists('g:loaded_ale_linters_coffee_coffeelint')
-    finish
-endif
-
-let g:loaded_ale_linters_coffee_coffeelint = 1
-
 function! ale_linters#coffee#coffeelint#Handle(buffer, lines)
     " Matches patterns like the following:
     "

--- a/ale_linters/cpp/cppcheck.vim
+++ b/ale_linters/cpp/cppcheck.vim
@@ -1,12 +1,6 @@
 " Author: Bart Libert <bart.libert@gmail.com>
 " Description: cppcheck linter for cpp files
 
-if exists('g:loaded_ale_linters_cpp_cppcheck')
-    finish
-endif
-
-let g:loaded_ale_linters_cpp_cppcheck = 1
-
 " Set this option to change the cppcheck options
 if !exists('g:ale_cpp_cppcheck_options')
     let g:ale_cpp_cppcheck_options = '--enable=style'

--- a/ale_linters/cpp/gcc.vim
+++ b/ale_linters/cpp/gcc.vim
@@ -1,12 +1,6 @@
 " Author: geam <mdelage@student.42.fr>
 " Description: gcc linter for cpp files
 
-if exists('g:loaded_ale_linters_cpp_gcc')
-    finish
-endif
-
-let g:loaded_ale_linters_cpp_gcc = 1
-
 " Set this option to change the GCC options for warnings for C.
 if !exists('g:ale_cpp_gcc_options')
   " added c++14 standard support

--- a/ale_linters/css/csslint.vim
+++ b/ale_linters/css/csslint.vim
@@ -1,12 +1,6 @@
 " Author: w0rp <devw0rp@gmail.com>
 " Description: This file adds support for checking CSS code with csslint.
 
-if exists('g:loaded_ale_linters_css_csslint')
-    finish
-endif
-
-let g:loaded_ale_linters_css_csslint = 1
-
 call ale#linter#Define('css', {
 \   'name': 'csslint',
 \   'executable': 'csslint',

--- a/ale_linters/d/dmd.vim
+++ b/ale_linters/d/dmd.vim
@@ -1,12 +1,6 @@
 " Author: w0rp <devw0rp@gmail.com>
 " Description: "dmd for D files"
 
-if exists('g:loaded_ale_linters_d_dmd')
-    finish
-endif
-
-let g:loaded_ale_linters_d_dmd = 1
-
 " A function for finding the dmd-wrapper script in the Vim runtime paths
 function! s:FindWrapperScript()
     for l:parent in split(&runtimepath, ',')

--- a/ale_linters/elixir/credo.vim
+++ b/ale_linters/elixir/credo.vim
@@ -1,11 +1,5 @@
 " Author: hauleth - https://github.com/haulethe
 
-if exists('g:loaded_ale_linters_elixir_credo')
-  finish
-endif
-
-let g:loaded_ale_linters_elixir_credo = 1
-
 function! ale_linters#elixir#credo#Handle(buffer, lines)
   " Matches patterns line the following:
   "

--- a/ale_linters/fortran/gcc.vim
+++ b/ale_linters/fortran/gcc.vim
@@ -1,12 +1,6 @@
 " Author: w0rp <devw0rp@gmail.com>
 " Description: gcc for Fortran files
 
-if exists('g:loaded_ale_linters_fortran_gcc')
-    finish
-endif
-
-let g:loaded_ale_linters_fortran_gcc = 1
-
 " Set this option to change the GCC options for warnings for Fortran.
 if !exists('g:ale_fortran_gcc_options')
     let g:ale_fortran_gcc_options = '-Wall'

--- a/ale_linters/go/gofmt.vim
+++ b/ale_linters/go/gofmt.vim
@@ -1,12 +1,6 @@
 " Author: neersighted <bjorn@neersighted.com>
 " Description: gofmt for Go files
 
-if exists('g:loaded_ale_linters_go_gofmt')
-    finish
-endif
-
-let g:loaded_ale_linters_go_gofmt = 1
-
 call ale#linter#Define('go', {
 \   'name': 'gofmt',
 \   'output_stream': 'stderr',
@@ -14,4 +8,3 @@ call ale#linter#Define('go', {
 \   'command': g:ale#util#stdin_wrapper . ' .go gofmt -e',
 \   'callback': 'ale#handlers#HandleUnixFormatAsError',
 \})
-

--- a/ale_linters/go/golint.vim
+++ b/ale_linters/go/golint.vim
@@ -1,12 +1,6 @@
 " Author: neersighted <bjorn@neersighted.com>
 " Description: golint for Go files
 
-if exists('g:loaded_ale_linters_go_golint')
-    finish
-endif
-
-let g:loaded_ale_linters_go_golint = 1
-
 call ale#linter#Define('go', {
 \   'name': 'golint',
 \   'executable': 'golint',

--- a/ale_linters/go/govet.vim
+++ b/ale_linters/go/govet.vim
@@ -1,12 +1,6 @@
 " Author: neersighted <bjorn@neersighted.com>
 " Description: go vet for Go files
 
-if exists('g:loaded_ale_linters_go_govet')
-    finish
-endif
-
-let g:loaded_ale_linters_go_govet = 1
-
 call ale#linter#Define('go', {
 \   'name': 'go vet',
 \   'output_stream': 'stderr',
@@ -14,4 +8,3 @@ call ale#linter#Define('go', {
 \   'command': g:ale#util#stdin_wrapper . ' .go go vet',
 \   'callback': 'ale#handlers#HandleUnixFormatAsError',
 \})
-

--- a/ale_linters/haskell/ghc.vim
+++ b/ale_linters/haskell/ghc.vim
@@ -1,12 +1,6 @@
 " Author: w0rp <devw0rp@gmail.com>
 " Description: ghc for Haskell files
 
-if exists('g:loaded_ale_linters_haskell_ghc')
-    finish
-endif
-
-let g:loaded_ale_linters_haskell_ghc = 1
-
 call ale#linter#Define('haskell', {
 \   'name': 'ghc',
 \   'output_stream': 'stderr',

--- a/ale_linters/haskell/hlint.vim
+++ b/ale_linters/haskell/hlint.vim
@@ -1,12 +1,6 @@
 " Author: jparoz <jesse.paroz@gmail.com>
 " Description: hlint for Haskell files
 
-if exists('g:loaded_ale_linters_haskell_hlint')
-    finish
-endif
-
-let g:loaded_ale_linters_haskell_hlint = 1
-
 function! ale_linters#haskell#hlint#Handle(buffer, lines)
     let l:errors = json_decode(join(a:lines, ''))
 

--- a/ale_linters/html/htmlhint.vim
+++ b/ale_linters/html/htmlhint.vim
@@ -1,12 +1,6 @@
 " Author: KabbAmine <amine.kabb@gmail.com>
 " Description: HTMLHint for checking html files
 
-if exists('g:loaded_ale_linters_html_htmlhint')
-    finish
-endif
-
-let g:loaded_ale_linters_html_htmlhint = 1
-
 call ale#linter#Define('html', {
 \   'name': 'htmlhint',
 \   'executable': 'htmlhint',

--- a/ale_linters/html/tidy.vim
+++ b/ale_linters/html/tidy.vim
@@ -1,12 +1,6 @@
 " Author: KabbAmine <amine.kabb@gmail.com>
 " Description: This file adds support for checking HTML code with tidy.
 
-if exists('g:loaded_ale_linters_html_tidy')
-    finish
-endif
-
-let g:loaded_ale_linters_html_tidy = 1
-
 " CLI options
 let g:ale_html_tidy_executable = get(g:, 'ale_html_tidy_executable', 'tidy')
 let g:ale_html_tidy_args = get(g:, 'ale_html_tidy_args', '-q -e -language en')

--- a/ale_linters/javascript/eslint.vim
+++ b/ale_linters/javascript/eslint.vim
@@ -1,12 +1,6 @@
 " Author: w0rp <devw0rp@gmail.com>
 " Description: eslint for JavaScript files
 
-if exists('g:loaded_ale_linters_javascript_eslint')
-    finish
-endif
-
-let g:loaded_ale_linters_javascript_eslint = 1
-
 let g:ale_javascript_eslint_executable =
 \   get(g:, 'ale_javascript_eslint_executable', 'eslint')
 

--- a/ale_linters/javascript/jscs.vim
+++ b/ale_linters/javascript/jscs.vim
@@ -1,12 +1,6 @@
 " Author: Chris Kyrouac - https://github.com/fijshion
 " Description: jscs for JavaScript files
 
-if exists('g:loaded_ale_linters_javascript_jscs')
-    finish
-endif
-
-let g:loaded_ale_linters_javascript_jscs = 1
-
 call ale#linter#Define('javascript', {
 \   'name': 'jscs',
 \   'executable': 'jscs',

--- a/ale_linters/javascript/jshint.vim
+++ b/ale_linters/javascript/jshint.vim
@@ -1,12 +1,6 @@
 " Author: Chris Kyrouac - https://github.com/fijshion
 " Description: JSHint for Javascript files
 
-if exists('g:loaded_ale_linters_javascript_jshint')
-    finish
-endif
-
-let g:loaded_ale_linters_javascript_jshint = 1
-
 let g:ale_javascript_jshint_executable =
 \   get(g:, 'ale_javascript_jshint_executable', 'jshint')
 

--- a/ale_linters/json/jsonlint.vim
+++ b/ale_linters/json/jsonlint.vim
@@ -1,11 +1,5 @@
 " Author: KabbAmine <amine.kabb@gmail.com>
 
-if exists('g:loaded_ale_linters_json_jsonlint')
-    finish
-endif
-
-let g:loaded_ale_linters_json_jsonlint = 1
-
 function! ale_linters#json#jsonlint#Handle(buffer, lines)
     " Matches patterns like the following:
     " line 2, col 15, found: 'STRING' - expected: 'EOF', '}', ',', ']'.

--- a/ale_linters/lua/luacheck.vim
+++ b/ale_linters/lua/luacheck.vim
@@ -1,12 +1,6 @@
 " Author: Sol Bekic https://github.com/s-ol
 " Description: luacheck linter for lua files
 
-if exists('g:loaded_ale_linters_lua_luacheck')
-    finish
-endif
-
-let g:loaded_ale_linters_lua_luacheck = 1
-
 let g:ale_lua_luacheck_executable =
 \   get(g:, 'ale_lua_luacheck_executable', 'luacheck')
 

--- a/ale_linters/perl/perl.vim
+++ b/ale_linters/perl/perl.vim
@@ -1,11 +1,6 @@
 " Author: Vincent Lequertier <https://github.com/SkySymbol>
 " Description: This file adds support for checking perl syntax
 
-if exists('g:loaded_ale_linters_perl_perlcritic')
-    finish
-endif
-
-let g:loaded_ale_linters_perl_perl = 1
 function! ale_linters#perl#perl#Handle(buffer, lines)
     let l:pattern = '\(.\+\) at \(.\+\) line \(\d\+\)'
     let l:output = []

--- a/ale_linters/perl/perlcritic.vim
+++ b/ale_linters/perl/perlcritic.vim
@@ -1,11 +1,6 @@
 " Author: Vincent Lequertier <https://github.com/SkySymbol>
 " Description: This file adds support for checking perl with perl critic
 
-if exists('g:loaded_ale_linters_perl_perlcritic')
-    finish
-endif
-
-let g:loaded_ale_linters_perl_perlcritic = 1
 function! ale_linters#perl#perlcritic#Handle(buffer, lines)
     let l:pattern = '\(.\+\) at \(.\+\) line \(\d\+\)'
     let l:output = []

--- a/ale_linters/php/php.vim
+++ b/ale_linters/php/php.vim
@@ -1,12 +1,6 @@
 " Author: Spencer Wood <https://github.com/scwood>
 " Description: This file adds support for checking PHP with php-cli
 
-if exists('g:loaded_ale_linters_php_php')
-    finish
-endif
-
-let g:loaded_ale_linters_php_php = 1
-
 function! ale_linters#php#php#Handle(buffer, lines)
     " Matches patterns like the following:
     "

--- a/ale_linters/php/phpcs.vim
+++ b/ale_linters/php/phpcs.vim
@@ -1,12 +1,6 @@
 " Author: jwilliams108 <https://github.com/jwilliams108>
 " Description: phpcs for PHP files
 
-if exists('g:loaded_ale_linters_php_phpcs')
-    finish
-endif
-
-let g:loaded_ale_linters_php_phpcs = 1
-
 function! ale_linters#php#phpcs#GetCommand(buffer)
     let l:command = 'phpcs -s --report=emacs --stdin-path=%s'
 

--- a/ale_linters/pug/puglint.vim
+++ b/ale_linters/pug/puglint.vim
@@ -1,12 +1,6 @@
 " Author: w0rp - <devw0rp@gmail.com>
 " Description: pug-lint for checking Pug/Jade files.
 
-if exists('g:loaded_ale_linters_pug_puglint')
-    finish
-endif
-
-let g:loaded_ale_linters_pug_puglint = 1
-
 call ale#linter#Define('pug', {
 \   'name': 'puglint',
 \   'executable': 'pug-lint',

--- a/ale_linters/python/flake8.vim
+++ b/ale_linters/python/flake8.vim
@@ -1,12 +1,6 @@
 " Author: w0rp <devw0rp@gmail.com>
 " Description: flake8 for python files
 
-if exists('g:loaded_ale_linters_python_flake8')
-    finish
-endif
-
-let g:loaded_ale_linters_python_flake8 = 1
-
 call ale#linter#Define('python', {
 \   'name': 'flake8',
 \   'executable': 'flake8',

--- a/ale_linters/ruby/rubocop.vim
+++ b/ale_linters/ruby/rubocop.vim
@@ -1,12 +1,6 @@
 " Author: ynonp - https://github.com/ynonp
 " Description: rubocop for Ruby files
 
-if exists('g:loaded_ale_linters_ruby_rubocop')
-    finish
-endif
-
-let g:loaded_ale_linters_ruby_rubocop = 1
-
 function! ale_linters#ruby#rubocop#Handle(buffer, lines)
     " Matches patterns line the following:
     "

--- a/ale_linters/sass/sasslint.vim
+++ b/ale_linters/sass/sasslint.vim
@@ -1,11 +1,5 @@
 " Author: KabbAmine - https://github.com/KabbAmine
 
-if exists('g:loaded_ale_linters_sass_sasslint')
-    finish
-endif
-
-let g:loaded_ale_linters_sass_sasslint = 1
-
 call ale#linter#Define('sass', {
 \   'name': 'sasslint',
 \   'executable': 'sass-lint',

--- a/ale_linters/scala/scalac.vim
+++ b/ale_linters/scala/scalac.vim
@@ -2,12 +2,6 @@
 " Author: Zoltan Kalmar - https://github.com/kalmiz
 " Description: Basic scala support using scalac
 
-if exists('g:loaded_ale_linters_scala_scalac')
-    finish
-endif
-
-let g:loaded_ale_linters_scala_scalac = 1
-
 function! ale_linters#scala#scalac#Handle(buffer, lines)
     " Matches patterns line the following:
     "

--- a/ale_linters/scss/sasslint.vim
+++ b/ale_linters/scss/sasslint.vim
@@ -1,11 +1,5 @@
 " Author: KabbAmine - https://github.com/KabbAmine
 
-if exists('g:loaded_ale_linters_scss_sasslint')
-    finish
-endif
-
-let g:loaded_ale_linters_scss_sasslint = 1
-
 call ale#linter#Define('scss', {
 \   'name': 'sasslint',
 \   'executable': 'sass-lint',

--- a/ale_linters/scss/scsslint.vim
+++ b/ale_linters/scss/scsslint.vim
@@ -1,12 +1,6 @@
 " Author: w0rp <devw0rp@gmail.com>
 " Description: This file add scsslint support for SCSS support
 
-if exists('g:loaded_ale_linters_scss_scsslint')
-    finish
-endif
-
-let g:loaded_ale_linters_scss_scsslint = 1
-
 function! ale_linters#scss#scsslint#Handle(buffer, lines)
     " Matches patterns like the following:
     "

--- a/ale_linters/sh/shell.vim
+++ b/ale_linters/sh/shell.vim
@@ -1,12 +1,6 @@
 " Author: w0rp <devw0rp@gmail.com>
 " Description: Lints sh files using bash -n
 
-if exists('g:loaded_ale_linters_sh_shell')
-    finish
-endif
-
-let g:loaded_ale_linters_sh_shell = 1
-
 " This option can be changed to change the default shell when the shell
 " cannot be taken from the hashbang line.
 if !exists('g:ale_linters_sh_shell_default_shell')

--- a/ale_linters/sh/shellcheck.vim
+++ b/ale_linters/sh/shellcheck.vim
@@ -2,12 +2,6 @@
 " Description: This file adds support for using the shellcheck linter with
 "   shell scripts.
 
-if exists('g:loaded_ale_linters_sh_shellcheck')
-    finish
-endif
-
-let g:loaded_ale_linters_sh_shellcheck = 1
-
 " This global variable can be set with a string of comma-seperated error
 " codes to exclude from shellcheck. For example:
 "

--- a/ale_linters/testft/testlinter.vim
+++ b/ale_linters/testft/testlinter.vim
@@ -1,0 +1,10 @@
+" Author: neersighted <bjorn@neersighted.com>
+" Description: dummy linter to use in tests
+
+call ale#linter#Define('testft', {
+\   'name': 'testlinter',
+\   'output_stream': 'stdout',
+\   'executable': 'testlinter',
+\   'command': 'testlinter',
+\   'callback': 'testCB',
+\})

--- a/ale_linters/typescript/tslint.vim
+++ b/ale_linters/typescript/tslint.vim
@@ -1,12 +1,6 @@
 " Author: Prashanth Chandra https://github.com/prashcr
 " Description: tslint for TypeScript files
 
-if exists('g:loaded_ale_linters_typescript_tslint')
-    finish
-endif
-
-let g:loaded_ale_linters_typescript_tslint = 1
-
 function! ale_linters#typescript#tslint#Handle(buffer, lines)
     " Matches patterns like the following:
     "

--- a/ale_linters/verilog/iverilog.vim
+++ b/ale_linters/verilog/iverilog.vim
@@ -1,12 +1,6 @@
 " Author: Masahiro H https://github.com/mshr-h
 " Description: iverilog for verilog files
 
-if exists('g:loaded_ale_linters_verilog_iverilog')
-    finish
-endif
-
-let g:loaded_ale_linters_verilog_iverilog = 1
-
 function! ale_linters#verilog#iverilog#Handle(buffer, lines)
     " Look for lines like the following.
     "

--- a/ale_linters/verilog/verilator.vim
+++ b/ale_linters/verilog/verilator.vim
@@ -1,12 +1,6 @@
 " Author: Masahiro H https://github.com/mshr-h
 " Description: verilator for verilog files
 
-if exists('g:loaded_ale_linters_verilog_verilator')
-    finish
-endif
-
-let g:loaded_ale_linters_verilog_verilator = 1
-
 function! ale_linters#verilog#verilator#Handle(buffer, lines)
     " Look for lines like the following.
     "

--- a/ale_linters/vim/vint.vim
+++ b/ale_linters/vim/vint.vim
@@ -1,12 +1,6 @@
 " Author: w0rp <devw0rp@gmail.com>, KabbAmine <amine.kabb@gmail.com>
 " Description: This file adds support for checking Vim code with Vint.
 
-if exists('g:loaded_ale_linters_vim_vint')
-    finish
-endif
-
-let g:loaded_ale_linters_vim_vint = 1
-
 " This flag can be used to change enable/disable style issues.
 let g:ale_vim_vint_show_style_issues =
 \   get(g:, 'ale_vim_vint_show_style_issues', 1)

--- a/ale_linters/yaml/yamllint.vim
+++ b/ale_linters/yaml/yamllint.vim
@@ -1,11 +1,5 @@
 " Author: KabbAmine <amine.kabb@gmail.com>
 
-if exists('g:loaded_ale_linters_yaml_yamllint')
-    finish
-endif
-
-let g:loaded_ale_linters_yaml_yamllint = 1
-
 function! ale_linters#yaml#yamllint#Handle(buffer, lines)
     " Matches patterns line the following:
     " something.yaml:1:1: [warning] missing document start "---" (document-start)

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -130,7 +130,6 @@ g:ale_linter_aliases                                     *g:ale_linter_aliases*
   following values: >
 
   {
-  \   'javscript.jsx': 'javascript',
   \   'zsh': 'sh',
   \   'csh': 'sh',
   \}
@@ -615,6 +614,14 @@ ale#linter#Define(filetype, linter)                       *ale#linter#Define()*
 ale#linter#Get(filetype)                                     *ale#linter#Get()*
   Return all of linters configured for a given filetype as a |List| of
   |Dictionary| values in the format specified by |ale#linter#Define()|.
+
+  Filetypes may be dot-seperated to invoke linters for multiple filetypes:
+  for instance, the filetype `javascript.jsx` will return linters for both the
+  `javascript` and `jsx` filetype.
+
+  Aliases may be defined in as described in |g:ale_linter_aliases|. Aliases
+  are applied after dot-seperated filetypes are broken up into their
+  components.
 
 
 ale#statusline#Status()                               *ale#statusline#Status()*

--- a/test/test_ale_linter_get.vader
+++ b/test/test_ale_linter_get.vader
@@ -1,19 +1,43 @@
 Before:
+  let g:testlinter1 = {'name': 'testlinter1', 'executable': 'testlinter1', 'command': 'testlinter1', 'callback': 'testCB1', 'output_stream': 'stdout'}
+  let g:testlinter2 = {'name': 'testlinter2', 'executable': 'testlinter2', 'command': 'testlinter2', 'callback': 'testCB2', 'output_stream': 'stdout'}
+
+  call ale#linter#Reset()
   let g:ale_linters = {}
   let g:ale_linter_aliases = {}
 
-After:
-  let g:ale_linters = {}
-  let g:ale_linter_aliases = {}
+Execute (Define a linter):
+  call ale#linter#Define('testft', g:testlinter1)
+Then (Get the defined linter):
+  AssertEqual [g:testlinter1], ale#linter#Get('testft')
 
-Execute (Defaults should be correct):
-  AssertEqual [{'output_stream': 'stdout', 'name': 'eslint', 'executable': 'eslint', 'command': 'eslint -f unix --stdin --stdin-filename %s', 'callback': 'ale_linters#javascript#eslint#Handle'}, {'output_stream': 'stdout', 'name': 'jscs', 'executable': 'jscs', 'command': 'jscs -r unix -n -', 'callback': 'ale#handlers#HandleUnixFormatAsError'}, {'output_stream': 'stdout', 'name': 'jshint', 'executable': 'jshint', 'command_callback': 'ale_linters#javascript#jshint#GetCommand', 'callback': 'ale#handlers#HandleUnixFormatAsError'}], ale#linter#Get('javascript')
+Execute (Define a couple linters, filtering one.):
+  call ale#linter#Define('testft', g:testlinter1)
+  call ale#linter#Define('testft', g:testlinter2)
+  let g:ale_linters = {'testft': ['testlinter1']}
+Then (Only the configured linter should be returned):
+  AssertEqual [g:testlinter1], ale#linter#Get('testft')
 
-Execute (You should be able to select only a few linters):
-  let g:ale_linters = {'javascript': ['eslint']}
-  AssertEqual [{'output_stream': 'stdout', 'name': 'eslint', 'executable': 'eslint', 'command': 'eslint -f unix --stdin --stdin-filename %s', 'callback': 'ale_linters#javascript#eslint#Handle'}], ale#linter#Get('javascript')
+Execute (Define a linter for a filetype, and create a filetype alias):
+  call ale#linter#Define('testft1', g:testlinter1)
+  let g:ale_linter_aliases = {'testft2': 'testft1'}
+Then (Linters should be transparently aliased):
+  AssertEqual [g:testlinter1], ale#linter#Get('testft2')
 
-Execute (You should be able to alias filetypes and select different linters):
-  let g:ale_linter_aliases = {'foobar': 'javascript'}
-  let g:ale_linters = {'javascript': ['eslint'], 'foobar': ['jshint']}
-  AssertEqual [{'output_stream': 'stdout', 'name': 'jshint', 'executable': 'jshint', 'command_callback': 'ale_linters#javascript#jshint#GetCommand', 'callback': 'ale#handlers#HandleUnixFormatAsError'}], ale#linter#Get('foobar')
+Execute (Define multiple linters, with filters and aliases):
+  call ale#linter#Define('testft1', g:testlinter1)
+  call ale#linter#Define('testft1', g:testlinter2)
+  let g:ale_linters = {'testft1': ['testlinter1'], 'testft2': ['testlinter2']}
+  let g:ale_linter_aliases = {'testft2': 'testft1'}
+Then (Linters should be transparently filtered and aliased):
+  AssertEqual [g:testlinter1], ale#linter#Get('testft1')
+  AssertEqual [g:testlinter2], ale#linter#Get('testft2')
+
+Execute (Define multiple linters for different filetypes):
+  call ale#linter#Define('testft1', g:testlinter1)
+  call ale#linter#Define('testft2', g:testlinter2)
+Then (Linters for dot-seperated filetypes should be properly handled):
+  AssertEqual [g:testlinter1, g:testlinter2], ale#linter#Get('testft1.testft2')
+
+Execute (Try to load a linter from disk):
+  AssertEqual [{'name': 'testlinter', 'output_stream': 'stdout', 'executable': 'testlinter', 'command': 'testlinter', 'callback': 'testCB'}], ale#linter#Get('testft')

--- a/test/test_ale_statusline.vader
+++ b/test/test_ale_statusline.vader
@@ -52,7 +52,7 @@ Execute (Given some warnings):
 Then (Statusline is formatted to the users preference):
   AssertEqual '3W', ale#statusline#Status()
 
-Execute (Given some warnings, and errors.):
+Execute (Given some warnings, and errors):
   call ale#statusline#Update(bufnr('%'), [{'type': 'E'}, {'type': 'W'}, {'type': 'W'}])
 
 Then (Statusline is formatted to the users preference):


### PR DESCRIPTION
This PR first and formost implements support for dot-seperated filetypes,
a very trivial change.

This closes #132

But more importantly, this PR vastly improves the test quality for
`ale#linter#Get`. It enables us to reset the state of ale's internal
linter cache, to facilitate better testing, as well as making use of
mocked linters instead of depending on linters on disk (which may
change). In addition, a dummy linter is defined to test the autoloading
behavior.

Header guards were removed from all linters as:

* A: ale won't try and load linters if they already exist in memory
* B: we can't reset state for testing if they can't be loaded again