### PR TITLE
add goflycheck for go files

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ name. That seems to be the fairest way to arrange this table.
 | Elm | [elm-make](https://github.com/elm-lang/elm-make) |
 | Erlang | [erlc](http://erlang.org/doc/man/erlc.html) |
 | Fortran | [gcc](https://gcc.gnu.org/) |
-| Go | [gofmt -e](https://golang.org/cmd/gofmt/), [go vet](https://golang.org/cmd/vet/), [golint](https://godoc.org/github.com/golang/lint), [go build](https://golang.org/cmd/go/), [gosimple](https://github.com/dominikh/go-tools/tree/master/cmd/gosimple), [staticcheck](https://github.com/dominikh/go-tools/tree/master/cmd/staticcheck) |
+| Go | [gofmt -e](https://golang.org/cmd/gofmt/), [go vet](https://golang.org/cmd/vet/), [golint](https://godoc.org/github.com/golang/lint), [go build](https://golang.org/cmd/go/), [gosimple](https://github.com/dominikh/go-tools/tree/master/cmd/gosimple), [staticcheck](https://github.com/dominikh/go-tools/tree/master/cmd/staticcheck), [goflycheck](https://github.com/dzhou121/goflycheck) |
 | Haml | [haml-lint](https://github.com/brigade/haml-lint)
 | Handlebars | [ember-template-lint](https://github.com/rwjblue/ember-template-lint) |
 | Haskell | [ghc](https://www.haskell.org/ghc/), [hlint](https://hackage.haskell.org/package/hlint), [hdevtools](https://hackage.haskell.org/package/hdevtools) |

--- a/ale_linters/go/goflycheck.vim
+++ b/ale_linters/go/goflycheck.vim
@@ -1,0 +1,9 @@
+" Author: dzhou121 <dzhou121@gmail.com>
+" Description: goflycheck for Go files
+
+call ale#linter#Define('go', {
+\   'name': 'goflycheck',
+\   'executable': 'goflycheck',
+\   'command': 'goflycheck %s',
+\   'callback': 'ale#handlers#HandleUnixFormatAsError',
+\})

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -123,7 +123,7 @@ The following languages and tools are supported.
 * Elm: 'elm-make'
 * Erlang: 'erlc'
 * Fortran: 'gcc'
-* Go: 'gofmt -e', 'go vet', 'golint', 'go build', 'gosimple', 'staticcheck'
+* Go: 'gofmt -e', 'go vet', 'golint', 'go build', 'gosimple', 'staticcheck', 'goflycheck'
 * Haml: 'hamllint'
 * Handlebars: 'ember-template-lint'
 * Haskell: 'ghc', 'hlint'


### PR DESCRIPTION
Add a new linter goflycheck for Golang. This linter is able to read stdin of the file buffer and take care of Golang package complexity from ale. 

https://github.com/dzhou121/goflycheck
