### PR TITLE
#272 Check if quickfix window is open before reopening

### DIFF
--- a/autoload/ale/list.vim
+++ b/autoload/ale/list.vim
@@ -36,10 +36,12 @@ function! ale#list#SetLists(buffer, loclist) abort
     if len(a:loclist) > 0 || g:ale_keep_list_window_open
         let l:winnr = winnr()
 
-        if g:ale_set_quickfix
-            copen
-        elseif g:ale_set_loclist
-            lopen
+        if !ale#list#IsQuickfixOpen()
+          if g:ale_set_quickfix
+              copen
+          elseif g:ale_set_loclist
+              lopen
+          endif
         endif
 
         " If focus changed, restore it (jump to the last window).

--- a/test/test_list_opening.vader
+++ b/test/test_list_opening.vader
@@ -49,6 +49,10 @@ Execute(The quickfix window should open for just the loclist):
   call ale#list#SetLists(bufnr('%'), g:loclist)
   Assert ale#list#IsQuickfixOpen()
 
+  " Clear the list and it should close again.
+  call ale#list#SetLists(bufnr('%'), [])
+  Assert !ale#list#IsQuickfixOpen()
+
 Execute(The quickfix window should stay open for just the loclist):
   let g:ale_open_list = 1
   let g:ale_keep_list_window_open = 1
@@ -75,6 +79,10 @@ Execute(The quickfix window should open for the quickfix list):
   " With a non-empty quickfix list, the window must open.
   call ale#list#SetLists(bufnr('%'), g:loclist)
   Assert ale#list#IsQuickfixOpen()
+
+  " Clear the list and it should close again.
+  call ale#list#SetLists(bufnr('%'), [])
+  Assert !ale#list#IsQuickfixOpen()
 
 Execute(The quickfix window should stay open for the quickfix list):
   let g:ale_set_quickfix = 1


### PR DESCRIPTION
This change fixes issue #272 by adding a check for whether the quickfix window is already open, and avoids unnecessarily reopening it if it is open.

This prevents an unnecessary BufEnter event being fired over and over when the quickfix window is reopened each time causing the bug under certain settings combinations.

When `g:ale_lint_on_enter = 1` and `g:ale_open_list = 1` we have a situation where a detected error opens the quickfix window, causing a BufEnter event, reopening the quickfix window, causing another BufEnter event...... into an infinite loop that uses a lot of cpu time every 300ms to run checks no matter what other settings you have.

I used the `ale#list#IsQuickfixOpen()` function in the same `list.vim` file to check if the quickfix window is open. Before this I believe it was only used in tests? Both the location list and quickfix window have `buftype == 'quickfix'` so it should detect both hopefully without any changes.