### PR TITLE
Added support for mdl, a markdown linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ name. That seems to be the fairest way to arrange this table.
 | JavaScript | [eslint](http://eslint.org/), [jscs](http://jscs.info/), [jshint](http://jshint.com/) |
 | JSON | [jsonlint](http://zaa.ch/jsonlint/) |
 | Lua | [luacheck](https://github.com/mpeterv/luacheck) |
+| Markdown | [mdl](https://github.com/mivok/markdownlint) |
 | Perl | [perl -c](https://perl.org/), [perl-critic](https://metacpan.org/pod/Perl::Critic) |
 | PHP | [php -l](https://secure.php.net/), [phpcs](https://github.com/squizlabs/PHP_CodeSniffer) |
 | Pug | [pug-lint](https://github.com/pugjs/pug-lint) |

--- a/ale_linters/markdown/mdl.vim
+++ b/ale_linters/markdown/mdl.vim
@@ -1,0 +1,35 @@
+" Author: Steve Dignam <steve@dignam.xyz>
+" Description: Support for mdl, a markdown linter
+
+function! ale_linters#markdown#mdl#Handle(buffer, lines) abort
+    " matches: '(stdin):173: MD004 Unordered list style'
+    let l:pattern = ':\(\d*\): \(.*\)$'
+    let l:output = []
+
+    for l:line in a:lines
+        let l:match = matchlist(l:line, l:pattern)
+
+        if len(l:match) == 0
+            continue
+        endif
+
+        call add(l:output, {
+        \   'bufnr': a:buffer,
+        \   'lnum': l:match[1] + 0,
+        \   'vcol': 0,
+        \   'col': -1,
+        \   'text': l:match[2],
+        \   'type': 'W',
+        \   'nr': -1,
+        \})
+    endfor
+
+    return l:output
+endfunction
+
+call ale#linter#Define('markdown', {
+\   'name': 'mdl',
+\   'executable': 'mdl',
+\   'command': 'mdl',
+\   'callback': 'ale_linters#markdown#mdl#Handle'
+\})

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -67,6 +67,7 @@ The following languages and tools are supported.
 * JavaScript: 'eslint', 'jscs', 'jshint'
 * JSON: 'jsonlint'
 * Lua: 'luacheck'
+* Markdown: 'mdl'
 * Perl: 'perl' (-c flag), 'perlcritic'
 * PHP: 'php' (-l flag), 'phpcs'
 * Pug: 'pug-lint'


### PR DESCRIPTION
Took me a bit [searching](https://github.com/w0rp/ale/issues/16) to realize that this plugin doesn't rely on `&errorformat`.

`let &errorformat = '%f: %l: %m'` --> `let pattern = ':\(\d*\): \(.*\)$'`

https://github.com/mivok/markdownlint