### PR TITLE
Choose shell dialect based on vim syntax

### DIFF
--- a/ale_linters/sh/shellcheck.vim
+++ b/ale_linters/sh/shellcheck.vim
@@ -16,9 +16,25 @@ else
     let s:exclude_option = ''
 endif
 
+function! s:GetDialectArgument()
+    if exists('b:is_bash') && b:is_bash
+        return '-s bash'
+    elseif exists('b:is_sh') && b:is_sh
+        return '-s sh'
+    elseif exists('b:is_kornshell') && b:is_kornshell
+        return '-s ksh'
+    endif
+
+    return ''
+endfunction
+
+function! ale_linters#sh#shellcheck#GetCommand(buffer)
+  return 'shellcheck ' . s:exclude_option . ' ' . s:GetDialectArgument() . ' -f gcc -'
+endfunction
+
 call ale#linter#Define('sh', {
 \   'name': 'shellcheck',
 \   'executable': 'shellcheck',
-\   'command': 'shellcheck ' . s:exclude_option . ' -f gcc -',
+\   'command_callback': 'ale_linters#sh#shellcheck#GetCommand',
 \   'callback': 'ale#handlers#HandleGCCFormat',
 \})


### PR DESCRIPTION
Shellcheck is smart enough to check the shebang in a given file to
determine which dialect to use. Unfortunately this doesn't work for
files without shebangs, even if it might be apparent what dialect should
be used, such as "bashrc" or "foo.bash". Luckily `filetype.vim` defines
specific vars based on which shell dialect is being used based on a huge
list of conditions. With this change we take those into account for all
the types shellcheck supports, otherwise we fallback to letting it try
and decide.

For more context I also made this change to syntastic a while ago https://github.com/scrooloose/syntastic/pull/1766