### PR TITLE
Add support for mlint, a MATLAB linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ name. That seems to be the fairest way to arrange this table.
 | JavaScript | [eslint](http://eslint.org/), [jscs](http://jscs.info/), [jshint](http://jshint.com/) |
 | JSON | [jsonlint](http://zaa.ch/jsonlint/) |
 | Lua | [luacheck](https://github.com/mpeterv/luacheck) |
+| MATLAB | [mlint](https://www.mathworks.com/help/matlab/ref/mlint.html) |
 | Perl | [perl -c](https://perl.org/), [perl-critic](https://metacpan.org/pod/Perl::Critic) |
 | PHP | [php -l](https://secure.php.net/), [phpcs](https://github.com/squizlabs/PHP_CodeSniffer) |
 | Pug | [pug-lint](https://github.com/pugjs/pug-lint) |

--- a/ale_linters/matlab/mlint.vim
+++ b/ale_linters/matlab/mlint.vim
@@ -1,8 +1,6 @@
 " Author: awlayton <alex@layton.in>
 " Description: mlint for MATLAB files
 
-let g:loaded_ale_linters_matlab_mlint = 1
-
 let g:ale_matlab_mlint_executable =
 \   get(g:, 'ale_matlab_mlint_executable', 'mlint')
 

--- a/ale_linters/matlab/mlint.vim
+++ b/ale_linters/matlab/mlint.vim
@@ -1,0 +1,59 @@
+" Author: awlayton <alex@layton.in>
+" Description: mlint for MATLAB files
+
+if exists('g:loaded_ale_linters_matlab_mlint')
+    finish
+endif
+
+let g:loaded_ale_linters_matlab_mlint = 1
+
+let g:ale_matlab_mlint_executable =
+\   get(g:, 'ale_matlab_mlint_executable', 'mlint')
+
+function! ale_linters#matlab#mlint#Handle(buffer, lines)
+    " Matches patterns like the following:
+    "
+    " L 27 (C 1): FNDEF: Terminate statement with semicolon to suppress output.
+    " L 30 (C 13-15): FNDEF: A quoted string is unterminated.
+    let l:pattern = '^L \(\d\+\) (C \([0-9-]\+\)): \([A-Z]\+\): \(.\+\)$'
+    let l:output = []
+
+    for l:line in a:lines
+        let l:match = matchlist(l:line, l:pattern)
+
+        if len(l:match) == 0
+            continue
+        endif
+
+        let l:lnum = l:match[1] + 0
+        let l:col = l:match[2] + 0
+        let l:code = l:match[3]
+        let l:text = l:match[4]
+
+        " Suppress erroneous waring about file name
+        if l:code ==# 'FNDEF'
+            continue
+        endif
+
+        " vcol is needed to indicate that the column is a character.
+        call add(l:output, {
+        \   'bufnr': a:buffer,
+        \   'lnum': l:lnum,
+        \   'vcol': 0,
+        \   'col': l:col,
+        \   'text': l:text,
+        \   'type': 'W',
+        \   'nr': -1,
+        \})
+    endfor
+
+    return l:output
+endfunction
+
+call ale#linter#Define('matlab', {
+\   'name': 'mlint',
+\   'executable': 'mlint',
+\   'command': g:ale#util#stdin_wrapper .
+\       ' .m ' . g:ale_matlab_mlint_executable . ' -id 2>&1',
+\   'callback': 'ale_linters#matlab#mlint#Handle',
+\})

--- a/ale_linters/matlab/mlint.vim
+++ b/ale_linters/matlab/mlint.vim
@@ -1,10 +1,6 @@
 " Author: awlayton <alex@layton.in>
 " Description: mlint for MATLAB files
 
-if exists('g:loaded_ale_linters_matlab_mlint')
-    finish
-endif
-
 let g:loaded_ale_linters_matlab_mlint = 1
 
 let g:ale_matlab_mlint_executable =
@@ -30,7 +26,8 @@ function! ale_linters#matlab#mlint#Handle(buffer, lines)
         let l:code = l:match[3]
         let l:text = l:match[4]
 
-        " Suppress erroneous waring about file name
+        " Suppress erroneous waring about filename
+        " TODO: Enable this error when copying filename is supported
         if l:code ==# 'FNDEF'
             continue
         endif
@@ -54,6 +51,7 @@ call ale#linter#Define('matlab', {
 \   'name': 'mlint',
 \   'executable': 'mlint',
 \   'command': g:ale#util#stdin_wrapper .
-\       ' .m ' . g:ale_matlab_mlint_executable . ' -id 2>&1',
+\       ' .m ' . g:ale_matlab_mlint_executable . ' -id',
+\   'output_stream': 'stderr',
 \   'callback': 'ale_linters#matlab#mlint#Handle',
 \})

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -67,6 +67,7 @@ The following languages and tools are supported.
 * JavaScript: 'eslint', 'jscs', 'jshint'
 * JSON: 'jsonlint'
 * Lua: 'luacheck'
+* MATLAB: 'mlint'
 * Perl: 'perl' (-c flag), 'perlcritic'
 * PHP: 'php' (-l flag), 'phpcs'
 * Pug: 'pug-lint'


### PR DESCRIPTION
I had to redirect stderr to stdout, so this probably doesn't work in Windows. Let  me know if I should do it a different way. I looked some and didn't see current support for any other linters that output to stderr.