### PR TITLE
Fix proper extension handling for tslint

### DIFF
--- a/ale_linters/typescript/tslint.vim
+++ b/ale_linters/typescript/tslint.vim
@@ -7,7 +7,8 @@ function! ale_linters#typescript#tslint#Handle(buffer, lines)
     " hello.ts[7, 41]: trailing whitespace
     " hello.ts[5, 1]: Forbidden 'var' keyword, use 'let' or 'const' instead
     "
-    let l:pattern = '.\+.ts\[\(\d\+\), \(\d\+\)\]: \(.\+\)'
+    let l:ext = '.' . fnamemodify(bufname(a:buffer), ':e')
+    let l:pattern = '.\+' . l:ext . '\[\(\d\+\), \(\d\+\)\]: \(.\+\)'
     let l:output = []
 
     for l:line in a:lines
@@ -41,7 +42,9 @@ function! ale_linters#typescript#tslint#BuildLintCommand(buffer_n) abort
   let l:tsconfig_path = ale#util#FindNearestFile(a:buffer_n, 'tslint.json')
   let l:tslint_options = empty(l:tsconfig_path) ? '' : '-c ' . l:tsconfig_path
 
-  return g:ale#util#stdin_wrapper . ' .ts tslint ' . l:tslint_options
+  let l:ext = '.' . fnamemodify(bufname(a:buffer_n), ':e')
+
+  return g:ale#util#stdin_wrapper . ' ' . l:ext . ' tslint ' . l:tslint_options
 endfunction
 
 call ale#linter#Define('typescript', {


### PR DESCRIPTION
Right now tslint linter assumes .ts extension, unfortunately, that doesn't work when linting .tsx files (jsx in typescript).

I've added a change to take the file extension into account.