### PR TITLE
Fix SwiftLint

### DIFF
--- a/ale_linters/swift/swiftlint.vim
+++ b/ale_linters/swift/swiftlint.vim
@@ -1,9 +1,9 @@
 " Author: David Mohundro <david@mohundro.com>
 " Description: swiftlint for swift files
 
-call ale#linter#Define('swiftlint', {
+call ale#linter#Define('swift', {
 \   'name': 'swiftlint',
 \   'executable': 'swiftlint',
-\   'command': g:ale#util#stdin_wrapper . ' .swift swiftlint',
+\   'command': 'swiftlint lint --use-stdin',
 \   'callback': 'ale#handlers#HandleGCCFormat',
 \})


### PR DESCRIPTION
1. Should be defined for 'swift' files, not 'swiftlint'.
2. Filepath should be supplied with `--path`, otherwise `swiftlint` cmd
treats is as a subcommand to run.