### PR TITLE
Make cargo linter lighter

### DIFF
--- a/ale_linters/rust/cargo.vim
+++ b/ale_linters/rust/cargo.vim
@@ -1,6 +1,8 @@
 " Author: Daniel Schemala <istjanichtzufassen@gmail.com>
 " Description: rustc invoked by cargo for rust files
 
+let g:ale_rust_cargo_use_check = get(g:, 'ale_rust_cargo_use_check', 0)
+
 function! ale_linters#rust#cargo#GetCargoExecutable(bufnr) abort
     if ale#util#FindNearestFile(a:bufnr, 'Cargo.toml') !=# ''
         return 'cargo'
@@ -11,10 +13,18 @@ function! ale_linters#rust#cargo#GetCargoExecutable(bufnr) abort
     endif
 endfunction
 
+function! ale_linters#rust#cargo#GetCommand(buffer) abort
+    let l:command = g:ale_rust_cargo_use_check
+    \   ? 'check'
+    \   : 'build'
+
+    return 'cargo ' . l:command . ' --frozen --message-format=json -q'
+endfunction
+
 call ale#linter#Define('rust', {
 \   'name': 'cargo',
 \   'executable_callback': 'ale_linters#rust#cargo#GetCargoExecutable',
-\   'command': 'cargo build --message-format=json -q',
+\   'command_callback': 'ale_linters#rust#cargo#GetCommand',
 \   'callback': 'ale#handlers#rust#HandleRustErrors',
 \   'output_stream': 'stdout',
 \})

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -43,6 +43,7 @@ CONTENTS                                                         *ale-contents*
     4.31. yamllint........................|ale-linter-options-yamllint|
     4.32. cmakelint.......................|ale-linter-options-cmakelint|
     4.33. perl-perl.......................|ale-linter-options-perl-perl|
+    4.34. rust-cargo......................|ale-linter-options-rust-cargo|
   5. Linter Integration Notes.............|ale-linter-integration|
     5.1.  merlin..........................|ale-linter-integration-ocaml-merlin|
     5.2. rust.............................|ale-integration-rust|
@@ -1119,6 +1120,17 @@ g:ale_perl_perl_options                               *g:ale_perl_perl_options*
 
   This variable can be changed to alter the command-line arguments to the perl
   invocation.
+
+-------------------------------------------------------------------------------
+4.34. rust-cargo                                *ale-linter-options-rust-cargo*
+
+g:ale_rust_cargo_use_check                         *g:ale_rust_cargo_use_check*
+
+  Type: |Number|
+  Default: `1`
+
+  When set to `1`, this option will cause ALE to use "cargo check" instead of
+  "cargo build". "cargo check" is supported since version 1.16.0 of Rust.
 
 ===============================================================================
 5. Linter Integration Notes                            *ale-linter-integration*


### PR DESCRIPTION
- Use `cargo check` instead of `cargo build`.
- Use `--frozen` to avoid locking the project.