### PR TITLE
tslint parameterized executable and config  path

### DIFF
--- a/ale_linters/typescript/tslint.vim
+++ b/ale_linters/typescript/tslint.vim
@@ -4,6 +4,9 @@
 let g:ale_typescript_tslint_executable =
 \   get(g:, 'ale_typescript_tslint_executable', 'tslint')
 
+let g:ale_typescript_tslint_config_path =
+\   get(g:, 'ale_typescript_tslint_config_path', '')
+
 function! ale_linters#typescript#tslint#GetExecutable(buffer) abort
 
   return ale#util#ResolveLocalPath(
@@ -49,8 +52,15 @@ function! ale_linters#typescript#tslint#Handle(buffer, lines) abort
 endfunction
 
 function! ale_linters#typescript#tslint#BuildLintCommand(buffer) abort
-  let l:tsconfig_path = ale#util#FindNearestFile(a:buffer, 'tslint.json')
-  let l:tslint_options = empty(l:tsconfig_path) ? '' : '-c ' . l:tsconfig_path
+  let g:ale_typescript_tslint_config_path = 
+  \   empty(g:ale_typescript_tslint_config_path) ? 
+  \         ale#util#FindNearestFile(a:buffer, 'tslint.json') 
+  \         : g:ale_typescript_tslint_config_path
+
+  let l:tslint_options = 
+  \   empty(g:ale_typescript_tslint_config_path) ? 
+  \         '' 
+  \         : '-c ' . g:ale_typescript_tslint_config_path
 
   return ale_linters#typescript#tslint#GetExecutable(a:buffer)
   \   . ' ' . l:tslint_options

--- a/ale_linters/typescript/tslint.vim
+++ b/ale_linters/typescript/tslint.vim
@@ -1,6 +1,18 @@
 " Author: Prashanth Chandra https://github.com/prashcr
 " Description: tslint for TypeScript files
 
+let g:ale_typescript_tslint_executable =
+\   get(g:, 'ale_typescript_tslint_executable', 'tslint')
+
+function! ale_linters#typescript#tslint#GetExecutable(buffer) abort
+
+  return ale#util#ResolveLocalPath(
+  \   a:buffer,
+  \   'node_modules/.bin/tslint',
+  \   g:ale_typescript_tslint_executable
+  \)
+endfunction
+
 function! ale_linters#typescript#tslint#Handle(buffer, lines) abort
     " Matches patterns like the following:
     "
@@ -40,12 +52,14 @@ function! ale_linters#typescript#tslint#BuildLintCommand(buffer) abort
   let l:tsconfig_path = ale#util#FindNearestFile(a:buffer, 'tslint.json')
   let l:tslint_options = empty(l:tsconfig_path) ? '' : '-c ' . l:tsconfig_path
 
-  return 'tslint ' . l:tslint_options . ' %t'
+  return ale_linters#typescript#tslint#GetExecutable(a:buffer)
+  \   . ' ' . l:tslint_options
+  \   . ' %t'
 endfunction
 
 call ale#linter#Define('typescript', {
 \   'name': 'tslint',
-\   'executable': 'tslint',
+\   'executable_callback': 'ale_linters#typescript#tslint#GetExecutable',
 \   'command_callback': 'ale_linters#typescript#tslint#BuildLintCommand',
 \   'callback': 'ale_linters#typescript#tslint#Handle',
 \})

--- a/ale_linters/typescript/tslint.vim
+++ b/ale_linters/typescript/tslint.vim
@@ -8,7 +8,6 @@ let g:ale_typescript_tslint_config_path =
 \   get(g:, 'ale_typescript_tslint_config_path', '')
 
 function! ale_linters#typescript#tslint#GetExecutable(buffer) abort
-
   return ale#util#ResolveLocalPath(
   \   a:buffer,
   \   'node_modules/.bin/tslint',
@@ -60,7 +59,7 @@ function! ale_linters#typescript#tslint#BuildLintCommand(buffer) abort
   let l:tslint_options = 
   \   empty(g:ale_typescript_tslint_config_path) ? 
   \         '' 
-  \         : '-c ' . g:ale_typescript_tslint_config_path
+  \         : '-c ' . fnameescape(g:ale_typescript_tslint_config_path)
 
   return ale_linters#typescript#tslint#GetExecutable(a:buffer)
   \   . ' ' . l:tslint_options


### PR DESCRIPTION
Allows the definition of the tslint executable path (At the moment only the global is used #355 ) using `ale_typescript_tslint_executable`. This defaults to `node_modules/.bin/tslint` if it's available or the global `tslint` otherwise.

As an extra this PR also allows the definition of the `tslint.json` configuraiton file using `ale_typescript_tslint_config_path`. It defaults to the closest configuration to the buffer if it's not manually defined.