### PR TITLE
Support linters that return warnings/errors for multiple files

### DIFF
--- a/ale_linters/go/gobuild.vim
+++ b/ale_linters/go/gobuild.vim
@@ -164,8 +164,6 @@ endfunction
 let s:path_pattern = '[a-zA-Z]\?\\\?:\?[[:alnum:]/\.\-_]\+'
 let s:handler_pattern = '^\(' . s:path_pattern . '\):\(\d\+\):\?\(\d\+\)\?: \(.\+\)$'
 
-let s:multibuffer = 0
-
 function! ale_linters#go#gobuild#Handler(buffer, lines) abort
   let l:output = []
 
@@ -182,7 +180,7 @@ function! ale_linters#go#gobuild#Handler(buffer, lines) abort
       continue
     endif
 
-    if !s:multibuffer && l:buffer != a:buffer
+    if !g:ale_experimental_multibuffer && l:buffer != a:buffer
       " strip lines from other buffers
       continue
     endif

--- a/ale_linters/go/gobuild.vim
+++ b/ale_linters/go/gobuild.vim
@@ -4,7 +4,7 @@
 " inspired by work from dzhou121 <dzhou121@gmail.com>
 
 function! ale_linters#go#gobuild#GoEnv(buffer) abort
-  if exists('s:go_env')
+  if exists('g:ale_linters#go#gobuild#go_env')
     return ''
   endif
 
@@ -15,15 +15,15 @@ let s:SplitChar = has('unix') ? ':' : ':'
 
 " get a list of all source directories from $GOPATH and $GOROOT
 function! s:SrcDirs() abort
-  let l:paths = split(s:go_env.GOPATH, s:SplitChar)
-  call add(l:paths, s:go_env.GOROOT)
+  let l:paths = split(g:ale_linters#go#gobuild#go_env.GOPATH, s:SplitChar)
+  call add(l:paths, g:ale_linters#go#gobuild#go_env.GOROOT)
 
   return l:paths
 endfunction
 
 " figure out from a directory like `/home/user/go/src/some/package` that the
 " import for that path is simply `some/package`
-function! s:PackageImportPath(buffer) abort
+function! ale_linters#go#gobuild#PackageImportPath(buffer) abort
   let l:bufname = resolve(bufname(a:buffer))
   let l:pkgdir = fnamemodify(l:bufname, ':p:h')
 
@@ -41,13 +41,13 @@ endfunction
 " get the package info data structure using `go list`
 function! ale_linters#go#gobuild#GoList(buffer, goenv_output) abort
   if !empty(a:goenv_output)
-    let s:go_env = {
+    let g:ale_linters#go#gobuild#go_env = {
     \ 'GOPATH': a:goenv_output[0],
     \ 'GOROOT': a:goenv_output[1],
     \}
   endif
 
-  return 'go list -json ' . shellescape(s:PackageImportPath(a:buffer))
+  return 'go list -json ' . shellescape(ale_linters#go#gobuild#PackageImportPath(a:buffer))
 endfunction
 
 let s:filekeys = [
@@ -68,7 +68,7 @@ let s:filekeys = [
 
 " get the go and test go files from the package
 " will return empty list if the package has any cgo or other invalid files
-function! s:PkgFiles(pkginfo) abort
+function! ale_linters#go#gobuild#PkgFiles(pkginfo) abort
   let l:files = []
 
   for l:key in s:filekeys
@@ -83,7 +83,7 @@ endfunction
 
 function! ale_linters#go#gobuild#CopyFiles(buffer, golist_output) abort
   let l:tempdir = tempname()
-  let l:temppkgdir = l:tempdir . '/src/' . s:PackageImportPath(a:buffer)
+  let l:temppkgdir = l:tempdir . '/src/' . ale_linters#go#gobuild#PackageImportPath(a:buffer)
   call mkdir(l:temppkgdir, 'p', 0700)
 
   if empty(a:golist_output)
@@ -94,15 +94,15 @@ function! ale_linters#go#gobuild#CopyFiles(buffer, golist_output) abort
   let l:pkginfo = json_decode(join(a:golist_output, "\n"))
 
   " get all files for the package
-  let l:files = s:PkgFiles(l:pkginfo)
+  let l:files = ale_linters#go#gobuild#PkgFiles(l:pkginfo)
 
   " copy the files to a temp directory with $GOPATH structure
   return 'cp ' . join(l:files, ' ') . ' ' . shellescape(l:temppkgdir) . ' && echo ' . shellescape(l:tempdir)
 endfunction
 
-function! ale_linters#go#gobuild#GetCommand(buffer, copy_output) abort
+function! ale_linters#go#gobuild#WriteBuffers(buffer, copy_output) abort
   let l:tempdir = a:copy_output[0]
-  let l:importpath = s:PackageImportPath(a:buffer)
+  let l:importpath = ale_linters#go#gobuild#PackageImportPath(a:buffer)
 
   " write the a:buffer and any modified buffers from the package to the tempdir
   for l:bufnum in range(1, bufnr('$'))
@@ -119,7 +119,7 @@ function! ale_linters#go#gobuild#GetCommand(buffer, copy_output) abort
     " only consider buffers other than a:buffer if they have the same import
     " path as a:buffer and are modified
     if l:bufnum != a:buffer
-      if s:PackageImportPath(l:bufnum) !=# l:importpath
+      if ale_linters#go#gobuild#PackageImportPath(l:bufnum) !=# l:importpath
         continue
       endif
 
@@ -128,30 +128,36 @@ function! ale_linters#go#gobuild#GetCommand(buffer, copy_output) abort
       endif
     endif
 
-    call writefile(getbufline(l:bufnum, 1, '$'), l:tempdir . '/src/' . s:PkgFile(l:bufnum))
+    call writefile(getbufline(l:bufnum, 1, '$'), l:tempdir . '/src/' . ale_linters#go#gobuild#PkgFile(l:bufnum))
   endfor
 
+  return 'echo ' . shellescape(l:tempdir)
+endfunction
+
+function! ale_linters#go#gobuild#GetCommand(buffer, copy_output) abort
+  let l:tempdir = a:copy_output[0]
+  let l:importpath = ale_linters#go#gobuild#PackageImportPath(a:buffer)
   let l:gopaths = [ l:tempdir ]
-  call extend(l:gopaths, split(s:go_env.GOPATH, s:SplitChar))
+  call extend(l:gopaths, split(g:ale_linters#go#gobuild#go_env.GOPATH, s:SplitChar))
 
   return 'GOPATH=' . shellescape(join(l:gopaths, s:SplitChar)) . ' go test -c -o /dev/null ' . shellescape(l:importpath)
 endfunction
 
-function! s:PkgFile(buffer) abort
+function! ale_linters#go#gobuild#PkgFile(buffer) abort
   let l:bufname = resolve(bufname(a:buffer))
-  let l:importpath = s:PackageImportPath(a:buffer)
+  let l:importpath = ale_linters#go#gobuild#PackageImportPath(a:buffer)
   let l:fname = fnamemodify(l:bufname, ':t')
 
   return l:importpath . '/' . l:fname
 endfunction
 
-function! s:FindBuffer(file) abort
+function! ale_linters#go#gobuild#FindBuffer(file) abort
   for l:buffer in range(1, bufnr('$'))
     if !buflisted(l:buffer)
       continue
     endif
 
-    let l:pkgfile = s:PkgFile(l:buffer)
+    let l:pkgfile = ale_linters#go#gobuild#PkgFile(l:buffer)
 
     if a:file =~ '/' . l:pkgfile . '$'
       return l:buffer
@@ -174,13 +180,13 @@ function! ale_linters#go#gobuild#Handler(buffer, lines) abort
       continue
     endif
 
-    let l:buffer = s:FindBuffer(l:match[1])
+    let l:buffer = ale_linters#go#gobuild#FindBuffer(l:match[1])
 
     if l:buffer == -1
       continue
     endif
 
-    if !g:ale_experimental_multibuffer && l:buffer != a:buffer
+    if !get(g:, 'ale_experimental_multibuffer', 0) && l:buffer != a:buffer
       " strip lines from other buffers
       continue
     endif
@@ -206,6 +212,7 @@ call ale#linter#Define('go', {
 \     {'callback': 'ale_linters#go#gobuild#GoEnv', 'output_stream': 'stdout'},
 \     {'callback': 'ale_linters#go#gobuild#GoList', 'output_stream': 'stdout'},
 \     {'callback': 'ale_linters#go#gobuild#CopyFiles', 'output_stream': 'stdout'},
+\     {'callback': 'ale_linters#go#gobuild#WriteBuffers', 'output_stream': 'stdout'},
 \     {'callback': 'ale_linters#go#gobuild#GetCommand', 'output_stream': 'stderr'},
 \   ],
 \   'callback': 'ale_linters#go#gobuild#Handler',

--- a/autoload/ale/engine.vim
+++ b/autoload/ale/engine.vim
@@ -201,6 +201,16 @@ function! s:FixLocList(buffer, loclist) abort
     let l:last_line_number = ale#util#GetLineCount(a:buffer)
 
     for l:item in a:loclist
+        if g:ale_experimental_multibuffer
+            let l:bufnr = a:buffer
+
+            if has_key(l:item, 'bufnr') && l:item.bufnr >= 0
+              let l:bufnr = l:item.bufnr
+            endif
+
+            let l:last_line_number = ale#util#GetLineCount(l:bufnr)
+        endif
+
         if l:item.lnum == 0
             " When errors appear at line 0, put them at line 1 instead.
             let l:item.lnum = 1

--- a/autoload/ale/sign.vim
+++ b/autoload/ale/sign.vim
@@ -67,10 +67,14 @@ endfunction
 " Given a loclist, combine the loclist into a list of signs such that only
 " one sign appears per line. Error lines will take precedence.
 " The loclist will have been previously sorted.
-function! ale#sign#CombineSigns(loclist) abort
+function! ale#sign#CombineSigns(buffer, loclist) abort
     let l:signlist = []
 
     for l:obj in a:loclist
+        if g:ale_experimental_multibuffer && has_key(l:obj, 'bufnr') && l:obj.bufnr >= 0 && l:obj.bufnr != a:buffer
+          continue
+        endif
+
         let l:should_append = 1
 
         if l:obj.lnum < 1
@@ -100,7 +104,7 @@ endfunction
 
 " This function will set the signs which show up on the left.
 function! ale#sign#SetSigns(buffer, loclist) abort
-    let l:signlist = ale#sign#CombineSigns(a:loclist)
+    let l:signlist = ale#sign#CombineSigns(a:buffer, a:loclist)
 
     " Find the current markers
     let l:current_id_list = ale#sign#FindCurrentSigns(a:buffer)

--- a/plugin/ale.vim
+++ b/plugin/ale.vim
@@ -119,6 +119,10 @@ if g:ale_echo_cursor
     augroup END
 endif
 
+" Experimental support for showing warnings/errors in buffers other than the one
+" being linted
+let g:ale_experimental_multibuffer = get(g:, 'ale_experimental_multibuffer', 0)
+
 " String format for statusline
 " Its a list where:
 " * The 1st element is for errors


### PR DESCRIPTION
This support must be explicitly enabled with:

```vim
let g:ale_experimental_multibuffer = 1
```

* Currently it works correctly for loclist/quickfix
* It does not attempt to update Signs on buffers other than the one that caused the linting
* Counts are derived from the number of errors the linter returned in total, not just for the file that caused the linting