### PR TITLE
Marks persist when switching from lintable to not lintable buffer

### DIFF
--- a/autoload/ale/filetypes.vim
+++ b/autoload/ale/filetypes.vim
@@ -58,3 +58,8 @@ function! ale#filetypes#GuessExtension(filetype) abort
     " Return an empty string if we don't find anything.
     return ''
 endfunction
+
+function! ale#filetypes#IsLintable(filetype) abort
+    let l:linters = ale#linter#Get(a:filetype)
+    return len(l:linters) != 0
+endfunction

--- a/autoload/ale/highlight.vim
+++ b/autoload/ale/highlight.vim
@@ -51,8 +51,9 @@ function! ale#highlight#UpdateHighlights() abort
     let l:has_new_items = has_key(s:buffer_highlights, l:buffer)
     let l:loclist = l:has_new_items ? remove(s:buffer_highlights, l:buffer) : []
     let l:current_id_map = s:GetCurrentMatchIDs(l:loclist)
+    let l:is_lintable_buffer = ale#filetypes#IsLintable(&filetype)
 
-    if l:has_new_items || !g:ale_enabled
+    if l:has_new_items || !l:is_lintable_buffer || !g:ale_enabled
         for l:match in s:GetALEMatches()
             if !has_key(l:current_id_map, l:match.id)
                 call matchdelete(l:match.id)


### PR DESCRIPTION
Hi

Please find below steps to reproduce persistent marks problem:
1. Open lintable file which contains marks
2. From this file switch to not lintable file
You should notice that some letters in not lintable files are highlighted. This happens because Ale does not cleared marks info on buffer switch.

