### PR TITLE
Improve formatting of ghc and hlint haskell linters

### DIFF
--- a/ale_linters/haskell/ghc.vim
+++ b/ale_linters/haskell/ghc.vim
@@ -29,9 +29,7 @@ function! ale_linters#haskell#ghc#Handle(buffer, lines)
             call add(l:corrected_lines, l:line)
         else
             if len(l:corrected_lines) > 0
-                if l:corrected_lines[-1] =~# ': error:$'
-                    let l:line = substitute(l:line, '\v^\s+', ' ', '')
-                endif
+                let l:line = substitute(l:line, '\v\s+', ' ', '')
                 let l:corrected_lines[-1] .= l:line
             endif
         endif

--- a/ale_linters/haskell/hlint.vim
+++ b/ale_linters/haskell/hlint.vim
@@ -13,7 +13,7 @@ function! ale_linters#haskell#hlint#Handle(buffer, lines)
         \   'lnum': l:error.startLine + 0,
         \   'vcol': 0,
         \   'col': l:error.startColumn + 0,
-        \   'text': l:error.severity . ': ' . l:error.hint,
+        \   'text': l:error.severity . ': ' . l:error.hint . '. Found: ' . l:error.from . ' Why not: ' . l:error.to,
         \   'type': l:error.severity ==# 'Error' ? 'E' : 'W',
         \})
     endfor


### PR DESCRIPTION
For ghc, it seemed that the conditional

```
if l:corrected_lines[-1] =~# ': error:$'
    let l:line = substitute(l:line, '\v^\s+', ' ', '')
endif
```

was never being reached. It's actually better to unconditionally
collapse whitespace anyway and so I simply removed the conditional
check.

For hlint I added more information about the error. This changes the
reported error from `Error: Avoid lambda` to something like:
` Error: Avoid lambda. Found: \ x -> foo x Why not: foo`