### PR TITLE
Pass the buffer's filename to Credo

### DIFF
--- a/ale_linters/elixir/credo.vim
+++ b/ale_linters/elixir/credo.vim
@@ -3,8 +3,8 @@
 function! ale_linters#elixir#credo#Handle(buffer, lines) abort
   " Matches patterns line the following:
   "
-  " stdin:19: F: Pipe chain should start with a raw value.
-  let l:pattern = '\v^stdin:(\d+):?(\d+)?: (.): (.+)$'
+  " lib/filename.ex:19:7: F: Pipe chain should start with a raw value.
+  let l:pattern = '\v^.+:(\d+):?(\d+)?: (.): (.+)$'
   let l:output = []
 
   for l:line in a:lines
@@ -41,5 +41,5 @@ endfunction
 call ale#linter#Define('elixir', {
       \ 'name': 'credo',
       \ 'executable': 'mix',
-      \ 'command': 'mix credo suggest --format=flycheck --read-from-stdin',
+      \ 'command': 'mix credo suggest --format=flycheck --read-from-stdin %s',
       \ 'callback': 'ale_linters#elixir#credo#Handle' })


### PR DESCRIPTION
By default, Credo attributes input from STDIN as though it came from a
file named `stdin`. This change passes the buffer's filename, too, so
that Credo can use that information when applying its configuration.

This is a nice improvement because files like `mix.exs` are normally
excluded from Credo-based linting. Previously, ALE would show lint
warnings for those files as they were edited. Now, they are correctly
honor the Credo configuration and don't produce lint output.