### PR TITLE
Better Unix pattern matching

### DIFF
--- a/autoload/ale/handlers.vim
+++ b/autoload/ale/handlers.vim
@@ -12,7 +12,7 @@ function! s:HandleUnixFormat(buffer, lines, type) abort
     " file.go:27: missing argument for Printf("%s"): format reads arg 2, have only 1 args
     " file.go:53:10: if block ends with a return statement, so drop this else and outdent its block (move short variable declaration to its own line if necessary)
     " file.go:5:2: expected declaration, found 'STRING' "log"
-    let l:pattern = '^' . s:path_pattern . ':\(\d\+\):\?\(\d\+\)\?:\? \(.\+\)$'
+    let l:pattern = '^' . s:path_pattern . ':\(\d\+\):\?\(\d\+\)\?[:\s]?\?\(.\+\)$'
     let l:output = []
 
     for l:line in a:lines


### PR DESCRIPTION
While working on adding a new linting engine to ale I noticed things were not working properly for some reason even though the program was spitting out the errors in standard unix format. It turns out that the spec doesn't seem to say anything about whitespaces therefore not all programs implement this properly.

To put it simply, we're only covering the "green" use case right now:

```diff
- file:line:column: body
+ file:line:column:body
```

This PR makes the whitespace optional so it doesn't break error message parsing.