### PR TITLE
Fix problems with nim check

### DIFF
--- a/ale_linters/nim/nimcheck.vim
+++ b/ale_linters/nim/nimcheck.vim
@@ -3,7 +3,7 @@
 
 
 function! ale_linters#nim#nimcheck#Handle(buffer, lines) abort
-    let l:buffer_filename = fnameescape(fnamemodify(bufname(a:buffer), ':p:t'))
+    let l:buffer_filename = fnamemodify(bufname(a:buffer), ':p:t')
     let l:pattern = '^\(.\+\.nim\)(\(\d\+\), \(\d\+\)) \(.\+\)'
     let l:output = [] 
 
@@ -18,7 +18,7 @@ function! ale_linters#nim#nimcheck#Handle(buffer, lines) abort
         " NOTE: Checking filename only is OK because nim enforces unique
         "       module names.
 
-        let l:temp_buffer_filename = fnameescape(fnamemodify(l:match[1], ':p:t'))
+        let l:temp_buffer_filename = fnamemodify(l:match[1], ':p:t')
         if l:buffer_filename !=# '' && l:temp_buffer_filename !=# l:buffer_filename
             continue
         endif

--- a/ale_linters/nim/nimcheck.vim
+++ b/ale_linters/nim/nimcheck.vim
@@ -3,6 +3,7 @@
 
 
 function! ale_linters#nim#nimcheck#Handle(buffer, lines) abort
+    let l:buffer_filename = fnameescape(fnamemodify(bufname(a:buffer), ':p:t'))
     let l:pattern = '^\(.\+\.nim\)(\(\d\+\), \(\d\+\)) \(.\+\)'
     let l:output = [] 
 
@@ -13,13 +14,22 @@ function! ale_linters#nim#nimcheck#Handle(buffer, lines) abort
             continue
         endif
 
-        let l:buffer = l:match[1] + 0
+        " Only show errors of the current buffer
+        " NOTE: Checking filename only is OK because nim enforces unique
+        "       module names.
+
+        let l:temp_buffer_filename = fnameescape(fnamemodify(l:match[1], ':p:t'))
+        if l:buffer_filename !=# '' && l:temp_buffer_filename !=# l:buffer_filename
+            continue
+        endif
+
         let l:line = l:match[2] + 0
         let l:column = l:match[3] + 0
         let l:text = l:match[4]
         let l:type = 'W'
 
-        let l:textmatch = matchlist(l:match[4], '\(.*\):')
+        " Extract error type from message of type 'Error: Some error message'
+        let l:textmatch = matchlist(l:match[4], '^\(.\{-}\): .\+$')
 
         if len(l:textmatch) > 0
             let l:errortype = l:textmatch[1]

--- a/test/handler/test_nim_handler.vader
+++ b/test/handler/test_nim_handler.vader
@@ -24,10 +24,18 @@ Execute(Parsing nim errors should work):
   \     'text': 'Hint: ''NotUsed'' is declared but not used [XDeclaredButNotUsed]',
   \     'type': 'W',
   \   },
+  \   {
+  \     'bufnr': 42,
+  \     'lnum': 12,
+  \     'col': 2,
+  \     'text': 'Error: with : character',
+  \     'type': 'E',
+  \   },
   \ ],
   \ ale_linters#nim#nimcheck#Handle(42, [
   \ 'Line with wrong( format)',
   \ 'foobar.nim(8, 8) Warning: use {.base.} for base methods; baseless methods are deprecated [UseBase]',
   \ 'foobar.nim(12, 2) Error: identifier expected, but found ''a.barfoo''',
   \ '/nested/folder/foobar.nim(2, 5) Hint: ''NotUsed'' is declared but not used [XDeclaredButNotUsed]',
+  \ 'foobar.nim(12, 2) Error: with : character',
   \ ])


### PR DESCRIPTION
- Multi file errors are not shown in the same buffer
- Fixes parsing of error type that contain ':'