### PR TITLE
flow linting should only happen on flow typed files.

### DIFF
--- a/ale_linters/javascript/flow.vim
+++ b/ale_linters/javascript/flow.vim
@@ -21,7 +21,7 @@ endfunction
 
 function! ale_linters#javascript#flow#GetCommand(buffer) abort
   return ale_linters#javascript#flow#GetExecutable(a:buffer)
-  \   . ' check-contents --json --from ale'
+  \   . ' check-contents --respect-pragma --json --from ale'
 endfunction
 
 function! ale_linters#javascript#flow#Handle(buffer, lines)


### PR DESCRIPTION
flow linting lights up on files that don't have the `@flow` comment. Using the `respect-pragma` option forces flow to only check files with the `@flow` heading.

The `--respect-pragma` was introduction with Flow 0.30 (current is 0.34) so I believe you'd have to have that version for linting to work. 