### PR TITLE
Typo correcting 3.0.7 -> 0.3.7 for `vint --no-color`

### DIFF
--- a/ale_linters/vim/vint.vim
+++ b/ale_linters/vim/vint.vim
@@ -7,7 +7,7 @@ let g:ale_vim_vint_show_style_issues =
 
 let s:warning_flag = g:ale_vim_vint_show_style_issues ? '-s' : '-w'
 let s:vint_version = ale#semver#Parse(system('vint --version'))
-let s:has_no_color_support = ale#semver#GreaterOrEqual(s:vint_version, [3, 0, 7])
+let s:has_no_color_support = ale#semver#GreaterOrEqual(s:vint_version, [0, 3, 7])
 let s:enable_neovim = has('nvim') ? ' --enable-neovim ' : ''
 let s:format = '-f "{file_path}:{line_number}:{column_number}: {severity}: {description} (see {reference})"'
 


### PR DESCRIPTION
Since there is no vint v3.0.7, I assumed (and confirmed) that the change was to target v0.3.7 of vint instead.

Comparing [0.3.7](https://github.com/Kuniwak/vint/blob/v0.3.7/vint/linting/cli.py#L75) with [0.3.6](https://github.com/Kuniwak/vint/blob/v0.3.6/vint/linting/cli.py#L75), it looks like the intended target version was 0.3.7 after all.

Did not add myself as a contributor since this only corrects a minor typo.