### PR TITLE
Rename g:ale_linters_sh_* to g:ale_sh_*

### DIFF
--- a/ale_linters/sh/shell.vim
+++ b/ale_linters/sh/shell.vim
@@ -1,13 +1,18 @@
 " Author: w0rp <devw0rp@gmail.com>
 " Description: Lints sh files using bash -n
 
+" Backwards compatibility
+if exists('g:ale_linters_sh_shell_default_shell')
+    let g:ale_sh_shell_default_shell = g:ale_linters_sh_shell_default_shell
+endif
+
 " This option can be changed to change the default shell when the shell
 " cannot be taken from the hashbang line.
-if !exists('g:ale_linters_sh_shell_default_shell')
-    let g:ale_linters_sh_shell_default_shell = fnamemodify($SHELL, ':t')
+if !exists('g:ale_sh_shell_default_shell')
+    let g:ale_sh_shell_default_shell = fnamemodify($SHELL, ':t')
 
-    if g:ale_linters_sh_shell_default_shell ==# ''
-        let g:ale_linters_sh_shell_default_shell = 'bash'
+    if g:ale_sh_shell_default_shell ==# ''
+        let g:ale_sh_shell_default_shell = 'bash'
     endif
 endif
 
@@ -26,7 +31,7 @@ function! ale_linters#sh#shell#GetExecutable(buffer) abort
         endfor
     endif
 
-    return ale#Var(a:buffer, 'linters_sh_shell_default_shell')
+    return ale#Var(a:buffer, 'sh_shell_default_shell')
 endfunction
 
 function! ale_linters#sh#shell#GetCommand(buffer) abort

--- a/ale_linters/sh/shellcheck.vim
+++ b/ale_linters/sh/shellcheck.vim
@@ -5,10 +5,9 @@
 " This global variable can be set with a string of comma-seperated error
 " codes to exclude from shellcheck. For example:
 "
-" let g:ale_linters_sh_shellcheck_exclusions = 'SC2002,SC2004'
-if !exists('g:ale_linters_sh_shellcheck_exclusions')
-    let g:ale_linters_sh_shellcheck_exclusions = ''
-endif
+" let g:ale_sh_shellcheck_exclusions = 'SC2002,SC2004'
+let g:ale_sh_shellcheck_exclusions =
+\   get(g:, 'ale_sh_shellcheck_exclusions', get(g:, 'ale_linters_sh_shellcheck_exclusions', ''))
 
 let g:ale_sh_shellcheck_executable =
 \   get(g:, 'ale_sh_shellcheck_executable', 'shellcheck')
@@ -33,7 +32,7 @@ function! s:GetDialectArgument() abort
 endfunction
 
 function! ale_linters#sh#shellcheck#GetCommand(buffer) abort
-    let l:exclude_option = ale#Var(a:buffer, 'linters_sh_shellcheck_exclusions')
+    let l:exclude_option = ale#Var(a:buffer, 'sh_shellcheck_exclusions')
 
     return ale_linters#sh#shellcheck#GetExecutable(a:buffer)
     \   . ' ' . ale#Var(a:buffer, 'sh_shellcheck_options')

--- a/doc/ale-sh.txt
+++ b/doc/ale-sh.txt
@@ -5,8 +5,8 @@ ALE Shell Integration                                          *ale-sh-options*
 -------------------------------------------------------------------------------
 shell                                                            *ale-sh-shell*
 
-g:ale_linters_sh_shell_default_shell     *g:ale_linters_sh_shell_default_shell*
-                                         *b:ale_linters_sh_shell_default_shell*
+g:ale_sh_shell_default_shell                     *g:ale_sh_shell_default_shell*
+                                                 *b:ale_sh_shell_default_shell*
   Type: |String|
   Default: The current shell (`$SHELL`) or `'bash'` if that cannot be read.
 
@@ -41,8 +41,8 @@ g:ale_sh_shellcheck_options                       *g:ale_sh_shellcheck_options*
   let g:ale_sh_shellcheck_options = '-x'
 <
 
-g:ale_linters_sh_shellcheck_exclusions *g:ale_linters_sh_shellcheck_exclusions*
-                                       *b:ale_linters_sh_shellcheck_exclusions*
+g:ale_sh_shellcheck_exclusions                 *g:ale_sh_shellcheck_exclusions*
+                                               *b:ale_sh_shellcheck_exclusions*
   Type: |String|
   Default: `''`
 
@@ -53,7 +53,7 @@ g:ale_linters_sh_shellcheck_exclusions *g:ale_linters_sh_shellcheck_exclusions*
   will be sourced by other scripts, use the buffer-local variant:
 >
     autocmd BufEnter PKGBUILD,.env
-    \   let b:ale_linters_sh_shellcheck_exclusions = 'SC2034,SC2154,SC2164'
+    \   let b:ale_sh_shellcheck_exclusions = 'SC2034,SC2154,SC2164'
 <
 
 -------------------------------------------------------------------------------

--- a/test/test_backwards_compatibility.vader
+++ b/test/test_backwards_compatibility.vader
@@ -1,0 +1,19 @@
+" These tests, and the code that it covers, may be removed upon a major release.
+
+After:
+  unlet! g:ale_linters_sh_shellcheck_exclusions
+  unlet! g:ale_sh_shellcheck_exclusions
+  unlet! g:ale_linters_sh_shell_default_shell
+  unlet! g:ale_sh_shell_default_shell
+
+Execute(Old variable name for the 'shellcheck' linter should still work):
+  let g:ale_linters_sh_shellcheck_exclusions = 'SC1234'
+  runtime ale_linters/sh/shellcheck.vim
+
+  AssertEqual 'SC1234', g:ale_sh_shellcheck_exclusions
+
+Execute (Old variable name for the 'shell' linter should still work):
+  let g:ale_linters_sh_shell_default_shell = 'woosh'
+  runtime ale_linters/sh/shell.vim
+
+  AssertEqual 'woosh', g:ale_sh_shell_default_shell


### PR DESCRIPTION
Following #514, I renamed \
`g:ale_linters_sh_shell_default_shell` to `g:ale_sh_shell_default_shell` \
and \
`g:ale_linters_sh_shellcheck_exclusions` to `g:ale_sh_shellcheck_exclusions`.

Note that the backwards compatibility for this doesn't cover the buffer-local variables. Should I handle those as well?