### PR TITLE
Fix typo in perlcritic linter dictionary

### DIFF
--- a/ale_linters/perl/perlcritic.vim
+++ b/ale_linters/perl/perlcritic.vim
@@ -35,7 +35,7 @@ endfunction
 call ale#linter#Define('perl', {
 \   'name': 'perlcritic',
 \   'executable': 'perlcritic',
-\   'output_stream': 'sdtout',
+\   'output_stream': 'stdout',
 \   'command': 'perlcritic --verbose 3 --nocolor',
 \   'callback': 'ale_linters#perl#perlcritic#Handle',
 \})


### PR DESCRIPTION
The linter validation logic was checking for `stdout`, `stderr`, or`both`, resulting in an exception being thrown when loading the perlcritic linter.

Fixes #241 