### PR TITLE
Add Ruby MRI linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ name. That seems to be the fairest way to arrange this table.
 | Puppet | [puppet](https://puppet.com), [puppet-lint](https://puppet-lint.com) |
 | Python | [flake8](http://flake8.pycqa.org/en/latest/), [mypy](http://mypy-lang.org/), [pylint](https://www.pylint.org/) |
 | reStructuredText | [proselint](http://proselint.com/)|
-| Ruby | [rubocop](https://github.com/bbatsov/rubocop) |
+| Ruby | [rubocop](https://github.com/bbatsov/rubocop), [ruby](https://www.ruby-lang.org) |
 | Rust | [rustc](https://www.rust-lang.org/), cargo (see `:help ale-integration-rust` for configuration instructions) |
 | SASS | [sass-lint](https://www.npmjs.com/package/sass-lint), [stylelint](https://github.com/stylelint/stylelint) |
 | SCSS | [sass-lint](https://www.npmjs.com/package/sass-lint), [scss-lint](https://github.com/brigade/scss-lint), [stylelint](https://github.com/stylelint/stylelint) |

--- a/ale_linters/ruby/ruby.vim
+++ b/ale_linters/ruby/ruby.vim
@@ -1,0 +1,46 @@
+" Author: Brandon Roehl - https://github.com/BrandonRoehl
+" Description: Ruby MRI for Ruby files
+
+function! ale_linters#ruby#ruby#Handle(buffer, lines) abort
+	" Matches patterns line the following:
+	"
+	" test.rb:3: warning: parentheses after method name is interpreted as an argument list, not a decomposed argument
+	" test.rb:8: syntax error, unexpected keyword_end, expecting end-of-input
+	let l:pattern = '\v^' . bufname(a:buffer) . ':(\d+): (warning: )?(.+)$'
+	let l:column = '\v^(\s+)\^$'
+
+	let l:output = []
+
+	for l:line in a:lines
+		let l:match = matchlist(l:line, l:pattern)
+
+		if len(l:match) == 0
+			let l:match = matchlist(l:line, l:column)
+			if len(l:match) != 0
+				let l:output[len(l:output) - 1]['col'] = len(l:match[1])
+			endif
+		else
+			call add(l:output, {
+						\   'bufnr': a:buffer,
+						\   'lnum': l:match[1] + 0,
+						\   'col': 0,
+						\   'text': l:match[2] . l:match[3],
+						\   'type': empty(l:match[2]) ? 'E' : 'W',
+						\})
+		endif
+	endfor
+
+	return l:output
+endfunction
+
+function! ale_linters#ruby#ruby#GetCommand(buffer) abort
+	return 'ruby -w -c -T1 ' . bufname(a:buffer)
+endfunction
+
+call ale#linter#Define('ruby', {
+			\   'name': 'ruby',
+			\   'executable': 'ruby',
+			\   'output_stream': 'stderr',
+			\   'command_callback': 'ale_linters#ruby#ruby#GetCommand',
+			\   'callback': 'ale_linters#ruby#ruby#Handle',
+			\})

--- a/ale_linters/ruby/ruby.vim
+++ b/ale_linters/ruby/ruby.vim
@@ -2,45 +2,39 @@
 " Description: Ruby MRI for Ruby files
 
 function! ale_linters#ruby#ruby#Handle(buffer, lines) abort
-	" Matches patterns line the following:
-	"
-	" test.rb:3: warning: parentheses after method name is interpreted as an argument list, not a decomposed argument
-	" test.rb:8: syntax error, unexpected keyword_end, expecting end-of-input
-	let l:pattern = '\v^' . bufname(a:buffer) . ':(\d+): (warning: )?(.+)$'
-	let l:column = '\v^(\s+)\^$'
+    " Matches patterns line the following:
+    "
+    " test.rb:3: warning: parentheses after method name is interpreted as an argument list, not a decomposed argument
+    " test.rb:8: syntax error, unexpected keyword_end, expecting end-of-input
+    let l:pattern = '\v^.+:(\d+): (warning: )?(.+)$'
+    let l:column = '\v^(\s+)\^$'
 
-	let l:output = []
+    let l:output = []
 
-	for l:line in a:lines
-		let l:match = matchlist(l:line, l:pattern)
-
-		if len(l:match) == 0
-			let l:match = matchlist(l:line, l:column)
-			if len(l:match) != 0
-				let l:output[len(l:output) - 1]['col'] = len(l:match[1])
-			endif
-		else
-			call add(l:output, {
-						\   'bufnr': a:buffer,
-						\   'lnum': l:match[1] + 0,
-						\   'col': 0,
-						\   'text': l:match[2] . l:match[3],
-						\   'type': empty(l:match[2]) ? 'E' : 'W',
-						\})
-		endif
-	endfor
-
-	return l:output
-endfunction
-
-function! ale_linters#ruby#ruby#GetCommand(buffer) abort
-	return 'ruby -w -c -T1 ' . bufname(a:buffer)
+    for l:line in a:lines
+        let l:match = matchlist(l:line, l:pattern)
+        if len(l:match) == 0
+            let l:match = matchlist(l:line, l:column)
+            if len(l:match) != 0
+                let l:output[len(l:output) - 1]['col'] = len(l:match[1])
+            endif
+        else
+            call add(l:output, {
+                        \  'bufnr': a:buffer,
+                        \  'lnum': l:match[1] + 0,
+                        \  'col': 0,
+                        \  'text': l:match[2] . l:match[3],
+                        \  'type': empty(l:match[2]) ? 'E' : 'W',
+                        \})
+        endif
+    endfor
+    return l:output
 endfunction
 
 call ale#linter#Define('ruby', {
-			\   'name': 'ruby',
-			\   'executable': 'ruby',
-			\   'output_stream': 'stderr',
-			\   'command_callback': 'ale_linters#ruby#ruby#GetCommand',
-			\   'callback': 'ale_linters#ruby#ruby#Handle',
-			\})
+            \   'name': 'ruby',
+            \   'executable': 'ruby',
+            \   'output_stream': 'stderr',
+            \   'command': 'ruby -w -c -T1 %t',
+            \   'callback': 'ale_linters#ruby#ruby#Handle',
+            \})

--- a/ale_linters/ruby/ruby.vim
+++ b/ale_linters/ruby/ruby.vim
@@ -8,7 +8,6 @@ function! ale_linters#ruby#ruby#Handle(buffer, lines) abort
     " test.rb:8: syntax error, unexpected keyword_end, expecting end-of-input
     let l:pattern = '\v^.+:(\d+): (warning: )?(.+)$'
     let l:column = '\v^(\s+)\^$'
-
     let l:output = []
 
     for l:line in a:lines
@@ -20,21 +19,22 @@ function! ale_linters#ruby#ruby#Handle(buffer, lines) abort
             endif
         else
             call add(l:output, {
-                        \  'bufnr': a:buffer,
-                        \  'lnum': l:match[1] + 0,
-                        \  'col': 0,
-                        \  'text': l:match[2] . l:match[3],
-                        \  'type': empty(l:match[2]) ? 'E' : 'W',
-                        \})
+            \   'bufnr': a:buffer,
+            \   'lnum': l:match[1] + 0,
+            \   'col': 0,
+            \   'text': l:match[2] . l:match[3],
+            \   'type': empty(l:match[2]) ? 'E' : 'W',
+            \})
         endif
     endfor
+
     return l:output
 endfunction
 
 call ale#linter#Define('ruby', {
-            \   'name': 'ruby',
-            \   'executable': 'ruby',
-            \   'output_stream': 'stderr',
-            \   'command': 'ruby -w -c -T1 %t',
-            \   'callback': 'ale_linters#ruby#ruby#Handle',
-            \})
+\   'name': 'ruby',
+\   'executable': 'ruby',
+\   'output_stream': 'stderr',
+\   'command': 'ruby -w -c -T1 %t',
+\   'callback': 'ale_linters#ruby#ruby#Handle',
+\})

--- a/test/handler/test_ruby_handler.vader
+++ b/test/handler/test_ruby_handler.vader
@@ -1,0 +1,40 @@
+Execute(The ruby handler should parse lines correctly and add the column if it can):
+  runtime ale_linters/ruby/ruby.vim
+  # Point Error
+  # Warning
+  # Line Error
+
+  AssertEqual
+  \ [
+  \   {
+  \     'bufnr': 255,
+  \     'lnum': 6,
+  \     'col': 13,
+  \     'text': "syntax error, unexpected ';'",
+  \     'type': 'E',
+  \   },
+  \   {
+  \     'bufnr': 255,
+  \     'lnum': 9,
+  \     'col': 0,
+  \     'text': 'Some error',
+  \     'type': 'W',
+  \   },
+  \   {
+  \     'bufnr': 255,
+  \     'lnum': 12,
+  \     'col': 0,
+  \     'text': 'syntax error, unexpected end-of-input, expecting keyword_end',
+  \     'type': 'E',
+  \   },
+  \ ],
+  \ ale_linters#ruby#ruby#Handle(255, [
+  \ "test.rb:6: syntax error, unexpected ';'",
+  \ "        t = ;",
+  \ "             ^",
+  \ "test.rb:9: warning: statement not reached",
+  \ "test.rb:12: syntax error, unexpected end-of-input, expecting keyword_end",
+  \ ])
+
+After:
+  call ale#linter#Reset()

--- a/test/handler/test_ruby_handler.vader
+++ b/test/handler/test_ruby_handler.vader
@@ -1,32 +1,31 @@
 Execute(The ruby handler should parse lines correctly and add the column if it can):
   runtime ale_linters/ruby/ruby.vim
-  # Point Error
-  # Warning
-  # Line Error
-
+  " Point Error
+  " Warning
+  " Line Error
   AssertEqual
   \ [
   \   {
-  \     'bufnr': 255,
   \     'lnum': 6,
+  \     'bufnr': 255,
   \     'col': 13,
-  \     'text': "syntax error, unexpected ';'",
   \     'type': 'E',
+  \     'text': 'syntax error, unexpected '';'''
   \   },
   \   {
-  \     'bufnr': 255,
   \     'lnum': 9,
+  \     'bufnr': 255,
   \     'col': 0,
-  \     'text': 'Some error',
   \     'type': 'W',
+  \     'text': 'warning: statement not reached'
   \   },
   \   {
-  \     'bufnr': 255,
   \     'lnum': 12,
+  \     'bufnr': 255,
   \     'col': 0,
-  \     'text': 'syntax error, unexpected end-of-input, expecting keyword_end',
   \     'type': 'E',
-  \   },
+  \     'text': 'syntax error, unexpected end-of-input, expecting keyword_end'
+  \   }
   \ ],
   \ ale_linters#ruby#ruby#Handle(255, [
   \ "test.rb:6: syntax error, unexpected ';'",


### PR DESCRIPTION
Add a linter for ruby that just uses ruby's standard with the general ruby command
```bash
ruby -c -w -T1 buffer.rb
```
This way you don't need to install or configure a gem like rubocop