### PR TITLE
Fixed a typo scss -> sass

### DIFF
--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -722,7 +722,7 @@ g:ale_css_stylelint_use_global                   *g:ale_css_stylelint_use_global
   global version of stylelint, in preference to locally installed versions of
   stylelint in node_modules.
 
-g:ale_scss_stylelint_executable                 *g:ale_scss_stylelint_executable*
+g:ale_sass_stylelint_executable                 *g:ale_sass_stylelint_executable*
 
   Type: |String|
   Default: `'stylelint'`
@@ -731,10 +731,10 @@ g:ale_scss_stylelint_executable                 *g:ale_scss_stylelint_executable
   directory. If no such path exists, this variable will be used instead.
 
   If you wish to use only a globally installed version of stylelint, set
-  |g:ale_scss_stylelint_use_global| to `1`.
+  |g:ale_sass_stylelint_use_global| to `1`.
 
 
-g:ale_scss_stylelint_use_global                 *g:ale_scss_stylelint_use_global*
+g:ale_sass_stylelint_use_global                 *g:ale_sass_stylelint_use_global*
 
   Type: |String|
   Default: `0`


### PR DESCRIPTION
Fixes helptag generation,
```
[dein] Vim(helptags):E154: Duplicate tag "g:ale_scss_stylelint_executable" in file /Users/aluberg/.config/nvim/.cache/init.vim/.dein/doc/ale.txt
[dein] function dein#end[1]..dein#util#_end[40]..dein#recache_runtimepath[1]..dein#install#_recache_runtimepath[20]..<SNR>16_helptags, line 12
```