### PR TITLE
Add options to facilitate linting only in normal mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ options off.
 
 ```vim
 " Write this in your vimrc file
-let g:ale_lint_on_text_changed = 0
+let g:ale_lint_on_text_changed = 'never'
 " You can disable this option too
 " if you don't want linters to run on opening a file
 let g:ale_lint_on_enter = 0
@@ -453,10 +453,10 @@ type, and this delay can be increased so linters are run less often. See
 `:help g:ale_lint_delay` for more information.
 
 If you don't wish to run linters while you type, you can disable that
-behaviour. Set `g:ale_lint_on_text_changed` to `0`. You won't get as frequent
-error checking, but ALE shouldn't block your ability to edit a document after
-you save a file, so the asynchronous nature of the plugin will still be an
-advantage.
+behaviour. Set `g:ale_lint_on_text_changed` to `never` or `normal`. You won't
+get as frequent error checking, but ALE shouldn't block your ability to edit a
+document after you save a file, so the asynchronous nature of the plugin will
+still be an advantage.
 
 If you are still concerned, you can turn the automatic linting off altogether,
 including the option `g:ale_lint_on_enter`, and you can run ALE manually with

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -262,7 +262,7 @@ g:ale_lint_delay                                             *g:ale_lint_delay*
 
   This variable controls the milliseconds delay after which the linters will
   be run after text is changed. This option is only meaningful with the
-  |g:ale_lint_on_text_changed| variable set to `1`.
+  |g:ale_lint_on_text_changed| variable set to `always`, `insert`, or `normal`.
 
 
 g:ale_lint_on_enter                                       *g:ale_lint_on_enter*
@@ -301,17 +301,27 @@ g:ale_lint_on_save                                         *g:ale_lint_on_save*
 
 g:ale_lint_on_text_changed                         *g:ale_lint_on_text_changed*
 
-  Type: |Number|
-  Default: `1`
+  Type: |String|
+  Default: `always`
 
   By default, ALE will check files with the various supported programs when
   text is changed by using the |TextChanged| event. If this behaviour is not
-  desired, then this option can be disabled by setting it to 0. The
+  desired, then this option can be disabled by setting it to `never`. The
   |g:ale_lint_delay| variable will be used to set a |timer_start()| on a
   delay, and each change to a file will continue to call |timer_stop()| and
   |timer_start()| repeatedly until the timer ticks by, and the linters will be
   run. The checking of files will run in the background, so it should not
-  inhibit editing files.
+  inhibit editing files. This option can also be set to `insert` or `normal`
+  to lint when text is changed only in insert or normal mode respectively.
+
+
+g:ale_lint_on_insert_leave                         *g:ale_lint_on_insert_leave*
+
+  Type: |Number|
+  Default: `0`
+
+  This option will make ALE run the linters whenever leaving insert mode when
+  it it set to `1` in your vimrc file.
 
 
 g:ale_linter_aliases                                     *g:ale_linter_aliases*

--- a/plugin/ale.vim
+++ b/plugin/ale.vim
@@ -154,15 +154,17 @@ let g:ale_history_enabled = get(g:, 'ale_history_enabled', 1)
 " A flag for storing the full output of commands in the history.
 let g:ale_history_log_output = get(g:, 'ale_history_log_output', 0)
 
-function! s:ALEInitAuGroups() abort
+function! ALEInitAuGroups() abort
     augroup ALERunOnTextChangedGroup
         autocmd!
-        if g:ale_enabled && g:ale_lint_on_text_changed ==? 'normal'
-            autocmd TextChanged * call ale#Queue(g:ale_lint_delay)
-        elseif g:ale_enabled && g:ale_lint_on_text_changed ==? 'insert'
-            autocmd TextChangedI * call ale#Queue(g:ale_lint_delay)
-        elseif g:ale_enabled && g:ale_lint_on_text_changed ==? 'always'
-            autocmd TextChanged,TextChangedI * call ale#Queue(g:ale_lint_delay)
+        if g:ale_enabled
+            if g:ale_lint_on_text_changed ==? 'always' || g:ale_lint_on_text_changed == 1
+                autocmd TextChanged,TextChangedI * call ale#Queue(g:ale_lint_delay)
+            elseif g:ale_lint_on_text_changed ==? 'normal'
+                autocmd TextChanged * call ale#Queue(g:ale_lint_delay)
+            elseif g:ale_lint_on_text_changed ==? 'insert'
+                autocmd TextChangedI * call ale#Queue(g:ale_lint_delay)
+            endif
         endif
     augroup END
 
@@ -236,10 +238,10 @@ function! s:ALEToggle() abort
         endif
     endif
 
-    call s:ALEInitAuGroups()
+    call ALEInitAuGroups()
 endfunction
 
-call s:ALEInitAuGroups()
+call ALEInitAuGroups()
 
 " Define commands for moving through warnings and errors.
 command! ALEPrevious :call ale#loclist_jumping#Jump('before', 0)

--- a/test/test_ale_info.vader
+++ b/test/test_ale_info.vader
@@ -19,7 +19,7 @@ Before:
   \  'let g:ale_lint_delay = 200',
   \  'let g:ale_lint_on_enter = 1',
   \  'let g:ale_lint_on_save = 1',
-  \  'let g:ale_lint_on_text_changed = 1',
+  \  'let g:ale_lint_on_text_changed = ''always''',
   \  'let g:ale_linter_aliases = {}',
   \  'let g:ale_linters = {}',
   \  'let g:ale_open_list = 0',

--- a/test/test_ale_init_au_groups.vader
+++ b/test/test_ale_init_au_groups.vader
@@ -1,0 +1,66 @@
+Before:
+  Save g:ale_lint_on_text_changed
+  Save g:ale_lint_on_insert_leave
+  autocmd!
+
+After:
+  Restore g:ale_lint_on_text_changed
+  Restore g:ale_lint_on_insert_leave
+  unlet! g:output
+  unlet! g:expected_autocmd
+  autocmd!
+
+Execute (ALE should bind to TextChanged events when g:ale_lint_on_text_changed = 1):
+  let g:expected_autocmd = join([
+  \  '',
+  \  '--- Auto-Commands ---',
+  \  'ALERunOnTextChangedGroup  TextChanged',
+  \  '    *         call ale#Queue(g:ale_lint_delay)',
+  \  'ALERunOnTextChangedGroup  TextChangedI',
+  \  '    *         call ale#Queue(g:ale_lint_delay)',
+  \], "\n")
+
+  let g:ale_lint_on_text_changed = 1
+  call ALEInitAuGroups()
+
+  redir => g:output
+  autocmd ALERunOnTextChangedGroup TextChanged,TextChangedI *
+  redir END
+
+  AssertEqual g:expected_autocmd, g:output
+
+Execute (ALE should bind to TextChanged events when g:ale_lint_on_text_changed = 'always'):
+  let g:expected_autocmd = join([
+  \  '',
+  \  '--- Auto-Commands ---',
+  \  'ALERunOnTextChangedGroup  TextChanged',
+  \  '    *         call ale#Queue(g:ale_lint_delay)',
+  \  'ALERunOnTextChangedGroup  TextChangedI',
+  \  '    *         call ale#Queue(g:ale_lint_delay)',
+  \], "\n")
+
+  let g:ale_lint_on_text_changed = 'always'
+  call ALEInitAuGroups()
+
+  redir => g:output
+  autocmd ALERunOnTextChangedGroup TextChanged,TextChangedI *
+  redir END
+
+  AssertEqual g:expected_autocmd, g:output
+
+Execute (ALE should bind to InsertLeave event when g:ale_lint_on_insert_leave = 1):
+  let g:expected_autocmd = join([
+  \  "",
+  \  "--- Auto-Commands ---",
+  \  "ALERunOnInsertLeave  InsertLeave",
+  \  "    *         call ale#Queue(0, 'lint_file')",
+  \], "\n")
+
+  let g:ale_lint_on_insert_leave = 1
+  call ALEInitAuGroups()
+
+  redir => g:output
+  autocmd ALERunOnInsertLeave InsertLeave *
+  redir END
+
+  AssertEqual g:expected_autocmd, g:output


### PR DESCRIPTION
Close #420 

__ale\_lint\_on\_text\_changed:__
Allow setting to 'insert' or 'normal' to lint when text is changed only in insert or normal mode respectively.

__ale\_lint\_on\_insert\_leave:__
This flag can be set to 1 to enable linting when leaving insert mode.