### PR TITLE
Improve flake8 message severity

### DIFF
--- a/ale_linters/python/flake8.vim
+++ b/ale_linters/python/flake8.vim
@@ -7,6 +7,34 @@ let g:ale_python_flake8_executable =
 let g:ale_python_flake8_args =
 \   get(g:, 'ale_python_flake8_args', '')
 
+" E999: Synax Error
+"
+" F601: dictionary key name repeated with different values
+" F602: dictionary key variable name repeated with different values
+" F621: too many expressions in an assignment with star-unpacking
+" F622: two or more starred expressions in an assignment (a, *b, *c = d)
+" F631: assertion test is a tuple, which are always True
+"
+" F701: a break statement outside of a while or for loop
+" F702: a continue statement outside of a while or for loop
+" F703: a continue statement in a finally block in a loop
+" F704: a yield or yield from statement outside of a function
+" F705: a return statement with arguments inside a generator
+" F706: a return statement outside of a function/method
+" F707: an except: block as not the last exception handler
+"
+" F811: redefinition of unused name from line N
+" F821: undefined name name
+" F822: undefined name name in __all__
+" F823: local variable name ... referenced before assignment
+let g:ale_python_flake8_error_codes =
+\   get(g:, 'python_flake8_error_codes', [
+\     'E999',
+\     'F601', 'F602', 'F621', 'F622', 'F631',
+\     'F701', 'F702', 'F703', 'F704', 'F705', 'F706', 'F707',
+\     'F811', 'F821', 'F823', 'F831',
+\   ])
+
 " A map from Python executable paths to semver strings parsed for those
 " executables, so we don't have to look up the version number constantly.
 let s:version_cache = {}
@@ -72,5 +100,5 @@ call ale#linter#Define('python', {
 \       {'callback': 'ale_linters#python#flake8#VersionCheck'},
 \       {'callback': 'ale_linters#python#flake8#GetCommand'},
 \   ],
-\   'callback': 'ale#handlers#HandlePEP8Format',
+\   'callback': 'ale#handlers#HandleFlake8Format',
 \})

--- a/autoload/ale/handlers.vim
+++ b/autoload/ale/handlers.vim
@@ -76,8 +76,6 @@ endfunction
 function! ale#handlers#HandlePEP8Format(buffer, lines) abort
     " Matches patterns line the following:
     "
-    " Matches patterns line the following:
-    "
     " stdin:6:6: E111 indentation is not a multiple of four
     " test.yml:35: [EANSIBLE0002] Trailing whitespace
     let l:pattern = '^' . s:path_pattern . ':\(\d\+\):\?\(\d\+\)\?: \[\?\(\([[:alpha:]]\)[[:alnum:]]\+\)\]\? \(.*\)$'
@@ -109,6 +107,45 @@ function! ale#handlers#HandlePEP8Format(buffer, lines) abort
         \   'col': l:match[2] + 0,
         \   'text': l:code . ': ' . l:match[5],
         \   'type': l:match[4] ==# 'E' ? 'E' : 'W',
+        \   'nr': -1,
+        \})
+    endfor
+
+    return l:output
+endfunction
+
+
+function! ale#handlers#HandleFlake8Format(buffer, lines) abort
+    " Matches patterns line the following:
+    "
+    " stdin:6:6: E111 indentation is not a multiple of four
+    "
+    " Uses g:ale_python_flake8_error_codes to decide the severity of the
+    " message
+    let l:pattern = '^' . s:path_pattern . ':\(\d\+\):\?\(\d\+\)\?: \(\([[:alpha:]]\)[[:alnum:]]\+\) \(.*\)$'
+    let l:output = []
+
+    for l:line in a:lines
+        let l:match = matchlist(l:line, l:pattern)
+
+        if len(l:match) == 0
+            continue
+        endif
+
+        let l:code = l:match[3]
+        if (l:code ==# 'W291' || l:code ==# 'W293')
+                    \ && !g:ale_warn_about_trailing_whitespace
+            " Skip warnings for trailing whitespace if the option is off.
+            continue
+        endif
+
+        call add(l:output, {
+        \   'bufnr': a:buffer,
+        \   'lnum': l:match[1] + 0,
+        \   'vcol': 0,
+        \   'col': l:match[2] + 0,
+        \   'text': l:code . ': ' . l:match[5],
+        \   'type': index(g:ale_python_flake8_error_codes , l:code) == -1 ? 'W' : 'E',
         \   'nr': -1,
         \})
     endfor


### PR DESCRIPTION
(party) fixes #430 

The `g:ale_python_flake8_error_codes` is deliberately undocumented – It seems unlikely that someone might want to modify it. but it's overrideable just in case.