### PR TITLE
shell: Don't default to fish

### DIFF
--- a/ale_linters/sh/shell.vim
+++ b/ale_linters/sh/shell.vim
@@ -11,7 +11,7 @@ endif
 if !exists('g:ale_sh_shell_default_shell')
     let g:ale_sh_shell_default_shell = fnamemodify($SHELL, ':t')
 
-    if g:ale_sh_shell_default_shell ==# ''
+    if g:ale_sh_shell_default_shell ==# '' || g:ale_sh_shell_default_shell ==# 'fish'
         let g:ale_sh_shell_default_shell = 'bash'
     endif
 endif

--- a/doc/ale-sh.txt
+++ b/doc/ale-sh.txt
@@ -8,7 +8,8 @@ shell                                                            *ale-sh-shell*
 g:ale_sh_shell_default_shell                     *g:ale_sh_shell_default_shell*
                                                  *b:ale_sh_shell_default_shell*
   Type: |String|
-  Default: The current shell (`$SHELL`) or `'bash'` if that cannot be read.
+  Default: The current shell (`$SHELL`). Falls back to `'bash'` if that cannot be
+  read or if the current shell is `'fish'`.
 
   When ALE runs the linter for shells with the `-n` flag, it will attempt to
   read the shell from the shebang (`#!`) line from the shell script to


### PR DESCRIPTION
When `$SHELL` was set to /usr/bin/fish, the shell linter defaulted to that. Since fish is not a POSIX compatible shell, `sh` scripts and the shell linter won't work with fish.