### PR TITLE
Added support for foodcritic

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ name. That seems to be the fairest way to arrange this table.
 | Bourne Shell | [-n flag](http://linux.die.net/man/1/sh), [shellcheck](https://www.shellcheck.net/) |
 | C | [cppcheck](http://cppcheck.sourceforge.net), [gcc](https://gcc.gnu.org/), [clang](http://clang.llvm.org/)|
 | C++ (filetype cpp) | [cppcheck] (http://cppcheck.sourceforge.net), [gcc](https://gcc.gnu.org/)|
+| Chef | [foodcritic](http://www.foodcritic.io/) |
 | CoffeeScript | [coffee](http://coffeescript.org/), [coffeelint](https://www.npmjs.com/package/coffeelint) |
 | CSS | [csslint](http://csslint.net/) |
 | Cython (pyrex filetype) | [cython](http://cython.org/) |

--- a/ale_linters/chef/foodcritic.vim
+++ b/ale_linters/chef/foodcritic.vim
@@ -1,0 +1,41 @@
+" Author: Edward Larkey <edwlarkey@mac.com>
+" Description: This file adds the foodcritic linter for Chef files.
+
+function! ale_linters#chef#foodcritic#Handle(buffer, lines)
+    " Matches patterns line the following:
+    "
+    " FC002: Avoid string interpolation where not required: httpd.rb:13
+    let l:pattern = '^\(.\+:\s.\+\):\s\(.\+\):\(\d\+\)$'
+    let l:output = []
+
+    for l:line in a:lines
+        let l:match = matchlist(l:line, l:pattern)
+
+        if len(l:match) == 0
+            continue
+        endif
+
+        let l:text = l:match[1]
+
+        " vcol is Needed to indicate that the column is a character.
+        call add(l:output, {
+        \   'bufnr': a:buffer,
+        \   'lnum': l:match[3] + 0,
+        \   'vcol': 0,
+        \   'col': 0,
+        \   'text': l:text,
+        \   'type': 'W',
+        \   'nr': -1,
+        \})
+    endfor
+
+    return l:output
+endfunction
+
+call ale#linter#Define('chef', {
+\   'name': 'foodcritic',
+\   'executable': 'foodcritic',
+\   'command': g:ale#util#stdin_wrapper . ' .rb foodcritic',
+\   'callback': 'ale_linters#chef#foodcritic#Handle',
+\})
+

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -58,6 +58,7 @@ The following languages and tools are supported.
 * Bourne Shell: 'shell' (-n flag), 'shellcheck'
 * C: 'cppcheck', 'gcc', 'clang'
 * C++ (filetype cpp): 'cppcheck', 'gcc'
+* Chef: 'foodcritic'
 * CoffeeScript: 'coffee', 'coffelint'
 * CSS: 'csslint'
 * Cython (pyrex filetype): 'cython'


### PR DESCRIPTION
Adding support the foodcritic linter for Chef files.
Listing all issues as warnings for now
Doesn't get in the way of rubocop linting if ft=ruby.chef
Updated documentation

Closes #127
