### PR TITLE
Fix PHP lint generic error without line number

### DIFF
--- a/ale_linters/php/php.vim
+++ b/ale_linters/php/php.vim
@@ -34,6 +34,6 @@ call ale#linter#Define('php', {
 \   'name': 'php',
 \   'executable': 'php',
 \   'output_stream': 'both',
-\   'command': 'php -l --',
+\   'command': 'php -l -d display_errors=1 --',
 \   'callback': 'ale_linters#php#php#Handle',
 \})


### PR DESCRIPTION
This makes php output more specific error messages. The format is the normal one ALE expects, but on some systems ALE does not work with PHP unless the display_errors=1 option is used. Without that option php will only output a generic message without a line number like "Errors parsing index.php".