### PR TITLE
Add puppet linters

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ name. That seems to be the fairest way to arrange this table.
 | Perl | [perl -c](https://perl.org/), [perl-critic](https://metacpan.org/pod/Perl::Critic) |
 | PHP | [php -l](https://secure.php.net/), [phpcs](https://github.com/squizlabs/PHP_CodeSniffer) |
 | Pug | [pug-lint](https://github.com/pugjs/pug-lint) |
+| Puppet | [puppet](https://puppet.com), [puppet-lint](https://puppet-lint.com) |
 | Python | [flake8](http://flake8.pycqa.org/en/latest/), [pylint](https://www.pylint.org/) |
 | Ruby | [rubocop](https://github.com/bbatsov/rubocop) |
 | SASS | [sass-lint](https://www.npmjs.com/package/sass-lint) |

--- a/ale_linters/puppet/puppet.vim
+++ b/ale_linters/puppet/puppet.vim
@@ -1,0 +1,37 @@
+" Author: Alexander Olofsson <alexander.olofsson@liu.se>
+
+function! ale_linters#puppet#puppet#Handle(buffer, lines)
+    " Matches patterns like the following:
+    " Error: Could not parse for environment production: Syntax error at ':' at /root/puppetcode/modules/nginx/manifests/init.pp:43:12
+
+    let l:pattern = '^Error: .*: \(.\+\) at .\+:\(\d\+\):\(\d\+\)$'
+    let l:output = []
+
+    for l:line in a:lines
+        let l:match = matchlist(l:line, l:pattern)
+
+        if len(l:match) == 0
+            continue
+        endif
+
+        " vcol is needed to indicate that the column is a character
+        call add(l:output, {
+        \   'bufnr': a:buffer,
+        \   'lnum': l:match[2] + 0,
+        \   'vcol': 0,
+        \   'col': l:match[3] + 0,
+        \   'text': l:match[1],
+        \   'type': 'E',
+        \   'nr': -1,
+        \})
+    endfor
+
+    return l:output
+endfunction
+
+call ale#linter#Define('puppet', {
+\   'name': 'puppet parser',
+\   'executable': 'puppet',
+\   'command': g:ale#util#stdin_wrapper . '.pp puppet parser validate --color=false',
+\   'callback': 'ale_linters#puppet#puppet#Handle',
+\})

--- a/ale_linters/puppet/puppet.vim
+++ b/ale_linters/puppet/puppet.vim
@@ -33,6 +33,6 @@ call ale#linter#Define('puppet', {
 \   'name': 'puppet',
 \   'executable': 'puppet',
 \   'output_stream': 'stderr',
-\   'command': g:ale#util#stdin_wrapper . '.pp puppet parser validate --color=false',
+\   'command': g:ale#util#stdin_wrapper . ' .pp puppet parser validate --color=false',
 \   'callback': 'ale_linters#puppet#puppet#Handle',
 \})

--- a/ale_linters/puppet/puppet.vim
+++ b/ale_linters/puppet/puppet.vim
@@ -30,8 +30,9 @@ function! ale_linters#puppet#puppet#Handle(buffer, lines)
 endfunction
 
 call ale#linter#Define('puppet', {
-\   'name': 'puppet parser',
+\   'name': 'puppet',
 \   'executable': 'puppet',
+\   'output_stream': 'stderr',
 \   'command': g:ale#util#stdin_wrapper . '.pp puppet parser validate --color=false',
 \   'callback': 'ale_linters#puppet#puppet#Handle',
 \})

--- a/ale_linters/puppet/puppetlint.vim
+++ b/ale_linters/puppet/puppetlint.vim
@@ -3,6 +3,6 @@
 call ale#linter#Define('puppet', {
 \   'name': 'puppetlint',
 \   'executable': 'puppet-lint',
-\   'command': g:ale#util#stdin_wrapper . '.pp puppet-lint --no-autoloader_layout-check --log-format "-:%{line}:%{column}: %{kind}: [%{check}] %{message}"',
+\   'command': g:ale#util#stdin_wrapper . ' .pp puppet-lint --no-autoloader_layout-check --log-format "-:%{line}:%{column}: %{kind}: [%{check}] %{message}"',
 \   'callback': 'ale#handlers#HandleGCCFormat',
 \})

--- a/ale_linters/puppet/puppetlint.vim
+++ b/ale_linters/puppet/puppetlint.vim
@@ -1,0 +1,8 @@
+" Author: Alexander Olofsson <alexander.olofsson@liu.se>
+
+call ale#linter#Define('puppet', {
+\   'name': 'puppetlint',
+\   'executable': 'puppet-lint',
+\   'command': g:ale#util#stdin_wrapper . '.pp puppet-lint --no-autoloader_layout-check --log-format "-:%{line}:%{column}: %{kind}: [%{check}] %{message}"',
+\   'callback': 'ale#handlers#HandleGCCFormat',
+\})

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -81,6 +81,7 @@ The following languages and tools are supported.
 * Perl: 'perl' (-c flag), 'perlcritic'
 * PHP: 'php' (-l flag), 'phpcs'
 * Pug: 'pug-lint'
+* Puppet: 'puppet', 'puppet-lint'
 * Python: 'flake8', 'pylint'
 * Ruby: 'rubocop'
 * SASS: 'sasslint'


### PR DESCRIPTION
Adds support for Puppet through `puppet parser validate` and `puppet-lint`.

This currently doesn't let `puppet-lint` do checks for auto-load layout, due to the way the stdin-wrapper works.

Closes #181