### PR TITLE
Check for existence of g:ale_emit_conflict_warnings before checking value

### DIFF
--- a/after/plugin/ale.vim
+++ b/after/plugin/ale.vim
@@ -4,7 +4,9 @@ endif
 
 let g:loaded_ale_after = 1
 
-if !g:ale_emit_conflict_warnings
+" Check if the flag is available and set to 0 to disable checking for and
+" emitting conflicting plugin warnings.
+if exists('g:ale_emit_conflict_warnings') && !g:ale_emit_conflict_warnings
     finish
 endif
 

--- a/after/plugin/ale.vim
+++ b/after/plugin/ale.vim
@@ -1,7 +1,12 @@
+" Author: w0rp <devw0rp@gmail.com>
+" Description: Follow-up checks for the plugin: warn about conflicting plugins.
+
+" A flag for ensuring that this is not run more than one time.
 if exists('g:loaded_ale_after')
     finish
 endif
 
+" Set the flag so this file is not run more than one time.
 let g:loaded_ale_after = 1
 
 " Check if the flag is available and set to 0 to disable checking for and
@@ -9,6 +14,8 @@ let g:loaded_ale_after = 1
 if exists('g:ale_emit_conflict_warnings') && !g:ale_emit_conflict_warnings
     finish
 endif
+
+" Conflicting Plugins Checks
 
 function! s:GetConflictingPluginWarning(plugin_name) abort
     return 'ALE conflicts with ' . a:plugin_name


### PR DESCRIPTION
Fixes #426. Added some documentation, too.

**Problem**
`g:ale_emit_conflict_warnings` does not get set to a value ([default is 1]( https://github.com/w0rp/ale/blob/master/plugin/ale.vim#L48)) in some circumstances, so when [its value is checked](https://github.com/w0rp/ale/blob/master/after/plugin/ale.vim#L7) in after/plugin/ale.vim, it is undefined. 

**This Solution**
Check for existence before checking the value.

**Another solution**
Another solution aside from checking `if exists('g:ale_emit_conflict_warnings')` would be to ensure `g:ale_emit_conflict_warnings` is set before any `finish` calls in plugin/ale.vim. However, that would leave `g:ale_emit_conflict_warnings` as a random variable that is set but never used since ale would [technically not work](https://github.com/w0rp/ale/blob/master/plugin/ale.vim#L31).