### PR TITLE
Fix Rubocop filename handling

### DIFF
--- a/ale_linters/ruby/rubocop.vim
+++ b/ale_linters/ruby/rubocop.vim
@@ -6,7 +6,7 @@ function! ale_linters#ruby#rubocop#Handle(buffer, lines) abort
     "
     " <path>/_:47:14: 83:29: C: Prefer single-quoted strings when you don't
     " need string interpolation or special symbols.
-    let l:pattern = '\v_:(\d+):(\d+): (.): (.+)'
+    let l:pattern = '\v:(\d+):(\d+): (.): (.+)'
     let l:output = []
 
     for l:line in a:lines
@@ -34,6 +34,12 @@ function! ale_linters#ruby#rubocop#Handle(buffer, lines) abort
     return l:output
 endfunction
 
+function! ale_linters#ruby#rubocop#GetCommand(_buffer) abort
+  return 'rubocop --format emacs --force-exclusion ' .
+        \ g:ale_ruby_rubocop_options .
+        \ ' --stdin ' . expand('%')
+endfunction
+
 " Set this option to change Rubocop options.
 if !exists('g:ale_ruby_rubocop_options')
     " let g:ale_ruby_rubocop_options = '--lint'
@@ -43,8 +49,6 @@ endif
 call ale#linter#Define('ruby', {
 \   'name': 'rubocop',
 \   'executable': 'rubocop',
-\   'command': 'rubocop --format emacs --force-exclusion --stdin '
-\   . g:ale_ruby_rubocop_options
-\   . ' %s',
+\   'command_callback': 'ale_linters#ruby#rubocop#GetCommand',
 \   'callback': 'ale_linters#ruby#rubocop#Handle',
 \})


### PR DESCRIPTION
In my previous change, I updated the Rubocop linter to pass the filename
to Rubocop. This change was tested on a file I expected Rubocop to
ignore and the experience in vim was as I expected. However, I soon
found that ALE wasn't finding errors in files that should not be
ignored. After investigation, I found a few issues that this commit
fixes:

1. We were not properly passing the current filename. We now use
   `expand` to get the filename.
2. The regular expression used in the callback was expecting the static
   value of `_` for the filename in output. We now use a looser regular
   expression that begins matching on the first `:`.
3. The linter was defined statically. By using the current filename when
   defining the command the linter would always use the filename of the
   first Ruby file the user opened. We now use a `command_callback` to
   inject the proper filename.

I tested these changes on a configuration with included and excluded
files and found it to work as I expected. Apologies for the earlier
incorrect change.