### PR TITLE
Flow: Fix case where 1st msg points to different file

### DIFF
--- a/ale_linters/javascript/flow.vim
+++ b/ale_linters/javascript/flow.vim
@@ -68,7 +68,6 @@ function! ale_linters#javascript#flow#Handle(buffer, lines) abort
         endif
 
         call add(l:output, {
-        \   'bufnr': a:buffer,
         \   'lnum': l:line,
         \   'col': l:col,
         \   'text': l:text,

--- a/ale_linters/javascript/flow.vim
+++ b/ale_linters/javascript/flow.vim
@@ -48,8 +48,10 @@ function! ale_linters#javascript#flow#Handle(buffer, lines) abort
         let l:col = 0
 
         for l:message in l:error.message
-            " Comments have no line of column information
-            if has_key(l:message, 'loc') && l:line ==# 0
+            " Comments have no line of column information, so we skip them.
+            " In certain cases, `l:message.loc.source` points to a different path
+            " than the buffer one, thus we skip this loc information too.
+            if has_key(l:message, 'loc') && l:line ==# 0 && l:message.loc.source ==# expand('#' . a:buffer . ':p')
                 let l:line = l:message.loc.start.line + 0
                 let l:col = l:message.loc.start.column + 0
             endif

--- a/test/handler/test_flow_handler.vader
+++ b/test/handler/test_flow_handler.vader
@@ -113,14 +113,12 @@ Execute(The flow handler should process errors correctly.):
   let g:expected = [
   \ {
   \   'lnum': 417,
-  \   'bufnr': 347,
   \   'type': 'E',
   \   'col': 10,
   \   'text': 'number: This type is incompatible with the expected return type of array type',
   \ },
   \ {
   \   'lnum': 419,
-  \   'bufnr': 347,
   \   'type': 'W',
   \   'col': 3,
   \   'text': 'unreachable code:',

--- a/test/handler/test_flow_handler.vader
+++ b/test/handler/test_flow_handler.vader
@@ -1,4 +1,15 @@
 Before:
+  runtime ale_linters/javascript/flow.vim
+
+After:
+  unlet! g:flow_output
+  unlet! g:expected
+  unlet! g:actual
+  call ale#linter#Reset()
+
+Execute(The flow handler should process errors correctly.):
+  e! /home/w0rp/Downloads/graphql-js/src/language/parser.js
+
   let g:flow_output = {
   \ "flowVersion": "0.39.0",
   \ "errors": [
@@ -100,16 +111,7 @@ Before:
   \ "passed": v:false
   \}
 
-  runtime ale_linters/javascript/flow.vim
-
-After:
-  unlet! g:flow_output
-  unlet! g:expected
-  unlet! g:actual
-  call ale#linter#Reset()
-
-Execute(The flow handler should process errors correctly.):
-  let g:actual = ale_linters#javascript#flow#Handle(347, [json_encode(g:flow_output)])
+  let g:actual = ale_linters#javascript#flow#Handle(bufnr(''), [json_encode(g:flow_output)])
   let g:expected = [
   \ {
   \   'lnum': 417,
@@ -123,6 +125,110 @@ Execute(The flow handler should process errors correctly.):
   \   'col': 3,
   \   'text': 'unreachable code:',
   \ },
+  \]
+
+  AssertEqual g:expected, g:actual
+
+Execute(The flow handler should fetch the correct location for the currently opened file, even when it's not in the first message.):
+  e! /Users/rav/Projects/vim-ale-flow/index.js
+
+  let g:flow_output = {
+  \ "flowVersion": "0.44.0",
+  \ "errors": [{
+  \   "operation": {
+  \     "context": "  <Foo foo=\"bar\"/>, document.getElementById('foo')",
+  \     "descr": "React element `Foo`",
+  \     "type": "Blame",
+  \     "loc": {
+  \       "source": "/Users/rav/Projects/vim-ale-flow/index.js",
+  \       "type": "SourceFile",
+  \       "start": {
+  \         "line": 6,
+  \         "column": 3,
+  \         "offset": 92
+  \       },
+  \       "end": {
+  \         "line": 6,
+  \         "column": 18,
+  \         "offset": 108
+  \       }
+  \     },
+  \     "path": "/Users/rav/Projects/vim-ale-flow/index.js",
+  \     "line": 6,
+  \     "endline": 6,
+  \     "start": 3,
+  \     "end": 18
+  \   },
+  \   "kind": "infer",
+  \   "level": "error",
+  \   "message": [{
+  \     "context": "module.exports = function(props: Props) {",
+  \     "descr": "property `bar`",
+  \     "type": "Blame",
+  \     "loc": {
+  \       "source": "/Users/rav/Projects/vim-ale-flow/foo.js",
+  \       "type": "SourceFile",
+  \       "start": {
+  \         "line": 9,
+  \         "column": 34,
+  \         "offset": 121
+  \       },
+  \       "end": {
+  \         "line": 9,
+  \         "column": 38,
+  \         "offset": 126
+  \       }
+  \     },
+  \     "path": "/Users/rav/Projects/vim-ale-flow/foo.js",
+  \     "line": 9,
+  \     "endline": 9,
+  \     "start": 34,
+  \     "end": 38
+  \   }, {
+  \     "context": v:null,
+  \     "descr": "Property not found in",
+  \     "type": "Comment",
+  \     "path": "",
+  \     "line": 0,
+  \     "endline": 0,
+  \     "start": 1,
+  \     "end": 0
+  \   }, {
+  \     "context": "  <Foo foo=\"bar\"/>, document.getElementById('foo')",
+  \     "descr": "props of React element `Foo`",
+  \     "type": "Blame",
+  \     "loc": {
+  \       "source": "/Users/rav/Projects/vim-ale-flow/index.js",
+  \       "type": "SourceFile",
+  \       "start": {
+  \         "line": 6,
+  \         "column": 3,
+  \         "offset": 92
+  \       },
+  \       "end": {
+  \         "line": 6,
+  \         "column": 18,
+  \         "offset": 108
+  \       }
+  \     },
+  \     "path": "/Users/rav/Projects/vim-ale-flow/index.js",
+  \     "line": 6,
+  \     "endline": 6,
+  \     "start": 3,
+  \     "end": 18
+  \   }]
+  \ }],
+  \ "passed": v:false
+  \}
+
+  let g:actual = ale_linters#javascript#flow#Handle(bufnr(''), [json_encode(g:flow_output)])
+  let g:expected = [
+  \ {
+  \   'lnum': 6,
+  \   'col': 3,
+  \   'type': 'E',
+  \   'text': 'property `bar`: Property not found in props of React element `Foo` See also: React element `Foo`'
+  \ }
   \]
 
   AssertEqual g:expected, g:actual


### PR DESCRIPTION
Take a look at [an example gist](https://gist.github.com/ravicious/ceaf1fd5c60791f527c8edc4a34e45d8). We assume that we have ale v1.2.0 installed and we open `index.js`. `error.json` represents the JSON output of Flow.

The current implementation takes [the first location information](https://github.com/w0rp/ale/blob/c9a5d9845b9bff9174c4bb3b67a9f7bfda190ee6/ale_linters/javascript/flow.vim#L50-L53) that it spots in `errors[0].message` elements. If you look at [`error.json`](https://gist.github.com/ravicious/ceaf1fd5c60791f527c8edc4a34e45d8#file-error-json), this is not correct in this case, as `errors[0].message[0].loc` points to a different file (`foo.js`) than the one opened in the current buffer (`index.js`).

This patch ensures that we only take the location information into consideration if the location source is equal to the buffer path.

Sorry for not writing any tests. 😐 I'm not familiar with Vader, but even if I was, I'd first need to come up with a more straightforward example that doesn't need React to be installed.