### PR TITLE
Add pylint formatter

### DIFF
--- a/ale_linters/python/pylint.vim
+++ b/ale_linters/python/pylint.vim
@@ -1,0 +1,9 @@
+" Author: keith <k@keith.so>
+" Description: pylint for python files
+
+call ale#linter#Define('python', {
+\   'name': 'pylint',
+\   'executable': 'pylint',
+\   'command': g:ale#util#stdin_wrapper . ' .py pylint --output-format text --msg-template="{path}:{line}:{column}: {msg_id} {msg}" --reports n',
+\   'callback': 'ale#handlers#HandlePEP8Format',
+\})

--- a/autoload/ale/handlers.vim
+++ b/autoload/ale/handlers.vim
@@ -4,7 +4,7 @@ scriptencoding utf-8
 "   linter which outputs warnings and errors in a format accepted by one of
 "   these functions can simply use one of these pre-defined error handlers.
 
-let s:path_pattern = '[a-zA-Z]\?\\\?:\?[[:alnum:]/\.-]\+'
+let s:path_pattern = '[a-zA-Z]\?\\\?:\?[[:alnum:]/\.\-_]\+'
 
 function! s:HandleUnixFormat(buffer, lines, type) abort
     " Matches patterns line the following:


### PR DESCRIPTION
This customizes the output format of pylint in order to use the same
pep8 parser

One thing to note here, pylint likes to output lots of comments or warnings, both of which use `--` in the gutter. There's a possibility we'd prefer the warnings to be displayed with `>>`, but I'll leave that up for debate here.