### PR TITLE
Skip I0011 messages in pylint.

### DIFF
--- a/autoload/ale/handlers.vim
+++ b/autoload/ale/handlers.vim
@@ -127,6 +127,11 @@ function! ale#handlers#HandlePEP8Format(buffer, lines) abort
             continue
         endif
 
+        if l:code ==# 'I0011'
+            " Skip 'Locally disabling' message
+             continue
+        endif
+
         call add(l:output, {
         \   'bufnr': a:buffer,
         \   'lnum': l:match[1] + 0,


### PR DESCRIPTION
Ignore 'Locally disabling %s' messages from pylint.

These are meant to be ignored by the linter (http://pylint-messages.wikidot.com/messages:i0011).