### PR TITLE
Remove 'col' from linters where it is hardcoded to 1

### DIFF
--- a/ale_linters/chef/foodcritic.vim
+++ b/ale_linters/chef/foodcritic.vim
@@ -17,7 +17,6 @@ function! ale_linters#chef#foodcritic#Handle(buffer, lines) abort
 
         let l:text = l:match[1]
 
-        " vcol is Needed to indicate that the column is a character.
         call add(l:output, {
         \   'bufnr': a:buffer,
         \   'lnum': l:match[3] + 0,

--- a/ale_linters/coffee/coffeelint.vim
+++ b/ale_linters/coffee/coffeelint.vim
@@ -32,7 +32,6 @@ function! ale_linters#coffee#coffeelint#Handle(buffer, lines) abort
         endif
 
         let l:line = l:match[1] + 0
-        let l:column = 1
         let l:type = l:match[3] ==# 'error' ? 'E' : 'W'
         let l:text = l:match[4]
 
@@ -40,7 +39,6 @@ function! ale_linters#coffee#coffeelint#Handle(buffer, lines) abort
         call add(l:output, {
         \   'bufnr': a:buffer,
         \   'lnum': l:line,
-        \   'col': l:column,
         \   'text': l:text,
         \   'type': l:type,
         \})

--- a/ale_linters/coffee/coffeelint.vim
+++ b/ale_linters/coffee/coffeelint.vim
@@ -35,7 +35,6 @@ function! ale_linters#coffee#coffeelint#Handle(buffer, lines) abort
         let l:type = l:match[3] ==# 'error' ? 'E' : 'W'
         let l:text = l:match[4]
 
-        " vcol is needed to indicate that the column is a character
         call add(l:output, {
         \   'bufnr': a:buffer,
         \   'lnum': l:line,

--- a/ale_linters/d/dmd.vim
+++ b/ale_linters/d/dmd.vim
@@ -68,7 +68,6 @@ function! ale_linters#d#dmd#Handle(buffer, lines) abort
         let l:type = l:match[3]
         let l:text = l:match[4]
 
-        " vcol is Needed to indicate that the column is a character.
         call add(l:output, {
         \   'bufnr': bufnr('%'),
         \   'lnum': l:line,

--- a/ale_linters/dockerfile/hadolint.vim
+++ b/ale_linters/dockerfile/hadolint.vim
@@ -23,7 +23,6 @@ function! ale_linters#dockerfile#hadolint#Handle(buffer, lines) abort
     let l:type = 'W'
     let l:text = l:match[3]
 
-    " vcol is Needed to indicate that the column is a character.
     call add(l:output, {
     \   'bufnr': a:buffer,
     \   'lnum': l:lnum,

--- a/ale_linters/elixir/credo.vim
+++ b/ale_linters/elixir/credo.vim
@@ -23,7 +23,6 @@ function! ale_linters#elixir#credo#Handle(buffer, lines) abort
       let l:type = 'W'
     endif
 
-    " vcol is Needed to indicate that the column is a character.
     call add(l:output, {
     \   'bufnr': a:buffer,
     \   'lnum': l:match[1] + 0,

--- a/ale_linters/elixir/dogma.vim
+++ b/ale_linters/elixir/dogma.vim
@@ -23,7 +23,6 @@ function! ale_linters#elixir#dogma#Handle(buffer, lines) abort
             let l:type = 'W'
         endif
 
-        " vcol is Needed to indicate that the column is a character.
         call add(l:output, {
         \   'bufnr': a:buffer,
         \   'lnum': l:match[1] + 0,

--- a/ale_linters/erlang/erlc.vim
+++ b/ale_linters/erlang/erlc.vim
@@ -73,7 +73,6 @@ function! ale_linters#erlang#erlc#Handle(buffer, lines) abort
             let l:type = 'E'
         endif
 
-        " vcol is Needed to indicate that the column is a character.
         call add(l:output, {
         \   'bufnr': a:buffer,
         \   'lnum': l:line,

--- a/ale_linters/haskell/hlint.vim
+++ b/ale_linters/haskell/hlint.vim
@@ -7,7 +7,6 @@ function! ale_linters#haskell#hlint#Handle(buffer, lines) abort
     let l:output = []
 
     for l:error in l:errors
-        " vcol is Needed to indicate that the column is a character.
         call add(l:output, {
         \   'bufnr': a:buffer,
         \   'lnum': l:error.startLine + 0,

--- a/ale_linters/html/tidy.vim
+++ b/ale_linters/html/tidy.vim
@@ -49,7 +49,6 @@ function! ale_linters#html#tidy#Handle(buffer, lines) abort
         let l:type = l:match[3] ==# 'Error' ? 'E' : 'W'
         let l:text = l:match[4]
 
-        " vcol is Needed to indicate that the column is a character.
         call add(l:output, {
         \   'bufnr': a:buffer,
         \   'lnum': l:line,

--- a/ale_linters/java/javac.vim
+++ b/ale_linters/java/javac.vim
@@ -34,7 +34,6 @@ function! ale_linters#java#javac#Handle(buffer, lines) abort
         call add(l:output, {
         \   'bufnr': a:buffer,
         \   'lnum': l:match[1] + 0,
-        \   'col': 1,
         \   'text': l:match[2] . ':' . l:match[3],
         \   'type': l:match[2] ==# 'error' ? 'E' : 'W',
         \})

--- a/ale_linters/javascript/eslint.vim
+++ b/ale_linters/javascript/eslint.vim
@@ -87,7 +87,6 @@ function! ale_linters#javascript#eslint#Handle(buffer, lines) abort
             let l:text .= ' [' . l:match[4] . ']'
         endif
 
-        " vcol is Needed to indicate that the column is a character.
         call add(l:output, {
         \   'bufnr': a:buffer,
         \   'lnum': l:match[1] + 0,

--- a/ale_linters/javascript/standard.vim
+++ b/ale_linters/javascript/standard.vim
@@ -47,7 +47,6 @@ function! ale_linters#javascript#standard#Handle(buffer, lines) abort
         let l:type = 'Error'
         let l:text = l:match[3]
 
-        " vcol is Needed to indicate that the column is a character.
         call add(l:output, {
         \   'bufnr': a:buffer,
         \   'lnum': l:match[1] + 0,

--- a/ale_linters/json/jsonlint.vim
+++ b/ale_linters/json/jsonlint.vim
@@ -14,7 +14,6 @@ function! ale_linters#json#jsonlint#Handle(buffer, lines) abort
             continue
         endif
 
-        " vcol is needed to indicate that the column is a character
         call add(l:output, {
         \   'bufnr': a:buffer,
         \   'lnum': l:match[1] + 0,

--- a/ale_linters/lua/luacheck.vim
+++ b/ale_linters/lua/luacheck.vim
@@ -19,7 +19,6 @@ function! ale_linters#lua#luacheck#Handle(buffer, lines) abort
             continue
         endif
 
-        " vcol is Needed to indicate that the column is a character.
         call add(l:output, {
         \   'bufnr': a:buffer,
         \   'lnum': l:match[1] + 0,

--- a/ale_linters/matlab/mlint.vim
+++ b/ale_linters/matlab/mlint.vim
@@ -40,7 +40,6 @@ function! ale_linters#matlab#mlint#Handle(buffer, lines) abort
             continue
         endif
 
-        " vcol is needed to indicate that the column is a character.
         call add(l:output, {
         \   'bufnr': a:buffer,
         \   'lnum': l:lnum,

--- a/ale_linters/perl/perl.vim
+++ b/ale_linters/perl/perl.vim
@@ -32,7 +32,6 @@ function! ale_linters#perl#perl#Handle(buffer, lines) abort
         let l:text = l:match[1]
         let l:type = 'E'
 
-        " vcol is Needed to indicate that the column is a character.
         call add(l:output, {
         \   'bufnr': a:buffer,
         \   'lnum': l:line,

--- a/ale_linters/perl/perl.vim
+++ b/ale_linters/perl/perl.vim
@@ -29,7 +29,6 @@ function! ale_linters#perl#perl#Handle(buffer, lines) abort
         endif
 
         let l:line = l:match[3]
-        let l:column = 1
         let l:text = l:match[1]
         let l:type = 'E'
 
@@ -37,7 +36,6 @@ function! ale_linters#perl#perl#Handle(buffer, lines) abort
         call add(l:output, {
         \   'bufnr': a:buffer,
         \   'lnum': l:line,
-        \   'col': l:column,
         \   'text': l:text,
         \   'type': l:type,
         \})

--- a/ale_linters/perl/perlcritic.vim
+++ b/ale_linters/perl/perlcritic.vim
@@ -13,7 +13,6 @@ function! ale_linters#perl#perlcritic#Handle(buffer, lines) abort
         endif
 
         let l:line = l:match[3]
-        let l:column = 1
         let l:text = l:match[1]
         let l:type = 'E'
 
@@ -21,7 +20,6 @@ function! ale_linters#perl#perlcritic#Handle(buffer, lines) abort
         call add(l:output, {
         \   'bufnr': a:buffer,
         \   'lnum': l:line,
-        \   'col': l:column,
         \   'text': l:text,
         \   'type': l:type,
         \})

--- a/ale_linters/perl/perlcritic.vim
+++ b/ale_linters/perl/perlcritic.vim
@@ -16,7 +16,6 @@ function! ale_linters#perl#perlcritic#Handle(buffer, lines) abort
         let l:text = l:match[1]
         let l:type = 'E'
 
-        " vcol is Needed to indicate that the column is a character.
         call add(l:output, {
         \   'bufnr': a:buffer,
         \   'lnum': l:line,

--- a/ale_linters/php/php.vim
+++ b/ale_linters/php/php.vim
@@ -16,7 +16,6 @@ function! ale_linters#php#php#Handle(buffer, lines) abort
             continue
         endif
 
-        " vcol is needed to indicate that the column is a character.
         call add(l:output, {
         \   'bufnr': a:buffer,
         \   'lnum': l:match[3] + 0,

--- a/ale_linters/php/phpcs.vim
+++ b/ale_linters/php/phpcs.vim
@@ -29,7 +29,6 @@ function! ale_linters#php#phpcs#Handle(buffer, lines) abort
         let l:text = l:match[4]
         let l:type = l:match[3]
 
-        " vcol is Needed to indicate that the column is a character.
         call add(l:output, {
         \   'bufnr': a:buffer,
         \   'lnum': l:match[1] + 0,

--- a/ale_linters/php/phpmd.vim
+++ b/ale_linters/php/phpmd.vim
@@ -18,7 +18,6 @@ function! ale_linters#php#phpmd#Handle(buffer, lines) abort
             continue
         endif
 
-        " vcol is Needed to indicate that the column is a character.
         call add(l:output, {
         \   'bufnr': a:buffer,
         \   'lnum': l:match[1] + 0,

--- a/ale_linters/puppet/puppet.vim
+++ b/ale_linters/puppet/puppet.vim
@@ -14,7 +14,6 @@ function! ale_linters#puppet#puppet#Handle(buffer, lines) abort
             continue
         endif
 
-        " vcol is needed to indicate that the column is a character
         call add(l:output, {
         \   'bufnr': a:buffer,
         \   'lnum': l:match[2] + 0,

--- a/ale_linters/ruby/rubocop.vim
+++ b/ale_linters/ruby/rubocop.vim
@@ -19,7 +19,6 @@ function! ale_linters#ruby#rubocop#Handle(buffer, lines) abort
         let l:text = l:match[4]
         let l:type = l:match[3]
 
-        " vcol is Needed to indicate that the column is a character.
         call add(l:output, {
         \   'bufnr': a:buffer,
         \   'lnum': l:match[1] + 0,

--- a/ale_linters/scala/scalac.vim
+++ b/ale_linters/scala/scalac.vim
@@ -25,7 +25,6 @@ function! ale_linters#scala#scalac#Handle(buffer, lines) abort
             let l:col = stridx(a:lines[l:ln + 1], '^')
         endif
 
-        " vcol is Needed to indicate that the column is a character.
         call add(l:output, {
         \   'bufnr': a:buffer,
         \   'lnum': l:match[1] + 0,

--- a/ale_linters/scala/scalac.vim
+++ b/ale_linters/scala/scalac.vim
@@ -23,10 +23,6 @@ function! ale_linters#scala#scalac#Handle(buffer, lines) abort
 
         if l:ln + 1 < len(a:lines)
             let l:col = stridx(a:lines[l:ln + 1], '^')
-
-            if l:col == -1
-                let l:col = 0
-            endif
         endif
 
         " vcol is Needed to indicate that the column is a character.

--- a/ale_linters/scss/scsslint.vim
+++ b/ale_linters/scss/scsslint.vim
@@ -20,7 +20,6 @@ function! ale_linters#scss#scsslint#Handle(buffer, lines) abort
             continue
         endif
 
-        " vcol is needed to indicate that the column is a character
         call add(l:output, {
         \   'bufnr': a:buffer,
         \   'lnum': l:match[1] + 0,

--- a/ale_linters/sh/shell.vim
+++ b/ale_linters/sh/shell.vim
@@ -49,7 +49,6 @@ function! ale_linters#sh#shell#Handle(buffer, lines) abort
         endif
 
         let l:line = l:match[1] + 0
-        let l:column = 1
         let l:text = l:match[2]
         let l:type = 'E'
 
@@ -57,7 +56,6 @@ function! ale_linters#sh#shell#Handle(buffer, lines) abort
         call add(l:output, {
         \   'bufnr': a:buffer,
         \   'lnum': l:line,
-        \   'col': l:column,
         \   'text': l:text,
         \   'type': l:type,
         \})

--- a/ale_linters/sh/shell.vim
+++ b/ale_linters/sh/shell.vim
@@ -52,7 +52,6 @@ function! ale_linters#sh#shell#Handle(buffer, lines) abort
         let l:text = l:match[2]
         let l:type = 'E'
 
-        " vcol is Needed to indicate that the column is a character.
         call add(l:output, {
         \   'bufnr': a:buffer,
         \   'lnum': l:line,

--- a/ale_linters/sml/smlnj.vim
+++ b/ale_linters/sml/smlnj.vim
@@ -23,7 +23,6 @@ function! ale_linters#sml#smlnj#Handle(buffer, lines) abort
         call add(l:out, {
         \   'bufnr': a:buffer,
         \   'lnum': l:match[1] + 0,
-        \   'col': 1,
         \   'text': l:match[2] . ': ' . l:match[3],
         \   'type': l:match[2] ==# 'error' ? 'E' : 'W',
         \})

--- a/ale_linters/typescript/tslint.vim
+++ b/ale_linters/typescript/tslint.vim
@@ -37,7 +37,6 @@ function! ale_linters#typescript#tslint#Handle(buffer, lines) abort
         let l:type = 'E'
         let l:text = l:match[3]
 
-        " vcol is Needed to indicate that the column is a character.
         call add(l:output, {
         \   'bufnr': a:buffer,
         \   'lnum': l:line,

--- a/ale_linters/typescript/typecheck.vim
+++ b/ale_linters/typescript/typecheck.vim
@@ -22,7 +22,6 @@ function! ale_linters#typescript#typecheck#Handle(buffer, lines) abort
         let l:type = 'E'
         let l:text = l:match[3]
 
-        " vcol is Needed to indicate that the column is a character.
         call add(l:output, {
         \   'bufnr': a:buffer,
         \   'lnum': l:line,

--- a/ale_linters/verilog/iverilog.vim
+++ b/ale_linters/verilog/iverilog.vim
@@ -25,7 +25,6 @@ function! ale_linters#verilog#iverilog#Handle(buffer, lines) abort
         call add(l:output, {
         \   'bufnr': a:buffer,
         \   'lnum': l:line,
-        \   'col': 1,
         \   'text': l:text,
         \   'type': l:type,
         \})

--- a/ale_linters/verilog/verilator.vim
+++ b/ale_linters/verilog/verilator.vim
@@ -39,7 +39,6 @@ function! ale_linters#verilog#verilator#Handle(buffer, lines) abort
             call add(l:output, {
             \   'bufnr': a:buffer,
             \   'lnum': l:line,
-            \   'col': 1,
             \   'text': l:text,
             \   'type': l:type,
             \})

--- a/ale_linters/yaml/yamllint.vim
+++ b/ale_linters/yaml/yamllint.vim
@@ -35,7 +35,6 @@ function! ale_linters#yaml#yamllint#Handle(buffer, lines) abort
         let l:type = l:match[3]
         let l:text = l:match[4]
 
-        " vcol is Needed to indicate that the column is a character.
         call add(l:output, {
         \   'bufnr': a:buffer,
         \   'lnum': l:line,

--- a/test/handler/test_coffeelint_handler.vader
+++ b/test/handler/test_coffeelint_handler.vader
@@ -6,7 +6,6 @@ Execute(The coffeelint handler should parse lines correctly):
   \   {
   \     'bufnr': 347,
   \     'lnum': 125,
-  \     'col': 1,
   \     'text': "Line exceeds maximum allowed length Length is 122, max is 120.",
   \     'type': 'E',
   \   },


### PR DESCRIPTION
When 'col' is 1, the first column will get highlighted for no reason. It
should be 0 (which is the default).

In the scalac linter there was also a check about the outcome of
`stridx`. It would set `l:col` to 0 if it was -1, and then it uses
`'col': l:col + 1` to convert the outcome of `stridx` to the actual
column number. This will make 'col' equals 1 when there is no match. We
can remove the check because `-1 + 1 = 0`.

I also encountered some old comments which I deleted in the second commit.