### PR TITLE
Adds options to foodcritic linter

### DIFF
--- a/ale_linters/chef/foodcritic.vim
+++ b/ale_linters/chef/foodcritic.vim
@@ -1,4 +1,5 @@
 " Author: Edward Larkey <edwlarkey@mac.com>
+" Author: Jose Junior <jose.junior@gmail.com>
 " Description: This file adds the foodcritic linter for Chef files.
 
 function! ale_linters#chef#foodcritic#Handle(buffer, lines) abort
@@ -30,10 +31,15 @@ function! ale_linters#chef#foodcritic#Handle(buffer, lines) abort
     return l:output
 endfunction
 
+" Support options!
+let g:ale_chef_foodcritic_options = get(g:, 'ale_chef_foodcritic_options', '')
+
 call ale#linter#Define('chef', {
 \   'name': 'foodcritic',
 \   'executable': 'foodcritic',
-\   'command': 'foodcritic %t',
+\   'command': 'foodcritic '
+\       . g:ale_chef_foodcritic_options
+\       . ' %t',
 \   'callback': 'ale_linters#chef#foodcritic#Handle',
 \})
 

--- a/ale_linters/chef/foodcritic.vim
+++ b/ale_linters/chef/foodcritic.vim
@@ -2,6 +2,10 @@
 " Author: Jose Junior <jose.junior@gmail.com>
 " Description: This file adds the foodcritic linter for Chef files.
 
+" Support options!
+let g:ale_chef_foodcritic_options = get(g:, 'ale_chef_foodcritic_options', '')
+let g:ale_chef_foodcritic_executable = get(g:, 'ale_chef_foodcritic_executable', 'foodcritic')
+
 function! ale_linters#chef#foodcritic#Handle(buffer, lines) abort
     " Matches patterns line the following:
     "
@@ -31,15 +35,18 @@ function! ale_linters#chef#foodcritic#Handle(buffer, lines) abort
     return l:output
 endfunction
 
-" Support options!
-let g:ale_chef_foodcritic_options = get(g:, 'ale_chef_foodcritic_options', '')
+function! ale_linters#chef#foodcritic#GetCommand(buffer) abort
+  return printf('%s %s %%t', 
+  \   g:ale_chef_foodcritic_executable,
+  \   escape(g:ale_chef_foodcritic_options, '~')
+	\)
+endfunction
+
 
 call ale#linter#Define('chef', {
 \   'name': 'foodcritic',
 \   'executable': 'foodcritic',
-\   'command': 'foodcritic '
-\       . g:ale_chef_foodcritic_options
-\       . ' %t',
+\   'command_callback': 'ale_linters#chef#foodcritic#GetCommand',
 \   'callback': 'ale_linters#chef#foodcritic#Handle',
 \})
 

--- a/doc/ale-chef.txt
+++ b/doc/ale-chef.txt
@@ -10,8 +10,16 @@ g:ale_chef_foodcritic_options                   *g:ale_chef_foodcritic_options*
   Type: |String|
   Default: `''`
 
-  This variable can be change to modify flags given to foodcritic.
+  This variable can be changed to modify flags given to foodcritic.
 
+
+g:ale_chef_foodcritic_executable             *g:ale_chef_foodcritic_executable*
+
+  Type: |String|
+  Default: `'foodcritic'`
+
+  This variable can be changed to point to the foodcritic binary in case it's
+  not on the $PATH or a specific version/path must be used. 
 
 -------------------------------------------------------------------------------
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-chef.txt
+++ b/doc/ale-chef.txt
@@ -1,0 +1,17 @@
+===============================================================================
+ALE Chef Integration                                         *ale-chef-options*
+
+
+-------------------------------------------------------------------------------
+foodcritc                                                 *ale-chef-foodcritic*
+
+g:ale_chef_foodcritic_options                   *g:ale_chef_foodcritic_options*
+
+  Type: |String|
+  Default: `''`
+
+  This variable can be change to modify flags given to foodcritic.
+
+
+-------------------------------------------------------------------------------
+  vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -16,6 +16,8 @@ CONTENTS                                                         *ale-contents*
       clang...............................|ale-c-clang|
       cppcheck............................|ale-c-cppcheck|
       gcc.................................|ale-c-gcc|
+    chef..................................|ale-chef-options|
+      foodcritic..........................|ale-chef-foodcritic|
     cpp...................................|ale-cpp-options|
       clang...............................|ale-cpp-clang|
       clangtidy...........................|ale-cpp-clangtidy|

--- a/test/test_foodcritic_command_callback.vader
+++ b/test/test_foodcritic_command_callback.vader
@@ -1,0 +1,26 @@
+Before:
+  let g:ale_chef_foodcritic_options = '-t ~F011'
+  let g:ale_chef_foodcritic_executable = 'foodcritic'
+
+  silent! cd /testplugin/test
+  let g:dir = getcwd()
+
+  runtime ale_linters/chef/foodcritic.vim
+
+After:
+  let g:ale_chef_foodcritic_options = ''
+  let g:ale_chef_foodcritic_executable = ''
+
+  silent execute 'cd ' . g:dir
+  unlet! g:dir
+
+  call ale#linter#Reset()
+
+Execute(command line should be assembled correctly):
+
+  AssertEqual
+  \ 'foodcritic -t \~F011 %t',
+  \ ale_linters#chef#foodcritic#GetCommand(bufnr(''))
+
+  :q
+


### PR DESCRIPTION
Adds a way to pass command line options to the foodcritic command and
documentation about it.