### PR TITLE
Tell gcc to use C, not C++, when linting C source files

### DIFF
--- a/ale_linters/c/gcc.vim
+++ b/ale_linters/c/gcc.vim
@@ -10,7 +10,7 @@ if !exists('g:ale_c_gcc_options')
 endif
 
 function! ale_linters#c#gcc#GetCommand(buffer) abort
-    return 'gcc -S -x c++ -fsyntax-only '
+    return 'gcc -S -x c -fsyntax-only '
     \      . g:ale_c_gcc_options . ' -'
 
 endfunction


### PR DESCRIPTION
A regression bug introduced (most likely by accident) here: #232

Maybe related to #278