### PR TITLE
Add tags for buffer-local variants of each linter option

### DIFF
--- a/ale_linters/javascript/xo.vim
+++ b/ale_linters/javascript/xo.vim
@@ -11,20 +11,20 @@ let g:ale_javascript_xo_use_global =
 \   get(g:, 'ale_javascript_xo_use_global', 0)
 
 function! ale_linters#javascript#xo#GetExecutable(buffer) abort
-    if g:ale_javascript_xo_use_global
-        return g:ale_javascript_xo_executable
+    if ale#Var(a:buffer, 'javascript_xo_use_global')
+        return ale#Var(a:buffer, 'javascript_xo_executable')
     endif
 
     return ale#path#ResolveLocalPath(
     \   a:buffer,
     \   'node_modules/.bin/xo',
-    \   g:ale_javascript_xo_executable
+    \   ale#Var(a:buffer, 'javascript_xo_executable')
     \)
 endfunction
 
 function! ale_linters#javascript#xo#GetCommand(buffer) abort
     return ale_linters#javascript#xo#GetExecutable(a:buffer)
-    \   . ' ' . g:ale_javascript_xo_options
+    \   . ' ' . ale#Var(a:buffer, 'javascript_xo_options')
     \   . ' --reporter unix --stdin --stdin-filename %s'
 endfunction
 

--- a/ale_linters/sh/shellcheck.vim
+++ b/ale_linters/sh/shellcheck.vim
@@ -20,12 +20,6 @@ function! ale_linters#sh#shellcheck#GetExecutable(buffer) abort
     return ale#Var(a:buffer, 'sh_shellcheck_executable')
 endfunction
 
-if g:ale_linters_sh_shellcheck_exclusions !=# ''
-    let s:exclude_option = '-e ' .  g:ale_linters_sh_shellcheck_exclusions
-else
-    let s:exclude_option = ''
-endif
-
 function! s:GetDialectArgument() abort
     if exists('b:is_bash') && b:is_bash
         return '-s bash'
@@ -39,9 +33,12 @@ function! s:GetDialectArgument() abort
 endfunction
 
 function! ale_linters#sh#shellcheck#GetCommand(buffer) abort
+    let l:exclude_option = ale#Var(a:buffer, 'linters_sh_shellcheck_exclusions')
+
     return ale_linters#sh#shellcheck#GetExecutable(a:buffer)
     \   . ' ' . ale#Var(a:buffer, 'sh_shellcheck_options')
-    \   . ' ' . s:exclude_option . ' ' . s:GetDialectArgument() . ' -f gcc -'
+    \   . ' ' . (!empty(l:exclude_option) ? '-e ' . l:exclude_option : '')
+    \   . ' ' . s:GetDialectArgument() . ' -f gcc -'
 endfunction
 
 call ale#linter#Define('sh', {

--- a/ale_linters/sml/smlnj.vim
+++ b/ale_linters/sml/smlnj.vim
@@ -39,7 +39,7 @@ function! ale_linters#sml#smlnj#Handle(buffer, lines) abort
     return l:out
 endfunction
 
-call g:ale#linter#Define('sml', {
+call ale#linter#Define('sml', {
 \   'name': 'smlnj',
 \   'executable': 'sml',
 \   'command': 'sml',

--- a/doc/ale-asm.txt
+++ b/doc/ale-asm.txt
@@ -1,12 +1,12 @@
 ===============================================================================
-ALE ASM Integration                                           *ale-asm-options*
+ALE Assembly Integration                                      *ale-asm-options*
 
 
 -------------------------------------------------------------------------------
 gcc                                                               *ale-asm-gcc*
 
 g:ale_asm_gcc_options                                   *g:ale_asm_gcc_options*
-
+                                                        *b:ale_asm_gcc_options*
   Type: |String|
   Default: `'-Wall'`
 

--- a/doc/ale-c.txt
+++ b/doc/ale-c.txt
@@ -6,7 +6,7 @@ ALE C Integration                                               *ale-c-options*
 clang                                                             *ale-c-clang*
 
 g:ale_c_clang_options                                   *g:ale_c_clang_options*
-
+                                                        *b:ale_c_clang_options*
   Type: |String|
   Default: `'-std=c11 -Wall'`
 
@@ -17,7 +17,7 @@ g:ale_c_clang_options                                   *g:ale_c_clang_options*
 cppcheck                                                       *ale-c-cppcheck*
 
 g:ale_c_cppcheck_options                             *g:ale_c_cppcheck_options*
-
+                                                     *b:ale_c_cppcheck_options*
   Type: |String|
   Default: `'--enable=style'`
 
@@ -28,7 +28,7 @@ g:ale_c_cppcheck_options                             *g:ale_c_cppcheck_options*
 gcc                                                                 *ale-c-gcc*
 
 g:ale_c_gcc_options                                       *g:ale_c_gcc_options*
-
+                                                          *b:ale_c_gcc_options*
   Type: |String|
   Default: `'-std=c11 -Wall'`
 

--- a/doc/ale-chef.txt
+++ b/doc/ale-chef.txt
@@ -6,7 +6,7 @@ ALE Chef Integration                                         *ale-chef-options*
 foodcritc                                                 *ale-chef-foodcritic*
 
 g:ale_chef_foodcritic_options                   *g:ale_chef_foodcritic_options*
-
+                                                *b:ale_chef_foodcritic_options*
   Type: |String|
   Default: `''`
 
@@ -14,12 +14,13 @@ g:ale_chef_foodcritic_options                   *g:ale_chef_foodcritic_options*
 
 
 g:ale_chef_foodcritic_executable             *g:ale_chef_foodcritic_executable*
-
+                                             *b:ale_chef_foodcritic_executable*
   Type: |String|
   Default: `'foodcritic'`
 
   This variable can be changed to point to the foodcritic binary in case it's
-  not on the $PATH or a specific version/path must be used. 
+  not on the $PATH or a specific version/path must be used.
+
 
 -------------------------------------------------------------------------------
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-cmake.txt
+++ b/doc/ale-cmake.txt
@@ -6,14 +6,15 @@ ALE CMake Integration                                       *ale-cmake-options*
 cmakelint                                                 *ale-cmake-cmakelint*
 
 g:ale_cmake_cmakelint_exectuable             *g:ale_cmake_cmakelint_executable*
-
+                                             *b:ale_cmake_cmakelint_executable*
   Type: |String|
   Default: `'cmakelint'`
 
   This variable can be set to change the path the cmakelint.
 
-g:ale_cmake_cmakelint_options                   *g:ale_cmake_cmakelint_options*
 
+g:ale_cmake_cmakelint_options                   *g:ale_cmake_cmakelint_options*
+                                                *b:ale_cmake_cmakelint_options*
   Type: |String|
   Default: `''`
 

--- a/doc/ale-cpp.txt
+++ b/doc/ale-cpp.txt
@@ -6,7 +6,7 @@ ALE C++ Integration                                           *ale-cpp-options*
 clang                                                           *ale-cpp-clang*
 
 g:ale_cpp_clang_options                               *g:ale_cpp_clang_options*
-
+                                                      *b:ale_cpp_clang_options*
   Type: |String|
   Default: `'-std=c++14 -Wall'`
 
@@ -17,7 +17,7 @@ g:ale_cpp_clang_options                               *g:ale_cpp_clang_options*
 clangtidy                                                   *ale-cpp-clangtidy*
 
 g:ale_cpp_clangtidy_options                       *g:ale_cpp_clangtidy_options*
-
+                                                  *b:ale_cpp_clangtidy_options*
   Type: |String|
   Default: `'-std=c++14 -Wall'`
 
@@ -28,7 +28,7 @@ g:ale_cpp_clangtidy_options                       *g:ale_cpp_clangtidy_options*
 cppcheck                                                     *ale-cpp-cppcheck*
 
 g:ale_cpp_cppcheck_options                         *g:ale_cpp_cppcheck_options*
-
+                                                   *b:ale_cpp_cppcheck_options*
   Type: |String|
   Default: `'--enable=style'`
 
@@ -39,7 +39,7 @@ g:ale_cpp_cppcheck_options                         *g:ale_cpp_cppcheck_options*
 gcc                                                               *ale-cpp-gcc*
 
 g:ale_cpp_gcc_options                                   *g:ale_cpp_gcc_options*
-
+                                                        *b:ale_cpp_gcc_options*
   Type: |String|
   Default: `'-std=c++14 -Wall'`
 

--- a/doc/ale-css.txt
+++ b/doc/ale-css.txt
@@ -6,7 +6,7 @@ ALE CSS Integration                                           *ale-css-options*
 stylelint                                                   *ale-css-stylelint*
 
 g:ale_css_stylelint_executable                 *g:ale_css_stylelint_executable*
-
+                                               *b:ale_css_stylelint_executable*
   Type: |String|
   Default: `'stylelint'`
 
@@ -16,15 +16,17 @@ g:ale_css_stylelint_executable                 *g:ale_css_stylelint_executable*
   If you wish to use only a globally installed version of stylelint, set
   |g:ale_css_stylelint_use_global| to `1`.
 
-g:ale_css_stylelint_options                    *g:ale_css_stylelint_options*
 
+g:ale_css_stylelint_options                    *g:ale_css_stylelint_options*
+                                               *b:ale_css_stylelint_options*
   Type: |String|
   Default: `''`
 
   This variable can be set to pass additional options to stylelint.
 
-g:ale_css_stylelint_use_global                 *g:ale_css_stylelint_use_global*
 
+g:ale_css_stylelint_use_global                 *g:ale_css_stylelint_use_global*
+                                               *b:ale_css_stylelint_use_global*
   Type: |String|
   Default: `0`
 

--- a/doc/ale-erlang.txt
+++ b/doc/ale-erlang.txt
@@ -6,9 +6,9 @@ ALE Erlang Integration                                     *ale-erlang-options*
 erlc                                                          *ale-erlang-erlc*
 
 g:ale_erlang_erlc_options                           *g:ale_erlang_erlc_options*
-
+                                                    *b:ale_erlang_erlc_options*
   Type: |String|
-  Default: '`''`'
+  Default: `''`
 
   This variable controls additional parameters passed to `erlc`, such as `-I`
   or `-pa`.

--- a/doc/ale-fortran.txt
+++ b/doc/ale-fortran.txt
@@ -6,7 +6,7 @@ ALE Fortran Integration                                   *ale-fortran-options*
 gcc                                                           *ale-fortran-gcc*
 
 g:ale_fortran_gcc_executable                     *g:ale_fortran_gcc_executable*
-
+                                                 *b:ale_fortran_gcc_executable*
   Type: |String|
   Default: `'gcc'`
 
@@ -15,7 +15,7 @@ g:ale_fortran_gcc_executable                     *g:ale_fortran_gcc_executable*
 
 
 g:ale_fortran_gcc_options                           *g:ale_fortran_gcc_options*
-
+                                                    *b:ale_fortran_gcc_options*
   Type: |String|
   Default: `'-Wall'`
 
@@ -23,7 +23,7 @@ g:ale_fortran_gcc_options                           *g:ale_fortran_gcc_options*
 
 
 g:ale_fortran_gcc_use_free_form               *g:ale_fortran_gcc_use_free_form*
-
+                                              *b:ale_fortran_gcc_use_free_form*
   Type: |Number|
   Default: `1`
 

--- a/doc/ale-go.txt
+++ b/doc/ale-go.txt
@@ -8,7 +8,6 @@ Integration Information
 The `gometalinter` linter is disabled by default, and all other Go linters
 supported by ALE are enabled by default. To enable `gometalinter`, update
 |g:ale_linters| as appropriate:
-
 >
   " Enable all of the linters you want for Go.
   let g:ale_linters = {'go': ['gometalinter', 'gofmt']}
@@ -18,12 +17,13 @@ supported by ALE are enabled by default. To enable `gometalinter`, update
 gometalinter                                             *ale-go-gometalinter*
 
 g:ale_go_gometalinter_options                  *g:ale_go_gometalinter_options*
-
+                                               *b:ale_go_gometalinter_options*
   Type: |String|
   Default: `''`
 
   This variable can be changed to alter the command-line arguments to the
   gometalinter invocation.
+
 
 -------------------------------------------------------------------------------
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-handlebars.txt
+++ b/doc/ale-handlebars.txt
@@ -6,9 +6,8 @@ ALE Handlebars Integration                             *ale-handlebars-options*
 ember-template-lint                          *ale-handlebars-embertemplatelint*
 
 g:ale_handlebars_embertemplatelint_executable
-                              \ *g:ale_handlebars_embertemplatelint_executable*
-
-  Type: |String|
+                                *g:ale_handlebars_embertemplatelint_executable*
+  Type: |String|                  *b:ale_handlebars_embertemplatelint_executable*
   Default: `'ember-template-lint'`
 
   ALE will look for ember-template-lint executable in ancestor node_modules
@@ -19,9 +18,8 @@ g:ale_handlebars_embertemplatelint_executable
 
 
 g:ale_handlebars_embertemplatelint_use_global
-                              \ *g:ale_handlebars_embertemplatelint_use_global*
-
-  Type: |Number|
+                                *g:ale_handlebars_embertemplatelint_use_global*
+  Type: |Number|                  *b:ale_handlebars_embertemplatelint_use_global*
   Default: `0`
 
   This variable controls whether or not ALE will search for a local

--- a/doc/ale-html.txt
+++ b/doc/ale-html.txt
@@ -6,7 +6,7 @@ ALE HTML Integration                                         *ale-html-options*
 htmlhint                                                    *ale-html-htmlhint*
 
 g:ale_html_htmlhint_options                       *g:ale_html_htmlhint_options*
-
+                                                  *b:ale_html_htmlhint_options*
   Type: |String|
   Default: `'--format=unix'`
 
@@ -14,7 +14,7 @@ g:ale_html_htmlhint_options                       *g:ale_html_htmlhint_options*
 
 
 g:ale_html_htmlhint_executable                 *g:ale_html_htmlhint_executable*
-
+                                               *b:ale_html_htmlhint_executable*
   Type: |String|
   Default: `'htmlhint'`
 
@@ -26,7 +26,7 @@ g:ale_html_htmlhint_executable                 *g:ale_html_htmlhint_executable*
 
 
 g:ale_html_htmlhint_use_global                 *g:ale_html_htmlhint_use_global*
-
+                                               *b:ale_html_htmlhint_use_global*
   Type: |String|
   Default: `0`
 
@@ -40,7 +40,7 @@ g:ale_html_htmlhint_use_global                 *g:ale_html_htmlhint_use_global*
 tidy                                                            *ale-html-tidy*
 
 g:ale_html_tidy_executable                         *g:ale_html_tidy_executable*
-
+                                                   *b:ale_html_tidy_executable*
   Type: |String|
   Default: `'tidy'`
 
@@ -48,7 +48,7 @@ g:ale_html_tidy_executable                         *g:ale_html_tidy_executable*
 
 
 g:ale_html_tidy_options                               *g:ale_html_tidy_options*
-
+                                                      *b:ale_html_tidy_options*
   Type: |String|
   Default: `'-q -e -language en'`
 

--- a/doc/ale-java.txt
+++ b/doc/ale-java.txt
@@ -6,7 +6,7 @@ ALE Java Integration                                         *ale-java-options*
 javac                                                          *ale-java-javac*
 
 g:ale_java_javac_classpath                         *g:ale_java_javac_classpath*
-
+                                                   *b:ale_java_javac_classpath*
   Type: |String|
   Default: `''`
 
@@ -14,7 +14,7 @@ g:ale_java_javac_classpath                         *g:ale_java_javac_classpath*
 
 
 g:ale_java_javac_options                             *g:ale_java_javac_options*
-
+                                                     *b:ale_java_javac_options*
   Type: |String|
   Default: `''`
 

--- a/doc/ale-javascript.txt
+++ b/doc/ale-javascript.txt
@@ -6,7 +6,7 @@ ALE JavaScript Integration                             *ale-javascript-options*
 eslint                                                  *ale-javascript-eslint*
 
 g:ale_javascript_eslint_executable         *g:ale_javascript_eslint_executable*
-
+                                           *b:ale_javascript_eslint_executable*
   Type: |String|
   Default: `'eslint'`
 
@@ -21,7 +21,7 @@ g:ale_javascript_eslint_executable         *g:ale_javascript_eslint_executable*
 
 
 g:ale_javascript_eslint_options               *g:ale_javascript_eslint_options*
-
+                                              *b:ale_javascript_eslint_options*
   Type: |String|
   Default: `''`
 
@@ -29,7 +29,7 @@ g:ale_javascript_eslint_options               *g:ale_javascript_eslint_options*
 
 
 g:ale_javascript_eslint_use_global         *g:ale_javascript_eslint_use_global*
-
+                                           *b:ale_javascript_eslint_use_global*
   Type: |Number|
   Default: `0`
 
@@ -43,7 +43,7 @@ g:ale_javascript_eslint_use_global         *g:ale_javascript_eslint_use_global*
 flow                                                      *ale-javascript-flow*
 
 g:ale_javascript_flow_executable             *g:ale_javascript_flow_executable*
-
+                                             *b:ale_javascript_flow_executable*
   Type: |String|
   Default: `'flow'`
 
@@ -55,7 +55,7 @@ g:ale_javascript_flow_executable             *g:ale_javascript_flow_executable*
 
 
 g:ale_javascript_flow_use_global             *g:ale_javascript_flow_use_global*
-
+                                             *b:ale_javascript_flow_use_global*
   Type: |Number|
   Default: `0`
 
@@ -69,7 +69,7 @@ g:ale_javascript_flow_use_global             *g:ale_javascript_flow_use_global*
 jshint                                                  *ale-javascript-jshint*
 
 g:ale_javascript_jshint_executable         *g:ale_javascript_jshint_executable*
-
+                                           *b:ale_javascript_jshint_executable*
   Type: |String|
   Default: `'jshint'`
 
@@ -83,7 +83,7 @@ g:ale_javascript_jshint_executable         *g:ale_javascript_jshint_executable*
 
 
 g:ale_javascript_jshint_use_global         *g:ale_javascript_jshint_use_global*
-
+                                           *b:ale_javascript_jshint_use_global*
   Type: |Number|
   Default: `0`
 
@@ -97,7 +97,7 @@ g:ale_javascript_jshint_use_global         *g:ale_javascript_jshint_use_global*
 standard                                              *ale-javascript-standard*
 
 g:ale_javascript_standard_executable     *g:ale_javascript_standard_executable*
-
+                                         *b:ale_javascript_standard_executable*
   Type: |String|
   Default: `'standard'`
 
@@ -107,7 +107,7 @@ g:ale_javascript_standard_executable     *g:ale_javascript_standard_executable*
 
 
 g:ale_javascript_standard_options           *g:ale_javascript_standard_options*
-
+                                            *b:ale_javascript_standard_options*
   Type: |String|
   Default: `''`
 
@@ -115,7 +115,7 @@ g:ale_javascript_standard_options           *g:ale_javascript_standard_options*
 
 
 g:ale_javascript_standard_use_global     *g:ale_javascript_standard_use_global*
-
+                                         *b:ale_javascript_standard_use_global*
   Type: |Number|
   Default: `0`
 
@@ -128,7 +128,7 @@ g:ale_javascript_standard_use_global     *g:ale_javascript_standard_use_global*
 xo                                                          *ale-javascript-xo*
 
 g:ale_javascript_xo_executable                 *g:ale_javascript_xo_executable*
-
+                                               *b:ale_javascript_xo_executable*
   Type: |String|
   Default: `'xo'`
 
@@ -138,7 +138,7 @@ g:ale_javascript_xo_executable                 *g:ale_javascript_xo_executable*
 
 
 g:ale_javascript_xo_options                       *g:ale_javascript_xo_options*
-
+                                                  *b:ale_javascript_xo_options*
   Type: |String|
   Default: `''`
 
@@ -146,7 +146,7 @@ g:ale_javascript_xo_options                       *g:ale_javascript_xo_options*
 
 
 g:ale_javascript_xo_use_global                 *g:ale_javascript_xo_use_global*
-
+                                               *b:ale_javascript_xo_use_global*
   Type: |Number|
   Default: `0`
 

--- a/doc/ale-lua.txt
+++ b/doc/ale-lua.txt
@@ -6,7 +6,7 @@ ALE Lua Integration                                           *ale-lua-options*
 4.12. luacheck                                               *ale-lua-luacheck*
 
 g:ale_lua_luacheck_executable                   *g:ale_lua_luacheck_executable*
-
+                                                *b:ale_lua_luacheck_executable*
   Type: |String|
   Default: `'luacheck'`
 

--- a/doc/ale-perl.txt
+++ b/doc/ale-perl.txt
@@ -6,7 +6,7 @@ ALE Perl Integration                                         *ale-perl-options*
 perl                                                            *ale-perl-perl*
 
 g:ale_perl_perl_executable                         *g:ale_perl_perl_executable*
-
+                                                   *b:ale_perl_perl_executable*
   Type: |String|
   Default: `'perl'`
 
@@ -14,7 +14,7 @@ g:ale_perl_perl_executable                         *g:ale_perl_perl_executable*
 
 
 g:ale_perl_perl_options                               *g:ale_perl_perl_options*
-
+                                                      *b:ale_perl_perl_options*
   Type: |String|
   Default: `'-X -c -Mwarnings -Ilib'`
 

--- a/doc/ale-php.txt
+++ b/doc/ale-php.txt
@@ -6,7 +6,7 @@ ALE PHP Integration                                           *ale-php-options*
 phpcs                                                           *ale-php-phpcs*
 
 g:ale_php_phpcs_standard                             *g:ale_php_phpcs_standard*
-
+                                                     *b:ale_php_phpcs_standard*
   Type: |String|
   Default: `''`
 
@@ -18,8 +18,8 @@ g:ale_php_phpcs_standard                             *g:ale_php_phpcs_standard*
 ------------------------------------------------------------------------------
 phpmd                                                           *ale-php-phpmd*
 
-g:ale_php_phpmd_ruleset                           *g:ale_php_phpmd_ruleset*
-
+g:ale_php_phpmd_ruleset                               *g:ale_php_phpmd_ruleset*
+                                                      *b:ale_php_phpmd_ruleset*
   Type: |String|
   Default: `'cleancode,codesize,controversial,design,naming,unusedcode'`
 

--- a/doc/ale-puppet.txt
+++ b/doc/ale-puppet.txt
@@ -6,7 +6,7 @@ ALE Puppet Integration                                     *ale-puppet-options*
 puppetlint                                              *ale-puppet-puppetlint*
 
 g:ale_puppet_puppetlint_executable         *g:ale_puppet_puppetlint_executable*
-
+                                           *b:ale_puppet_puppetlint_executable*
   Type: |String|
   Default: `'puppet-lint'`
 
@@ -14,7 +14,7 @@ g:ale_puppet_puppetlint_executable         *g:ale_puppet_puppetlint_executable*
 
 
 g:ale_puppet_puppetlint_options               *g:ale_puppet_puppetlint_options*
-
+                                              *b:ale_puppet_puppetlint_options*
   Type: |String|
   Default: `'--no-autoloader_layout-check'`
 

--- a/doc/ale-python.txt
+++ b/doc/ale-python.txt
@@ -6,7 +6,7 @@ ALE Python Integration                                     *ale-python-options*
 flake8                                                      *ale-python-flake8*
 
 g:ale_python_flake8_executable                 *g:ale_python_flake8_executable*
-
+                                               *b:ale_python_flake8_executable*
   Type: |String|
   Default: `'flake8'`
 
@@ -14,7 +14,7 @@ g:ale_python_flake8_executable                 *g:ale_python_flake8_executable*
 
 
 g:ale_python_flake8_options                       *g:ale_python_flake8_options*
-
+                                                  *b:ale_python_flake8_options*
   Type: |String|
   Default: `''`
 
@@ -35,7 +35,7 @@ g:ale_python_flake8_options                       *g:ale_python_flake8_options*
 mypy                                                          *ale-python-mypy*
 
 g:ale_python_mypy_options                           *g:ale_python_mypy_options*
-
+                                                    *b:ale_python_mypy_options*
   Type: |String|
   Default: `''`
 
@@ -47,7 +47,7 @@ g:ale_python_mypy_options                           *g:ale_python_mypy_options*
 pylint                                                      *ale-python-pylint*
 
 g:ale_python_pylint_executable                 *g:ale_python_pylint_executable*
-
+                                               *b:ale_python_pylint_executable*
   Type: |String|
   Default: `'pylint'`
 
@@ -55,7 +55,7 @@ g:ale_python_pylint_executable                 *g:ale_python_pylint_executable*
 
 
 g:ale_python_pylint_options                       *g:ale_python_pylint_options*
-
+                                                  *b:ale_python_pylint_options*
   Type: |String|
   Default: `''`
 

--- a/doc/ale-ruby.txt
+++ b/doc/ale-ruby.txt
@@ -6,7 +6,7 @@ ALE Ruby Integration                                         *ale-ruby-options*
 reek                                                            *ale-ruby-reek*
 
 g:ale_ruby_reek_show_context                     *g:ale_ruby_reek_show_context*
-
+                                                 *b:ale_ruby_reek_show_context*
   Type: |Number|
   Default: 0
 
@@ -15,7 +15,7 @@ g:ale_ruby_reek_show_context                     *g:ale_ruby_reek_show_context*
 
 
 g:ale_ruby_reek_show_wiki_link                 *g:ale_ruby_reek_show_wiki_link*
-
+                                               *b:ale_ruby_reek_show_wiki_link*
   Type: |Number|
   Default: 0
 
@@ -27,7 +27,7 @@ g:ale_ruby_reek_show_wiki_link                 *g:ale_ruby_reek_show_wiki_link*
 rubocop                                                      *ale-ruby-rubocop*
 
 g:ale_ruby_rubocop_options                         *g:ale_ruby_rubocop_options*
-
+                                                   *b:ale_ruby_rubocop_options*
   Type: |String|
   Default: `''`
 

--- a/doc/ale-rust.txt
+++ b/doc/ale-rust.txt
@@ -33,7 +33,7 @@ Integration Information
 cargo                                                          *ale-rust-cargo*
 
 g:ale_rust_cargo_use_check                         *g:ale_rust_cargo_use_check*
-
+                                                   *b:ale_rust_cargo_use_check*
   Type: |Number|
   Default: `1`
 
@@ -45,7 +45,7 @@ g:ale_rust_cargo_use_check                         *g:ale_rust_cargo_use_check*
 rustc                                                          *ale-rust-rustc*
 
 g:ale_rust_ignore_error_codes                   *g:ale_rust_ignore_error_codes*
-
+                                                *b:ale_rust_ignore_error_codes*
   Type: |List| of |String|s
   Default: []
 

--- a/doc/ale-sass.txt
+++ b/doc/ale-sass.txt
@@ -6,7 +6,7 @@ ALE SASS Integration                                         *ale-sass-options*
 stylelint                                                  *ale-sass-stylelint*
 
 g:ale_sass_stylelint_executable               *g:ale_sass_stylelint_executable*
-
+                                              *b:ale_sass_stylelint_executable*
   Type: |String|
   Default: `'stylelint'`
 
@@ -18,7 +18,7 @@ g:ale_sass_stylelint_executable               *g:ale_sass_stylelint_executable*
 
 
 g:ale_sass_stylelint_use_global               *g:ale_sass_stylelint_use_global*
-
+                                              *b:ale_sass_stylelint_use_global*
   Type: |String|
   Default: `0`
 

--- a/doc/ale-scss.txt
+++ b/doc/ale-scss.txt
@@ -6,7 +6,7 @@ ALE SCSS Integration                                         *ale-scss-options*
 stylelint                                                  *ale-scss-stylelint*
 
 g:ale_scss_stylelint_executable               *g:ale_scss_stylelint_executable*
-
+                                              *b:ale_scss_stylelint_executable*
   Type: |String|
   Default: `'stylelint'`
 
@@ -18,7 +18,7 @@ g:ale_scss_stylelint_executable               *g:ale_scss_stylelint_executable*
 
 
 g:ale_scss_stylelint_use_global               *g:ale_scss_stylelint_use_global*
-
+                                              *b:ale_scss_stylelint_use_global*
   Type: |String|
   Default: `0`
 

--- a/doc/ale-sh.txt
+++ b/doc/ale-sh.txt
@@ -6,7 +6,7 @@ ALE Shell Integration                                          *ale-sh-options*
 shell                                                            *ale-sh-shell*
 
 g:ale_linters_sh_shell_default_shell     *g:ale_linters_sh_shell_default_shell*
-
+                                         *b:ale_linters_sh_shell_default_shell*
   Type: |String|
   Default: The current shell (`$SHELL`) or `'bash'` if that cannot be read.
 
@@ -20,7 +20,7 @@ g:ale_linters_sh_shell_default_shell     *g:ale_linters_sh_shell_default_shell*
 shellcheck                                                  *ale-sh-shellcheck*
 
 g:ale_sh_shellcheck_executable                 *g:ale_sh_shellcheck_executable*
-
+                                               *b:ale_sh_shellcheck_executable*
   Type: |String|
   Default: `'shellcheck'`
 
@@ -28,7 +28,7 @@ g:ale_sh_shellcheck_executable                 *g:ale_sh_shellcheck_executable*
 
 
 g:ale_sh_shellcheck_options                       *g:ale_sh_shellcheck_options*
-
+                                                  *b:ale_sh_shellcheck_options*
   Type: |String|
   Default: `''`
 
@@ -37,18 +37,24 @@ g:ale_sh_shellcheck_options                       *g:ale_sh_shellcheck_options*
 
   For example, if we want shellcheck to follow external sources (`see SC1091`)
   we can set the variable as such:
-
+>
   let g:ale_sh_shellcheck_options = '-x'
-
+<
 
 g:ale_linters_sh_shellcheck_exclusions *g:ale_linters_sh_shellcheck_exclusions*
-
+                                       *b:ale_linters_sh_shellcheck_exclusions*
   Type: |String|
   Default: `''`
 
   Set this variable to exclude test(s) for shellcheck (-e/--exclude option).
   To exclude more than one option, separate them with commas.
 
+  For example, to ignore some warnings that aren't applicable to files that
+  will be sourced by other scripts, use the buffer-local variant:
+>
+    autocmd BufEnter PKGBUILD,.env
+    \   let b:ale_sh_shellcheck_exclusions = 'SC2034,SC2154,SC2164'
+<
 
 -------------------------------------------------------------------------------
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-sh.txt
+++ b/doc/ale-sh.txt
@@ -53,7 +53,7 @@ g:ale_linters_sh_shellcheck_exclusions *g:ale_linters_sh_shellcheck_exclusions*
   will be sourced by other scripts, use the buffer-local variant:
 >
     autocmd BufEnter PKGBUILD,.env
-    \   let b:ale_sh_shellcheck_exclusions = 'SC2034,SC2154,SC2164'
+    \   let b:ale_linters_sh_shellcheck_exclusions = 'SC2034,SC2154,SC2164'
 <
 
 -------------------------------------------------------------------------------

--- a/doc/ale-spec.txt
+++ b/doc/ale-spec.txt
@@ -12,14 +12,15 @@ Integration Information
 
   Currently linters must be enabled globally.  The rpmlint linter can be
   enabled with:
-
+>
   let g:ale_linters = {'spec': ['rpmlint']}
+<
 
 -------------------------------------------------------------------------------
 rpmlint                                                      *ale-spec-rpmlint*
 
 g:ale_spec_rpmlint_executable                   *g:ale_spec_rpmlint_executable*
-
+                                                *b:ale_spec_rpmlint_executable*
   Type: |String|
   Default: `'rpmlint'`
 
@@ -27,15 +28,16 @@ g:ale_spec_rpmlint_executable                   *g:ale_spec_rpmlint_executable*
 
 
 g:ale_spec_rpmlint_options                         *g:ale_spec_rpmlint_options*
-
+                                                   *b:ale_spec_rpmlint_options*
   Type: |String|
   Default: `''`
 
   Set this to pass extra arguments to rpmlint.
 
   For example, to instruct rpmlint to use a specific configuration file:
-
+>
   let g:ale_spec_rpmlint_options = '-f custom.cf'
+<
 
 -------------------------------------------------------------------------------
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-tex.txt
+++ b/doc/ale-tex.txt
@@ -6,7 +6,7 @@ ALE TeX Integration                                           *ale-tex-options*
 chktex                                                         *ale-tex-chktex*
 
 g:ale_tex_chktex_executable                       *g:ale_tex_chktex_executable*
-
+                                                  *b:ale_tex_chktex_executable*
   Type: |String|
   Default: `'chktex'`
 
@@ -14,7 +14,7 @@ g:ale_tex_chktex_executable                       *g:ale_tex_chktex_executable*
 
 
 g:ale_tex_chktex_options                             *g:ale_tex_chktex_options*
-
+                                                     *b:ale_tex_chktex_options*
   Type: |String|
   Default: `'-I'`
 
@@ -25,7 +25,7 @@ g:ale_tex_chktex_options                             *g:ale_tex_chktex_options*
 lacheck                                                       *ale-tex-lacheck*
 
 g:ale_lacheck_executable                             *g:ale_lacheck_executable*
-
+                                                     *b:ale_lacheck_executable*
   Type: |String|
   Default: '`lacheck`'
 

--- a/doc/ale-typescript.txt
+++ b/doc/ale-typescript.txt
@@ -6,7 +6,7 @@ ALE TypeScript Integration                             *ale-typescript-options*
 tslint                                                  *ale-typescript-tslint*
 
 g:ale_typescript_tslint_executable         *g:ale_typescript_tslint_executable*
-
+                                           *b:ale_typescript_tslint_executable*
   Type: |String|
   Default: `'tslint'`
 
@@ -18,7 +18,7 @@ g:ale_typescript_tslint_executable         *g:ale_typescript_tslint_executable*
 
 
 g:ale_typescript_tslint_config_path       *g:ale_typescript_tslint_config_path*
-
+                                          *b:ale_typescript_tslint_config_path*
   Type: |String|
   Default: `''`
 
@@ -27,7 +27,7 @@ g:ale_typescript_tslint_config_path       *g:ale_typescript_tslint_config_path*
 
 
 g:ale_typescript_tslint_use_global         *g:ale_typescript_tslint_use_global*
-
+                                           *b:ale_typescript_tslint_use_global*
   Type: |Number|
   Default: `0`
 
@@ -35,6 +35,7 @@ g:ale_typescript_tslint_use_global         *g:ale_typescript_tslint_use_global*
   tslint first. If this variable is set to `1`, then ALE will always use the
   global version of tslint, in preference to locally installed versions of
   tslint in node_modules.
+
 
 -------------------------------------------------------------------------------
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-vim.txt
+++ b/doc/ale-vim.txt
@@ -6,7 +6,7 @@ ALE Vim Integration                                           *ale-vim-options*
 vint                                                             *ale-vim-vint*
 
 g:ale_vim_vint_show_style_issues             *g:ale_vim_vint_show_style_issues*
-
+                                             *b:ale_vim_vint_show_style_issues*
   Type: |Number|
   Default: `1`
 

--- a/doc/ale-yaml.txt
+++ b/doc/ale-yaml.txt
@@ -1,12 +1,12 @@
 ===============================================================================
-ALE Yaml Integration                                         *ale-yaml-options*
+ALE YAML Integration                                         *ale-yaml-options*
 
 
 -------------------------------------------------------------------------------
 yamllint                                                    *ale-yaml-yamllint*
 
 g:ale_yaml_yamllint_executable                 *g:ale_yaml_yamllint_executable*
-
+                                               *b:ale_yaml_yamllint_executable*
   Type: |String|
   Default: `'yamllint'`
 
@@ -14,7 +14,7 @@ g:ale_yaml_yamllint_executable                 *g:ale_yaml_yamllint_executable*
 
 
 g:ale_yaml_yamllint_options                       *g:ale_yaml_yamllint_options*
-
+                                                  *b:ale_yaml_yamllint_options*
   Type: |String|
   Default: `''`
 


### PR DESCRIPTION
I blindly went ahead and added buffer-local variables for each linter option to the documentation. I also added an example to use the buffer-local variables with shellcheck, but I noticed that the shellcheck linter doesn't use the `ale#Var` function. This may also be the case in other linters, so consider this pull request a WIP while I'm going to check that.

I also made some stylistic changes.

<!--
When creating new pull requests, please consider the following.

* Read the Contributing guide linked above first.
* If you are adding a new linter, remember to update the README.md file and
  doc/ale.txt first.
* If you add or modify a function for converting error lines into loclist items
  that ALE can work with, please add Vader tests for them. Look at existing
  tests in the test/handler directory, etc.
* If you add or modify a function for computing a command line string for
  running a command, please add Vader tests for that.
* Generally try and cover anything with Vader tests, although some things just
  can't be tested with Vader, or at least they can be hard to test. Consider
  breaking up your code so that some parts can be tested, and generally open up
  a discussion about it.
* Have fun!
-->
