### PR TITLE
Add erlc lint for Erlang (#248)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ name. That seems to be the fairest way to arrange this table.
 | D | [dmd](https://dlang.org/dmd-linux.html)^ |
 | Elixir | [credo](https://github.com/rrrene/credo) |
 | Elm | [elm-make](https://github.com/elm-lang/elm-make) |
+| Erlang | [erlc](http://erlang.org/doc/man/erlc.html) |
 | Fortran | [gcc](https://gcc.gnu.org/) |
 | Go | [gofmt -e](https://golang.org/cmd/gofmt/), [go vet](https://golang.org/cmd/vet/), [golint](https://godoc.org/github.com/golang/lint), [go build](https://golang.org/cmd/go/) |
 | Haskell | [ghc](https://www.haskell.org/ghc/), [hlint](https://hackage.haskell.org/package/hlint) |

--- a/ale_linters/erlang/erlc.vim
+++ b/ale_linters/erlang/erlc.vim
@@ -1,0 +1,74 @@
+" Author: Magnus Ottenklinger - https://github.com/evnu
+
+function! ale_linters#erlang#erlc#Handle(buffer, lines)
+  " Matches patterns like the following:
+  "
+  " error.erl:4: variable 'B' is unbound
+  " error.erl:3: Warning: function main/0 is unused
+  " error.erl:4: Warning: variable 'A' is unused
+  let l:pattern = '\v^([^:]+):(\d+): (Warning: )?(.+)$'
+
+  " parse_transforms are a special case. The error message does not indicate a location:
+  " error.erl: undefined parse transform 'some_parse_transform'
+  let l:pattern_parse_transform = '\v(undefined parse transform .*)$'
+  let l:output = []
+
+  for l:line in a:lines
+    let l:match = matchlist(l:line, l:pattern)
+    let l:match_parse_transform = matchlist(l:line, l:pattern_parse_transform)
+
+    " Determine if the output indicates an error. We distinguish between two cases:
+    "
+    " 1) normal errors match l:pattern
+    " 2) parse_transform errors match l:pattern_parse_transform
+    "
+    " If none of the patterns above match, the line can be ignored
+    if len(l:match) == 0 " not a 'normal' warning or error
+        if len(l:match_parse_transform) == 0 " also not a parse_transform error
+            continue
+        endif
+
+        let l:text = l:match_parse_transform[0]
+        call add(l:output, {
+                    \   'bufnr': a:buffer,
+                    \   'lnum': 0,
+                    \   'vcol': 0,
+                    \   'col': 0,
+                    \   'type': 'E',
+                    \   'text': l:text,
+                    \   'nr': -1,
+                    \})
+        continue
+    endif
+
+    let l:line = l:match[2]
+    let l:warning_or_text = l:match[3]
+    let l:text = l:match[4]
+
+    if !empty(l:warning_or_text)
+        let l:type = 'W'
+    else
+        let l:type = 'E'
+    endif
+
+    " vcol is Needed to indicate that the column is a character.
+    call add(l:output, {
+    \   'bufnr': a:buffer,
+    \   'lnum': l:line,
+    \   'vcol': 0,
+    \   'col': 0,
+    \   'type': l:type,
+    \   'text': l:text,
+    \   'nr': -1,
+    \})
+  endfor
+
+  return l:output
+endfunction
+
+call ale#linter#Define('erlang', {
+      \ 'name': 'erlc',
+      \ 'executable': 'erlc',
+      \ 'command': g:ale#util#stdin_wrapper . ' .erl erlc '
+      \             . get(g:, 'ale_erlang_erlc_flags', ''),
+      \ 'callback': 'ale_linters#erlang#erlc#Handle' })

--- a/ale_linters/erlang/erlc.vim
+++ b/ale_linters/erlang/erlc.vim
@@ -13,6 +13,11 @@ function! ale_linters#erlang#erlc#Handle(buffer, lines)
   let l:pattern_parse_transform = '\v(undefined parse transform .*)$'
   let l:output = []
 
+  let l:pattern_no_module_definition = '\v(no module definition)$'
+  let l:pattern_unused = '\v(.* is unused)$'
+
+  let l:is_hrl = expand('%:e') ==# 'hrl'
+
   for l:line in a:lines
     let l:match = matchlist(l:line, l:pattern)
     let l:match_parse_transform = matchlist(l:line, l:pattern_parse_transform)
@@ -44,6 +49,15 @@ function! ale_linters#erlang#erlc#Handle(buffer, lines)
     let l:line = l:match[2]
     let l:warning_or_text = l:match[3]
     let l:text = l:match[4]
+
+    " If this file is a header .hrl, ignore the following expected messages:
+    " - 'no module definition'
+    " - 'X is unused'
+    if l:is_hrl &&
+                \ (match(l:text, l:pattern_no_module_definition) != -1 ||
+                \  match(l:text, l:pattern_unused) != -1)
+        continue
+    endif
 
     if !empty(l:warning_or_text)
         let l:type = 'W'

--- a/ale_linters/erlang/erlc.vim
+++ b/ale_linters/erlang/erlc.vim
@@ -16,11 +16,10 @@ function! ale_linters#erlang#erlc#Handle(buffer, lines)
   let l:pattern_no_module_definition = '\v(no module definition)$'
   let l:pattern_unused = '\v(.* is unused)$'
 
-  let l:is_hrl = expand('%:e') ==# 'hrl'
+  let l:is_hrl = fnamemodify(bufname(a:buffer), ':e') ==# 'hrl'
 
   for l:line in a:lines
     let l:match = matchlist(l:line, l:pattern)
-    let l:match_parse_transform = matchlist(l:line, l:pattern_parse_transform)
 
     " Determine if the output indicates an error. We distinguish between two cases:
     "
@@ -29,20 +28,22 @@ function! ale_linters#erlang#erlc#Handle(buffer, lines)
     "
     " If none of the patterns above match, the line can be ignored
     if len(l:match) == 0 " not a 'normal' warning or error
+
+        let l:match_parse_transform = matchlist(l:line, l:pattern_parse_transform)
+
         if len(l:match_parse_transform) == 0 " also not a parse_transform error
             continue
         endif
 
-        let l:text = l:match_parse_transform[0]
         call add(l:output, {
-                    \   'bufnr': a:buffer,
-                    \   'lnum': 0,
-                    \   'vcol': 0,
-                    \   'col': 0,
-                    \   'type': 'E',
-                    \   'text': l:text,
-                    \   'nr': -1,
-                    \})
+        \   'bufnr': a:buffer,
+        \   'lnum': 0,
+        \   'vcol': 0,
+        \   'col': 0,
+        \   'type': 'E',
+        \   'text': l:match_parse_transform[0],
+        \   'nr': -1,
+        \})
         continue
     endif
 
@@ -81,8 +82,8 @@ function! ale_linters#erlang#erlc#Handle(buffer, lines)
 endfunction
 
 call ale#linter#Define('erlang', {
-      \ 'name': 'erlc',
-      \ 'executable': 'erlc',
-      \ 'command': g:ale#util#stdin_wrapper . ' .erl erlc '
-      \             . get(g:, 'ale_erlang_erlc_flags', ''),
-      \ 'callback': 'ale_linters#erlang#erlc#Handle' })
+\   'name': 'erlc',
+\   'executable': 'erlc',
+\   'command': g:ale#util#stdin_wrapper . ' .erl erlc '
+\               . get(g:, 'ale_erlang_erlc_flags', ''),
+\   'callback': 'ale_linters#erlang#erlc#Handle' })

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -34,6 +34,7 @@ CONTENTS                                                         *ale-contents*
     4.22. rustc...........................|ale-linter-options-rustc|
     4.23. python-mypy.....................|ale-linter-options-python-mypy|
     4.24. python-pylint...................|ale-linter-options-python-pylint|
+    4.25. erlang..........................|ale-linter-options-erlang|
   5. Linter Integration Notes.............|ale-linter-integration|
     5.1.  merlin..........................|ale-linter-integration-ocaml-merlin|
     5.2. rust.............................|ale-integration-rust|
@@ -78,6 +79,7 @@ The following languages and tools are supported.
 * D: 'dmd'
 * Elixir: 'credo'
 * Elm: 'elm-make'
+* Erlang: 'erlc'
 * Fortran: 'gcc'
 * Go: 'gofmt -e', 'go vet', 'golint', 'go build'
 * Haskell: 'ghc', 'hlint'
@@ -825,6 +827,17 @@ g:ale_python_pylint_options                       *g:ale_python_pylint_options*
 
   after making sure it's installed for the appropriate Python versions (e.g.
   `python3 -m pip install --user pylint`).
+
+------------------------------------------------------------------------------
+4.25. erlang                                       *ale-linter-options-erlang*
+
+g:ale_erlang_erlc_flags                              *g:ale_erlang_erlc_flags*
+
+  Type: |String|
+  Default: '`''`'
+
+  This variable controls additional parameters passed to `erlc`, such as `-I`
+  or `-pa`.
 
 ===============================================================================
 5. Linter Integration Notes                            *ale-linter-integration*


### PR DESCRIPTION
This pull-request adds support for linting Erlang by using `erlc` (See #248). `erlc` needs to be configured manually in order to find non-standard include files or `parse_transform` modules. For this, I added a new option `g:ale_erlang_erlc_flags`.

As the error format on `parse_transform` errors is different to the usual format, the error handling is split into two steps (check normal error/warning, check `parse_transform` error). I am currently unaware of a better way to achieve this.