### PR TITLE
Added support for javac (with eclipse classpath support for now)

### DIFF
--- a/ale_linters/java/javac.vim
+++ b/ale_linters/java/javac.vim
@@ -9,6 +9,7 @@ let g:loaded_ale_linters_java_javac = 1
 let g:ale_java_javac_classpath = ''
 
 let s:eclipse_classpath = ''
+let s:tmppath = '/tmp/java_ale/'
 
 function! ale_linters#java#javac#Handle(buffer, lines) abort
     " Look for lines like the following.
@@ -69,7 +70,7 @@ endif
 endfunction
 
 function! ale_linters#java#javac#GetCommand(buffer)
-    let l:path = '/tmp/java_ale/' . expand('%:p:h')
+    let l:path = s:tmppath . expand('%:p:h')
     let l:file = expand('%:t')
     let l:buf = getline(1, '$')
 
@@ -85,7 +86,7 @@ function! ale_linters#java#javac#GetCommand(buffer)
 endfunction
 
 function! ale_linters#java#javac#CleanupTmp()
-    call delete('/tmp/java_ale/', 'rf')
+    call delete(s:tmppath, 'rf')
 endfunction
 
 autocmd! BufEnter *.java call ale_linters#java#javac#CheckEclipseClasspath()

--- a/ale_linters/java/javac.vim
+++ b/ale_linters/java/javac.vim
@@ -1,0 +1,101 @@
+" Author: farenjihn <farenjihn@gmail.com>
+" Description: Lints java files using javac
+
+if exists('g:loaded_ale_linters_java_javac')
+    finish
+endif
+
+let g:loaded_ale_linters_java_javac = 1
+let g:ale_java_javac_classpath = ''
+
+let s:eclipse_classpath = ''
+
+function! ale_linters#java#javac#Handle(buffer, lines) abort
+    " Look for lines like the following.
+    "
+    " Main.java:13: warning: [deprecation] donaught() in Testclass has been deprecated
+    " Main.java:16: error: ';' expected
+
+    let l:pattern = '^.*\:\(\d\+\):\ \(.*\):\(.*\)$'
+    let l:output = []
+
+    for l:line in a:lines
+        let l:match = matchlist(l:line, l:pattern)
+
+        if len(l:match) == 0
+            continue
+        endif
+
+        call add(l:output, {
+            \   'bufnr': a:buffer,
+            \   'lnum': l:match[1] + 0,
+            \   'vcol': 0,
+            \   'col': 1,
+            \   'text': l:match[2] . ':' . l:match[3],
+            \   'type': l:match[2] ==# 'error' ? 'E' : 'W',
+            \   'nr': -1,
+            \})
+    endfor
+
+    return l:output
+endfunction
+
+function! ale_linters#java#javac#ParseEclipseClasspath()
+python << EOF
+
+import xml.etree.ElementTree as ET, vim
+tree = ET.parse(".classpath")
+root = tree.getroot()
+
+classpath = ''
+
+for child in root:
+    classpath += child.get("path")
+    classpath += ':'
+
+vim.command("let l:eclipse_classpath = '%s'" % classpath);
+
+EOF
+
+let s:eclipse_classpath = l:eclipse_classpath
+endfunction
+
+function! ale_linters#java#javac#CheckEclipseClasspath()
+	" Eclipse .classpath parsing through python
+	if file_readable('.classpath')
+		let l:eclipse_classpath = ale_linters#java#javac#ParseEclipseClasspath()
+endif
+
+endfunction
+
+function! ale_linters#java#javac#GetCommand(buffer)
+    let l:path = '/tmp/java_ale/' . expand('%:p:h')
+    let l:file = expand('%:t')
+    let l:buf = getline(1, '$')
+
+    " Javac cannot compile files from stdin so we move a copy into /tmp instead
+    call mkdir(l:path, 'p')
+    call writefile(l:buf, l:path . '/' . l:file)
+
+    return 'javac '
+        \ . '-Xlint '
+        \ . '-cp ' . s:eclipse_classpath . g:ale_java_javac_classpath . ':. '
+        \ . g:ale_java_javac_options
+        \ . ' ' . l:path . '/' . l:file
+endfunction
+
+function! ale_linters#java#javac#CleanupTmp()
+    call delete('/tmp/java_ale/', 'rf')
+endfunction
+
+autocmd! BufEnter *.java call ale_linters#java#javac#CheckEclipseClasspath()
+autocmd! BufLeave *.java call ale_linters#java#javac#CleanupTmp()
+
+call ale_linters#java#javac#CheckEclipseClasspath()
+call ale#linter#Define('java', {
+\   'name': 'javac',
+\   'output_stream': 'stderr',
+\   'executable': 'javac',
+\   'command_callback': 'ale_linters#java#javac#GetCommand',
+\   'callback': 'ale_linters#java#javac#Handle',
+\})

--- a/ale_linters/java/javac.vim
+++ b/ale_linters/java/javac.vim
@@ -1,10 +1,6 @@
 " Author: farenjihn <farenjihn@gmail.com>
 " Description: Lints java files using javac
 
-if exists('g:loaded_ale_linters_java_javac')
-    finish
-endif
-
 let g:loaded_ale_linters_java_javac = 1
 let g:ale_java_javac_classpath = ''
 
@@ -28,47 +24,47 @@ function! ale_linters#java#javac#Handle(buffer, lines) abort
         endif
 
         call add(l:output, {
-            \   'bufnr': a:buffer,
-            \   'lnum': l:match[1] + 0,
-            \   'vcol': 0,
-            \   'col': 1,
-            \   'text': l:match[2] . ':' . l:match[3],
-            \   'type': l:match[2] ==# 'error' ? 'E' : 'W',
-            \   'nr': -1,
-            \})
+        \   'bufnr': a:buffer,
+        \   'lnum': l:match[1] + 0,
+        \   'vcol': 0,
+        \   'col': 1,
+        \   'text': l:match[2] . ':' . l:match[3],
+        \   'type': l:match[2] ==# 'error' ? 'E' : 'W',
+        \   'nr': -1,
+        \})
     endfor
 
     return l:output
 endfunction
 
 function! ale_linters#java#javac#ParseEclipseClasspath()
-let l:eclipse_classpath = ''
+    let l:eclipse_classpath = ''
 
 python << EOF
 
-import xml.etree.ElementTree as ET, vim
-tree = ET.parse(".classpath")
-root = tree.getroot()
+    import xml.etree.ElementTree as ET, vim
+    tree = ET.parse(".classpath")
+    root = tree.getroot()
 
-classpath = ''
+    classpath = ''
 
-for child in root:
-    classpath += child.get("path")
-    classpath += ':'
+    for child in root:
+        classpath += child.get("path")
+        classpath += ':'
 
-vim.command("let l:eclipse_classpath = '%s'" % classpath);
+        vim.command("let l:eclipse_classpath = '%s'" % classpath);
 
+# Cannot indent this EOF token as per :h python
 EOF
 
-return l:eclipse_classpath
+    return l:eclipse_classpath
 endfunction
 
 function! ale_linters#java#javac#CheckEclipseClasspath()
     " Eclipse .classpath parsing through python
     if file_readable('.classpath')
         let s:eclipse_classpath = ale_linters#java#javac#ParseEclipseClasspath()
-endif
-
+    endif
 endfunction
 
 function! ale_linters#java#javac#GetCommand(buffer)
@@ -81,10 +77,10 @@ function! ale_linters#java#javac#GetCommand(buffer)
     call writefile(l:buf, l:path . '/' . l:file)
 
     return 'javac '
-        \ . '-Xlint '
-        \ . '-cp ' . s:eclipse_classpath . g:ale_java_javac_classpath . ':. '
-        \ . g:ale_java_javac_options
-        \ . ' ' . l:path . '/' . l:file
+    \ . '-Xlint '
+    \ . '-cp ' . s:eclipse_classpath . g:ale_java_javac_classpath . ':. '
+    \ . g:ale_java_javac_options
+    \ . ' ' . l:path . '/' . l:file
 endfunction
 
 function! ale_linters#java#javac#CleanupTmp()

--- a/ale_linters/java/javac.vim
+++ b/ale_linters/java/javac.vim
@@ -58,13 +58,13 @@ vim.command("let l:eclipse_classpath = '%s'" % classpath);
 
 EOF
 
-let s:eclipse_classpath = l:eclipse_classpath
+return l:eclipse_classpath
 endfunction
 
 function! ale_linters#java#javac#CheckEclipseClasspath()
 	" Eclipse .classpath parsing through python
 	if file_readable('.classpath')
-		let l:eclipse_classpath = ale_linters#java#javac#ParseEclipseClasspath()
+		let s:eclipse_classpath = ale_linters#java#javac#ParseEclipseClasspath()
 endif
 
 endfunction
@@ -89,8 +89,10 @@ function! ale_linters#java#javac#CleanupTmp()
     call delete(s:tmppath, 'rf')
 endfunction
 
-autocmd! BufEnter *.java call ale_linters#java#javac#CheckEclipseClasspath()
-autocmd! BufLeave *.java call ale_linters#java#javac#CleanupTmp()
+augroup java_ale_au
+	autocmd! BufEnter *.java call ale_linters#java#javac#CheckEclipseClasspath()
+	autocmd! BufLeave *.java call ale_linters#java#javac#CleanupTmp()
+augroup END
 
 call ale_linters#java#javac#CheckEclipseClasspath()
 call ale#linter#Define('java', {

--- a/ale_linters/java/javac.vim
+++ b/ale_linters/java/javac.vim
@@ -42,6 +42,8 @@ function! ale_linters#java#javac#Handle(buffer, lines) abort
 endfunction
 
 function! ale_linters#java#javac#ParseEclipseClasspath()
+let l:eclipse_classpath = ''
+
 python << EOF
 
 import xml.etree.ElementTree as ET, vim

--- a/ale_linters/java/javac.vim
+++ b/ale_linters/java/javac.vim
@@ -64,9 +64,9 @@ return l:eclipse_classpath
 endfunction
 
 function! ale_linters#java#javac#CheckEclipseClasspath()
-	" Eclipse .classpath parsing through python
-	if file_readable('.classpath')
-		let s:eclipse_classpath = ale_linters#java#javac#ParseEclipseClasspath()
+    " Eclipse .classpath parsing through python
+    if file_readable('.classpath')
+        let s:eclipse_classpath = ale_linters#java#javac#ParseEclipseClasspath()
 endif
 
 endfunction
@@ -92,8 +92,8 @@ function! ale_linters#java#javac#CleanupTmp()
 endfunction
 
 augroup java_ale_au
-	autocmd! BufEnter *.java call ale_linters#java#javac#CheckEclipseClasspath()
-	autocmd! BufLeave *.java call ale_linters#java#javac#CleanupTmp()
+    autocmd! BufEnter *.java call ale_linters#java#javac#CheckEclipseClasspath()
+    autocmd! BufLeave *.java call ale_linters#java#javac#CleanupTmp()
 augroup END
 
 call ale_linters#java#javac#CheckEclipseClasspath()


### PR DESCRIPTION
This is my first real try at VimL so I am unaware of the quality of this changeset.

I had to do a few things to get javac to work with ALE, mainly:
1. javac doesn't support compiling from stdin so I clone the current buffer into /tmp/java_ale and tell javac to generate *.class files there by setting the appropriate classpath.
2. I clean the files left in /tmp/ every time a buffer with the ".java" extension is closed. If there is a better behaviour to have about this please tell me so I can change it.
3. For now I only check for a ".classpath" file in the current working directory and parse it using a few lines of python to create the final javac command. I can try and add maven/other tools support later in.
4. I parse the classpath file every time a buffer with the ".java" extension is opened. This is because it might have changed in between if the project the user is working on is not stable. If this seems inappropriate tell me what it should do.

All in all this is me trying to contribute to this awesome plugin. Hope it can help!
