### PR TITLE
Some fixes in markdown documents

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@
 
 <a name="guidelines"></a>
 
-# 1. Guidelines
+## 1. Guidelines
 
 Have fun, and work on whatever floats your boat. Take It Easy :tm:.
 
@@ -31,7 +31,7 @@ will check your code while you type.
 
 <a name="issues"></a>
 
-# 2. Creating Issues
+## 2. Creating Issues
 
 Before creating any issues, please look through the current list of issues and
 pull requests, and ensure that the issue hasn't already been reported. If an
@@ -52,7 +52,7 @@ can understand you.
 
 <a name="pull-requests"></a>
 
-# 3. Creating Pull Requests
+## 3. Creating Pull Requests
 
 For code you write, make sure to credit yourself at the top of files you add,
 and probably those you modify. You can write some comments at the top of your
@@ -71,7 +71,7 @@ If you want to credit multiple authors, you can comma separate them.
 
 <a name="adding-a-new-linter"></a>
 
-# 3.i. Adding a New Linter
+### 3.i. Adding a New Linter
 
 If you add a new linter, look for existing handlers first in the
 [handlers.vim](autoload/ale/handlers.vim) file. One of the handlers there may
@@ -87,7 +87,7 @@ alphabetically in the table and list.
 
 <a name="adding-new-options"></a>
 
-# 3.ii. Adding New Options
+### 3.ii. Adding New Options
 
 If you add new options to the plugin, make sure to document those new options
 in the [README.md](README.md) file, and also in the [help file](doc/ale.txt).
@@ -104,7 +104,7 @@ easy to see what the default is with `:echo g:ale...`.
 
 <a name="writing-documentation"></a>
 
-# 4. Writing Documentation
+## 4. Writing Documentation
 
 If you are adding new linters, changing the API, adding new options, etc., you
 _must_ write some documentation describing it in the `doc/ale.txt` file.  New
@@ -113,7 +113,7 @@ quick overview of the supported tools.
 
 <a name="documenting-new-linters"></a>
 
-# 4.i Documenting New Linters
+### 4.i Documenting New Linters
 
 If you add a new linter to the project, edit the table in the `README.md` file,
 and edit the list of linters at the top of the `doc/ale.txt` file. The linters
@@ -125,7 +125,7 @@ giving some unfair preference to any particular tool or language.
 
 <a name="editing-online-documentation"></a>
 
-# 4.ii Editing the Online Documentation
+### 4.ii Editing the Online Documentation
 
 The "online documentation" file used for this project lives in `doc/ale.txt`.
 This is the file used for generating `:help` text inside Vim itself. There are
@@ -145,7 +145,7 @@ some guidlines to follow for this file.
 
 <a name="documenting-linter-options"></a>
 
-# 4.iii Documenting Linter Options
+### 4.iii Documenting Linter Options
 
 For documenting new linter options, please add a new sub-section under the
 "Linter Specific Options" section describing all of the global options added
@@ -155,7 +155,7 @@ to look up the default value easily by typing `:echo g:ale_...`.
 
 <a name="in-case-of-busses"></a>
 
-# 5. In Case of Busses
+## 5. In Case of Busses
 
 Should the principal author of the ALE project and all collaborators with the
 required access needed to properly administrate the project on GitHub or any

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,12 +3,12 @@
 1. [Guidelines](#guidelines)
 2. [Creating Issues](#issues)
 3. [Creating Pull Requests](#pull-requests)
- 1. [Adding a New Linter](#adding-a-new-linter)
- 2. [Adding New Options](#adding-new-options)
+    1. [Adding a New Linter](#adding-a-new-linter)
+    2. [Adding New Options](#adding-new-options)
 4. [Writing Documentation](#writing-documentation)
- 1. [Documenting New Linters](#documenting-new-linters)
- 2. [Editing the Online Documentation](#editing-online-documentation)
- 3. [Documenting Linter Options](#documenting-new-options)
+    1. [Documenting New Linters](#documenting-new-linters)
+    2. [Editing the Online Documentation](#editing-online-documentation)
+    3. [Documenting Linter Options](#documenting-new-options)
 5. [In Case of Busses](#in-case-of-busses)
 
 <a name="guidelines"></a>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@
 4. [Writing Documentation](#writing-documentation)
     1. [Documenting New Linters](#documenting-new-linters)
     2. [Editing the Online Documentation](#editing-online-documentation)
-    3. [Documenting Linter Options](#documenting-new-options)
+    3. [Documenting Linter Options](#documenting-linter-options)
 5. [In Case of Busses](#in-case-of-busses)
 
 <a name="guidelines"></a>

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ In other words, this plugin allows you to lint while you type.
 4. [Contributing](#contributing)
 5. [FAQ](#faq)
     1. [How do I disable particular linters?](#faq-disable-linters)
-    2. [How can I keep the sign gutter open?](#faq-disable-linters)
+    2. [How can I keep the sign gutter open?](#faq-keep-signs)
     3. [How can I change the signs ALE uses?](#faq-change-signs)
     4. [How can I show errors or warnings in my statusline?](#faq-statusline)
     5. [How can I change the format for echo messages?](#faq-echo-format)

--- a/README.md
+++ b/README.md
@@ -20,22 +20,22 @@ In other words, this plugin allows you to lint while you type.
 1. [Supported Languages and Tools](#supported-languages)
 2. [Usage](#usage)
 3. [Installation](#installation)
- 1. [Installation with Pathogen](#installation-with-pathogen)
- 2. [Installation with Vundle](#installation-with-vundle)
- 3. [Manual Installation](#manual-installation)
+    1. [Installation with Pathogen](#installation-with-pathogen)
+    2. [Installation with Vundle](#installation-with-vundle)
+    3. [Manual Installation](#manual-installation)
 4. [Contributing](#contributing)
 5. [FAQ](#faq)
- 1. [How do I disable particular linters?](#faq-disable-linters)
- 2. [How can I keep the sign gutter open?](#faq-disable-linters)
- 3. [How can I change the signs ALE uses?](#faq-change-signs)
- 4. [How can I show errors or warnings in my statusline?](#faq-statusline)
- 5. [How can I change the format for echo messages?](#faq-echo-format)
- 6. [How can I execute some code when ALE stops linting?](#faq-autocmd)
- 7. [How can I navigate between errors quickly?](#faq-navigation)
- 8. [How can I run linters only when I save files?](#faq-lint-on-save)
- 9. [How can I use the quickfix list instead of the loclist?](#faq-quickfix)
- 10. [How can I check JSX files with both stylelint and eslint?](#faq-jsx-stylelint-eslint)
- 11. [Will this plugin eat all of my laptop battery power?](#faq-my-battery-is-sad)
+    1. [How do I disable particular linters?](#faq-disable-linters)
+    2. [How can I keep the sign gutter open?](#faq-disable-linters)
+    3. [How can I change the signs ALE uses?](#faq-change-signs)
+    4. [How can I show errors or warnings in my statusline?](#faq-statusline)
+    5. [How can I change the format for echo messages?](#faq-echo-format)
+    6. [How can I execute some code when ALE stops linting?](#faq-autocmd)
+    7. [How can I navigate between errors quickly?](#faq-navigation)
+    8. [How can I run linters only when I save files?](#faq-lint-on-save)
+    9. [How can I use the quickfix list instead of the loclist?](#faq-quickfix)
+    10. [How can I check JSX files with both stylelint and eslint?](#faq-jsx-stylelint-eslint)
+    11. [Will this plugin eat all of my laptop battery power?](#faq-my-battery-is-sad)
 
 <a name="supported-languages"></a>
 
@@ -309,9 +309,9 @@ let g:ale_statusline_format = ['⨉ %d', '⚠ %d', '⬥ ok']
 There are 3 global options that allow customizing the echoed message.
 
 - `g:ale_echo_msg_format` where:
-  * `%s` is the error message itself
-  * `%linter%` is the linter name
-  * `%severity` is the severity type
+    * `%s` is the error message itself
+    * `%linter%` is the linter name
+    * `%severity` is the severity type
 - `g:ale_echo_msg_error_str` is the string used for error severity.
 - `g:ale_echo_msg_warning_str` is the string used for warning severity.
 


### PR DESCRIPTION
Changes in GitHub's markdown parser caused the lists to render incorrectly. See https://github.com/blog/2333-a-formal-spec-for-github-flavored-markdown

I also fixed some other issues I noticed like heading sizes and broken links.