### PR TITLE
Add support for Swift with swiftlint

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ name. That seems to be the fairest way to arrange this table.
 | SASS | [sass-lint](https://www.npmjs.com/package/sass-lint), [stylelint](https://github.com/stylelint/stylelint) |
 | SCSS | [sass-lint](https://www.npmjs.com/package/sass-lint), [scss-lint](https://github.com/brigade/scss-lint), [stylelint](https://github.com/stylelint/stylelint) |
 | Scala | [scalac](http://scala-lang.org) |
+| Swift | [swiftlint](https://swift.org/) |
 | Tex | [proselint](http://proselint.com/) |
 | Text | [proselint](http://proselint.com/) |
 | TypeScript | [tslint](https://github.com/palantir/tslint), typecheck |

--- a/ale_linters/swift/swiftlint.vim
+++ b/ale_linters/swift/swiftlint.vim
@@ -1,0 +1,9 @@
+" Author: David Mohundro <david@mohundro.com>
+" Description: swiftlint for swift files
+
+call ale#linter#Define('swiftlint', {
+\   'name': 'swiftlint',
+\   'executable': 'swiftlint',
+\   'command': g:ale#util#stdin_wrapper . ' swiftlint',
+\   'callback': 'ale#handlers#HandleGCCFormat',
+\})

--- a/ale_linters/swift/swiftlint.vim
+++ b/ale_linters/swift/swiftlint.vim
@@ -4,6 +4,6 @@
 call ale#linter#Define('swiftlint', {
 \   'name': 'swiftlint',
 \   'executable': 'swiftlint',
-\   'command': g:ale#util#stdin_wrapper . ' swiftlint',
+\   'command': g:ale#util#stdin_wrapper . ' .swift swiftlint',
 \   'callback': 'ale#handlers#HandleGCCFormat',
 \})

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -91,6 +91,7 @@ The following languages and tools are supported.
 * SASS: 'sasslint', 'stylelint'
 * SCSS: 'sasslint', 'scsslint', 'stylelint'
 * Scala: 'scalac'
+* Swift: 'swiftlint'
 * TypeScript: 'tslint', 'typecheck'
 * Verilog: 'iverilog', 'verilator'
 * Vim: 'vint'


### PR DESCRIPTION
As far as I can tell, SwiftLint seems to follow the GCC format exactly.

See https://github.com/realm/SwiftLint.