### PR TITLE
turn on lint_file for crystal build to resolve `require` path errors

### DIFF
--- a/ale_linters/crystal/crystal.vim
+++ b/ale_linters/crystal/crystal.vim
@@ -26,7 +26,7 @@ endfunction
 function! ale_linters#crystal#crystal#GetCommand(buffer) abort
     let l:crystal_cmd = 'crystal build -f json --no-codegen -o '
     let l:crystal_cmd .= shellescape(g:ale#util#nul_file)
-    let l:crystal_cmd .= ' %t'
+    let l:crystal_cmd .= ' %s'
 
     return l:crystal_cmd
 endfunction
@@ -35,6 +35,7 @@ call ale#linter#Define('crystal', {
 \   'name': 'crystal',
 \   'executable': 'crystal',
 \   'output_stream': 'both',
+\   'lint_file': 1,
 \   'command_callback': 'ale_linters#crystal#crystal#GetCommand',
 \   'callback': 'ale_linters#crystal#crystal#Handle',
 \})


### PR DESCRIPTION
Related to #474, this turns on `lint_file: 1` for the Crystal linter to resolve errors with relative required files and required globs. 

Example of what this fixes:

```crystal
# test.cr
require "./src/*"
```

Error produced:

>test.cr|1 col 1 error| while requiring "./src/*": can't find file './src/*' relative to '/var/folders/2r/jtsw1zv54t17s8g8m698jg_h0000gn/T/nvimWQ9DHV/2'
