### PR TITLE
Catch g++ fatal error

### DIFF
--- a/autoload/ale/handlers.vim
+++ b/autoload/ale/handlers.vim
@@ -67,7 +67,7 @@ function! ale#handlers#HandleGCCFormat(buffer, lines) abort
         \   'vcol': 0,
         \   'col': l:match[2] + 0,
         \   'text': l:match[4],
-        \   'type': l:match[3] ==# 'error' ? 'E' : 'W',
+        \   'type': l:match[3] =~# 'error' ? 'E' : 'W',
         \   'nr': -1,
         \})
     endfor


### PR DESCRIPTION
In some cases I get "fatal error" in g++ (I don't know exactly why):

```
../Software/Toys/pdfs/RooKstMuMuFoldedP5.h:15:10: fatal error: 'RooAbsPdf.h' file not found
```

Catch these.