### PR TITLE
Haskell:  new ghc-mod linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ name. That seems to be the fairest way to arrange this table.
 | Go | [gofmt -e](https://golang.org/cmd/gofmt/), [go vet](https://golang.org/cmd/vet/), [golint](https://godoc.org/github.com/golang/lint), [gometalinter](https://github.com/alecthomas/gometalinter), [go build](https://golang.org/cmd/go/), [gosimple](https://github.com/dominikh/go-tools/tree/master/cmd/gosimple), [staticcheck](https://github.com/dominikh/go-tools/tree/master/cmd/staticcheck) |
 | Haml | [haml-lint](https://github.com/brigade/haml-lint)
 | Handlebars | [ember-template-lint](https://github.com/rwjblue/ember-template-lint) |
-| Haskell | [ghc](https://www.haskell.org/ghc/), [hlint](https://hackage.haskell.org/package/hlint), [hdevtools](https://hackage.haskell.org/package/hdevtools) |
+| Haskell | [ghc](https://www.haskell.org/ghc/), [ghc-mod](https://github.com/DanielG/ghc-mod), [hlint](https://hackage.haskell.org/package/hlint), [hdevtools](https://hackage.haskell.org/package/hdevtools) |
 | HTML | [HTMLHint](http://htmlhint.com/), [proselint](http://proselint.com/), [tidy](http://www.html-tidy.org/) |
 | Java | [javac](http://www.oracle.com/technetwork/java/javase/downloads/index.html) |
 | JavaScript | [eslint](http://eslint.org/), [jscs](http://jscs.info/), [jshint](http://jshint.com/), [flow](https://flowtype.org/), [standard](http://standardjs.com/), [xo](https://github.com/sindresorhus/xo)

--- a/ale_linters/haskell/ghc-mod.vim
+++ b/ale_linters/haskell/ghc-mod.vim
@@ -1,0 +1,16 @@
+" Author: wizzup <wizzup@gmail.com>
+" Description: ghc-mod for Haskell files
+
+call ale#linter#Define('haskell', {
+\   'name': 'ghc-mod',
+\   'executable': 'ghc-mod',
+\   'command': 'ghc-mod check %t',
+\   'callback': 'ale#handlers#haskell#HandleGHCFormat',
+\})
+
+call ale#linter#Define('haskell', {
+\   'name': 'stack-ghc-mod',
+\   'executable': 'stack',
+\   'command': 'stack exec ghc-mod check %t',
+\   'callback': 'ale#handlers#haskell#HandleGHCFormat',
+\})

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -136,7 +136,7 @@ The following languages and tools are supported.
 * Go: 'gofmt', 'go vet', 'golint', 'go build', 'gosimple', 'staticcheck'
 * Haml: 'hamllint'
 * Handlebars: 'ember-template-lint'
-* Haskell: 'ghc', 'hlint', 'hdevtools'
+* Haskell: 'ghc', 'ghc-mod', 'hlint', 'hdevtools'
 * HTML: 'HTMLHint', 'proselint', 'tidy'
 * Java: 'javac'
 * JavaScript: 'eslint', 'jscs', 'jshint', 'flow', 'xo'

--- a/test/handler/test_ghc_mod_handler.vader
+++ b/test/handler/test_ghc_mod_handler.vader
@@ -1,0 +1,27 @@
+Execute(HandleGhcFormat should handle ghc-mod problems):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 2,
+  \     'col': 1,
+  \     'type': 'E',
+  \     'text': 'Failed to load interface for ‘Missing’Use -v to see a list of the files searched for.',
+  \   },
+  \   {
+  \     'lnum': 2,
+  \     'col': 1,
+  \     'type': 'E',
+  \     'text': ' Suggestion: Use camelCaseFound:  my_variable = ...Why not:  myVariable = ...',
+  \   },
+  \   {
+  \     'lnum': 6,
+  \     'col': 1,
+  \     'type': 'E',
+  \     'text': ' Warning: Eta reduceFound:  myFunc x = succ xWhy not:  myFunc = succ',
+  \   },
+  \ ],
+  \ ale#handlers#haskell#HandleGHCFormat(bufnr(''), [
+  \   'check1.hs:2:1:Failed to load interface for ‘Missing’Use -v to see a list of the files searched for.',
+  \   'check2.hs:2:1: Suggestion: Use camelCaseFound:  my_variable = ...Why not:  myVariable = ...',
+  \   'check2.hs:6:1: Warning: Eta reduceFound:  myFunc x = succ xWhy not:  myFunc = succ',
+  \ ])


### PR DESCRIPTION
Since `hdevtools` seem to have [problem](https://github.com/hdevtools/hdevtools/issues/49) with `stack`, I would love to propose `ghc-mod` as alternative linter.

I made this by modify the `hdevtools` linter. ` ale/ale_linters/haskell/hdevtools.vim
`
Never develop vim plugin before, I have no idea how to full-test.

I have use it for a while and it seem to work. I have [eagletmt/ghcmod-vim
](https://github.com/eagletmt/ghcmod-vim) and lint message seem to be the same.

Please take a look