### PR TITLE
LaTeX Linters

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ name. That seems to be the fairest way to arrange this table.
 | HTML | [HTMLHint](http://htmlhint.com/), [tidy](http://www.html-tidy.org/) |
 | JavaScript | [eslint](http://eslint.org/), [jscs](http://jscs.info/), [jshint](http://jshint.com/), [FlowType](https://flowtype.org/) |
 | JSON | [jsonlint](http://zaa.ch/jsonlint/) |
+| LaTeX | [chktex](http://www.nongnu.org/chktex/) |
 | Lua | [luacheck](https://github.com/mpeterv/luacheck) |
 | Markdown | [mdl](https://github.com/mivok/markdownlint), [proselint](http://proselint.com/)|
 | MATLAB | [mlint](https://www.mathworks.com/help/matlab/ref/mlint.html) |

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ name. That seems to be the fairest way to arrange this table.
 | HTML | [HTMLHint](http://htmlhint.com/), [tidy](http://www.html-tidy.org/) |
 | JavaScript | [eslint](http://eslint.org/), [jscs](http://jscs.info/), [jshint](http://jshint.com/), [FlowType](https://flowtype.org/) |
 | JSON | [jsonlint](http://zaa.ch/jsonlint/) |
-| LaTeX | [chktex](http://www.nongnu.org/chktex/) |
+| LaTeX | [chktex](http://www.nongnu.org/chktex/), [lacheck](https://www.ctan.org/pkg/lacheck) |
 | Lua | [luacheck](https://github.com/mpeterv/luacheck) |
 | Markdown | [mdl](https://github.com/mivok/markdownlint), [proselint](http://proselint.com/)|
 | MATLAB | [mlint](https://www.mathworks.com/help/matlab/ref/mlint.html) |

--- a/ale_linters/tex/chktex.vim
+++ b/ale_linters/tex/chktex.vim
@@ -1,0 +1,63 @@
+" Author: Andrew Balmos - <andrew@balmos.org>
+" Description: chktex for LaTeX files
+
+let g:ale_tex_chktex_executable =
+\   get(g:, 'ale_tex_chktex_executable', 'chktex')
+
+let g:ale_tex_chktex_options =
+\   get(g:, 'ale_tex_chktex_options', '-I')
+
+function! ale_linters#tex#chktex#GetCommand(buffer) abort
+  " Check for optional .chktexrc
+  let l:chktex_config = ale#util#FindNearestFile(
+  \   a:buffer,
+  \   '.chktexrc')
+
+  let l:command = g:ale_tex_chktex_executable
+  " Avoid bug when used without -p (last warning has gibberish for a filename)
+  let l:command .= ' -v0 -p stdin -q'
+
+  if !empty(l:chktex_config)
+    let l:command .= ' -l ' . fnameescape(l:chktex_config)
+  endif
+
+  let l:command .= ' ' . g:ale_tex_chktex_options
+
+  return l:command
+endfunction
+
+function! ale_linters#tex#chktex#Handle(buffer, lines) abort
+  " Mattes lines like:
+  "
+  " stdin:499:2:24:Delete this space to maintain correct pagereferences.
+  " stdin:507:81:3:You should enclose the previous parenthesis with `{}'.
+  let l:pattern = '^stdin:\(\d\+\):\(\d\+\):\d\+:\(.\+\)$'
+  let l:output = []
+
+  for l:line in a:lines
+    let l:match = matchlist(l:line, l:pattern)
+
+    if len(l:match) == 0
+      continue
+    endif
+
+    call add(l:output, {
+    \   'bufnr': a:buffer,
+    \   'lnum': l:match[1] + 0,
+    \   'vcol': 0,
+    \   'col': l:match[2] + 0,
+    \   'text': l:match[3],
+    \   'type': 'W',
+    \   'nr': -1
+    \})
+  endfor
+
+  return l:output
+endfunction
+
+call ale#linter#Define('tex', {
+\   'name': 'chktex',
+\   'executable': 'chktex',
+\   'command_callback': 'ale_linters#tex#chktex#GetCommand',
+\   'callback': 'ale_linters#tex#chktex#Handle'
+\})

--- a/ale_linters/tex/chktex.vim
+++ b/ale_linters/tex/chktex.vim
@@ -31,7 +31,7 @@ function! ale_linters#tex#chktex#Handle(buffer, lines) abort
   "
   " stdin:499:2:24:Delete this space to maintain correct pagereferences.
   " stdin:507:81:3:You should enclose the previous parenthesis with `{}'.
-  let l:pattern = '^stdin:\(\d\+\):\(\d\+\):\d\+:\(.\+\)$'
+  let l:pattern = '^stdin:\(\d\+\):\(\d\+\):\(\d\+\):\(.\+\)$'
   let l:output = []
 
   for l:line in a:lines
@@ -46,7 +46,7 @@ function! ale_linters#tex#chktex#Handle(buffer, lines) abort
     \   'lnum': l:match[1] + 0,
     \   'vcol': 0,
     \   'col': l:match[2] + 0,
-    \   'text': l:match[3],
+    \   'text': l:match[4] . ' (' . (l:match[3]+0) . ')',
     \   'type': 'W',
     \   'nr': -1
     \})

--- a/ale_linters/tex/lacheck.vim
+++ b/ale_linters/tex/lacheck.vim
@@ -10,8 +10,7 @@ function! ale_linters#tex#lacheck#Handle(buffer, lines) abort
   " "book.tex", line 37: possible unwanted space at "{"
   " "book.tex", line 38: missing `\ ' after "etc."
 
-  " stdin-wrapper makes files like: /tmp/tmp.0hV8ww029I/file.tex
-  let l:pattern = '^".\+/file.tex", line \(\d\+\): \(.\+\)$'
+  let l:pattern = '^".\+", line \(\d\+\): \(.\+\)$'
   let l:output = []
 
   for l:line in a:lines

--- a/ale_linters/tex/lacheck.vim
+++ b/ale_linters/tex/lacheck.vim
@@ -1,0 +1,51 @@
+" Author: Andrew Balmos - <andrew@balmos.org>
+" Description: lacheck for LaTeX files
+
+let g:ale_tex_lacheck_executable =
+\   get(g:, 'ale_tex_lacheck_executable', 'lacheck')
+
+function! ale_linters#tex#lacheck#Handle(buffer, lines) abort
+  " Mattes lines like:
+  "
+  " "book.tex", line 37: possible unwanted space at "{"
+  " "book.tex", line 38: missing `\ ' after "etc."
+
+  " stdin-wrapper makes files like: /tmp/tmp.0hV8ww029I/file.tex
+  let l:pattern = '^".\+/file.tex", line \(\d\+\): \(.\+\)$'
+  let l:output = []
+
+  for l:line in a:lines
+    let l:match = matchlist(l:line, l:pattern)
+
+    if len(l:match) == 0
+      continue
+    endif
+
+    " lacheck follows `\input{}` commands. If the cwd is not the same as the
+    " file in the buffer then it will fail to find the inputed items. We do not
+    " want warnings from those items anyway
+    if !empty(matchstr(l:match[2], '^Could not open ".\+"$'))
+      continue
+    endif
+
+    call add(l:output, {
+    \   'bufnr': a:buffer,
+    \   'lnum': l:match[1] + 0,
+    \   'vcol': 0,
+    \   'col': 0,
+    \   'text': l:match[2],
+    \   'type': 'W',
+    \   'nr': -1
+    \})
+  endfor
+
+  return l:output
+endfunction
+
+call ale#linter#Define('tex', {
+\   'name': 'lacheck',
+\   'executable': 'lacheck',
+\   'command': g:ale#util#stdin_wrapper . ' .tex '
+\      . g:ale_tex_lacheck_executable,
+\   'callback': 'ale_linters#tex#lacheck#Handle'
+\})

--- a/autoload/ale/linter.vim
+++ b/autoload/ale/linter.vim
@@ -9,6 +9,7 @@ let s:linters = {}
 let s:default_ale_linter_aliases = {
 \   'zsh': 'sh',
 \   'csh': 'sh',
+\   'plaintex': 'tex'
 \}
 
 " Default linters to run for particular filetypes.

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -29,6 +29,7 @@ CONTENTS                                                         *ale-contents*
     4.17. python-flake8.........................|ale-linter-options-python-flake8|
     4.18. ruby-rubocop..........................|ale-linter-options-ruby-rubocop|
     4.19. chktex................................|ale-linter-options-chktex|
+    4.20. lacheck...............................|ale-linter-options-lacheck|
   5. Linter Integration Notes...................|ale-linter-integration|
     5.1.  merlin................................|ale-linter-integration-ocaml-merlin|
   6. Commands/Keybinds..........................|ale-commands|
@@ -76,7 +77,7 @@ The following languages and tools are supported.
 * HTML: 'HTMLHint', 'tidy'
 * JavaScript: 'eslint', 'jscs', 'jshint', 'flow'
 * JSON: 'jsonlint'
-* LaTeX: 'chktex'
+* LaTeX: 'chktex', 'lacheck'
 * Lua: 'luacheck'
 * Markdown: 'mdl'
 * MATLAB: 'mlint'
@@ -660,6 +661,16 @@ g:ale_tex_chktex_options                             *g:ale_tex_chktex_options*
   Default: `'-I'`
 
   This variable can be changed to modify flags given to chktex.
+
+------------------------------------------------------------------------------
+4.20. lacheck                                     *ale-linter-options-lacheck*
+
+g:ale_lacheck_executable                            *g:ale_lacheck_executable*
+
+  Type: |String|
+  Default: '`lacheck`'
+
+  This variable can be changed to change the path to lacheck.
 
 ===============================================================================
 5. Linter Integration Notes                            *ale-linter-integration*

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -27,6 +27,8 @@ CONTENTS                                                         *ale-contents*
     4.15. htmlhint..............................|ale-linter-options-htmlhint|
     4.16. c-clang...............................|ale-linter-options-c-clang|
     4.17. python-flake8.........................|ale-linter-options-python-flake8|
+    4.18. ruby-rubocop..........................|ale-linter-options-ruby-rubocop|
+    4.19. chktex................................|ale-linter-options-chktex|
   5. Linter Integration Notes...................|ale-linter-integration|
     5.1.  merlin................................|ale-linter-integration-ocaml-merlin|
   6. Commands/Keybinds..........................|ale-commands|
@@ -74,6 +76,7 @@ The following languages and tools are supported.
 * HTML: 'HTMLHint', 'tidy'
 * JavaScript: 'eslint', 'jscs', 'jshint', 'flow'
 * JSON: 'jsonlint'
+* LaTeX: 'chktex'
 * Lua: 'luacheck'
 * Markdown: 'mdl'
 * MATLAB: 'mlint'
@@ -640,6 +643,23 @@ g:ale_ruby_rubocop_options                         *g:ale_ruby_rubocop_options*
   Default: `''`
 
   This variable can be change to modify flags given to rubocop.
+
+-------------------------------------------------------------------------------
+4.19. chktex                                        *ale-linter-options-chktex*
+
+g:ale_tex_chktex_executable                       *g:ale_tex_chktex_executable*
+
+  Type: |String|
+  Default: `'chktex'`
+
+  This variable can be changed to change the path to chktex.
+
+g:ale_tex_chktex_options                             *g:ale_tex_chktex_options*
+
+  Type: |String|
+  Default: `'-I'`
+
+  This variable can be changed to modify flags given to chktex.
 
 ===============================================================================
 5. Linter Integration Notes                            *ale-linter-integration*


### PR DESCRIPTION
Adds support for `chktex` and `lacheck`. 

`chktex`: 

Supports finding a project's `.chktexrc` file. It uses `ale#util#FindNearestFile` even though that is _not_ the search algorithm `chktex` uses. However, I find this to be the least surprising implementation for users that have a directory structure within their LaTeX project. For example, normal latex practice is to run `latex`, `lacheck`, etc. on the top most tex file in the root of the project. These programs then typically follow `\input{}` commands into the other files. As a result `chktex` expects `.chktexrc` to be in the current working directory. However, when editing a tex file from a sub-directory ale somewhat _incorrectly_ calls `chktex` (at least with respect to how `chktex` is usually called). Therefore, we look up the project tree for a `.chktexrc`.

`lacheck`:

`lacheck` has the same problem but it does not have a configuration file so I just throw away lint errors that are not for the file in the buffer -- see viml comments