### PR TITLE
Nvim: pass functions as funcrefs

### DIFF
--- a/autoload/ale/engine.vim
+++ b/autoload/ale/engine.vim
@@ -205,19 +205,19 @@ function! s:RunJob(command, generic_job_options) abort
         if l:output_stream ==# 'stderr'
             " Read from stderr instead of stdout.
             let l:job = jobstart(l:command, {
-            \   'on_stderr': 's:GatherOutputNeoVim',
-            \   'on_exit': 's:HandleExitNeoVim',
+            \   'on_stderr': function('s:GatherOutputNeoVim'),
+            \   'on_exit': function('s:HandleExitNeoVim'),
             \})
         elseif l:output_stream ==# 'both'
             let l:job = jobstart(l:command, {
-            \   'on_stdout': 's:GatherOutputNeoVim',
-            \   'on_stderr': 's:GatherOutputNeoVim',
-            \   'on_exit': 's:HandleExitNeoVim',
+            \   'on_stdout': function('s:GatherOutputNeoVim'),
+            \   'on_stderr': function('s:GatherOutputNeoVim'),
+            \   'on_exit': function('s:HandleExitNeoVim'),
             \})
         else
             let l:job = jobstart(l:command, {
-            \   'on_stdout': 's:GatherOutputNeoVim',
-            \   'on_exit': 's:HandleExitNeoVim',
+            \   'on_stdout': function('s:GatherOutputNeoVim'),
+            \   'on_exit': function('s:HandleExitNeoVim'),
             \})
         endif
     else


### PR DESCRIPTION
neovim/neovim#5529 merged support for Vim's partial functions, which
made nvim more strict about dictionary functions and callbacks, to
match Vim behavior.