### PR TITLE
Add yamllint option to pass in more options

### DIFF
--- a/ale_linters/yaml/yamllint.vim
+++ b/ale_linters/yaml/yamllint.vim
@@ -1,5 +1,21 @@
 " Author: KabbAmine <amine.kabb@gmail.com>
 
+let g:ale_yaml_yamllint_executable =
+\   get(g:, 'ale_yaml_yamllint_executable', 'yamllint')
+
+let g:ale_yaml_yamllint_options =
+\   get(g:, 'ale_yaml_yamllint_options', '')
+
+function! ale_linters#yaml#yamllint#GetExecutable(buffer) abort
+    return g:ale_yaml_yamllint_executable
+endfunction
+
+function! ale_linters#yaml#yamllint#GetCommand(buffer) abort
+    return ale_linters#yaml_yamllint#GetExecutable(a:buffer)
+    \   . ' ' . g:ale_yaml_yamllint_options
+    \   . ' -f parsable %t'
+endfunction
+
 function! ale_linters#yaml#yamllint#Handle(buffer, lines) abort
     " Matches patterns line the following:
     " something.yaml:1:1: [warning] missing document start "---" (document-start)
@@ -36,7 +52,7 @@ endfunction
 
 call ale#linter#Define('yaml', {
 \   'name': 'yamllint',
-\   'executable': 'yamllint',
-\   'command': 'yamllint -f parsable %t',
+\   'executable_callback': 'ale_linters#yaml#yamllint#GetExecutable',
+\   'command_callback': 'ale_linters#yaml#yamllint#GetCommand',
 \   'callback': 'ale_linters#yaml#yamllint#Handle',
 \})

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -40,6 +40,7 @@ CONTENTS                                                         *ale-contents*
     4.28. phpmd...........................|ale-linter-options-phpmd|
     4.29. xo..............................|ale-linter-options-xo|
     4.30. javac...........................|ale-linter-options-javac|
+    4.31. yamllint........................|ale-linter-options-yamllint|
   5. Linter Integration Notes.............|ale-linter-integration|
     5.1.  merlin..........................|ale-linter-integration-ocaml-merlin|
     5.2. rust.............................|ale-integration-rust|
@@ -975,6 +976,24 @@ g:ale_java_javac_options                             *g:ale_java_javac_options*
   Default: `''`
 
   This variable can be set to pass additional options to javac.
+
+------------------------------------------------------------------------------
+4.31. yamllint                                    *ale-linter-options-yamllint*
+
+g:ale_yaml_yamllint_executable                 *g:ale_yaml_yamllint_executable*
+
+  Type: |String|
+  Default: `'yamllint'`
+
+  This variable can be set to change the path to yamllint.
+
+
+g:ale_yaml_yamllint_options                       *g:ale_yaml_yamllint_options*
+
+  Type: |String|
+  Default: `''`
+
+  This variable can be set to pass additional options to yamllint.
 
 ===============================================================================
 5. Linter Integration Notes                            *ale-linter-integration*


### PR DESCRIPTION
Need more options.

I'm not sure that the global variables is needed here. (if they are not used explicitly)
```viml
if exists('g:ale_yaml_yamllint_executable')
  return g:ale_yaml_yamllint_executable
endif
```