### PR TITLE
WIP: Add support for error details

### DIFF
--- a/ale_linters/elm/make.vim
+++ b/ale_linters/elm/make.vim
@@ -25,6 +25,7 @@ function! ale_linters#elm#make#Handle(buffer, lines) abort
                     \    'col': l:error.region.start.column,
                     \    'type': (l:error.type ==? 'error') ? 'E' : 'W',
                     \    'text': l:error.overview,
+                    \    'detail': l:error.overview . "\n\n" . l:error.details
                     \})
                 endif
             endfor

--- a/autoload/ale/cursor.vim
+++ b/autoload/ale/cursor.vim
@@ -93,3 +93,28 @@ function! ale#cursor#EchoCursorWarningWithDelay() abort
         let s:cursor_timer = timer_start(10, function('ale#cursor#EchoCursorWarning'))
     endif
 endfunction
+
+
+function! ale#cursor#ShowCursorDetail(...) abort
+    " Only show the details in normal mode, otherwise we will get problems.
+    if mode() !=# 'n'
+        return
+    endif
+
+    let l:buffer = bufnr('%')
+
+    if !has_key(g:ale_buffer_info, l:buffer)
+        return
+    endif
+
+    let l:pos = getcurpos()
+    let l:loclist = g:ale_buffer_info[l:buffer].loclist
+    let l:index = ale#util#BinarySearch(l:loclist, l:pos[1], l:pos[2])
+
+    if l:index >= 0
+        let l:loc = l:loclist[l:index]
+        if has_key(l:loc, 'detail')
+            echo l:loc.detail
+        endif
+    endif
+endfunction

--- a/autoload/ale/engine.vim
+++ b/autoload/ale/engine.vim
@@ -332,6 +332,10 @@ function! ale#engine#FixLocList(buffer, linter, loclist) abort
         \   'linter_name': a:linter.name,
         \}
 
+        if has_key(l:old_item, 'detail')
+            let l:item.detail = l:old_item.detail
+        endif
+
         if l:item.lnum == 0
             " When errors appear at line 0, put them at line 1 instead.
             let l:item.lnum = 1

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -1142,7 +1142,6 @@ ALEPrevious                                                       *ALEPrevious*
 ALEPreviousWrap                                               *ALEPreviousWrap*
 ALENext                                                               *ALENext*
 ALENextWrap                                                       *ALENextWrap*
-ALENextWrap                                                       *ALENextWrap*
                                                       *ale-navigation-commands*
 
   Move between warnings or errors in a buffer.

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -1142,6 +1142,7 @@ ALEPrevious                                                       *ALEPrevious*
 ALEPreviousWrap                                               *ALEPreviousWrap*
 ALENext                                                               *ALENext*
 ALENextWrap                                                       *ALENextWrap*
+ALENextWrap                                                       *ALENextWrap*
                                                       *ale-navigation-commands*
 
   Move between warnings or errors in a buffer.
@@ -1172,6 +1173,14 @@ ALEToggle                                                           *ALEToggle*
   Enable or disable ALE, including all of its autocmd events, loclist items,
   quickfix items, signs, current jobs, etc. Calling this option will change
   the |g:ale_enabled| variable.
+
+
+ALEDetail                                                           *ALEDetail*
+
+  Show the full linter message for the current line. This will only have an
+  effect on lines that contain a linter message.
+
+  A plug mapping `<Plug>(ale_detail)` is defined for this command.
 
 ===============================================================================
 7. API                                                                *ale-api*

--- a/plugin/ale.vim
+++ b/plugin/ale.vim
@@ -208,6 +208,9 @@ command! ALEPreviousWrap :call ale#loclist_jumping#Jump('before', 1)
 command! ALENext :call ale#loclist_jumping#Jump('after', 0)
 command! ALENextWrap :call ale#loclist_jumping#Jump('after', 1)
 
+" A command for showing error details.
+command! ALEDetail :call ale#cursor#ShowCursorDetail()
+
 " A command for turning ALE on or off.
 command! ALEToggle :call s:ALEToggle()
 " A command for linting manually.
@@ -225,6 +228,7 @@ nnoremap <silent> <Plug>(ale_next) :ALENext<Return>
 nnoremap <silent> <Plug>(ale_next_wrap) :ALENextWrap<Return>
 nnoremap <silent> <Plug>(ale_toggle) :ALEToggle<Return>
 nnoremap <silent> <Plug>(ale_lint) :ALELint<Return>
+nnoremap <silent> <Plug>(ale_detail) :ALEDetail<Return>
 
 " Housekeeping
 

--- a/test/test_cursor_warnings.vader
+++ b/test/test_cursor_warnings.vader
@@ -95,4 +95,19 @@ Then(Check the cursor output):
     :mess
   redir END
 
-  AssertEqual "Every statement should end with a semicolon", g:output[-1]
+  let g:lines = split(g:output, "\n")
+
+  AssertEqual "Every statement should end with a semicolon", g:lines[-1]
+
+Execute(Evaluate the cursor detail function at line 2):
+  :2
+  call ale#cursor#ShowCursorDetail()
+
+Then(Check the cursor output):
+  redir => g:output
+    :mess
+  redir END
+
+  let g:lines = split(g:output, "\n")
+
+  AssertEqual "Infix operators must be spaced. (space-infix-ops)", g:lines[-1]

--- a/test/test_cursor_warnings.vader
+++ b/test/test_cursor_warnings.vader
@@ -10,7 +10,8 @@ Before:
   \       'nr': -1,
   \       'type': 'E',
   \       'col': 10,
-  \       'text': 'Missing semicolon. (semi)'
+  \       'text': 'Missing semicolon. (semi)',
+  \       'detail': 'Every statement should end with a semicolon'
   \     },
   \     {
   \       'lnum': 2,
@@ -84,3 +85,14 @@ Then(Check the cursor output):
   let g:lines = split(g:output, "\n")
 
   AssertEqual 'Missing radix parameter (radix)', g:lines[-1]
+
+Execute(Evaluate the cursor detail function at line 1):
+  :1
+  call ale#cursor#ShowCursorDetail()
+
+Then(Check the cursor output):
+  redir => g:output
+    :mess
+  redir END
+
+  AssertEqual "Every statement should end with a semicolon", g:output[-1]


### PR DESCRIPTION
Fixes #225.

Hey there! I made a start adding error detail support to Ale. I'm pretty new to writing Vimscript, so any feedback is appreciated! The idea is that there's an additional detail field linters can set. A special command and keybinding can be set to display that detail field for the line the cursor is on, if it exists. This makes the addition completely backwards compatible with the way Ale currently works.

Does this seem the correct way forward?

I've added a Vader test for this feature, but I'm having some issue running the tests. It seems that once I run `make` once, the test files are somehow cached. Additional runs do not see to reflect changes made in test files. Is this a known problem and is there a work around?

Thanks!