### PR TITLE
Added ability to reload compilation flags for c and c++

### DIFF
--- a/ale_linters/c/gcc.vim
+++ b/ale_linters/c/gcc.vim
@@ -9,12 +9,16 @@ if !exists('g:ale_c_gcc_options')
     let g:ale_c_gcc_options = '-std=c11 -Wall'
 endif
 
+function! ale_linters#c#gcc#GetCommand(buffer) abort
+    return 'gcc -S -x c++ -fsyntax-only '
+    \      . g:ale_c_gcc_options . ' -'
+
+endfunction
+
 call ale#linter#Define('c', {
 \   'name': 'gcc',
 \   'output_stream': 'stderr',
 \   'executable': 'gcc',
-\   'command': 'gcc -S -x c -fsyntax-only '
-\       . g:ale_c_gcc_options
-\       . ' -',
+\   'command_callback': 'ale_linters#c#gcc#GetCommand',
 \   'callback': 'ale#handlers#HandleGCCFormat',
 \})

--- a/ale_linters/cpp/gcc.vim
+++ b/ale_linters/cpp/gcc.vim
@@ -15,12 +15,16 @@ if !exists('g:ale_cpp_gcc_options')
     let g:ale_cpp_gcc_options = '-std=c++14 -Wall'
 endif
 
+function! ale_linters#cpp#gcc#GetCommand(buffer) abort
+    return 'gcc -S -x c++ -fsyntax-only '
+    \      . g:ale_cpp_gcc_options . ' -'
+
+endfunction
+
 call ale#linter#Define('cpp', {
 \   'name': 'g++',
 \   'output_stream': 'stderr',
 \   'executable': 'g++',
-\   'command': 'gcc -S -x c++ -fsyntax-only '
-\       . g:ale_cpp_gcc_options
-\       . ' -',
+\   'command_callback': 'ale_linters#cpp#gcc#GetCommand',
 \   'callback': 'ale#handlers#HandleGCCFormat',
 \})


### PR DESCRIPTION
I've noticed that `g:ale_c_gcc_options` and `g:ale_cpp_gcc_options` are set permamently to `linter.command`.

Here's a fix that alowes you to modify compilation flags dynamicly.