### PR TITLE
Add node_modules support for JSHint, and use the global config as a fallback

### DIFF
--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -399,7 +399,24 @@ g:ale_javascript_jshint_executable         *g:ale_javascript_jshint_executable*
   Type: |String|
   Default: `'jshint'`
 
+  ALE will first discover the jshint path in an ancestor node_modules
+  directory. If no such path exists, this variable will be used instead.
+
   This variable can be changed to change the path to jshint.
+
+  If you wish to use only a globally installed version of jshint, set
+  |g:ale_javascript_jshint_use_global| to `1`.
+
+
+g:ale_javascript_jshint_use_global         *g:ale_javascript_jshint_use_global*
+
+  Type: |String|
+  Default: `0`
+
+  This variable controls whether or not ALE will search for a local path for
+  jshint first. If this variable is set to `1`, then ALE will always use the
+  global version of jshint, in preference to locally installed versions of
+  jshint in node_modules.
 
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
This pull request will apply the same basic logic I just applied to `eslint` to `jshint` as well, for using a local `node_modules` version. In addition, it will now use the global JSHint configuration path only as a default when `.jshintrc` cannot be found, rather than always explicitly overriding the local configuration file.

I'll leave this up for others to take a look at.

@bartlibert Does this look good to you? I believe you are using ALE with a JSHint configuration file.