### PR TITLE
Add support for tslint.json file detection in tslint

### DIFF
--- a/ale_linters/typescript/tslint.vim
+++ b/ale_linters/typescript/tslint.vim
@@ -37,12 +37,16 @@ function! ale_linters#typescript#tslint#Handle(buffer, lines)
     return l:output
 endfunction
 
-let s:tsconfig_path = ale#util#FindNearestFile(bufnr('%'), 'tslint.json')
-let s:tslint_options = empty(s:tsconfig_path) ? '' : '-c ' . s:tsconfig_path
+function! ale_linters#typescript#tslint#BuildLintCommand(buffer_n) abort
+  let l:tsconfig_path = ale#util#FindNearestFile(a:buffer_n, 'tslint.json')
+  let l:tslint_options = empty(l:tsconfig_path) ? '' : '-c ' . l:tsconfig_path
+
+  return g:ale#util#stdin_wrapper . ' .ts tslint ' . l:tslint_options
+endfunction
 
 call ale#linter#Define('typescript', {
 \   'name': 'tslint',
 \   'executable': 'tslint',
-\   'command': g:ale#util#stdin_wrapper . ' .ts tslint ' . s:tslint_options,
+\   'command_callback': 'ale_linters#typescript#tslint#BuildLintCommand',
 \   'callback': 'ale_linters#typescript#tslint#Handle',
 \})

--- a/ale_linters/typescript/tslint.vim
+++ b/ale_linters/typescript/tslint.vim
@@ -37,9 +37,12 @@ function! ale_linters#typescript#tslint#Handle(buffer, lines)
     return l:output
 endfunction
 
+let s:tsconfig_path = ale#util#FindNearestFile(bufnr('%'), 'tslint.json')
+let s:tslint_options = empty(s:tsconfig_path) ? '' : '-c ' . s:tsconfig_path
+
 call ale#linter#Define('typescript', {
 \   'name': 'tslint',
 \   'executable': 'tslint',
-\   'command': g:ale#util#stdin_wrapper . ' .ts tslint',
+\   'command': g:ale#util#stdin_wrapper . ' .ts tslint ' . s:tslint_options,
 \   'callback': 'ale_linters#typescript#tslint#Handle',
 \})


### PR DESCRIPTION
By default tslint looks for the tslint.json file in the checked file directory. By providing option `-c` with the path to a tslint.json file we can override that.

The option is not set if the tslint.config is not found up the directory tree.