### PR TITLE
Add CUDA linter using clang

### DIFF
--- a/ale_linters/cuda/clang.vim
+++ b/ale_linters/cuda/clang.vim
@@ -1,0 +1,19 @@
+" Author: Lucas Kolstad
+" Description: clang linter for cuda files
+
+let g:ale_cuda_clang_options = get(g:, 'ale_cuda_clang_options', '-Wall')
+
+
+function! ale_linters#cuda#clang#GetCommand(buffer) abort
+    return 'clang++ -x cuda -fsyntax-only '
+    \   . '-iquote ' . fnameescape(fnamemodify(bufname(a:buffer), ':p:h'))
+    \   . ' ' . g:ale_cuda_clang_options . ' -'
+endfunction
+
+call ale#linter#Define('cuda', {
+\   'name': 'clang',
+\   'output_stream': 'stderr',
+\   'executable': 'clang++',
+\   'command_callback': 'ale_linters#cuda#clang#GetCommand',
+\   'callback': 'ale#handlers#HandleGCCFormat',
+\})

--- a/doc/ale-cuda.txt
+++ b/doc/ale-cuda.txt
@@ -1,0 +1,17 @@
+===============================================================================
+ALE CUDA Integration                                         *ale-cuda-options*
+
+
+-------------------------------------------------------------------------------
+clang                                                          *ale-cuda-clang*
+
+g:ale_cuda_clang_options                             *g:ale_cuda_clang_options*
+
+  Type: |String|
+  Default: `'-Wall'`
+
+  This variable can be change to modify flags given to clang.
+
+
+-------------------------------------------------------------------------------
+  vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:


### PR DESCRIPTION
This is an initial example of a CUDA linter using clang. However, there are some issues to consider before merging regarding default behavior. I need to add more tests and docs as well, but that depends on our choice of behavior somewhat.

Issue #439 requested CUDA support - and I've commented there about the problems found doing this.