### PR TITLE
add gometalinter

### DIFF
--- a/ale_linters/go/gobuild.vim
+++ b/ale_linters/go/gobuild.vim
@@ -4,7 +4,7 @@
 " inspired by work from dzhou121 <dzhou121@gmail.com>
 
 function! ale_linters#go#gobuild#GoEnv(buffer) abort
-  if exists('s:go_env')
+  if exists('g:ale_linters#go#gobuild#go_env')
     return ''
   endif
 
@@ -15,15 +15,15 @@ let s:SplitChar = has('unix') ? ':' : ':'
 
 " get a list of all source directories from $GOPATH and $GOROOT
 function! s:SrcDirs() abort
-  let l:paths = split(s:go_env.GOPATH, s:SplitChar)
-  call add(l:paths, s:go_env.GOROOT)
+  let l:paths = split(g:ale_linters#go#gobuild#go_env.GOPATH, s:SplitChar)
+  call add(l:paths, g:ale_linters#go#gobuild#go_env.GOROOT)
 
   return l:paths
 endfunction
 
 " figure out from a directory like `/home/user/go/src/some/package` that the
 " import for that path is simply `some/package`
-function! s:PackageImportPath(buffer) abort
+function! ale_linters#go#gobuild#PackageImportPath(buffer) abort
   let l:bufname = resolve(bufname(a:buffer))
   let l:pkgdir = fnamemodify(l:bufname, ':p:h')
 
@@ -41,13 +41,13 @@ endfunction
 " get the package info data structure using `go list`
 function! ale_linters#go#gobuild#GoList(buffer, goenv_output) abort
   if !empty(a:goenv_output)
-    let s:go_env = {
+    let g:ale_linters#go#gobuild#go_env = {
     \ 'GOPATH': a:goenv_output[0],
     \ 'GOROOT': a:goenv_output[1],
     \}
   endif
 
-  return 'go list -json ' . shellescape(s:PackageImportPath(a:buffer))
+  return 'go list -json ' . shellescape(ale_linters#go#gobuild#PackageImportPath(a:buffer))
 endfunction
 
 let s:filekeys = [
@@ -68,7 +68,7 @@ let s:filekeys = [
 
 " get the go and test go files from the package
 " will return empty list if the package has any cgo or other invalid files
-function! s:PkgFiles(pkginfo) abort
+function! ale_linters#go#gobuild#PkgFiles(pkginfo) abort
   let l:files = []
 
   for l:key in s:filekeys
@@ -83,7 +83,7 @@ endfunction
 
 function! ale_linters#go#gobuild#CopyFiles(buffer, golist_output) abort
   let l:tempdir = tempname()
-  let l:temppkgdir = l:tempdir . '/src/' . s:PackageImportPath(a:buffer)
+  let l:temppkgdir = l:tempdir . '/src/' . ale_linters#go#gobuild#PackageImportPath(a:buffer)
   call mkdir(l:temppkgdir, 'p', 0700)
 
   if empty(a:golist_output)
@@ -94,15 +94,15 @@ function! ale_linters#go#gobuild#CopyFiles(buffer, golist_output) abort
   let l:pkginfo = json_decode(join(a:golist_output, "\n"))
 
   " get all files for the package
-  let l:files = s:PkgFiles(l:pkginfo)
+  let l:files = ale_linters#go#gobuild#PkgFiles(l:pkginfo)
 
   " copy the files to a temp directory with $GOPATH structure
   return 'cp ' . join(l:files, ' ') . ' ' . shellescape(l:temppkgdir) . ' && echo ' . shellescape(l:tempdir)
 endfunction
 
-function! ale_linters#go#gobuild#GetCommand(buffer, copy_output) abort
+function! ale_linters#go#gobuild#WriteBuffers(buffer, copy_output) abort
   let l:tempdir = a:copy_output[0]
-  let l:importpath = s:PackageImportPath(a:buffer)
+  let l:importpath = ale_linters#go#gobuild#PackageImportPath(a:buffer)
 
   " write the a:buffer and any modified buffers from the package to the tempdir
   for l:bufnum in range(1, bufnr('$'))
@@ -119,7 +119,7 @@ function! ale_linters#go#gobuild#GetCommand(buffer, copy_output) abort
     " only consider buffers other than a:buffer if they have the same import
     " path as a:buffer and are modified
     if l:bufnum != a:buffer
-      if s:PackageImportPath(l:bufnum) !=# l:importpath
+      if ale_linters#go#gobuild#PackageImportPath(l:bufnum) !=# l:importpath
         continue
       endif
 
@@ -128,30 +128,36 @@ function! ale_linters#go#gobuild#GetCommand(buffer, copy_output) abort
       endif
     endif
 
-    call writefile(getbufline(l:bufnum, 1, '$'), l:tempdir . '/src/' . s:PkgFile(l:bufnum))
+    call writefile(getbufline(l:bufnum, 1, '$'), l:tempdir . '/src/' . ale_linters#go#gobuild#PkgFile(l:bufnum))
   endfor
 
+  return 'echo ' . shellescape(l:tempdir)
+endfunction
+
+function! ale_linters#go#gobuild#GetCommand(buffer, copy_output) abort
+  let l:tempdir = a:copy_output[0]
+  let l:importpath = ale_linters#go#gobuild#PackageImportPath(a:buffer)
   let l:gopaths = [ l:tempdir ]
-  call extend(l:gopaths, split(s:go_env.GOPATH, s:SplitChar))
+  call extend(l:gopaths, split(g:ale_linters#go#gobuild#go_env.GOPATH, s:SplitChar))
 
   return 'GOPATH=' . shellescape(join(l:gopaths, s:SplitChar)) . ' go test -c -o /dev/null ' . shellescape(l:importpath)
 endfunction
 
-function! s:PkgFile(buffer) abort
+function! ale_linters#go#gobuild#PkgFile(buffer) abort
   let l:bufname = resolve(bufname(a:buffer))
-  let l:importpath = s:PackageImportPath(a:buffer)
+  let l:importpath = ale_linters#go#gobuild#PackageImportPath(a:buffer)
   let l:fname = fnamemodify(l:bufname, ':t')
 
   return l:importpath . '/' . l:fname
 endfunction
 
-function! s:FindBuffer(file) abort
+function! ale_linters#go#gobuild#FindBuffer(file) abort
   for l:buffer in range(1, bufnr('$'))
     if !buflisted(l:buffer)
       continue
     endif
 
-    let l:pkgfile = s:PkgFile(l:buffer)
+    let l:pkgfile = ale_linters#go#gobuild#PkgFile(l:buffer)
 
     if a:file =~ '/' . l:pkgfile . '$'
       return l:buffer
@@ -164,8 +170,6 @@ endfunction
 let s:path_pattern = '[a-zA-Z]\?\\\?:\?[[:alnum:]/\.\-_]\+'
 let s:handler_pattern = '^\(' . s:path_pattern . '\):\(\d\+\):\?\(\d\+\)\?: \(.\+\)$'
 
-let s:multibuffer = 0
-
 function! ale_linters#go#gobuild#Handler(buffer, lines) abort
   let l:output = []
 
@@ -176,13 +180,13 @@ function! ale_linters#go#gobuild#Handler(buffer, lines) abort
       continue
     endif
 
-    let l:buffer = s:FindBuffer(l:match[1])
+    let l:buffer = ale_linters#go#gobuild#FindBuffer(l:match[1])
 
     if l:buffer == -1
       continue
     endif
 
-    if !s:multibuffer && l:buffer != a:buffer
+    if !get(g:, 'ale_experimental_multibuffer', 0) && l:buffer != a:buffer
       " strip lines from other buffers
       continue
     endif
@@ -208,6 +212,7 @@ call ale#linter#Define('go', {
 \     {'callback': 'ale_linters#go#gobuild#GoEnv', 'output_stream': 'stdout'},
 \     {'callback': 'ale_linters#go#gobuild#GoList', 'output_stream': 'stdout'},
 \     {'callback': 'ale_linters#go#gobuild#CopyFiles', 'output_stream': 'stdout'},
+\     {'callback': 'ale_linters#go#gobuild#WriteBuffers', 'output_stream': 'stdout'},
 \     {'callback': 'ale_linters#go#gobuild#GetCommand', 'output_stream': 'stderr'},
 \   ],
 \   'callback': 'ale_linters#go#gobuild#Handler',

--- a/ale_linters/go/gometalinter.vim
+++ b/ale_linters/go/gometalinter.vim
@@ -25,7 +25,6 @@ function! ale_linters#go#gometalinter#Handler(buffer, lines) abort
   let l:output = []
 
   for l:line in a:lines
-    echomsg l:line
     let l:match = matchlist(l:line, s:handler_pattern)
 
     if len(l:match) == 0

--- a/ale_linters/go/gometalinter.vim
+++ b/ale_linters/go/gometalinter.vim
@@ -1,0 +1,71 @@
+let s:SplitChar = has('unix') ? ':' : ':'
+
+let g:ale_linters#go#gometalinter#args = get(g:, 'ale_linters#go#gometalinter#args', [
+\   '--fast',
+\   '--tests',
+\ ])
+
+function! s:Args() abort
+  return join(map(copy(g:ale_linters#go#gometalinter#args), 'shellescape(v:val)'), ' ')
+endfunction
+
+function! ale_linters#go#gometalinter#GetCommand(buffer, copy_output) abort
+  let l:tempdir = a:copy_output[0]
+  let l:importpath = ale_linters#go#gobuild#PackageImportPath(a:buffer)
+  let l:gopaths = [ l:tempdir ]
+  call extend(l:gopaths, split(g:ale_linters#go#gobuild#go_env.GOPATH, s:SplitChar))
+
+  return 'GOPATH=' . shellescape(join(l:gopaths, s:SplitChar)) . ' gometalinter ' . s:Args() . ' ' . shellescape(l:tempdir . '/src/' . l:importpath)
+endfunction
+
+let s:path_pattern = '[a-zA-Z]\?\\\?:\?[[:alnum:]/\.\-_]\+'
+let s:handler_pattern = '^\(' . s:path_pattern . '\):\(\d\+\):\?\(\d\+\)\?:\?\([a-zA-Z]\+\): \(.\+\)$'
+
+function! ale_linters#go#gometalinter#Handler(buffer, lines) abort
+  let l:output = []
+
+  for l:line in a:lines
+    echomsg l:line
+    let l:match = matchlist(l:line, s:handler_pattern)
+
+    if len(l:match) == 0
+      continue
+    endif
+
+    let l:buffer = ale_linters#go#gobuild#FindBuffer(l:match[1])
+
+    if l:buffer == -1
+      continue
+    endif
+
+    if !get(g:, 'ale_experimental_multibuffer', 0) && l:buffer != a:buffer
+      " strip lines from other buffers
+      continue
+    endif
+
+    call add(l:output, {
+    \   'bufnr': l:buffer,
+    \   'lnum': l:match[2] + 0,
+    \   'vcol': 0,
+    \   'col': l:match[3] + 0,
+    \   'text': l:match[5],
+    \   'type': toupper(l:match[4][0]),
+    \   'nr': -1,
+    \})
+  endfor
+
+  return l:output
+endfunction
+
+call ale#linter#Define('go', {
+\   'name': 'gometalinter',
+\   'executable': 'gometalinter',
+\   'command_chain': [
+\     {'callback': 'ale_linters#go#gobuild#GoEnv', 'output_stream': 'stdout'},
+\     {'callback': 'ale_linters#go#gobuild#GoList', 'output_stream': 'stdout'},
+\     {'callback': 'ale_linters#go#gobuild#CopyFiles', 'output_stream': 'stdout'},
+\     {'callback': 'ale_linters#go#gobuild#WriteBuffers', 'output_stream': 'stdout'},
+\     {'callback': 'ale_linters#go#gometalinter#GetCommand', 'output_stream': 'stdout'},
+\   ],
+\   'callback': 'ale_linters#go#gometalinter#Handler',
+\})

--- a/autoload/ale/util.vim
+++ b/autoload/ale/util.vim
@@ -90,6 +90,17 @@ function! ale#util#LocItemCompare(left, right) abort
         return 1
     endif
 
+    " put warnings after errors (for the same line) since the text that shows
+    " when the cursor is moved will show only the first entry
+
+    if a:left['type'] < a:right['type']
+      return -1
+    endif
+
+    if a:left['type'] > a:right['type']
+      return 1
+    endif
+
     if a:left['col'] < a:right['col']
         return -1
     endif

--- a/test/test_loclist_sorting.vader
+++ b/test/test_loclist_sorting.vader
@@ -1,9 +1,10 @@
 Before:
   let g:loclist = [
-  \ {'lnum': 5, 'col': 5},
-  \ {'lnum': 5, 'col': 4},
-  \ {'lnum': 2, 'col': 10},
-  \ {'lnum': 3, 'col': 2},
+  \ {'lnum': 5, 'col': 5, 'type': 'W'},
+  \ {'lnum': 5, 'col': 4, 'type': 'W'},
+  \ {'lnum': 2, 'col': 10, 'type': 'W'},
+  \ {'lnum': 3, 'col': 2, 'type': 'W'},
+  \ {'lnum': 3, 'col': 1, 'type': 'E'},
   \]
 
 Execute (Sort loclist with comparison function):
@@ -11,10 +12,11 @@ Execute (Sort loclist with comparison function):
 
 Then (loclist item should be sorted):
   AssertEqual [
-  \ {'lnum': 2, 'col': 10},
-  \ {'lnum': 3, 'col': 2},
-  \ {'lnum': 5, 'col': 4},
-  \ {'lnum': 5, 'col': 5},
+  \ {'lnum': 2, 'col': 10, 'type': 'W'},
+  \ {'lnum': 3, 'col': 1, 'type': 'E'},
+  \ {'lnum': 3, 'col': 2, 'type': 'W'},
+  \ {'lnum': 5, 'col': 4, 'type': 'W'},
+  \ {'lnum': 5, 'col': 5, 'type': 'W'},
   \], g:loclist
 
 After:


### PR DESCRIPTION
It would be nice to find a way to put this combine several lint commands within the `gobuild` linter so that files are only copied once. This linter has a different handler pattern though.