### PR TITLE
Add the pylint symbol name for the msg_id of the error/warning.

### DIFF
--- a/ale_linters/python/pylint.vim
+++ b/ale_linters/python/pylint.vim
@@ -14,7 +14,7 @@ endfunction
 function! ale_linters#python#pylint#GetCommand(buffer) abort
     return ale_linters#python#pylint#GetExecutable(a:buffer)
     \   . ' ' . g:ale_python_pylint_options
-    \   . ' --output-format text --msg-template="{path}:{line}:{column}: {msg_id} {msg}" --reports n'
+    \   . ' --output-format text --msg-template="{path}:{line}:{column}: {msg_id} ({symbol}) {msg}" --reports n'
     \   . ' %t'
 endfunction
 


### PR DESCRIPTION
Would like to see the Pylint symbol in the error/warning message. This makes it easier to add "ignore" comments in the code. Since Pylint is recommending that the symbol be used instead of the msg_id, this change shows the symbol as well.