### PR TITLE
Add support for gosimple and staticcheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ name. That seems to be the fairest way to arrange this table.
 | Elm | [elm-make](https://github.com/elm-lang/elm-make) |
 | Erlang | [erlc](http://erlang.org/doc/man/erlc.html) |
 | Fortran | [gcc](https://gcc.gnu.org/) |
-| Go | [gofmt -e](https://golang.org/cmd/gofmt/), [go vet](https://golang.org/cmd/vet/), [golint](https://godoc.org/github.com/golang/lint), [go build](https://golang.org/cmd/go/) |
+| Go | [gofmt -e](https://golang.org/cmd/gofmt/), [go vet](https://golang.org/cmd/vet/), [golint](https://godoc.org/github.com/golang/lint), [go build](https://golang.org/cmd/go/), [gosimple](https://github.com/dominikh/go-tools/tree/master/cmd/gosimple), [staticcheck](https://github.com/dominikh/go-tools/tree/master/cmd/staticcheck) |
 | Haml | [haml-lint](https://github.com/brigade/haml-lint)
 | Haskell | [ghc](https://www.haskell.org/ghc/), [hlint](https://hackage.haskell.org/package/hlint), [hdevtools](https://hackage.haskell.org/package/hdevtools) |
 | HTML | [HTMLHint](http://htmlhint.com/), [proselint](http://proselint.com/), [tidy](http://www.html-tidy.org/) |

--- a/ale_linters/go/gosimple.vim
+++ b/ale_linters/go/gosimple.vim
@@ -1,0 +1,9 @@
+" Author: Ben Reedy <https://github.com/breed808>
+" Description: gosimple for Go files
+
+call ale#linter#Define('go', {
+\   'name': 'gosimple',
+\   'executable': 'gosimple',
+\   'command': 'gosimple %t',
+\   'callback': 'ale#handlers#HandleUnixFormatAsWarning',
+\})

--- a/ale_linters/go/staticcheck.vim
+++ b/ale_linters/go/staticcheck.vim
@@ -1,0 +1,9 @@
+" Author: Ben Reedy <https://github.com/breed808>
+" Description: staticcheck for Go files
+
+call ale#linter#Define('go', {
+\   'name': 'staticcheck',
+\   'executable': 'staticcheck',
+\   'command': 'staticcheck %t',
+\   'callback': 'ale#handlers#HandleUnixFormatAsWarning',
+\})

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -119,7 +119,7 @@ The following languages and tools are supported.
 * Elm: 'elm-make'
 * Erlang: 'erlc'
 * Fortran: 'gcc'
-* Go: 'gofmt -e', 'go vet', 'golint', 'go build'
+* Go: 'gofmt -e', 'go vet', 'golint', 'go build', 'gosimple', 'staticcheck'
 * Haml: 'hamllint'
 * Haskell: 'ghc', 'hlint'
 * HTML: 'HTMLHint', 'proselint', 'tidy'


### PR DESCRIPTION
Shamelessly copied `golint.vim` and replaced with `gosimple`/`staticcheck`. Surprised at how easy it was to add a linter to ALE.

Let me know if anything needs correcting.