### PR TITLE
Fix mypy linter line numbers

### DIFF
--- a/ale_linters/python/mypy.vim
+++ b/ale_linters/python/mypy.vim
@@ -19,12 +19,12 @@ endfunction
 function! g:ale_linters#python#mypy#Handle(buffer, lines) abort
     " Look for lines like the following:
     "
-    " file.py:4: error: No library stub file for module 'django.db'
+    " file.py:4:0: error: No library stub file for module 'django.db'
     "
     " Lines like these should be ignored below:
     "
-    " file.py:4: note: (Stub files are from https://github.com/python/typeshed)
-    let l:pattern = '^.\+:\(\d\+\):\?\(\d\+\)\?: \([^:]\+\): \(.\+\)$'
+    " file.py:4:0: note: (Stub files are from https://github.com/python/typeshed)
+    let l:pattern = '^.\+:\(\d\+\):\(\d\+\): \([^:]\+\): \(.\+\)$'
     let l:output = []
 
     for l:line in a:lines

--- a/test/test_mypy_handler.vader
+++ b/test/test_mypy_handler.vader
@@ -14,8 +14,8 @@ Execute(The mypy handler should parse lines correctly):
   \   },
   \ ],
   \ ale_linters#python#mypy#Handle(347, [
-  \   "file.py:4: error: No library stub file for module 'django.db'",
-  \   'file.py:4: note: (Stub files are from https://github.com/python/typeshed)',
+  \   "file.py:4:0: error: No library stub file for module 'django.db'",
+  \   'file.py:4:0: note: (Stub files are from https://github.com/python/typeshed)',
   \ ])
 
 After:


### PR DESCRIPTION
The mypy linter is currently assigning the column of the error as the line number (at least for me running under neovim 0.1.7).  I'm not entirely sure why this is the case, but unconditionally matching the column number fixes the problem.  The column number should always be there anyway, as mypy is always called with the `--show-column-numbers` flag.