### PR TITLE
Add rpm spec file linter (rpmlint)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ name. That seems to be the fairest way to arrange this table.
 | Puppet | [puppet](https://puppet.com), [puppet-lint](https://puppet-lint.com) |
 | Python | [flake8](http://flake8.pycqa.org/en/latest/), [mypy](http://mypy-lang.org/), [pylint](https://www.pylint.org/) |
 | reStructuredText | [proselint](http://proselint.com/)|
+| RPM spec | [rpmlint](https://github.com/rpm-software-management/rpmlint) |
 | Ruby | [rubocop](https://github.com/bbatsov/rubocop), [ruby](https://www.ruby-lang.org) |
 | Rust | [rustc](https://www.rust-lang.org/), cargo (see `:help ale-integration-rust` for configuration instructions) |
 | SASS | [sass-lint](https://www.npmjs.com/package/sass-lint), [stylelint](https://github.com/stylelint/stylelint) |

--- a/ale_linters/spec/rpmlint.vim
+++ b/ale_linters/spec/rpmlint.vim
@@ -1,0 +1,85 @@
+" Author: Jason Tibbitts <tibbs@math.uh.edu>
+" Description: Adds support for checking RPM spec files with rpmlint
+
+" rpmlint will produce varions types of output:
+"
+" Lines like the following are output when the file is simply not able to be
+" parsed by rpmspec -P:
+"   apcupsd.spec: E: specfile-error warning: bogus date in %changelog: Mon Oct 1 2005 - Foo
+"   apcupsd.spec: E: specfile-error error: %changelog not in descending chronological order
+" They do not contain a line number, and there's not a whole lot that can be
+" done to locate them besides grep for them.  rpmlint is just passing the
+" output from rpm along with the filename, an error indicator, and an error
+" type.
+"
+" Lines like the following:
+"   cyrus-imapd.spec:23: W: macro-in-comment %version
+"   cyrus-imapd.spec:18: E: hardcoded-library-path in %_prefix/lib/%name
+" indicate warnings and errors, respectively.  No column numbers are provided
+"
+" Lines like:
+"   apcupsd.spec: I: checking
+"   apcupsd.spec: I: checking-url https://downloads.sourceforge.net/apcupsd/apcupsd-3.14.14.tar.gz (timeout 10 seconds)
+" are merely informational and are only output when -v is passed.  But they
+" may be useful in a log to know why things are taking so long.
+"
+" And this is always output at the end and should just be ignored:
+"   0 packages and 1 specfiles checked; 4 errors, 0 warnings.
+
+let g:ale_spec_rpmlint_executable =
+\   get(g:, 'ale_spec_rpmlint_executable', 'rpmlint')
+
+let g:ale_spec_rpmlint_options =
+\   get(g:, 'ale_spec_rpmlint_options', '')
+
+function! ale_linters#spec#rpmlint#GetExecutable(buffer) abort
+    return ale#Var(a:buffer, 'spec_rpmlint_executable')
+endfunction
+
+function! ale_linters#spec#rpmlint#GetCommand(buffer) abort
+    return ale_linters#spec#rpmlint#GetExecutable(a:buffer)
+    \   . ' ' . ale#Var(a:buffer, 'spec_rpmlint_options')
+    \   . ' -o "NetworkEnabled False"'
+    \   . ' -v'
+    \   . ' %t'
+endfunction
+
+function! ale_linters#spec#rpmlint#Handle(buffer, lines) abort
+    " let l:pat_inform = '^.\+: I: \(.+\)'
+    let l:pat_errwarn = '^.\+:\(\d\+\): \([EW]\): \(.\+\)'
+    let l:pat_baderr = '^.\+: E: \(.\+\)'
+    let l:output = []
+
+    for l:line in a:lines
+        let l:match_errwarn = matchlist(l:line, l:pat_errwarn)
+        let l:match_baderr = matchlist(l:line, l:pat_baderr)
+
+        if len(l:match_errwarn) > 0
+            let l:text = l:match_errwarn[3]
+            let l:type = l:match_errwarn[2]
+            let l:lnum = l:match_errwarn[1] + 0
+        elseif len(l:match_baderr) > 0
+            let l:text = l:match_baderr[1]
+            let l:type = 'E'
+            let l:lnum = 1
+        else
+            continue
+        endif
+
+        call add(l:output, {
+        \   'bufnr': a:buffer,
+        \   'lnum': l:lnum,
+        \   'text': l:text,
+        \   'type': l:type,
+        \})
+    endfor
+
+    return l:output
+endfunction
+
+call ale#linter#Define('spec', {
+\   'name': 'rpmlint',
+\   'executable_callback': 'ale_linters#spec#rpmlint#GetExecutable',
+\   'command_callback': 'ale_linters#spec#rpmlint#GetCommand',
+\   'callback': 'ale_linters#spec#rpmlint#Handle',
+\})

--- a/doc/ale-spec.txt
+++ b/doc/ale-spec.txt
@@ -1,0 +1,28 @@
+===============================================================================
+ALE RPM Spec Integration                                     *ale-spec-options*
+
+
+-------------------------------------------------------------------------------
+rpmlint                                                      *ale-spec-rpmlint*
+
+g:ale_spec_rpmlint_executable                 *g:ale_spec_rpmlint_executable*
+
+  Type: |String|
+  Default: `'rpmlint'`
+
+  This variable sets executable used for rpmlint.
+
+
+g:ale_spec_rpmlint_options                       *g:ale_spec_rpmlint_options*
+
+  Type: |String|
+  Default: `''`
+
+  Set this to pass extra arguments to rpmlint.
+
+  For example, to instruct rpmlint to use a specific configuration file:
+
+  let g:ale_spec_rpmlint_options = '-f custom.cf'
+
+-------------------------------------------------------------------------------
+  vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -71,6 +71,8 @@ CONTENTS                                                         *ale-contents*
     sh....................................|ale-sh-options|
       shell...............................|ale-sh-shell|
       shellcheck..........................|ale-sh-shellcheck|
+    spec..................................|ale-spec-options|
+      rpmlint.............................|ale-spec-rpmlint|
     tex...................................|ale-tex-options|
       chktex..............................|ale-tex-chktex|
       lacheck.............................|ale-tex-lacheck|
@@ -149,6 +151,7 @@ The following languages and tools are supported.
 * Puppet: 'puppet', 'puppet-lint'
 * Python: 'flake8', 'mypy', 'pylint'
 * reStructuredText: 'proselint'
+* RPM spec: 'spec'
 * Rust: 'rustc' (see |ale-integration-rust|)
 * Ruby: 'rubocop'
 * SASS: 'sasslint', 'stylelint'

--- a/test/handler/test_rpmlint_handler.vader
+++ b/test/handler/test_rpmlint_handler.vader
@@ -18,7 +18,7 @@ Execute(The rpmlint handler should parse error messages correctly):
   \   {
   \     'bufnr': 42,
   \     'lnum': 1,
-  \     'text': 'warning: bogus date in %changelog: Mon Oct 1 2005 - Foo',
+  \     'text': 'specfile-error warning: bogus date in %changelog: Mon Oct 1 2005 - Foo',
   \     'type': 'E',
   \   },
   \ ],

--- a/test/handler/test_rpmlint_handler.vader
+++ b/test/handler/test_rpmlint_handler.vader
@@ -1,0 +1,29 @@
+Execute(The rpmlint handler should parse error messages correctly):
+    runtime ale_linters/spec/rpmlint.vim
+
+AssertEqual
+  \ [
+  \   {
+  \     'lnum': 23,
+  \     'text': 'macro-in-comment %version',
+  \     'type': 'W',
+  \   },
+  \   {
+  \     'lnum': 17,
+  \     'text': 'hardcoded-library-path in %_prefix/lib/%name',
+  \     'type': 'E',
+  \   },
+  \   {
+  \     'lnum': 1,
+  \     'text': 'warning: bogus date in %changelog: Mon Oct 1 2005 - Foo',
+  \     'type': 'E',
+  \   },
+  \ ],
+  \ ale_linters#spec#rpmlint#Handle(42, [
+  \   'cyrus-imapd.spec:23: W: macro-in-comment %version',
+  \   'cyrus-imapd.spec:17: E: hardcoded-library-path in %_prefix/lib/%name',
+  \   'apcupsd.spec: E: specfile-error warning: bogus date in %changelog: Mon Oct 1 2005 - Foo',
+\ ])
+
+
+

--- a/test/handler/test_rpmlint_handler.vader
+++ b/test/handler/test_rpmlint_handler.vader
@@ -1,7 +1,7 @@
 Execute(The rpmlint handler should parse error messages correctly):
-    runtime ale_linters/spec/rpmlint.vim
+  runtime ale_linters/spec/rpmlint.vim
 
-AssertEqual
+  AssertEqual
   \ [
   \   {
   \     'lnum': 23,
@@ -23,7 +23,4 @@ AssertEqual
   \   'cyrus-imapd.spec:23: W: macro-in-comment %version',
   \   'cyrus-imapd.spec:17: E: hardcoded-library-path in %_prefix/lib/%name',
   \   'apcupsd.spec: E: specfile-error warning: bogus date in %changelog: Mon Oct 1 2005 - Foo',
-\ ])
-
-
-
+  \ ])

--- a/test/handler/test_rpmlint_handler.vader
+++ b/test/handler/test_rpmlint_handler.vader
@@ -4,16 +4,19 @@ Execute(The rpmlint handler should parse error messages correctly):
   AssertEqual
   \ [
   \   {
+  \     'bufnr': 42,
   \     'lnum': 23,
   \     'text': 'macro-in-comment %version',
   \     'type': 'W',
   \   },
   \   {
+  \     'bufnr': 42,
   \     'lnum': 17,
   \     'text': 'hardcoded-library-path in %_prefix/lib/%name',
   \     'type': 'E',
   \   },
   \   {
+  \     'bufnr': 42,
   \     'lnum': 1,
   \     'text': 'warning: bogus date in %changelog: Mon Oct 1 2005 - Foo',
   \     'type': 'E',


### PR DESCRIPTION
This is a rough attempt at adding a linter for RPM spec files using rpmlint.  It appears to work well enough, but note the following:

* I basically don't know what I'm doing.  I have many years of programming experience but outside of setting variables in my .vimrc, vim isn't something I've done before.
* Some rpmlint errors do not have line numbers.  I just made them show up at line 1 but perhaps there's a better way to handle that.
* The vim modeline reads 'spec' but everyone's going to call them "RPM spec files".  I'm not sure where that should actually go in the documentation.
* Editing vim help files is... weird.  I tried to get things to line up the right way but I'm not sure if it's done the right way.
* I added an entry for the test suite but I didn't try actually running it.  I guess the CI setup will yell at me if it doesn't run properly.

So, anyway, it's a first try.  Please let me know what I can do to make it better.