### PR TITLE
Add support for linting Handlebars templates with ember-template-lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ name. That seems to be the fairest way to arrange this table.
 | Fortran | [gcc](https://gcc.gnu.org/) |
 | Go | [gofmt -e](https://golang.org/cmd/gofmt/), [go vet](https://golang.org/cmd/vet/), [golint](https://godoc.org/github.com/golang/lint), [go build](https://golang.org/cmd/go/), [gosimple](https://github.com/dominikh/go-tools/tree/master/cmd/gosimple), [staticcheck](https://github.com/dominikh/go-tools/tree/master/cmd/staticcheck) |
 | Haml | [haml-lint](https://github.com/brigade/haml-lint)
+| Handlebars | [ember-template-lint](https://github.com/rwjblue/ember-template-lint) |
 | Haskell | [ghc](https://www.haskell.org/ghc/), [hlint](https://hackage.haskell.org/package/hlint), [hdevtools](https://hackage.haskell.org/package/hdevtools) |
 | HTML | [HTMLHint](http://htmlhint.com/), [proselint](http://proselint.com/), [tidy](http://www.html-tidy.org/) |
 | Java | [javac](http://www.oracle.com/technetwork/java/javase/downloads/index.html) |

--- a/ale_linters/handlebars/embertemplatelint.vim
+++ b/ale_linters/handlebars/embertemplatelint.vim
@@ -1,0 +1,55 @@
+" Author: Adrian Zalewski <aazalewski@hotmail.com>
+" Description: Ember-template-lint for checking Handlebars files
+
+let g:ale_handlebars_embertemplatelint_executable =
+\   get(g:, 'ale_handlebars_embertemplatelint_executable', 'ember-template-lint')
+
+let g:ale_handlebars_embertemplatelint_use_global =
+\   get(g:, 'ale_handlebars_embertemplatelint_use_global', 0)
+
+function! ale_linters#handlebars#embertemplatelint#GetExecutable(buffer) abort
+    if g:ale_handlebars_embertemplatelint_use_global
+        return g:ale_handlebars_embertemplatelint_executable
+    endif
+
+    return ale#util#ResolveLocalPath(
+    \   a:buffer,
+    \   'node_modules/.bin/ember-template-lint',
+    \   g:ale_handlebars_embertemplatelint_executable
+    \)
+endfunction
+
+function! ale_linters#handlebars#embertemplatelint#GetCommand(buffer) abort
+    return ale_linters#handlebars#embertemplatelint#GetExecutable(a:buffer)
+    \   . ' --json %t'
+endfunction
+
+function! ale_linters#handlebars#embertemplatelint#Handle(buffer, lines) abort
+    if len(a:lines) == 0
+      return []
+    end
+
+    let l:output = []
+
+    let l:input_json = json_decode(join(a:lines, ''))
+    let l:file_errors = values(l:input_json)[0]
+
+    for l:error in l:file_errors
+        call add(l:output, {
+        \   'bufnr': a:buffer,
+        \   'lnum': l:error.line,
+        \   'col': l:error.column,
+        \   'text': l:error.rule . ': ' . l:error.message,
+        \   'type': l:error.severity == 1 ? 'W' : 'E',
+        \})
+    endfor
+
+    return l:output
+endfunction
+
+call ale#linter#Define('handlebars', {
+\   'name': 'ember-template-lint',
+\   'executable_callback': 'ale_linters#handlebars#embertemplatelint#GetExecutable',
+\   'command_callback': 'ale_linters#handlebars#embertemplatelint#GetCommand',
+\   'callback': 'ale_linters#handlebars#embertemplatelint#Handle',
+\})

--- a/doc/ale-handlebars.txt
+++ b/doc/ale-handlebars.txt
@@ -1,0 +1,34 @@
+===============================================================================
+ALE Handlebars Integration                             *ale-handlebars-options*
+
+
+-------------------------------------------------------------------------------
+ember-template-lint                          *ale-handlebars-embertemplatelint*
+
+g:ale_handlebars_embertemplatelint_executable
+                              \ *g:ale_handlebars_embertemplatelint_executable*
+
+  Type: |String|
+  Default: `'ember-template-lint'`
+
+  ALE will look for ember-template-lint executable in ancestor node_modules
+  directory. When it cannot find it, this variable will be used instead.
+
+  If you wish to use only a globally installed version of ember-template-lint,
+  set |g:ale_handlebars_embertemplatelint_use_global| to `1`.
+
+
+g:ale_handlebars_embertemplatelint_use_global
+                              \ *g:ale_handlebars_embertemplatelint_use_global*
+
+  Type: |Number|
+  Default: `0`
+
+  This variable controls whether or not ALE will search for a local
+  ember-template-lint executable first. If this variable is set to `1`, then
+  ALE will always use the global version of ember-template-lint, in preference
+  to version installed in local node_modules directory.
+
+
+-------------------------------------------------------------------------------
+  vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -31,6 +31,8 @@ CONTENTS                                                         *ale-contents*
       erlc................................|ale-erlang-erlc|
     fortran...............................|ale-fortran-options|
       gcc.................................|ale-fortran-gcc|
+    handlebars............................|ale-handlebars-options|
+      ember-template-lint.................|ale-handlebars-embertemplatelint|
     html..................................|ale-html-options|
       htmlhint............................|ale-html-htmlhint|
       tidy................................|ale-html-tidy|
@@ -123,6 +125,7 @@ The following languages and tools are supported.
 * Fortran: 'gcc'
 * Go: 'gofmt -e', 'go vet', 'golint', 'go build', 'gosimple', 'staticcheck'
 * Haml: 'hamllint'
+* Handlebars: 'ember-template-lint'
 * Haskell: 'ghc', 'hlint'
 * HTML: 'HTMLHint', 'proselint', 'tidy'
 * Java: 'javac'

--- a/test/handler/test_embertemplatelint_handler.vader
+++ b/test/handler/test_embertemplatelint_handler.vader
@@ -1,0 +1,56 @@
+" Author: Adrian Zalewski <aazalewski@hotmail.com>
+
+Before:
+  runtime ale_linters/handlebars/embertemplatelint.vim
+
+Execute(The ember-template-lint handler should parse lines correctly):
+  let input_lines = split('{
+  \ "/ember-project/app/templates/application.hbs": [
+  \   {
+  \     "moduleId": "app/templates/application",
+  \     "rule": "bare-strings",
+  \     "severity": 2,
+  \     "message": "Non-translated string used",
+  \     "line": 1,
+  \     "column": 10,
+  \     "source": " Bare String\n"
+  \   },
+  \   {
+  \     "moduleId": "app/templates/application",
+  \     "rule": "invalid-interactive",
+  \     "severity": 1,
+  \     "message": "Interaction added to non-interactive element",
+  \     "line": 3,
+  \     "column": 6,
+  \     "source": "<span {{action someAction}}></span>"
+  \   }
+  \ ]
+  \ }', '\n')
+
+  AssertEqual
+  \ [
+  \   {
+  \     'bufnr': 347,
+  \     'lnum': 1,
+  \     'col': 10,
+  \     'text': 'bare-strings: Non-translated string used',
+  \     'type': 'E',
+  \   },
+  \   {
+  \     'bufnr': 347,
+  \     'lnum': 3,
+  \     'col': 6,
+  \     'text': 'invalid-interactive: Interaction added to non-interactive element',
+  \     'type': 'W',
+  \   },
+  \ ],
+  \ ale_linters#handlebars#embertemplatelint#Handle(347, input_lines)
+
+Execute(The ember-template-lint handler should handle no lint errors/warnings):
+  AssertEqual
+  \ [
+  \ ],
+  \ ale_linters#handlebars#embertemplatelint#Handle(347, [])
+
+After:
+  call ale#linter#Reset()


### PR DESCRIPTION
Added support for linting using [ember-template-lint](https://github.com/rwjblue/ember-template-lint) Handlebars template linter.

Both basic test and documentation entries included - did my best to follow [contribution guide](https://github.com/w0rp/ale/blob/master/CONTRIBUTING.md). Let me know if I missed anything/something seems out of place.