### PR TITLE
Add typecheck linter for typescript

### DIFF
--- a/ale_linters/typescript/typecheck.vim
+++ b/ale_linters/typescript/typecheck.vim
@@ -12,8 +12,6 @@ function! ale_linters#typescript#typecheck#Handle(buffer, lines)
 
     for l:line in a:lines
         let l:match = matchlist(l:line, l:pattern)
-        echom len(l:match)
-        echom join(l:match, ", ")
 
         if len(l:match) == 0
             continue

--- a/ale_linters/typescript/typecheck.vim
+++ b/ale_linters/typescript/typecheck.vim
@@ -1,0 +1,47 @@
+" Author: Prashanth Chandra https://github.com/prashcr, Aleh Kashnikau https://github.com/mkusher
+" Description: type checker for TypeScript files
+
+function! ale_linters#typescript#typecheck#Handle(buffer, lines)
+    " Matches patterns like the following:
+    "
+    " hello.ts[7, 41]: Property 'a' does not exist on type 'A'
+    " hello.ts[16, 7]: Type 'A' is not assignable to type 'B'
+    "
+    let l:pattern = '.\+.ts\[\(\d\+\), \(\d\+\)\]: \(.\+\)'
+    let l:output = []
+
+    for l:line in a:lines
+        let l:match = matchlist(l:line, l:pattern)
+        echom len(l:match)
+        echom join(l:match, ", ")
+
+        if len(l:match) == 0
+            continue
+        endif
+
+        let l:line = l:match[1] + 0
+        let l:column = l:match[2] + 0
+        let l:type = 'E'
+        let l:text = l:match[3]
+
+        " vcol is Needed to indicate that the column is a character.
+        call add(l:output, {
+        \   'bufnr': a:buffer,
+        \   'lnum': l:line,
+        \   'vcol': 0,
+        \   'col': l:column,
+        \   'text': l:text,
+        \   'type': l:type,
+        \   'nr': -1,
+        \})
+    endfor
+
+    return l:output
+endfunction
+
+call ale#linter#Define('typescript', {
+\   'name': 'typecheck',
+\   'executable': 'typecheck',
+\   'command': 'typecheck %s',
+\   'callback': 'ale_linters#typescript#typecheck#Handle',
+\})


### PR DESCRIPTION
Solves #20 

- Linters name: `typecheck`
- Required npm package: `ts-type-checker`(https://www.npmjs.com/package/ts-type-checker)

It uses my simple wrapper around typescript compiler . `npm i -g ts-type-checker` would be enough.
typecheck.vim is almost a copy of tslint.vim.