### PR TITLE
Thread support for nimcheck

### DIFF
--- a/ale_linters/nim/nimcheck.vim
+++ b/ale_linters/nim/nimcheck.vim
@@ -52,7 +52,7 @@ endfunction
 
 
 function! ale_linters#nim#nimcheck#GetCommand(buffer)
-    return 'nim check --path:' . fnameescape(fnamemodify(bufname(a:buffer), ':p:h')) . ' --verbosity:0 --colors:off --listFullPaths %t'
+    return 'nim check --path:' . fnameescape(fnamemodify(bufname(a:buffer), ':p:h')) . '--threads:on --verbosity:0 --colors:off --listFullPaths %t'
 endfunction
 
 


### PR DESCRIPTION
Added a '--threads:on' switch to the nim check command so that it doesn't produce errors when using one of the various modules that require threads.