### PR TITLE
update doc/ale.txt

### DIFF
--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -134,7 +134,7 @@ The following languages and tools are supported.
 * Go: 'gofmt', 'go vet', 'golint', 'go build', 'gosimple', 'staticcheck'
 * Haml: 'hamllint'
 * Handlebars: 'ember-template-lint'
-* Haskell: 'ghc', 'hlint'
+* Haskell: 'ghc', 'hlint', 'hdevtools'
 * HTML: 'HTMLHint', 'proselint', 'tidy'
 * Java: 'javac'
 * JavaScript: 'eslint', 'jscs', 'jshint', 'flow', 'xo'


### PR DESCRIPTION
Missing hdevtools in ale.txt
Readme.md has `Haskell | ghc, hlint, hdevtools`