### PR TITLE
PHP: Fix double errors and support fatal errors

### DIFF
--- a/ale_linters/php/php.vim
+++ b/ale_linters/php/php.vim
@@ -1,11 +1,11 @@
-" Author: Spencer Wood <https://github.com/scwood>
+" Author: Spencer Wood <https://github.com/scwood>, Adriaan Zonnenberg <amz@adriaan.xyz>
 " Description: This file adds support for checking PHP with php-cli
 
 function! ale_linters#php#php#Handle(buffer, lines) abort
     " Matches patterns like the following:
     "
     " PHP Parse error:  syntax error, unexpected ';', expecting ']' in - on line 15
-    let l:pattern = '\vParse error:\s+(.+unexpected ''(.+)%(expecting.+)@<!''.*|.+) in - on line (\d+)'
+    let l:pattern = '\vPHP %(Fatal|Parse) error:\s+(.+unexpected ''(.+)%(expecting.+)@<!''.*|.+) in - on line (\d+)'
 
     let l:output = []
 

--- a/test/handler/test_php_handler.vader
+++ b/test/handler/test_php_handler.vader
@@ -3,6 +3,7 @@ Given (Some invalid lines of PHP):
   class Foo { / }
   $foo)
   ['foo' 'bar']
+  function count() {}
 
 Execute(The php handler should parse lines correctly):
   runtime ale_linters/php/php.vim
@@ -39,6 +40,13 @@ Execute(The php handler should parse lines correctly):
   \   },
   \   {
   \     'bufnr': 347,
+  \     'lnum': 5,
+  \     'col': 0,
+  \     'text': "Cannot redeclare count()",
+  \     'type': 'E',
+  \   },
+  \   {
+  \     'bufnr': 347,
   \     'lnum': 21,
   \     'col': 0,
   \     'text': "syntax error, unexpected end of file",
@@ -54,10 +62,12 @@ Execute(The php handler should parse lines correctly):
   \ ],
   \ ale_linters#php#php#Handle(347, [
   \   'This line should be ignored completely',
+  \   "Parse error:  syntax error, This line should be ignored completely in - on line 1",
   \   "PHP Parse error:  syntax error, unexpected ';', expecting ']' in - on line 1",
   \   "PHP Parse error:  syntax error, unexpected '/', expecting function (T_FUNCTION) or const (T_CONST) in - on line 2",
   \   "PHP Parse error:  syntax error, unexpected ')' in - on line 3",
   \   "PHP Parse error:  syntax error, unexpected ''bar'' (T_CONSTANT_ENCAPSED_STRING), expecting ']' in - on line 4",
+  \   "PHP Fatal error:  Cannot redeclare count() in - on line 5",
   \   'PHP Parse error:  syntax error, unexpected end of file in - on line 21',
   \   'PHP Parse error: Invalid numeric literal in - on line 47',
   \ ])


### PR DESCRIPTION
Because the `-d display_errors=1` argument is used on the PHP linter, errors show up 2 times like this:

```
PHP Parse error:  syntax error, unexpected end of file in - on line 9

Parse error: syntax error, unexpected end of file in - on line 9
Errors parsing -
```

Both of the lines were matched. This fixes it by looking for `PHP Parse error` specifically. 

I wonder if we can remove `-d display_errors=1`  or only look at the first line, but I don't know if either of those options have any side effects.

I also added support for "Fatal errors" by adding `Fatal` in addition to `Parse` to the pattern.