### PR TITLE
Redirect go build output to /dev/null

### DIFF
--- a/ale_linters/go/gobuild.vim
+++ b/ale_linters/go/gobuild.vim
@@ -2,7 +2,7 @@
 " Description: go build for Go files
 
 function! s:FindGobuildScript() abort
-    return g:ale#util#stdin_wrapper . ' .go go build'
+    return g:ale#util#stdin_wrapper . ' .go go build -o /dev/null'
 endfunction
 
 let g:ale#util#gobuild_script =


### PR DESCRIPTION
Named file file will be created after ALE, this can redirect the output to /dev/null if go build failed.