### PR TITLE
Disable rpmlint by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,7 @@ name. That seems to be the fairest way to arrange this table.
 | Puppet | [puppet](https://puppet.com), [puppet-lint](https://puppet-lint.com) |
 | Python | [flake8](http://flake8.pycqa.org/en/latest/), [mypy](http://mypy-lang.org/), [pylint](https://www.pylint.org/) |
 | reStructuredText | [proselint](http://proselint.com/)|
-| RPM spec | [rpmlint](https://github.com/rpm-software-management/rpmlint) (disabled by default; see `:help
-ale-integration-spec`) |
+| RPM spec | [rpmlint](https://github.com/rpm-software-management/rpmlint) (disabled by default; see `:help ale-integration-spec`) |
 | Ruby | [reek](https://github.com/troessner/reek), [rubocop](https://github.com/bbatsov/rubocop), [ruby](https://www.ruby-lang.org) |
 | Rust | [rustc](https://www.rust-lang.org/), cargo (see `:help ale-integration-rust` for configuration instructions) |
 | SASS | [sass-lint](https://www.npmjs.com/package/sass-lint), [stylelint](https://github.com/stylelint/stylelint) |

--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ name. That seems to be the fairest way to arrange this table.
 | Puppet | [puppet](https://puppet.com), [puppet-lint](https://puppet-lint.com) |
 | Python | [flake8](http://flake8.pycqa.org/en/latest/), [mypy](http://mypy-lang.org/), [pylint](https://www.pylint.org/) |
 | reStructuredText | [proselint](http://proselint.com/)|
-| RPM spec | [rpmlint](https://github.com/rpm-software-management/rpmlint) |
+| RPM spec | [rpmlint](https://github.com/rpm-software-management/rpmlint) (disabled by default; see `:help
+ale-integration-spec`) |
 | Ruby | [reek](https://github.com/troessner/reek), [rubocop](https://github.com/bbatsov/rubocop), [ruby](https://www.ruby-lang.org) |
 | Rust | [rustc](https://www.rust-lang.org/), cargo (see `:help ale-integration-rust` for configuration instructions) |
 | SASS | [sass-lint](https://www.npmjs.com/package/sass-lint), [stylelint](https://github.com/stylelint/stylelint) |

--- a/autoload/ale/linter.vim
+++ b/autoload/ale/linter.vim
@@ -20,11 +20,13 @@ let s:default_ale_linter_aliases = {
 " No linters are used for plaintext files by default.
 "
 " Only cargo is enabled for Rust by default.
+" rpmlint is disabled by default because it can result in code execution.
 let s:default_ale_linters = {
 \   'csh': ['shell'],
 \   'go': ['go build', 'gofmt', 'golint', 'gosimple', 'go vet', 'staticcheck'],
 \   'help': [],
 \   'rust': ['cargo'],
+\   'spec': [],
 \   'text': [],
 \   'zsh': ['shell'],
 \}

--- a/doc/ale-spec.txt
+++ b/doc/ale-spec.txt
@@ -1,11 +1,10 @@
 ===============================================================================
 ALE RPM Spec Integration                                     *ale-spec-options*
 
-
 -------------------------------------------------------------------------------
 rpmlint                                                      *ale-spec-rpmlint*
 
-g:ale_spec_rpmlint_executable                 *g:ale_spec_rpmlint_executable*
+g:ale_spec_rpmlint_executable                   *g:ale_spec_rpmlint_executable*
 
   Type: |String|
   Default: `'rpmlint'`
@@ -13,7 +12,7 @@ g:ale_spec_rpmlint_executable                 *g:ale_spec_rpmlint_executable*
   This variable sets executable used for rpmlint.
 
 
-g:ale_spec_rpmlint_options                       *g:ale_spec_rpmlint_options*
+g:ale_spec_rpmlint_options                         *g:ale_spec_rpmlint_options*
 
   Type: |String|
   Default: `''`

--- a/doc/ale-spec.txt
+++ b/doc/ale-spec.txt
@@ -1,5 +1,19 @@
 ===============================================================================
 ALE RPM Spec Integration                                     *ale-spec-options*
+                                                         *ale-integration-spec*
+
+-------------------------------------------------------------------------------
+Integration Information
+
+  The rpmlint linter is disabled by default, because running rpmlint can
+  result in the execution of code embedded in the spec file and rpmlint makes
+  no distinction between checks which are safe to run on untrusted files and
+  those which are not.
+
+  Currently linters must be enabled globally.  The rpmlint linter can be
+  enabled with:
+
+  let g:ale_linters = {'spec': ['rpmlint']}
 
 -------------------------------------------------------------------------------
 rpmlint                                                      *ale-spec-rpmlint*


### PR DESCRIPTION
It was pointed out to me that it's not safe to run rpmlint because it can result in execution of code embedded in the spec file.  This PR disables it by default and provides instructions for enabling it.

If a buffer-local linters setting is implemented, I'll send another PR updating the instructions if necessary.