### PR TITLE
Added options variable for htmlhint

### DIFF
--- a/ale_linters/html/htmlhint.vim
+++ b/ale_linters/html/htmlhint.vim
@@ -2,11 +2,11 @@
 " Description: HTMLHint for checking html files
 
 " CLI options
-let g:ale_html_htmlhint_options = get(g:, 'ale_html_htmlhint_options', '--format=unix stdin')
+let g:ale_html_htmlhint_options = get(g:, 'ale_html_htmlhint_options', '--format=unix')
 
 call ale#linter#Define('html', {
 \   'name': 'htmlhint',
 \   'executable': 'htmlhint',
-\   'command': 'htmlhint ' . g:ale_html_htmlhint_options,
+\   'command': 'htmlhint ' . g:ale_html_htmlhint_options . ' stdin',
 \   'callback': 'ale#handlers#HandleUnixFormatAsError',
 \})

--- a/ale_linters/html/htmlhint.vim
+++ b/ale_linters/html/htmlhint.vim
@@ -1,9 +1,12 @@
-" Author: KabbAmine <amine.kabb@gmail.com>
+" Author: KabbAmine <amine.kabb@gmail.com>, deathmaz <00maz1987@gmail.com>
 " Description: HTMLHint for checking html files
+
+" CLI options
+let g:ale_html_htmlhint_options = get(g:, 'ale_html_htmlhint_options', '--format=unix stdin')
 
 call ale#linter#Define('html', {
 \   'name': 'htmlhint',
 \   'executable': 'htmlhint',
-\   'command': 'htmlhint --format=unix stdin',
+\   'command': 'htmlhint ' . g:ale_html_htmlhint_options,
 \   'callback': 'ale#handlers#HandleUnixFormatAsError',
 \})

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -549,6 +549,17 @@ g:ale_cpp_cppcheck_options                           *g:ale_cpp_cppcheck_options
   This variable can be changed to modify flags given to cppcheck.
 
 
+-------------------------------------------------------------------------------
+4.14. htmlhint                                      *ale-linter-options-htmlhint*
+
+g:ale_html_htmlhint_options                         *g:ale_html_htmlhint_options*
+
+  Type: |String|
+  Default: `'--format=unix stdin'`
+
+  This variable can be changed to modify flags given to HTMLHint.
+
+
 ===============================================================================
 5. Commands/Keybinds                                             *ale-commands*
 

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -556,7 +556,7 @@ g:ale_cpp_cppcheck_options                           *g:ale_cpp_cppcheck_options
 g:ale_html_htmlhint_options                         *g:ale_html_htmlhint_options*
 
   Type: |String|
-  Default: `'--format=unix stdin'`
+  Default: `'--format=unix'`
 
   This variable can be changed to modify flags given to HTMLHint.
 

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -23,6 +23,7 @@ CONTENTS                                                         *ale-contents*
     4.11. luacheck..............................|ale-linter-options-luacheck|
     4.12. c-cppcheck............................|ale-linter-options-c-cppcheck|
     4.13. cpp-cppcheck..........................|ale-linter-options-cpp-cppcheck|
+    4.14. htmlhint..............................|ale-linter-options-htmlhint|
   5. Commands/Keybinds..........................|ale-commands|
   6. API........................................|ale-api|
   7. Special Thanks.............................|ale-special-thanks|


### PR DESCRIPTION
Currently htmlhint has a bug which prevents htmlhint from using .htmlhintrc file
But it works if I add it as a param to command:
```viml
let g:ale_html_htmlhint_options = '--config ~/.htmlhintrc --format=unix stdin'
```