### PR TITLE
Enable Rubocop to exclude files based on config

### DIFF
--- a/ale_linters/ruby/rubocop.vim
+++ b/ale_linters/ruby/rubocop.vim
@@ -43,9 +43,8 @@ endif
 call ale#linter#Define('ruby', {
 \   'name': 'rubocop',
 \   'executable': 'rubocop',
-\   'command': 'rubocop --format emacs --stdin '
+\   'command': 'rubocop --format emacs --force-exclusion --stdin '
 \   . g:ale_ruby_rubocop_options
-\   . ' _',
+\   . ' %s',
 \   'callback': 'ale_linters#ruby#rubocop#Handle',
 \})
-


### PR DESCRIPTION
When using `--stdin`, Rubocop requires that you also pass the associated
file name. ALE was previously passing `_` as the filename. By passing
the actual relative path to the file and enabling the
`--force-exclusion` option, we can get Rubocop to respect excluded files
in the configuration.

Closes #197