### PR TITLE
Add eslint option to pass in more options

### DIFF
--- a/ale_linters/javascript/eslint.vim
+++ b/ale_linters/javascript/eslint.vim
@@ -4,6 +4,9 @@
 let g:ale_javascript_eslint_executable =
 \   get(g:, 'ale_javascript_eslint_executable', 'eslint')
 
+let g:ale_javascript_eslint_options =
+\   get(g:, 'ale_javascript_eslint_options', '')
+
 let g:ale_javascript_eslint_use_global =
 \   get(g:, 'ale_javascript_eslint_use_global', 0)
 
@@ -21,6 +24,7 @@ endfunction
 
 function! ale_linters#javascript#eslint#GetCommand(buffer) abort
     return ale_linters#javascript#eslint#GetExecutable(a:buffer)
+    \   . ' ' . g:ale_javascript_eslint_options
     \   . ' -f unix --stdin --stdin-filename %s'
 endfunction
 

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -383,6 +383,14 @@ g:ale_javascript_eslint_executable         *g:ale_javascript_eslint_executable*
   |g:ale_javascript_eslint_use_global| to `1`.
 
 
+g:ale_javascript_eslint_options               *g:ale_javascript_eslint_options*
+
+  Type: |String|
+  Default: `''`
+
+  This variable can be set to pass additional options to eslint.
+
+
 g:ale_javascript_eslint_use_global         *g:ale_javascript_eslint_use_global*
 
   Type: |String|


### PR DESCRIPTION
This adds an eslint option to customize the eslint command without affecting the executable callback, so that users can pass more options to eslint such as `'--rulesdir $ESLINT_RULES_DIR'` (this option cannot be set inside `.eslintrc`).