### PR TITLE
Added a missing space to the nimcheck command

### DIFF
--- a/ale_linters/nim/nimcheck.vim
+++ b/ale_linters/nim/nimcheck.vim
@@ -52,7 +52,7 @@ endfunction
 
 
 function! ale_linters#nim#nimcheck#GetCommand(buffer)
-    return 'nim check --path:' . fnameescape(fnamemodify(bufname(a:buffer), ':p:h')) . '--threads:on --verbosity:0 --colors:off --listFullPaths %t'
+    return 'nim check --path:' . fnameescape(fnamemodify(bufname(a:buffer), ':p:h')) . ' --threads:on --verbosity:0 --colors:off --listFullPaths %t'
 endfunction
 
 


### PR DESCRIPTION
I forgot to add a leading space when adding `--threads:on` to the nimcheck command.
My apologies for making this stupid mistake :).