### PR TITLE
Fix the go build linter

### DIFF
--- a/ale_linters/go/gobuild.vim
+++ b/ale_linters/go/gobuild.vim
@@ -1,7 +1,7 @@
 " Author: dzhou121 <dzhou121@gmail.com>, Ryan Norris <rynorris@gmail.com>
 " Description: go build for Go files
 
-function! s:FindGobuildScript() abort
+function! ale_linters#go#gobuild#GetCommand(buffer) abort
     " Get absolute path to the directory containing the current file.
     " This directory by definition contains all the files for this go package.
     let l:this_package = expand('%:p:h')
@@ -36,13 +36,10 @@ function! s:FindGobuildScript() abort
     return g:ale#util#stdin_wrapper . ' .go go tool compile -I ' . l:import_path . ' -o /dev/null ' . join(l:all_files)
 endfunction
 
-let g:ale#util#gobuild_script =
-\   get(g:, 'ale_go_gobuild_script', s:FindGobuildScript())
-
 call ale#linter#Define('go', {
 \   'name': 'go build',
 \   'output_stream': 'stdout',
 \   'executable': 'go',
-\   'command': g:ale#util#gobuild_script,
+\   'command_callback': 'ale_linters#go#gobuild#GetCommand',
 \   'callback': 'ale#handlers#HandleUnixFormatAsError',
 \})

--- a/ale_linters/go/gobuild.vim
+++ b/ale_linters/go/gobuild.vim
@@ -1,4 +1,4 @@
-" Author: dzhou121 <dzhou121@gmail.com>
+" Author: dzhou121 <dzhou121@gmail.com>, Ryan Norris <rynorris@gmail.com>
 " Description: go build for Go files
 
 function! s:FindGobuildScript() abort

--- a/ale_linters/go/gobuild.vim
+++ b/ale_linters/go/gobuild.vim
@@ -14,12 +14,12 @@ function! ale_linters#go#gobuild#GetCommand(buffer) abort
     " We'll then pass this list to go compile and stdin_wrapper will add on
     " the temporary version of the current file.
     let l:this_file = expand('%:p:t')
-    call filter(l:all_files, 'fnamemodify(v:val, ":t") != l:this_file')
+    call filter(l:all_files, 'fnamemodify(v:val, '':t'') != l:this_file')
 
     " We're also going to need the system information in order to find the
     " correct import directory.  We'll pull these from go itself since then
     " we're guaranteed they'll match what it's looking for.
-    " The version string is of the form "go version go1.6.2 darwin/amd64".
+    " The version string is of the form 'go version go1.6.2 darwin/amd64'.
     let l:go_version_string = system('go version')
     let l:version_part = substitute(l:go_version_string, '.* ', '', '')
     let l:goos = substitute(l:version_part, '/.*', '', '')

--- a/ale_linters/go/gobuild.vim
+++ b/ale_linters/go/gobuild.vim
@@ -7,6 +7,7 @@ function! s:FindGobuildScript() abort
     let l:this_package = expand('%:p:h')
 
     " Get a listing of all go files in the directory.
+    " TODO: Handle packages that contain c files.
     let l:all_files = globpath(l:this_package, '*.go', 1, 1)
 
     " Filter out the current file since we don't want to include it twice.

--- a/ale_linters/go/gobuild.vim
+++ b/ale_linters/go/gobuild.vim
@@ -2,9 +2,12 @@
 " Description: go build for Go files
 
 function! ale_linters#go#gobuild#GetCommand(buffer) abort
+    " Get name of buffer the command is being run in.
+    let l:this_bufname = bufname(a:buffer)
+    "
     " Get absolute path to the directory containing the current file.
     " This directory by definition contains all the files for this go package.
-    let l:this_package = expand('%:p:h')
+    let l:this_package = fnamemodify(l:this_bufname, ':p:h')
 
     " Get a listing of all go files in the directory.
     " TODO: Handle packages that contain c files.
@@ -13,7 +16,7 @@ function! ale_linters#go#gobuild#GetCommand(buffer) abort
     " Filter out the current file since we don't want to include it twice.
     " We'll then pass this list to go compile and stdin_wrapper will add on
     " the temporary version of the current file.
-    let l:this_file = expand('%:p:t')
+    let l:this_file = fnamemodify(l:this_bufname, ':p:t')
     call filter(l:all_files, 'fnamemodify(v:val, '':t'') != l:this_file')
 
     " We're also going to need the system information in order to find the
@@ -34,17 +37,11 @@ function! ale_linters#go#gobuild#GetCommand(buffer) abort
     " On Unix, the value is a colon-separated string.
     " On Windows, the value is a semicolon-separated string.
     " On Plan 9, the value is a list.
-    let l:unix_oses = ['android', 'darwin', 'dragonfly', 'freebsd', 'linux',
-                      \'nacl', 'netbsd', 'openbsd', 'solaris']
-    if index(l:unix_oses, l:goos) >= 0
+    if has('unix')
       let l:gopaths = split($GOPATH, ':')
-    elseif l:goos ==# 'windows'
-      let l:gopaths = split($GOPATH, ';')
-    elseif l:goos ==# 'plan9'
-      " No idea if vim handles list-type environment variables properly.
-      let l:gopaths = $GOPATH
     else
-      echoerr 'Unknown value for GOOS: ' . l:goos
+      " Assume windows,  just ignore Plan 9.
+      let l:gopaths = split($GOPATH, ';')
     endif
 
     let l:import_args = map(l:gopaths, '''-I '' . v:val . ''/pkg/'' . l:goos . ''_'' . l:goarch')

--- a/ale_linters/go/gobuild.vim
+++ b/ale_linters/go/gobuild.vim
@@ -2,7 +2,37 @@
 " Description: go build for Go files
 
 function! s:FindGobuildScript() abort
-    return g:ale#util#stdin_wrapper . ' .go go build -o /dev/null'
+    " Get absolute path to the directory containing the current file.
+    " This directory by definition contains all the files for this go package.
+    let l:this_package = expand('%:p:h')
+
+    " Get a listing of all go files in the directory.
+    let l:all_files = globpath(l:this_package, '*.go', 1, 1)
+
+    " Filter out the current file since we don't want to include it twice.
+    " We'll then pass this list to go compile and stdin_wrapper will add on
+    " the temporary version of the current file.
+    let l:this_file = expand('%:p:t')
+    call filter(l:all_files, 'fnamemodify(v:val, ":t") != l:this_file')
+
+    " We're also going to need the system information in order to find the
+    " correct import directory.  We'll pull these from go itself since then
+    " we're guaranteed they'll match what it's looking for.
+    " The version string is of the form "go version go1.6.2 darwin/amd64".
+    let l:go_version_string = system('go version')
+    let l:version_part = substitute(l:go_version_string, '.* ', '', '')
+    let l:goos = substitute(l:version_part, '/.*', '', '')
+    let l:goarch = substitute(l:version_part, '.*/', '', '')
+
+    " goarch comes with a troublesome trailing newline,  so strip that off.
+    let l:goarch = substitute(l:goarch, '\n\+$', '', '')
+
+    " Finally build the import path.
+    " TODO: Handle GOPATHs that contain multiple directories.
+    let l:gopath = $GOPATH
+    let l:import_path = l:gopath . '/pkg/' . l:goos . '_' . l:goarch
+
+    return g:ale#util#stdin_wrapper . ' .go go tool compile -I ' . l:import_path . ' -o /dev/null ' . join(l:all_files)
 endfunction
 
 let g:ale#util#gobuild_script =
@@ -10,7 +40,7 @@ let g:ale#util#gobuild_script =
 
 call ale#linter#Define('go', {
 \   'name': 'go build',
-\   'output_stream': 'stderr',
+\   'output_stream': 'stdout',
 \   'executable': 'go',
 \   'command': g:ale#util#gobuild_script,
 \   'callback': 'ale#handlers#HandleUnixFormatAsError',

--- a/ale_linters/go/gobuild.vim
+++ b/ale_linters/go/gobuild.vim
@@ -38,9 +38,9 @@ function! ale_linters#go#gobuild#GetCommand(buffer) abort
                       \'nacl', 'netbsd', 'openbsd', 'solaris']
     if index(l:unix_oses, l:goos) >= 0
       let l:gopaths = split($GOPATH, ':')
-    elseif l:goos == 'windows'
+    elseif l:goos ==# 'windows'
       let l:gopaths = split($GOPATH, ';')
-    elseif l:goos == 'plan9'
+    elseif l:goos ==# 'plan9'
       " No idea if vim handles list-type environment variables properly.
       let l:gopaths = $GOPATH
     else

--- a/ale_linters/go/gobuild.vim
+++ b/ale_linters/go/gobuild.vim
@@ -49,7 +49,7 @@ function! ale_linters#go#gobuild#GetCommand(buffer) abort
 
     let l:import_args = map(l:gopaths, '''-I '' . v:val . ''/pkg/'' . l:goos . ''_'' . l:goarch')
 
-    return g:ale#util#stdin_wrapper . ' .go go tool compile ' . join(l:import_args) . ' -o /dev/null ' . join(l:all_files)
+    return g:ale#util#stdin_wrapper . ' .go go tool compile ' . join(l:import_args) . ' -o '. g:ale#util#nul_file . join(l:all_files)
 endfunction
 
 call ale#linter#Define('go', {

--- a/ale_linters/go/gobuild.vim
+++ b/ale_linters/go/gobuild.vim
@@ -40,7 +40,7 @@ function! ale_linters#go#gobuild#GetCommand(buffer) abort
       let l:gopaths = split($GOPATH, ':')
     elseif l:goos == 'windows'
       let l:gopaths = split($GOPATH, ';')
-    elseif l:goos = 'plan9'
+    elseif l:goos == 'plan9'
       " No idea if vim handles list-type environment variables properly.
       let l:gopaths = $GOPATH
     else

--- a/ale_linters/go/gobuild.vim
+++ b/ale_linters/go/gobuild.vim
@@ -46,7 +46,7 @@ function! ale_linters#go#gobuild#GetCommand(buffer) abort
 
     let l:import_args = map(l:gopaths, '''-I '' . v:val . ''/pkg/'' . l:goos . ''_'' . l:goarch')
 
-    return g:ale#util#stdin_wrapper . ' .go go tool compile ' . join(l:import_args) . ' -o '. g:ale#util#nul_file . join(l:all_files)
+    return g:ale#util#stdin_wrapper . ' .go go tool compile ' . join(l:import_args) . ' -o /dev/null ' . join(l:all_files)
 endfunction
 
 call ale#linter#Define('go', {


### PR DESCRIPTION
Fixes #234 

In order to get around the fact that "go build" wants all your files to be in one directory,  and we don't want to copy all the files to the temp directory,  I've worked around it by building up a command using the underlying "go compile" to achieve the same result.

Open Issues:

- Won't work if your GOPATH has multiple directories.
- Won't work if your package contains .c/.h files (ie. not pure go).
- I've only tested it on OSX.  I don't have another system to test on :(
- Dependent modules must be already built.  It will not compile dependencies,  and expects them to already be present in the $GOPATH/pkg directory.

Even with those problems,  I believe this will work in MOST cases.

Things I DID test and definitely do work:

- Linting a single file.
- Linting a _test.go test file.
- Linting multiple files in different splits (and from different packages).