### PR TITLE
Fix PHP column matching for unexpected single quotes

### DIFF
--- a/ale_linters/php/php.vim
+++ b/ale_linters/php/php.vim
@@ -5,7 +5,7 @@ function! ale_linters#php#php#Handle(buffer, lines) abort
     " Matches patterns like the following:
     "
     " PHP Parse error:  syntax error, unexpected ';', expecting ']' in - on line 15
-    let l:pattern = 'Parse error:\s\+\(.\{-}unexpected ''\(.\{-}\)''.\{-}\|.*\) in - on line \(\d\+\)'
+    let l:pattern = 'Parse error:\s\+\(.\{-}unexpected ''\(.\+\)\%(expecting.\+\)\@<!''.\{-}\|.\+\) in - on line \(\d\+\)'
 
     let l:output = []
 

--- a/ale_linters/php/php.vim
+++ b/ale_linters/php/php.vim
@@ -5,7 +5,7 @@ function! ale_linters#php#php#Handle(buffer, lines) abort
     " Matches patterns like the following:
     "
     " PHP Parse error:  syntax error, unexpected ';', expecting ']' in - on line 15
-    let l:pattern = 'Parse error:\s\+\(.\{-}unexpected ''\(.\+\)\%(expecting.\+\)\@<!''.\{-}\|.\+\) in - on line \(\d\+\)'
+    let l:pattern = '\vParse error:\s+(.+unexpected ''(.+)%(expecting.+)@<!''.*|.+) in - on line (\d+)'
 
     let l:output = []
 

--- a/test/test_php_handler.vader
+++ b/test/test_php_handler.vader
@@ -1,3 +1,9 @@
+Given (Some invalid lines of PHP):
+  [foo;]
+  class Foo { / }
+  $foo)
+  ['foo' 'bar']
+
 Execute(The php handler should parse lines correctly):
   runtime ale_linters/php/php.vim
 
@@ -5,30 +11,30 @@ Execute(The php handler should parse lines correctly):
   \ [
   \   {
   \     'bufnr': 347,
-  \     'lnum': 47,
-  \     'col': 0,
+  \     'lnum': 1,
+  \     'col': 5,
   \     'text': "syntax error, unexpected ';', expecting ']'",
   \     'type': 'E',
   \   },
   \   {
   \     'bufnr': 347,
-  \     'lnum': 56,
-  \     'col': 0,
+  \     'lnum': 2,
+  \     'col': 13,
   \     'text': "syntax error, unexpected '/', expecting function (T_FUNCTION) or const (T_CONST)",
   \     'type': 'E',
   \   },
   \   {
   \     'bufnr': 347,
-  \     'lnum': 13,
-  \     'col': 0,
+  \     'lnum': 3,
+  \     'col': 5,
   \     'text': "syntax error, unexpected ')'",
   \     'type': 'E',
   \   },
   \   {
   \     'bufnr': 347,
-  \     'lnum': 5,
-  \     'col': 0,
-  \     'text': "Invalid numeric literal",
+  \     'lnum': 4,
+  \     'col': 8,
+  \     'text': "syntax error, unexpected ''bar'' (T_CONSTANT_ENCAPSED_STRING), expecting ']'",
   \     'type': 'E',
   \   },
   \   {
@@ -38,14 +44,22 @@ Execute(The php handler should parse lines correctly):
   \     'text': "syntax error, unexpected end of file",
   \     'type': 'E',
   \   },
+  \   {
+  \     'bufnr': 347,
+  \     'lnum': 47,
+  \     'col': 0,
+  \     'text': "Invalid numeric literal",
+  \     'type': 'E',
+  \   },
   \ ],
   \ ale_linters#php#php#Handle(347, [
   \   'This line should be ignored completely',
-  \   "PHP Parse error:  syntax error, unexpected ';', expecting ']' in - on line 47",
-  \   "PHP Parse error:  syntax error, unexpected '/', expecting function (T_FUNCTION) or const (T_CONST) in - on line 56",
-  \   "PHP Parse error:  syntax error, unexpected ')' in - on line 13",
-  \   'PHP Parse error: Invalid numeric literal in - on line 5',
+  \   "PHP Parse error:  syntax error, unexpected ';', expecting ']' in - on line 1",
+  \   "PHP Parse error:  syntax error, unexpected '/', expecting function (T_FUNCTION) or const (T_CONST) in - on line 2",
+  \   "PHP Parse error:  syntax error, unexpected ')' in - on line 3",
+  \   "PHP Parse error:  syntax error, unexpected ''bar'' (T_CONSTANT_ENCAPSED_STRING), expecting ']' in - on line 4",
   \   'PHP Parse error:  syntax error, unexpected end of file in - on line 21',
+  \   'PHP Parse error: Invalid numeric literal in - on line 47',
   \ ])
 
 After:


### PR DESCRIPTION
Unexpected single quotes resulted in an empty match, because PHP
surrounds the errors with quotes, and we check for the next quote to be
the ending delimiter.

For example: an unexpected string 'foo' would be presented as
`unexpected ''foo''`, and then the match would be `''`. The inner part
of that match is an empty string.

This adds a check for the keyword "expecting". Any quote after
"expecting" won't be matched, so we can use greedy matching instead of
non-greedy.

I also cleaned up the pattern a bit and added tests for the column matches.