### PR TITLE
Add PHP 7 compatibility

### DIFF
--- a/ale_linters/php/php.vim
+++ b/ale_linters/php/php.vim
@@ -5,7 +5,7 @@ function! ale_linters#php#php#Handle(buffer, lines) abort
     " Matches patterns like the following:
     "
     " PHP Parse error:  syntax error, unexpected ';', expecting ']' in - on line 15
-    let l:pattern = '\vPHP %(Fatal|Parse) error:\s+(.+unexpected ''(.+)%(expecting.+)@<!''.*|.+) in - on line (\d+)'
+    let l:pattern = '\v^%(Fatal|Parse) error:\s+(.+unexpected ''(.+)%(expecting.+)@<!''.*|.+) in - on line (\d+)'
 
     let l:output = []
 
@@ -23,7 +23,7 @@ endfunction
 call ale#linter#Define('php', {
 \   'name': 'php',
 \   'executable': 'php',
-\   'output_stream': 'both',
-\   'command': 'php -l -d display_errors=1 --',
+\   'output_stream': 'stdout',
+\   'command': 'php -l -d error_reporting=E_ALL -d display_errors=1 --',
 \   'callback': 'ale_linters#php#php#Handle',
 \})

--- a/test/handler/test_php_handler.vader
+++ b/test/handler/test_php_handler.vader
@@ -48,14 +48,14 @@ Execute(The php handler should parse lines correctly):
   \ ],
   \ ale_linters#php#php#Handle(347, [
   \   'This line should be ignored completely',
-  \   "Parse error:  syntax error, This line should be ignored completely in - on line 1",
-  \   "PHP Parse error:  syntax error, unexpected ';', expecting ']' in - on line 1",
-  \   "PHP Parse error:  syntax error, unexpected '/', expecting function (T_FUNCTION) or const (T_CONST) in - on line 2",
-  \   "PHP Parse error:  syntax error, unexpected ')' in - on line 3",
-  \   "PHP Parse error:  syntax error, unexpected ''bar'' (T_CONSTANT_ENCAPSED_STRING), expecting ']' in - on line 4",
-  \   "PHP Fatal error:  Cannot redeclare count() in - on line 5",
-  \   'PHP Parse error:  syntax error, unexpected end of file in - on line 21',
-  \   'PHP Parse error: Invalid numeric literal in - on line 47',
+  \   "PHP Parse error:  syntax error, This line should be ignored completely in - on line 1",
+  \   "Parse error:  syntax error, unexpected ';', expecting ']' in - on line 1",
+  \   "Parse error:  syntax error, unexpected '/', expecting function (T_FUNCTION) or const (T_CONST) in - on line 2",
+  \   "Parse error:  syntax error, unexpected ')' in - on line 3",
+  \   "Parse error:  syntax error, unexpected ''bar'' (T_CONSTANT_ENCAPSED_STRING), expecting ']' in - on line 4",
+  \   "Fatal error:  Cannot redeclare count() in - on line 5",
+  \   'Parse error:  syntax error, unexpected end of file in - on line 21',
+  \   'Parse error: Invalid numeric literal in - on line 47',
   \ ])
 
 After:


### PR DESCRIPTION
PHP 7+ displays error slightly different. In PHP5 errors where displayed both on stderr and stdout (which also depends on php.ini, I think).

For example one could get output like this:

```
PHP Parse error:  syntax error, unexpected ';', expecting ']' in - on line 15
Parse error:  syntax error, unexpected ';', expecting ']' in - on line 15
```

Because of that PHP ale linter was ignoring second version. However, since PHP7
errors are always displayed as `Parse error: ...` without the `PHP ` prefix.

This pull request is changing pattern to match both formats and additionaly it's deduping list, so older PHP versions won't report same error twice.
