### PR TITLE
Add vint support for Neovim commands

### DIFF
--- a/ale_linters/vim/vint.vim
+++ b/ale_linters/vim/vint.vim
@@ -6,6 +6,7 @@ let g:ale_vim_vint_show_style_issues =
 \   get(g:, 'ale_vim_vint_show_style_issues', 1)
 
 let s:warning_flag = g:ale_vim_vint_show_style_issues ? '-s' : '-w'
+let s:enable_neovim = has('nvim') ? ' --enable-neovim ' : ''
 let s:format = '-f "{file_path}:{line_number}:{column_number}: {severity}: {description} (see {reference})"'
 
 call ale#linter#Define('vim', {
@@ -15,6 +16,7 @@ call ale#linter#Define('vim', {
 \       . ' .vim vint '
 \       . s:warning_flag
 \       . ' --no-color '
+\       . s:enable_neovim
 \       . s:format,
 \   'callback': 'ale#handlers#HandleGCCFormat',
 \})


### PR DESCRIPTION
This PR stops vint returning errors like `E492: Not an editor command: tnoremap <silent> <C-s> <C-\><C-n>` when running ale under Neovim.