### PR TITLE
Add ALEInfo command to get list of available/enabled linters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ test: test-setup
 		echo "Running tests for $$vim"; \
 		echo '========================================'; \
 		echo; \
-		docker run -it $(DOCKER_FLAGS) $$vim '+Vader! test/*' || EXIT=$$?; \
+		docker run -a stderr $(DOCKER_FLAGS) $$vim '+Vader! test/*' || EXIT=$$?; \
 	done; \
 	echo; \
 	echo '========================================'; \

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ test: test-setup
 		echo "Running tests for $$vim"; \
 		echo '========================================'; \
 		echo; \
-		docker run -a stderr $(DOCKER_FLAGS) $$vim '+Vader! test/*' || EXIT=$$?; \
+		docker run -it $(DOCKER_FLAGS) $$vim '+Vader! test/*' || EXIT=$$?; \
 	done; \
 	echo; \
 	echo '========================================'; \

--- a/plugin/ale.vim
+++ b/plugin/ale.vim
@@ -138,6 +138,9 @@ command! ALEPreviousWrap :call ale#loclist_jumping#Jump('before', 1)
 command! ALENext :call ale#loclist_jumping#Jump('after', 0)
 command! ALENextWrap :call ale#loclist_jumping#Jump('after', 1)
 
+" Define command to get information about current filetype.
+command! ALEInfo :call ale#linter#Info()
+
 " <Plug> mappings for commands
 nnoremap <silent> <Plug>(ale_previous) :ALEPrevious<Return>
 nnoremap <silent> <Plug>(ale_previous_wrap) :ALEPreviousWrap<Return>

--- a/test/test_ale_info.vader
+++ b/test/test_ale_info.vader
@@ -1,0 +1,102 @@
+Before:
+  let g:testlinter1 = {'name': 'testlinter1', 'executable': 'testlinter1', 'command': 'testlinter1', 'callback': 'testCB1', 'output_stream': 'stdout'}
+  let g:testlinter2 = {'name': 'testlinter2', 'executable': 'testlinter2', 'command': 'testlinter2', 'callback': 'testCB2', 'output_stream': 'stdout'}
+
+  call ale#linter#Reset()
+  let g:ale_linters = {}
+  let g:ale_linter_aliases = {}
+
+Given nolintersft (Empty buffer):
+Do (ALEInfo with no linters):
+  :redir @a\<Enter>
+  :ALEInfo\<Enter>
+  :redir END\<Enter>
+  "aP
+Expect (Test ALEInfo works with no available linters):
+
+   Current Filetype: nolintersft
+  Available Linters: []
+    Enabled Linters: []
+
+Given (Empty buffer):
+Do (ALEInfo with no filetype):
+  :redir @a\<Enter>
+  :ALEInfo\<Enter>
+  :redir END\<Enter>
+  "aP
+Expect (Test ALEInfo works with no filetype):
+
+   Current Filetype: 
+  Available Linters: []
+    Enabled Linters: []
+
+Given testft (Empty buffer):
+Do (Define one linter and ALEInfo):
+  :call ale#linter#Define('testft', g:testlinter1)\<Enter>
+  :redir @a\<Enter>
+  :ALEInfo\<Enter>
+  :redir END\<Enter>
+  "aP
+Expect (Test ALEInfo works with a single linter):
+
+   Current Filetype: testft
+  Available Linters: ['testlinter1']
+    Enabled Linters: ['testlinter1']
+
+Given testft (Empty buffer):
+Do (Define two linters and ALEInfo):
+  :call ale#linter#Define('testft', g:testlinter1)\<Enter>
+  :call ale#linter#Define('testft', g:testlinter2)\<Enter>
+  :redir @a\<Enter>
+  :ALEInfo\<Enter>
+  :redir END\<Enter>
+  "aP
+Expect (Test ALEInfo works with multiple linters):
+
+   Current Filetype: testft
+  Available Linters: ['testlinter1', 'testlinter2']
+    Enabled Linters: ['testlinter1', 'testlinter2']
+
+Given testft (Empty buffer):
+Do (Define two linters, enable only one and ALEInfo):
+  :call ale#linter#Define('testft', g:testlinter1)\<Enter>
+  :call ale#linter#Define('testft', g:testlinter2)\<Enter>
+  :let g:ale_linters = { 'testft': ['testlinter2'] }\<Enter>
+  :redir @a\<Enter>
+  :ALEInfo\<Enter>
+  :redir END\<Enter>
+  "aP
+Expect (Test ALEInfo calculates enabled linters correctly):
+
+   Current Filetype: testft
+  Available Linters: ['testlinter1', 'testlinter2']
+    Enabled Linters: ['testlinter2']
+
+Given testft (Empty buffer):
+Do (Define linters for two filetypes and ALEInfo):
+  :call ale#linter#Define('testft', g:testlinter1)\<Enter>
+  :call ale#linter#Define('testft2', g:testlinter2)\<Enter>
+  :redir @a\<Enter>
+  :ALEInfo\<Enter>
+  :redir END\<Enter>
+  "aP
+Expect (Test ALEInfo only returns linters for current filetype):
+
+   Current Filetype: testft
+  Available Linters: ['testlinter1']
+    Enabled Linters: ['testlinter1']
+
+Given testft.testft2 (Empty buffer with two filetypes):
+Do (Define linters for two filetypes and ALEInfo):
+  :call ale#linter#Define('testft', g:testlinter1)\<Enter>
+  :call ale#linter#Define('testft2', g:testlinter2)\<Enter>
+  :redir @a\<Enter>
+  :ALEInfo\<Enter>
+  :redir END\<Enter>
+  "aP
+Expect (Test ALEInfo works with compound filetypes):
+
+   Current Filetype: testft.testft2
+  Available Linters: ['testlinter1', 'testlinter2']
+    Enabled Linters: ['testlinter1', 'testlinter2']
+

--- a/test/test_ale_info.vader
+++ b/test/test_ale_info.vader
@@ -6,96 +6,86 @@ Before:
   let g:ale_linters = {}
   let g:ale_linter_aliases = {}
 
-Given nolintersft (Empty buffer):
-Do (ALEInfo with no linters):
-  :redir @a\<Enter>
-  :silent ALEInfo\<Enter>
-  :redir END\<Enter>
-  "aP
-Expect (Test ALEInfo works with no available linters):
+After:
+  unlet! g:output
 
-   Current Filetype: nolintersft
-  Available Linters: []
-    Enabled Linters: []
+Given nolintersft (Empty buffer with no linters):
+Execute (ALEInfo with no linters should return the right output):
+  redir => g:output
+  silent ALEInfo
+  redir END
+  AssertEqual "\n
+              \ Current Filetype: nolintersft\n
+              \Available Linters: []\n
+              \  Enabled Linters: []", g:output
 
-Given (Empty buffer):
-Do (ALEInfo with no filetype):
-  :redir @a\<Enter>
-  :silent ALEInfo\<Enter>
-  :redir END\<Enter>
-  "aP
-Expect (Test ALEInfo works with no filetype):
-
-   Current Filetype: 
-  Available Linters: []
-    Enabled Linters: []
-
-Given testft (Empty buffer):
-Do (Define one linter and ALEInfo):
-  :call ale#linter#Define('testft', g:testlinter1)\<Enter>
-  :redir @a\<Enter>
-  :silent ALEInfo\<Enter>
-  :redir END\<Enter>
-  "aP
-Expect (Test ALEInfo works with a single linter):
-
-   Current Filetype: testft
-  Available Linters: ['testlinter1']
-    Enabled Linters: ['testlinter1']
+Given (Empty buffer with no filetype):
+Execute (ALEInfo with no filetype should return the right output):
+  redir => g:output
+  silent ALEInfo
+  redir END
+  AssertEqual "\n
+              \ Current Filetype: \n
+              \Available Linters: []\n
+              \  Enabled Linters: []", g:output
 
 Given testft (Empty buffer):
-Do (Define two linters and ALEInfo):
-  :call ale#linter#Define('testft', g:testlinter1)\<Enter>
-  :call ale#linter#Define('testft', g:testlinter2)\<Enter>
-  :redir @a\<Enter>
-  :silent ALEInfo\<Enter>
-  :redir END\<Enter>
-  "aP
-Expect (Test ALEInfo works with multiple linters):
-
-   Current Filetype: testft
-  Available Linters: ['testlinter1', 'testlinter2']
-    Enabled Linters: ['testlinter1', 'testlinter2']
+Execute (ALEInfo with a single linter should return the right output):
+  call ale#linter#Define('testft', g:testlinter1)
+  redir => g:output
+  silent ALEInfo
+  redir END
+  AssertEqual "\n
+              \ Current Filetype: testft\n
+              \Available Linters: ['testlinter1']\n
+              \  Enabled Linters: ['testlinter1']", g:output
 
 Given testft (Empty buffer):
-Do (Define two linters, enable only one and ALEInfo):
-  :call ale#linter#Define('testft', g:testlinter1)\<Enter>
-  :call ale#linter#Define('testft', g:testlinter2)\<Enter>
-  :let g:ale_linters = { 'testft': ['testlinter2'] }\<Enter>
-  :redir @a\<Enter>
-  :silent ALEInfo\<Enter>
-  :redir END\<Enter>
-  "aP
-Expect (Test ALEInfo calculates enabled linters correctly):
-
-   Current Filetype: testft
-  Available Linters: ['testlinter1', 'testlinter2']
-    Enabled Linters: ['testlinter2']
+Execute (ALEInfo with two linters should return the right output):
+  call ale#linter#Define('testft', g:testlinter1)
+  call ale#linter#Define('testft', g:testlinter2)
+  redir => g:output
+  silent ALEInfo
+  redir END
+  AssertEqual "\n
+              \ Current Filetype: testft\n
+              \Available Linters: ['testlinter1', 'testlinter2']\n
+              \  Enabled Linters: ['testlinter1', 'testlinter2']", g:output
 
 Given testft (Empty buffer):
-Do (Define linters for two filetypes and ALEInfo):
-  :call ale#linter#Define('testft', g:testlinter1)\<Enter>
-  :call ale#linter#Define('testft2', g:testlinter2)\<Enter>
-  :redir @a\<Enter>
-  :silent ALEInfo\<Enter>
-  :redir END\<Enter>
-  "aP
-Expect (Test ALEInfo only returns linters for current filetype):
+Execute (ALEInfo should calculate enabled linters correctly):
+  call ale#linter#Define('testft', g:testlinter1)
+  call ale#linter#Define('testft', g:testlinter2)
+  let g:ale_linters = { 'testft': ['testlinter2'] }
+  redir => g:output
+  silent ALEInfo
+  redir END
+  AssertEqual "\n
+              \ Current Filetype: testft\n
+              \Available Linters: ['testlinter1', 'testlinter2']\n
+              \  Enabled Linters: ['testlinter2']", g:output
 
-   Current Filetype: testft
-  Available Linters: ['testlinter1']
-    Enabled Linters: ['testlinter1']
+Given testft (Empty buffer):
+Execute (ALEInfo should only return linters for current filetype):
+  call ale#linter#Define('testft', g:testlinter1)
+  call ale#linter#Define('testft2', g:testlinter2)
+  redir => g:output
+  silent ALEInfo
+  redir END
+  AssertEqual "\n
+              \ Current Filetype: testft\n
+              \Available Linters: ['testlinter1']\n
+              \  Enabled Linters: ['testlinter1']", g:output
 
 Given testft.testft2 (Empty buffer with two filetypes):
-Do (Define linters for two filetypes and ALEInfo):
-  :call ale#linter#Define('testft', g:testlinter1)\<Enter>
-  :call ale#linter#Define('testft2', g:testlinter2)\<Enter>
-  :redir @a\<Enter>
-  :silent ALEInfo\<Enter>
-  :redir END\<Enter>
-  "aP
-Expect (Test ALEInfo works with compound filetypes):
+Execute (ALEInfo with compound filetypes should return linters for both of them):
+  call ale#linter#Define('testft', g:testlinter1)
+  call ale#linter#Define('testft2', g:testlinter2)
+  redir => g:output
+  silent ALEInfo
+  redir END
+  AssertEqual "\n
+              \ Current Filetype: testft.testft2\n
+              \Available Linters: ['testlinter1', 'testlinter2']\n
+              \  Enabled Linters: ['testlinter1', 'testlinter2']", g:output
 
-   Current Filetype: testft.testft2
-  Available Linters: ['testlinter1', 'testlinter2']
-    Enabled Linters: ['testlinter1', 'testlinter2']

--- a/test/test_ale_info.vader
+++ b/test/test_ale_info.vader
@@ -9,7 +9,7 @@ Before:
 Given nolintersft (Empty buffer):
 Do (ALEInfo with no linters):
   :redir @a\<Enter>
-  :ALEInfo\<Enter>
+  :silent ALEInfo\<Enter>
   :redir END\<Enter>
   "aP
 Expect (Test ALEInfo works with no available linters):
@@ -21,7 +21,7 @@ Expect (Test ALEInfo works with no available linters):
 Given (Empty buffer):
 Do (ALEInfo with no filetype):
   :redir @a\<Enter>
-  :ALEInfo\<Enter>
+  :silent ALEInfo\<Enter>
   :redir END\<Enter>
   "aP
 Expect (Test ALEInfo works with no filetype):
@@ -34,7 +34,7 @@ Given testft (Empty buffer):
 Do (Define one linter and ALEInfo):
   :call ale#linter#Define('testft', g:testlinter1)\<Enter>
   :redir @a\<Enter>
-  :ALEInfo\<Enter>
+  :silent ALEInfo\<Enter>
   :redir END\<Enter>
   "aP
 Expect (Test ALEInfo works with a single linter):
@@ -48,7 +48,7 @@ Do (Define two linters and ALEInfo):
   :call ale#linter#Define('testft', g:testlinter1)\<Enter>
   :call ale#linter#Define('testft', g:testlinter2)\<Enter>
   :redir @a\<Enter>
-  :ALEInfo\<Enter>
+  :silent ALEInfo\<Enter>
   :redir END\<Enter>
   "aP
 Expect (Test ALEInfo works with multiple linters):
@@ -63,7 +63,7 @@ Do (Define two linters, enable only one and ALEInfo):
   :call ale#linter#Define('testft', g:testlinter2)\<Enter>
   :let g:ale_linters = { 'testft': ['testlinter2'] }\<Enter>
   :redir @a\<Enter>
-  :ALEInfo\<Enter>
+  :silent ALEInfo\<Enter>
   :redir END\<Enter>
   "aP
 Expect (Test ALEInfo calculates enabled linters correctly):
@@ -77,7 +77,7 @@ Do (Define linters for two filetypes and ALEInfo):
   :call ale#linter#Define('testft', g:testlinter1)\<Enter>
   :call ale#linter#Define('testft2', g:testlinter2)\<Enter>
   :redir @a\<Enter>
-  :ALEInfo\<Enter>
+  :silent ALEInfo\<Enter>
   :redir END\<Enter>
   "aP
 Expect (Test ALEInfo only returns linters for current filetype):
@@ -91,7 +91,7 @@ Do (Define linters for two filetypes and ALEInfo):
   :call ale#linter#Define('testft', g:testlinter1)\<Enter>
   :call ale#linter#Define('testft2', g:testlinter2)\<Enter>
   :redir @a\<Enter>
-  :ALEInfo\<Enter>
+  :silent ALEInfo\<Enter>
   :redir END\<Enter>
   "aP
 Expect (Test ALEInfo works with compound filetypes):
@@ -99,4 +99,3 @@ Expect (Test ALEInfo works with compound filetypes):
    Current Filetype: testft.testft2
   Available Linters: ['testlinter1', 'testlinter2']
     Enabled Linters: ['testlinter1', 'testlinter2']
-


### PR DESCRIPTION
Fixes #228 by adding a direct analog of SyntasticInfo which displays list of available and enabled linters.

Example output:

```
:ALEInfo
 Current Filetype: go
Available Linters: ['go build', 'gofmt', 'golint', 'go vet']
  Enabled Linters: ['go build']
Press ENTER or type command to continue
```