### PR TITLE
Add puppet-lint config options and documentation

### DIFF
--- a/ale_linters/puppet/puppetlint.vim
+++ b/ale_linters/puppet/puppetlint.vim
@@ -1,10 +1,26 @@
-" Author: Alexander Olofsson <alexander.olofsson@liu.se>
+" Author: Alexander Olofsson <alexander.olofsson@liu.se>, Robert Flechtner <flechtner@chemmedia.de>
+" Description: puppet-lint for puppet files
+
+let g:ale_puppet_puppetlint_executable =
+\   get(g:, 'ale_puppet_puppetlint_executable', 'puppet-lint')
+
+let g:ale_puppet_puppetlint_options =
+\   get(g:, 'ale_puppet_puppetlint_options', '')
+
+function! ale_linters#puppet#puppetlint#GetExecutable(buffer) abort
+    return g:ale_puppet_puppetlint_executable
+endfunction
+
+function! ale_linters#puppet#puppetlint#GetCommand(buffer) abort
+    return ale_linters#puppet#puppetlint#GetExecutable(a:buffer)
+    \   . ' ' . g:ale_puppet_puppetlint_options
+    \   . ' --log-format "-:%{line}:%{column}: %{kind}: [%{check}] %{message}"'
+    \   . ' %t'
+endfunction
 
 call ale#linter#Define('puppet', {
 \   'name': 'puppetlint',
-\   'executable': 'puppet-lint',
-\   'command': 'puppet-lint --no-autoloader_layout-check'
-\   .   ' --log-format "-:%{line}:%{column}: %{kind}: [%{check}] %{message}"'
-\   .   ' %t',
+\   'executable_callback': 'ale_linters#puppet#puppetlint#GetExecutable',
+\   'command_callback': 'ale_linters#puppet#puppetlint#GetCommand',
 \   'callback': 'ale#handlers#gcc#HandleGCCFormat',
 \})

--- a/doc/ale-puppet.txt
+++ b/doc/ale-puppet.txt
@@ -1,0 +1,26 @@
+===============================================================================
+ALE Puppet Integration                                     *ale-puppet-options*
+
+
+-------------------------------------------------------------------------------
+puppetlint                                              *ale-puppet-puppetlint*
+
+g:ale_puppet_puppetlint_executable         *g:ale_puppet_puppetlint_executable*
+
+  Type: |String|
+  Default: `'puppet-lint'`
+
+  This variable can be changed to specify the executable used for puppet-lint.
+
+
+g:ale_puppet_puppetlint_options               *g:ale_puppet_puppetlint_options*
+
+  Type: |String|
+  Default: `''`
+
+  This variable can be changed to add command-line arguments to the
+  puppet-lint invocation.
+
+
+-------------------------------------------------------------------------------
+  vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:


### PR DESCRIPTION
This adds variables for specifying the puppet-lint executable and additional command line arguments. It also removes the hard-coded '--no-autoloader_layout-check' argument.