### PR TITLE
Use latest C++ standard

### DIFF
--- a/ale_linters/cpp/clang.vim
+++ b/ale_linters/cpp/clang.vim
@@ -3,10 +3,7 @@
 
 " Set this option to change the Clang options for warnings for CPP.
 if !exists('g:ale_cpp_clang_options')
-    " let g:ale_cpp_clang_options = '-Wall'
-    " let g:ale_cpp_clang_options = '-std=c99 -Wall'
-    " c11 compatible
-    let g:ale_cpp_clang_options = '-std=c11 -Wall'
+    let g:ale_cpp_clang_options = '-std=c++14 -Wall'
 endif
 
 call ale#linter#Define('cpp', {

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -758,7 +758,7 @@ g:ale_c_clang_options                                   *g:ale_c_clang_options*
 g:ale_cpp_clang_options                               *g:ale_cpp_clang_options*
 
   Type: |String|
-  Default: `'-std=c11 -Wall'`
+  Default: `'-std=c++14 -Wall'`
 
   This variable can be changed to modify flags given to clang.
 


### PR DESCRIPTION
The linter for C++ should use the standard for C++.