### PR TITLE
Write erlc output files to the temporary directory

### DIFF
--- a/ale_linters/erlang/erlc.vim
+++ b/ale_linters/erlang/erlc.vim
@@ -3,7 +3,8 @@
 let g:ale_erlang_erlc_options = get(g:, 'ale_erlang_erlc_options', '')
 
 function! ale_linters#erlang#erlc#GetCommand(buffer) abort
-    return 'erlc ' . g:ale_erlang_erlc_options . ' %t'
+    let l:temp_dir = has('win32') ? $TMP : $TMPDIR
+    return 'erlc -o ' . l:temp_dir . ' ' . g:ale_erlang_erlc_options . ' %t'
 endfunction
 
 function! ale_linters#erlang#erlc#Handle(buffer, lines) abort

--- a/ale_linters/erlang/erlc.vim
+++ b/ale_linters/erlang/erlc.vim
@@ -3,8 +3,9 @@
 let g:ale_erlang_erlc_options = get(g:, 'ale_erlang_erlc_options', '')
 
 function! ale_linters#erlang#erlc#GetCommand(buffer) abort
-    let l:temp_dir = has('win32') ? $TMP : $TMPDIR
-    return 'erlc -o ' . l:temp_dir . ' ' . g:ale_erlang_erlc_options . ' %t'
+    let l:output_file = tempname()
+    call ale#engine#ManageFile(a:buffer, l:output_file)
+    return 'erlc -o ' . fnameescape(l:output_file) . ' ' . g:ale_erlang_erlc_options . ' %t'
 endfunction
 
 function! ale_linters#erlang#erlc#Handle(buffer, lines) abort


### PR DESCRIPTION
In particular, if we're working with a leex (.xrl) or yecc (.yrl) source
file, erlc would otherwise generate the corresponding .erl file in the
current directory (often the project root), which is generally not what
we want.

Unconditionally writing erlc output to a temporary directory also
matches [Flycheck's behavior](https://github.com/flycheck/flycheck/blob/master/flycheck.el#L7014).