### PR TITLE
Add options variable for ruby-rubocop

### DIFF
--- a/ale_linters/ruby/rubocop.vim
+++ b/ale_linters/ruby/rubocop.vim
@@ -34,10 +34,18 @@ function! ale_linters#ruby#rubocop#Handle(buffer, lines)
     return l:output
 endfunction
 
+" Set this option to change Rubocop options.
+if !exists('g:ale_ruby_rubocop_options')
+    " let g:ale_ruby_rubocop_options = '--lint'
+    let g:ale_ruby_rubocop_options = ''
+endif
+
 call ale#linter#Define('ruby', {
 \   'name': 'rubocop',
 \   'executable': 'rubocop',
-\   'command': 'rubocop --format emacs --stdin _',
+\   'command': 'rubocop --format emacs --stdin '
+\   . g:ale_ruby_rubocop_options
+\   . ' _',
 \   'callback': 'ale_linters#ruby#rubocop#Handle',
 \})
 

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -631,6 +631,16 @@ Python 3, you may want to set >
 after making sure it's installed for the appropriate Python versions (e.g.
 `python3 -m pip install --user flake8`).
 
+-------------------------------------------------------------------------------
+4.18. ruby-rubocop                            *ale-linter-options-ruby-rubocop*
+
+g:ale_ruby_rubocop_options                         *g:ale_ruby_rubocop_options*
+
+  Type: |String|
+  Default: `''`
+
+  This variable can be change to modify flags given to rubocop.
+
 ===============================================================================
 5. Linter Integration Notes                            *ale-linter-integration*
 


### PR DESCRIPTION
The reason for adding an options variable to Ruby Rubocop is I wanted to specify --lint when running Rubocop from ALE.

I find Rubocop's style cops too verbose and picky when I'm writing Ruby code, so I prefer to run it with only the lint cops enabled. I usually wait until I'm mostly done before turning on the Rubocop style cops.