### PR TITLE
Add gometalinter linter for go files

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ name. That seems to be the fairest way to arrange this table.
 | Elm | [elm-make](https://github.com/elm-lang/elm-make) |
 | Erlang | [erlc](http://erlang.org/doc/man/erlc.html) |
 | Fortran | [gcc](https://gcc.gnu.org/) |
-| Go | [gofmt -e](https://golang.org/cmd/gofmt/), [go vet](https://golang.org/cmd/vet/), [golint](https://godoc.org/github.com/golang/lint), [go build](https://golang.org/cmd/go/), [gosimple](https://github.com/dominikh/go-tools/tree/master/cmd/gosimple), [staticcheck](https://github.com/dominikh/go-tools/tree/master/cmd/staticcheck) |
+| Go | [gofmt -e](https://golang.org/cmd/gofmt/), [go vet](https://golang.org/cmd/vet/), [golint](https://godoc.org/github.com/golang/lint), [gometalinter](https://github.com/alecthomas/gometalinter), [go build](https://golang.org/cmd/go/), [gosimple](https://github.com/dominikh/go-tools/tree/master/cmd/gosimple), [staticcheck](https://github.com/dominikh/go-tools/tree/master/cmd/staticcheck) |
 | Haml | [haml-lint](https://github.com/brigade/haml-lint)
 | Handlebars | [ember-template-lint](https://github.com/rwjblue/ember-template-lint) |
 | Haskell | [ghc](https://www.haskell.org/ghc/), [hlint](https://hackage.haskell.org/package/hlint), [hdevtools](https://hackage.haskell.org/package/hdevtools) |

--- a/ale_linters/go/gometalinter.vim
+++ b/ale_linters/go/gometalinter.vim
@@ -1,0 +1,61 @@
+" Author: Ben Reedy <https://github.com/breed808>
+" Description: Adds support for the gometalinter suite for Go files
+
+" Disable gometalinter by default
+if !exists('g:ale_go_gometalinter_enabled')
+    let g:ale_go_gometalinter_enabled = 0
+endif
+
+if !exists('g:ale_go_gometalinter_options')
+    let g:ale_go_gometalinter_options = ''
+endif
+
+function! ale_linters#go#gometalinter#GetCommand(buffer) abort
+    if g:ale_go_gometalinter_enabled == 1
+        return 'gometalinter ' . g:ale_go_gometalinter_options . ' ' . fnameescape(fnamemodify(bufname(a:buffer), ':p:h'))
+    endif
+    return ''
+endfunction
+
+function! ale_linters#go#gometalinter#Handler(buffer, lines) abort
+    " Matches patterns line the following:
+    "
+    " file.go:27: missing argument for Printf("%s"): format reads arg 2, have only 1 args
+    " file.go:53:10: if block ends with a return statement, so drop this else and outdent its block (move short variable declaration to its own line if necessary)
+    " file.go:5:2: expected declaration, found 'STRING' "log"
+
+    " gometalinter returns relative paths so use tail of filename as part of pattern matcher
+    let l:filename = fnamemodify(bufname(a:buffer), ':t')
+    let l:path_pattern = '[a-zA-Z]\?\\\?:\?[[:alnum:]/\.\-_]\+'
+    let l:pattern = '^' . l:path_pattern . ':\(\d\+\):\?\(\d\+\)\?:\?:\?\(warning\|error\):\?\s\*\?\(.\+\)$'
+    let l:output = []
+
+    for l:line in a:lines
+        let l:match = matchlist(l:line, l:pattern)
+
+        " Omit errors from files other than the one currently open
+        if len(l:match) == 0 || l:line !~ l:filename
+            continue
+        endif
+
+        " vcol is Needed to indicate that the column is a character.
+        call add(l:output, {
+        \   'bufnr': a:buffer,
+        \   'lnum': l:match[1] + 0,
+        \   'vcol': 0,
+        \   'col': l:match[2] + 0,
+        \   'text': l:match[4],
+        \   'type': tolower(l:match[3]) ==# 'warning' ? 'W' : 'E',
+        \   'nr': -1,
+        \})
+    endfor
+    return l:output
+endfunction
+
+call ale#linter#Define('go', {
+\   'name': 'gometalinter',
+\   'executable': 'gometalinter',
+\   'command_callback': 'ale_linters#go#gometalinter#GetCommand',
+\   'callback': 'ale_linters#go#gometalinter#Handler',
+\   'lint_file': 1,
+\})

--- a/ale_linters/go/gometalinter.vim
+++ b/ale_linters/go/gometalinter.vim
@@ -1,20 +1,14 @@
 " Author: Ben Reedy <https://github.com/breed808>
 " Description: Adds support for the gometalinter suite for Go files
 
-" Disable gometalinter by default
-if !exists('g:ale_go_gometalinter_enabled')
-    let g:ale_go_gometalinter_enabled = 0
-endif
-
 if !exists('g:ale_go_gometalinter_options')
     let g:ale_go_gometalinter_options = ''
 endif
 
 function! ale_linters#go#gometalinter#GetCommand(buffer) abort
-    if g:ale_go_gometalinter_enabled == 1
-        return 'gometalinter ' . g:ale_go_gometalinter_options . ' ' . fnameescape(fnamemodify(bufname(a:buffer), ':p:h'))
-    endif
-    return ''
+    return 'gometalinter '
+    \   . g:ale_go_gometalinter_options
+    \   . ' ' . fnameescape(fnamemodify(bufname(a:buffer), ':p:h'))
 endfunction
 
 function! ale_linters#go#gometalinter#Handler(buffer, lines) abort
@@ -49,6 +43,7 @@ function! ale_linters#go#gometalinter#Handler(buffer, lines) abort
         \   'nr': -1,
         \})
     endfor
+
     return l:output
 endfunction
 

--- a/autoload/ale/linter.vim
+++ b/autoload/ale/linter.vim
@@ -22,6 +22,7 @@ let s:default_ale_linter_aliases = {
 " Only cargo is enabled for Rust by default.
 let s:default_ale_linters = {
 \   'csh': ['shell'],
+\   'go': ['go build', 'gofmt', 'golint', 'gosimple', 'go vet', 'staticcheck'],
 \   'help': [],
 \   'rust': ['cargo'],
 \   'text': [],

--- a/doc/ale-go.txt
+++ b/doc/ale-go.txt
@@ -1,0 +1,25 @@
+===============================================================================
+ALE Go Integration                                            *ale-go-options*
+
+
+-------------------------------------------------------------------------------
+gometalinter                                             *ale-go-gometalinter*
+
+g:ale_go_gometalinter_enabled                  *g:ale_go_gometalinter_enabled*
+
+  Type: |Integer|
+  Default: 0
+
+  This variable can be change to enable gometalinter for go files.
+
+
+g:ale_go_gometalinter_options                  *g:ale_go_gometalinter_options*
+
+  Type: |String|
+  Default: `''`
+
+  This variable can be changed to alter the command-line arguments to the
+  gometalinter invocation.
+
+-------------------------------------------------------------------------------
+  vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-go.txt
+++ b/doc/ale-go.txt
@@ -3,6 +3,18 @@ ALE Go Integration                                            *ale-go-options*
 
 
 -------------------------------------------------------------------------------
+Integration Information
+
+The `gometalinter` linter is disabled by default, and all other Go linters
+supported by ALE are enabled by default. To enable `gometalinter`, update
+|g:ale_linters| as appropriate:
+
+>
+  " Enable all of the linters you want for Go.
+  let g:ale_linters = {'go': ['gometalinter', 'gofmt']}
+<
+
+-------------------------------------------------------------------------------
 gometalinter                                             *ale-go-gometalinter*
 
 g:ale_go_gometalinter_enabled                  *g:ale_go_gometalinter_enabled*

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -31,6 +31,8 @@ CONTENTS                                                         *ale-contents*
       erlc................................|ale-erlang-erlc|
     fortran...............................|ale-fortran-options|
       gcc.................................|ale-fortran-gcc|
+    go....................................|ale-go-options|
+      gometalinter........................|ale-go-gometalinter|
     handlebars............................|ale-handlebars-options|
       ember-template-lint.................|ale-handlebars-embertemplatelint|
     html..................................|ale-html-options|
@@ -123,7 +125,7 @@ The following languages and tools are supported.
 * Elm: 'elm-make'
 * Erlang: 'erlc'
 * Fortran: 'gcc'
-* Go: 'gofmt -e', 'go vet', 'golint', 'go build', 'gosimple', 'staticcheck'
+* Go: 'gofmt', 'go vet', 'golint', 'go build', 'gosimple', 'staticcheck'
 * Haml: 'hamllint'
 * Handlebars: 'ember-template-lint'
 * Haskell: 'ghc', 'hlint'


### PR DESCRIPTION
Referring to #419 for this.
Added the `gometalinter` to ALE, but left it disabled by default (see `g:ale_go_gometalinter_enabled`) as it conflicts with a number of existing ALE linters for Go (`golint`, `govet`, `gosimple`, `staticcheck`, etc).

Vader tests for this haven't been written yet, but it is on my to-do list (along with the tests for the `gobuild` linter).