### PR TITLE
Update line marker pattern for new gfortran

### DIFF
--- a/ale_linters/fortran/gcc.vim
+++ b/ale_linters/fortran/gcc.vim
@@ -12,7 +12,7 @@ function! ale_linters#fortran#gcc#Handle(buffer, lines) abort
     "
     " :21.34:
     " Error: Expected comma in I/O list at (1)
-    let l:line_marker_pattern = '^:\(\d\+\)\.\(\d\+\):$'
+    let l:line_marker_pattern = ':\(\d\+\)[.:]\=\(\d\+\)\=:\=$'
     let l:message_pattern = '^\(Error\|Warning\): \(.\+\)$'
     let l:looking_for_message = 0
     let l:last_loclist_obj = {}

--- a/test/test_fortran_handler.vader
+++ b/test/test_fortran_handler.vader
@@ -1,0 +1,118 @@
+Execute(The fortran handler should parse lines from GCC 4.1.2 correctly):
+  runtime ale_linters/fortran/gcc.vim
+
+  AssertEqual
+  \ [
+  \   {
+  \     'bufnr': 357,
+  \     'lnum': 4,
+  \     'vcol': 0,
+  \     'col': 0,
+  \     'text': "Symbol ‘b’ at (1) has no IMPLICIT type",
+  \     'type': 'E',
+  \     'nr': -1,
+  \   },
+  \   {
+  \     'bufnr': 357,
+  \     'lnum': 3,
+  \     'vcol': 0,
+  \     'col': 0,
+  \     'text': "Symbol ‘a’ at (1) has no IMPLICIT type",
+  \     'type': 'E',
+  \     'nr': -1,
+  \   },
+  \ ],
+  \ ale_linters#fortran#gcc#Handle(357, [
+  \   " In file :4",
+  \   "",
+  \   "write(*,*) b",
+  \   "           1",
+  \   "Error: Symbol ‘b’ at (1) has no IMPLICIT type",
+  \   " In file :3",
+  \   "",
+  \   "write(*,*) a",
+  \   "           1",
+  \   "Error: Symbol ‘a’ at (1) has no IMPLICIT type",
+  \ ])
+
+After:
+  call ale#linter#Reset()
+
+
+Execute(The fortran handler should parse lines from GCC 4.9.3 correctly):
+  runtime ale_linters/fortran/gcc.vim
+
+  AssertEqual
+  \ [
+  \   {
+  \     'bufnr': 357,
+  \     'lnum': 3,
+  \     'vcol': 0,
+  \     'col': 12,
+  \     'text': "Symbol ‘a’ at (1) has no IMPLICIT type",
+  \     'type': 'E',
+  \     'nr': -1,
+  \   },
+  \   {
+  \     'bufnr': 357,
+  \     'lnum': 4,
+  \     'vcol': 0,
+  \     'col': 12,
+  \     'text': "Symbol ‘b’ at (1) has no IMPLICIT type",
+  \     'type': 'E',
+  \     'nr': -1,
+  \   },
+  \ ],
+  \ ale_linters#fortran#gcc#Handle(357, [
+  \   ":3.12:",
+  \   "",
+  \   "write(*,*) a",
+  \   "           1",
+  \   "Error: Symbol ‘a’ at (1) has no IMPLICIT type",
+  \   ":4.12:",
+  \   "",
+  \   "write(*,*) b",
+  \   "           1",
+  \   "Error: Symbol ‘b’ at (1) has no IMPLICIT type",
+  \ ])
+
+After:
+  call ale#linter#Reset()
+
+
+
+Execute(The fortran handler should parse lines from GCC 6.3.1 correctly):
+  runtime ale_linters/fortran/gcc.vim
+
+  AssertEqual
+  \ [
+  \   {
+  \     'bufnr': 337,
+  \     'lnum': 3,
+  \     'vcol': 0,
+  \     'col': 12,
+  \     'text': "Symbol ‘a’ at (1) has no IMPLICIT type",
+  \     'type': 'E',
+  \     'nr': -1,
+  \   },
+  \   {
+  \     'bufnr': 337,
+  \     'lnum': 4,
+  \     'vcol': 0,
+  \     'col': 12,
+  \     'text': "Symbol ‘b’ at (1) has no IMPLICIT type",
+  \     'type': 'E',
+  \     'nr': -1,
+  \   },
+  \ ],
+  \ ale_linters#fortran#gcc#Handle(337, [
+  \   "<stdin>:3:12:",
+  \   "",
+  \   "Error: Symbol ‘a’ at (1) has no IMPLICIT type",
+  \   "<stdin>:4:12:",
+  \   "",
+  \   "Error: Symbol ‘b’ at (1) has no IMPLICIT type",
+  \ ])
+
+After:
+  call ale#linter#Reset()


### PR DESCRIPTION
On my system the gfortran linter did not work, I suspect this to be due to a change in the output format.
I've generalized the regex slightly so that it matches my output also.