### PR TITLE
Add linter for Crystal lang

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ name. That seems to be the fairest way to arrange this table.
 | Chef | [foodcritic](http://www.foodcritic.io/) |
 | CMake | [cmakelint](https://github.com/richq/cmake-lint) |
 | CoffeeScript | [coffee](http://coffeescript.org/), [coffeelint](https://www.npmjs.com/package/coffeelint) |
+| Crystal | [crystal](https://crystal-lang.org/) |
 | CSS | [csslint](http://csslint.net/), [stylelint](https://github.com/stylelint/stylelint) |
 | Cython (pyrex filetype) | [cython](http://cython.org/) |
 | D | [dmd](https://dlang.org/dmd-linux.html) |

--- a/ale_linters/crystal/crystal.vim
+++ b/ale_linters/crystal/crystal.vim
@@ -1,0 +1,40 @@
+" Author: Jordan Andree <https://github.com/jordanandree>
+" Description: This file adds support for checking Crystal with crystal build
+
+function! ale_linters#crystal#crystal#Handle(buffer, lines) abort
+    let l:output = []
+
+    let l:lines = join(a:lines, '')
+    
+    if !empty(l:lines)
+      let l:errors = json_decode(l:lines)
+
+      for l:error in l:errors
+          call add(l:output, {
+          \   'bufnr': a:buffer,
+          \   'lnum': l:error.line + 0,
+          \   'col': l:error.column + 0,
+          \   'text': l:error.message,
+          \   'type': 'E',
+          \})
+      endfor
+    endif
+
+    return l:output
+endfunction
+
+function! ale_linters#crystal#crystal#GetCommand(buffer) abort
+  let l:crystal_cmd = 'crystal build -f json --no-codegen -o '
+  let l:crystal_cmd .= shellescape(g:ale#util#nul_file)
+  let l:crystal_cmd .= ' %t'
+
+  return l:crystal_cmd
+endfunction
+
+call ale#linter#Define('crystal', {
+\   'name': 'crystal',
+\   'executable': 'crystal',
+\   'output_stream': 'both',
+\   'command_callback': 'ale_linters#crystal#crystal#GetCommand',
+\   'callback': 'ale_linters#crystal#crystal#Handle',
+\})

--- a/test/handler/test_crystal_handler.vader
+++ b/test/handler/test_crystal_handler.vader
@@ -1,0 +1,18 @@
+Execute(The crystal handler should parse lines correctly and add the column if it can):
+  runtime ale_linters/crystal/crystal.vim
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 2,
+  \     'bufnr': 255,
+  \     'col': 1,
+  \     'type': 'E',
+  \     'text': 'unexpected token: EOF'
+  \   }
+  \ ],
+  \ ale_linters#crystal#crystal#Handle(255, [
+  \ '[{"file":"/tmp/test.cr","line":2,"column":1,"size":null,"message":"unexpected token: EOF"}]'
+  \ ])
+
+After:
+  call ale#linter#Reset()


### PR DESCRIPTION
Adds linter for [Crystal lang](https://crystal-lang.org) using the packaged `build` command:

```sh
$ crystal build -f json --no-codegen -o /dev/null
```
the `-o` argument will implement `g:ale#util#nul_file`

also adds Vader tests
