### PR TITLE
Fix parsing of currently shown signs with Spanish locale

### DIFF
--- a/autoload/ale/sign.vim
+++ b/autoload/ale/sign.vim
@@ -42,7 +42,8 @@ function! ale#sign#ParseSigns(line_list) abort
     " line=4  id=1  name=ALEErrorSign
     " строка=1  id=1000001  имя=ALEErrorSign
     " 行=1  識別子=1000001  名前=ALEWarningSign
-    let l:pattern = '^.*=\d*  .*=\(\d\+\)  .*=ALE\(Warning\|Error\|Dummy\)Sign'
+    " línea=12 id=1000001 nombre=ALEWarningSign
+    let l:pattern = '^.*=\d*\s\+.*=\(\d\+\)\s\+.*=ALE\(Warning\|Error\|Dummy\)Sign'
 
     let l:id_list = []
 

--- a/test/test_sign_parsing.vader
+++ b/test/test_sign_parsing.vader
@@ -6,3 +6,6 @@ Execute (Parsing Russian signs should work):
 
 Execute (Parsing Japanese signs should work):
   AssertEqual [1000001], ale#sign#ParseSigns(['    行=1  識別子=1000001  名前=ALEWarningSign'])
+
+Execute (Parsing Spanish signs should work):
+  AssertEqual [1000001], ale#sign#ParseSigns(['    línea=12 id=1000001 nombre=ALEWarningSign'])


### PR DESCRIPTION
Usually, the sign column should disappear when a linter is run and it has nothing to complain about. This stopped working for me with commit https://github.com/w0rp/ale/commit/8df2444ec487903cbb7018a3550e71ab7f006288 . Not sure why, but when using the Spanish locale, there is only one space instead of two which separates the columns. This patch fixes the parsing.