### PR TITLE
Add support for nix linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ name. That seems to be the fairest way to arrange this table.
 | Lua | [luacheck](https://github.com/mpeterv/luacheck) |
 | Markdown | [mdl](https://github.com/mivok/markdownlint), [proselint](http://proselint.com/)|
 | MATLAB | [mlint](https://www.mathworks.com/help/matlab/ref/mlint.html) |
+| nix | [nix-instantiate](http://nixos.org/nix/manual/#sec-nix-instantiate) |
 | nroff | [proselint](http://proselint.com/)|
 | OCaml | [merlin](https://github.com/the-lambda-church/merlin) see `:help ale-integration-ocaml-merlin` for configuration instructions
 | Perl | [perl -c](https://perl.org/), [perl-critic](https://metacpan.org/pod/Perl::Critic) |

--- a/ale_linters/nix/nix.vim
+++ b/ale_linters/nix/nix.vim
@@ -1,0 +1,34 @@
+" Author: Alistair Bill <@alibabzo>
+" Description: nix-instantiate linter for nix files
+
+function! ale_linters#nix#nix#Handle(buffer, lines) abort
+
+    let l:pattern = '^\(.\+\): \(.\+\), at .*:\(\d\+\):\(\d\+\)$'
+    let l:output = []
+
+    for l:line in a:lines
+        let l:match = matchlist(l:line, l:pattern)
+
+        if len(l:match) == 0
+            continue
+        endif
+
+        call add(l:output, {
+        \   'bufnr': a:buffer,
+        \   'lnum': l:match[3] + 0,
+        \   'col': l:match[4] + 0,
+        \   'text': l:match[1] . ': ' . l:match[2],
+        \   'type': l:match[1] =~# '^error' ? 'E' : 'W',
+        \})
+    endfor
+
+    return l:output
+endfunction
+
+call ale#linter#Define('nix', {
+\   'name': 'nix',
+\   'output_stream': 'stderr',
+\   'executable': 'nix-instantiate',
+\   'command': 'nix-instantiate --parse -',
+\   'callback': 'ale_linters#nix#nix#Handle',
+\})

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -101,6 +101,7 @@ The following languages and tools are supported.
 * Lua: 'luacheck'
 * Markdown: 'mdl', 'proselint'
 * MATLAB: 'mlint'
+* nix: 'nix-instantiate'
 * nroff: 'proselint'
 * OCaml: 'merlin' (see |ale-linter-integration-ocaml-merlin|)
 * Perl: 'perl' (-c flag), 'perlcritic'

--- a/test/test_nix_handler.vader
+++ b/test/test_nix_handler.vader
@@ -1,0 +1,26 @@
+Execute(The nix handler should parse nix-instantiate error messages correctly):
+  runtime ale_linters/nix/nix.vim
+
+  AssertEqual
+  \ [
+  \   {
+  \     'bufnr': 47,
+  \     'lnum': 23,
+  \     'col': 14,
+  \     'text': 'error: syntax error, unexpected IN',
+  \     'type': 'E',
+  \   },
+  \   {
+  \     'bufnr': 47,
+  \     'lnum': 3,
+  \     'col': 12,
+  \     'text': 'error: syntax error, unexpected ''='', expecting '';''',
+  \     'type': 'E',
+  \   },
+  \
+  \ ],
+  \ ale_linters#nix#nix#Handle(47, [
+  \   'This line should be ignored',
+  \   'error: syntax error, unexpected IN, at /path/to/filename.nix:23:14',
+  \   'error: syntax error, unexpected ''='', expecting '';'', at /path/to/filename.nix:3:12',
+  \ ])


### PR DESCRIPTION
This adds support for linting nix files for the [Nix package manager](https://nixos.org/nix/).

I'm not a regex wizard, so there might well be a better way of pattern matching the output of `nix-instantiate`.