### PR TITLE
Fix pattern of output for coffeelint

### DIFF
--- a/ale_linters/coffee/coffeelint.vim
+++ b/ale_linters/coffee/coffeelint.vim
@@ -21,7 +21,7 @@ function! ale_linters#coffee#coffeelint#Handle(buffer, lines) abort
     " stdin,14,,error,Throwing strings is forbidden
     "
     " Note that we currently ignore lineNumberEnd for multiline errors
-    let l:pattern = 'stdin,\(\d\+\),\(\d*\),\(.\+\),\(.\+\)'
+    let l:pattern = 'stdin,\(\d\+\),\(\d*\),\(.\{-1,}\),\(.\+\)'
     let l:output = []
 
     for l:line in a:lines

--- a/test/handler/test_coffeelint_handler.vader
+++ b/test/handler/test_coffeelint_handler.vader
@@ -1,0 +1,20 @@
+Execute(The coffeelint handler should parse lines correctly):
+  runtime ale_linters/coffee/coffeelint.vim
+
+  AssertEqual
+  \ [
+  \   {
+  \     'bufnr': 347,
+  \     'lnum': 125,
+  \     'col': 1,
+  \     'text': "Line exceeds maximum allowed length Length is 122, max is 120.",
+  \     'type': 'E',
+  \   },
+  \ ],
+  \ ale_linters#coffee#coffeelint#Handle(347, [
+  \   "path,lineNumber,lineNumberEnd,level,message",
+  \   "stdin,125,,error,Line exceeds maximum allowed length Length is 122, max is 120.",
+  \ ])
+
+After:
+  call ale#linter#Reset()


### PR DESCRIPTION
Sometimes output of coffeelint contains comma `,` like `max_line_length` error below.

```
Line exceeds maximum allowed length Length is 122, max is 120.
```

This PR fixes it.