### PR TITLE
Update flow.vim

### DIFF
--- a/ale_linters/javascript/flow.vim
+++ b/ale_linters/javascript/flow.vim
@@ -51,7 +51,8 @@ function! ale_linters#javascript#flow#Handle(buffer, lines) abort
             " Comments have no line of column information, so we skip them.
             " In certain cases, `l:message.loc.source` points to a different path
             " than the buffer one, thus we skip this loc information too.
-            if has_key(l:message, 'loc') && l:line ==# 0 && l:message.loc.source ==# expand('#' . a:buffer . ':p')
+            let l:fullFilePath = expand('#' . a:buffer . ':p') 
+            if has_key(l:message, 'loc') && l:line ==# 0 && match(l:fullFilePath, l:message.loc.source)
                 let l:line = l:message.loc.start.line + 0
                 let l:col = l:message.loc.start.column + 0
             endif


### PR DESCRIPTION
The current exact equality operator breaks all my errors. One side of the operator uses a full file path, and the other side uses a relative path according the current workdir. 

WARNING: I have not tested this with Vader. I just needed a quick fix to solve my current problem (all my flow errors lack a line number). This fixes my problem and I thought an untested pull request is more helpful than a plain issue.