### PR TITLE
go build: skip not current buffer

### DIFF
--- a/ale_linters/go/gobuild.vim
+++ b/ale_linters/go/gobuild.vim
@@ -43,7 +43,7 @@ function! ale_linters#go#gobuild#Handler(buffer, lines) abort
 
     for l:match in ale_linters#go#gobuild#GetMatches(a:lines)
         " Omit errors from imported go packages
-        if ale#path#IsBufferPath(a:buffer, l:match[0])
+        if !ale#path#IsBufferPath(a:buffer, l:match[1])
             continue
         endif
 

--- a/test/handler/test_gobuild_handler.vader
+++ b/test/handler/test_gobuild_handler.vader
@@ -28,7 +28,7 @@ Execute (The gobuild handler should handle names with spaces):
   \ ]), 'v:val[1:4]')
 
 Execute (The gobuild handler should handle relative paths correctly):
-  :file! /foo/bar/baz.go
+  :e! /foo/bar/baz.go
 
   AssertEqual
   \ [
@@ -39,6 +39,6 @@ Execute (The gobuild handler should handle relative paths correctly):
   \     'type': 'E',
   \   },
   \ ],
-  \ ale_linters#go#gobuild#Handler(42, [
+  \ ale_linters#go#gobuild#Handler(bufnr('$'), [
   \   'baz.go:27: missing argument for Printf("%s"): format reads arg 2, have only 1 args',
   \ ])


### PR DESCRIPTION
l:match[0] stores full error string e.g. './foo.go:4: bar declared and not used'.
Filename is l:match[1], also if I'm not mistaken we need to skip not current buffer. Thus, we omitting match if ale#path#IsBufferPath(a:buffer, l:match[1]) returns false - error is not from current buffer.
resolves #528 