### PR TITLE
Make jshint work with html

### DIFF
--- a/ale_linters/javascript/jshint.vim
+++ b/ale_linters/javascript/jshint.vim
@@ -28,7 +28,7 @@ function! ale_linters#javascript#jshint#GetCommand(buffer) abort
     \)
 
     let l:command = ale_linters#javascript#jshint#GetExecutable(a:buffer)
-    let l:command .= ' --reporter unix'
+    let l:command .= ' --reporter unix --extract auto'
 
     if !empty(l:jshint_config)
         let l:command .= ' --config ' . fnameescape(l:jshint_config)


### PR DESCRIPTION
This makes the jshint linter work on html files.

The jshint linter can be made "available" to html files by doing this alias thing: 

```vim
let g:ale_linter_aliases = {'html': ['html', 'javascript']}
```

However, jshint wouldn't actually work with html files. It would just complain that your html on line 0 was incorrect javascript syntax. With this change, I'm able to see jshint work as desired on embedded javascript inside html script tags.