### PR TITLE
Fix Credo's line-matching pattern

### DIFF
--- a/ale_linters/elixir/credo.vim
+++ b/ale_linters/elixir/credo.vim
@@ -4,7 +4,7 @@ function! ale_linters#elixir#credo#Handle(buffer, lines) abort
   " Matches patterns line the following:
   "
   " lib/filename.ex:19:7: F: Pipe chain should start with a raw value.
-  let l:pattern = '\v^.+:(\d+):?(\d+)?: (.): (.+)$'
+  let l:pattern = '\v:(\d+):?(\d+)?: (.): (.+)$'
   let l:output = []
 
   for l:line in a:lines

--- a/test/test_credo_handler.vader
+++ b/test/test_credo_handler.vader
@@ -1,0 +1,33 @@
+Execute(The credo handler should parse lines correctly):
+  runtime ale_linters/elixir/credo.vim
+
+  AssertEqual
+  \ [
+  \   {
+  \     'bufnr': 347,
+  \     'lnum': 1,
+  \     'vcol': 0,
+  \     'col': 4,
+  \     'text': 'There is no whitespace around parentheses/brackets most of the time, but here there is.',
+  \     'type': 'E',
+  \     'nr': -1,
+  \   },
+  \   {
+  \     'bufnr': 347,
+  \     'lnum': 26,
+  \     'vcol': 0,
+  \     'col': 0,
+  \     'text': 'If/else blocks should not have a negated condition in `if`.',
+  \     'type': 'W',
+  \     'nr': -1,
+  \   },
+  \ ],
+  \ ale_linters#elixir#credo#Handle(347, [
+  \   'This line should be ignored completely',
+  \   'lib/filename.ex:1:4: C: There is no whitespace around parentheses/brackets most of the time, but here there is.',
+  \   'lib/phoenix/channel.ex:26: R: If/else blocks should not have a negated condition in `if`.',
+  \ ])
+
+After:
+  call ale#linter#Reset()
+


### PR DESCRIPTION
In d3e7d3d5, the line matching pattern was changed to handle filenames
other than `stdin`. Unfortunately, this broke the pattern's ability to
reliably extract both line and column numbers because the latter is an
optional match and the filename portion was very greedy. This resulted
in line numbers being discarded (treated as part of the filename) and
column numbers being interpreted as line numbers.

This change simplifies the pattern to only anchor on the line's suffix,
ignoring the filename portion entirely.

Alternatively, we could use vim's `\f` ("file name characters") class,
but that could still run into problems when `:`'s naturally appear in
the filename.