### PR TITLE
Adds semistandard for javascript

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ name. That seems to be the fairest way to arrange this table.
 | Haskell | [ghc](https://www.haskell.org/ghc/), [hlint](https://hackage.haskell.org/package/hlint) |
 | HTML | [HTMLHint](http://htmlhint.com/), [proselint](http://proselint.com/), [tidy](http://www.html-tidy.org/) |
 | Java | [javac](http://www.oracle.com/technetwork/java/javase/downloads/index.html) |
-| JavaScript | [eslint](http://eslint.org/), [jscs](http://jscs.info/), [jshint](http://jshint.com/), [flow](https://flowtype.org/), [standard](http://standardjs.com/)
+| JavaScript | [eslint](http://eslint.org/), [jscs](http://jscs.info/), [jshint](http://jshint.com/), [flow](https://flowtype.org/), [standard](http://standardjs.com/), [semistandard](https://github.com/Flet/semistandard)
 | JSON | [jsonlint](http://zaa.ch/jsonlint/) |
 | LaTeX | [chktex](http://www.nongnu.org/chktex/), [lacheck](https://www.ctan.org/pkg/lacheck) |
 | Lua | [luacheck](https://github.com/mpeterv/luacheck) |

--- a/ale_linters/javascript/semistandard.vim
+++ b/ale_linters/javascript/semistandard.vim
@@ -1,0 +1,69 @@
+" Author: Eric Mrak <@mrak>
+" Description: semistandard for JavaScript files
+
+let g:ale_javascript_semistandard_executable =
+\   get(g:, 'ale_javascript_semistandard_executable', 'semistandard')
+
+let g:ale_javascript_semistandard_options =
+\   get(g:, 'ale_javascript_semistandard_options', '')
+
+let g:ale_javascript_semistandard_use_global =
+\   get(g:, 'ale_javascript_semistandard_use_global', 0)
+
+function! ale_linters#javascript#semistandard#GetExecutable(buffer) abort
+    if g:ale_javascript_semistandard_use_global
+        return g:ale_javascript_semistandard_executable
+    endif
+
+    return ale#util#ResolveLocalPath(
+    \   a:buffer,
+    \   'node_modules/.bin/semistandard',
+    \   g:ale_javascript_semistandard_executable
+    \)
+endfunction
+
+function! ale_linters#javascript#semistandard#GetCommand(buffer) abort
+    return ale_linters#javascript#semistandard#GetExecutable(a:buffer)
+    \   . ' ' . g:ale_javascript_semistandard_options
+    \   . ' --stdin %s'
+endfunction
+
+function! ale_linters#javascript#semistandard#Handle(buffer, lines) abort
+    " Matches patterns line the following:
+    "
+    " /path/to/some-filename.js:47:14: Strings must use singlequote.
+    " /path/to/some-filename.js:56:41: Expected indentation of 2 spaces but found 4.
+    " /path/to/some-filename.js:13:3: Parsing error: Unexpected token
+    let l:pattern = '^.*:\(\d\+\):\(\d\+\): \(.\+\)$'
+    let l:output = []
+
+    for l:line in a:lines
+        let l:match = matchlist(l:line, l:pattern)
+
+        if len(l:match) == 0
+            continue
+        endif
+
+        let l:type = 'Error'
+        let l:text = l:match[3]
+
+        " vcol is Needed to indicate that the column is a character.
+        call add(l:output, {
+        \   'bufnr': a:buffer,
+        \   'lnum': l:match[1] + 0,
+        \   'col': l:match[2] + 0,
+        \   'text': l:text,
+        \   'type': 'E',
+        \})
+    endfor
+
+    return l:output
+endfunction
+
+call ale#linter#Define('javascript', {
+\   'name': 'semistandard',
+\   'executable_callback': 'ale_linters#javascript#semistandard#GetExecutable',
+\   'command_callback': 'ale_linters#javascript#semistandard#GetCommand',
+\   'callback': 'ale_linters#javascript#semistandard#Handle',
+\})
+

--- a/test/test_semistandard_handler.vader
+++ b/test/test_semistandard_handler.vader
@@ -1,0 +1,38 @@
+Execute(The semistandard handler should parse lines correctly):
+  runtime ale_linters/javascript/semistandard.vim
+
+  AssertEqual
+  \ [
+  \   {
+  \     'bufnr': 347,
+  \     'lnum': 47,
+  \     'col': 14,
+  \     'text': 'Expected indentation of 2 spaces but found 4.',
+  \     'type': 'E',
+  \   },
+  \   {
+  \     'bufnr': 347,
+  \     'lnum': 56,
+  \     'col': 41,
+  \     'text': 'Strings must use singlequote.',
+  \     'type': 'E',
+  \   },
+  \   {
+  \     'bufnr': 347,
+  \     'lnum': 13,
+  \     'col': 3,
+  \     'text': 'Parsing error: Unexpected token',
+  \     'type': 'E',
+  \   },
+  \ ],
+  \ ale_linters#javascript#semistandard#Handle(347, [
+  \   'This line should be ignored completely',
+  \   '/path/to/some-filename.js:47:14: Expected indentation of 2 spaces but found 4.',
+  \   '/path/to/some-filename.js:56:41: Strings must use singlequote.',
+  \   'This line should be ignored completely',
+  \   '/path/to/some-filename.js:13:3: Parsing error: Unexpected token',
+  \ ])
+
+After:
+  call ale#linter#Reset()
+


### PR DESCRIPTION
`semistandard` is identical to `standard`, but enforces semicolon usage. This is more or less a direct copy of the existing `standard` integration.