### PR TITLE
Add support for multiple filetypes in filetype aliasing

### DIFF
--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -380,6 +380,14 @@ g:ale_linter_aliases                                     *g:ale_linter_aliases*
   not the aliased type (`'php'`). This allows an aliased type to run a
   different set of linters from the type it is being mapped to.
 
+  Passing a list of filetypes is also supported. Say you want to lint
+  javascript and css embedded in HTML (using linters that support that).
+  You could alias `html` like so:
+
+  `let g:ale_linter_aliases = {'html': ['html', 'javascript', 'css']}`
+
+  Note that `html` itself was included as an alias. That is because aliases
+  will override the original linters for the aliased filetepe.
 
 g:ale_linters                                                   *g:ale_linters*
 

--- a/test/test_linter_retrieval.vader
+++ b/test/test_linter_retrieval.vader
@@ -39,5 +39,19 @@ Execute (Define multiple linters for different filetypes):
 Then (Linters for dot-seperated filetypes should be properly handled):
   AssertEqual [g:testlinter1, g:testlinter2], ale#linter#Get('testft1.testft2')
 
+Execute (Define multiple aliases for a filetype):
+  call ale#linter#Define('testft1', g:testlinter1)
+  call ale#linter#Define('testft2', g:testlinter2)
+  let ale_linter_aliases = {'testft3': ['testft1', 'testft2']}
+Then (Linters should be transparently aliased):
+  AssertEqual [g:testlinter1, g:testlinter2], ale#linter#Get('testft3')
+
+Execute (Alias a filetype to itself plus another one):
+  call ale#linter#Define('testft1', g:testlinter1)
+  call ale#linter#Define('testft2', g:testlinter2)
+  let ale_linter_aliases = {'testft1': ['testft1', 'testft2']}
+Then (The original linters should still be there):
+  AssertEqual [g:testlinter1, g:testlinter2], ale#linter#Get('testft1')
+
 Execute (Try to load a linter from disk):
   AssertEqual [{'name': 'testlinter', 'output_stream': 'stdout', 'executable': 'testlinter', 'command': 'testlinter', 'callback': 'testCB', 'read_buffer': 1, 'lint_file': 0}], ale#linter#Get('testft')


### PR DESCRIPTION
Now we can set a list of filetypes when aliasing new ones.

This is my first work on a plugin for vim, and my first contribution for a project on github. So, please, go easy on me ;)

All tests are passing so I think I didn't break anything. But the way that `ale#linter#GetAll` is handling failures during the load of linter files is kind of bothering me. I kept the same approach as before, if a failure occurs, an empty list of linters is returned. But, now that function is loading linters for multiple filetypes so returning nothing while at least one linter could be functional may be a little drastic, or may be not. What do you think about that?