### PR TITLE
Add cpplint linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ name. That seems to be the fairest way to arrange this table.
 | Bash | [-n flag](https://www.gnu.org/software/bash/manual/bash.html#index-set), [shellcheck](https://www.shellcheck.net/) |
 | Bourne Shell | [-n flag](http://linux.die.net/man/1/sh), [shellcheck](https://www.shellcheck.net/) |
 | C | [cppcheck](http://cppcheck.sourceforge.net), [gcc](https://gcc.gnu.org/), [clang](http://clang.llvm.org/)|
-| C++ (filetype cpp) | [clang](http://clang.llvm.org/), [clangtidy](http://clang.llvm.org/extra/clang-tidy/), [cppcheck](http://cppcheck.sourceforge.net), [gcc](https://gcc.gnu.org/)|
+| C++ (filetype cpp) | [clang](http://clang.llvm.org/), [clangtidy](http://clang.llvm.org/extra/clang-tidy/), [cppcheck](http://cppcheck.sourceforge.net), [cpplint](https://github.com/google/styleguide/tree/gh-pages/cpplint), [gcc](https://gcc.gnu.org/)|
 | C# | [mcs](http://www.mono-project.com/docs/about-mono/languages/csharp/) |
 | Chef | [foodcritic](http://www.foodcritic.io/) |
 | CMake | [cmakelint](https://github.com/richq/cmake-lint) |

--- a/ale_linters/cpp/cpplint.vim
+++ b/ale_linters/cpp/cpplint.vim
@@ -1,0 +1,15 @@
+" Author: Dawid Kurek https://github.com/dawikur
+" Description: cpplint for cpp files
+
+if !exists('g:ale_cpp_cpplint_options')
+    let g:ale_cpp_cpplint_options = ''
+endif
+
+call ale#linter#Define('cpp', {
+\   'name': 'cpplint',
+\   'output_stream': 'stderr',
+\   'executable': 'cpplint',
+\   'command': 'cpplint %s',
+\   'callback': 'ale#handlers#cpplint#HandleCppLintFormat',
+\   'lint_file': 1,
+\})

--- a/autoload/ale/handlers/cpplint.vim
+++ b/autoload/ale/handlers/cpplint.vim
@@ -1,0 +1,20 @@
+" Author: Dawid Kurek https://github.com/dawikur
+" Description: Handle errors for cpplint.
+
+function! ale#handlers#cpplint#HandleCppLintFormat(buffer, lines) abort
+    " Look for lines like the following.
+    " test.cpp:5:  Estra space after ( in function call [whitespace/parents] [4]
+    let l:pattern = '^.\{-}:\(\d\+\): \(.\+\)'
+    let l:output = []
+
+    for l:match in ale#util#GetMatches(a:lines, l:pattern)
+        call add(l:output, {
+        \   'lnum': l:match[1] + 0,
+        \   'col': 0,
+        \   'text': l:match[2],
+        \   'type': 'W',
+        \})
+    endfor
+
+    return l:output
+endfunction

--- a/doc/ale-cpp.txt
+++ b/doc/ale-cpp.txt
@@ -59,6 +59,17 @@ g:ale_cpp_cppcheck_options                         *g:ale_cpp_cppcheck_options*
 
 
 -------------------------------------------------------------------------------
+cpplint                                                       *ale-cpp-cpplint*
+
+g:ale_cpp_cpplint_options                           *g:ale_cpp_cpplint_options*
+                                                    *b:ale_cpp_cpplint_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be changed to modify flags given to cpplint.
+
+
+-------------------------------------------------------------------------------
 gcc                                                               *ale-cpp-gcc*
 
 g:ale_cpp_gcc_options                                   *g:ale_cpp_gcc_options*

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -22,6 +22,7 @@ CONTENTS                                                         *ale-contents*
       clang...............................|ale-cpp-clang|
       clangtidy...........................|ale-cpp-clangtidy|
       cppcheck............................|ale-cpp-cppcheck|
+      cpplint.............................|ale-cpp-cpplint|
       gcc.................................|ale-cpp-gcc|
     css...................................|ale-css-options|
       stylelint...........................|ale-css-stylelint|
@@ -120,7 +121,7 @@ The following languages and tools are supported.
 * Bash: 'shell' (-n flag), 'shellcheck'
 * Bourne Shell: 'shell' (-n flag), 'shellcheck'
 * C: 'cppcheck', 'gcc', 'clang'
-* C++ (filetype cpp): 'clang', 'clangtidy', 'cppcheck', 'gcc'
+* C++ (filetype cpp): 'clang', 'clangtidy', 'cppcheck', 'cpplint', 'gcc'
 * C#: 'mcs'
 * Chef: 'foodcritic'
 * CMake: 'cmakelint'

--- a/test/handler/test_cpplint_handler.vader
+++ b/test/handler/test_cpplint_handler.vader
@@ -1,0 +1,27 @@
+Before:
+  runtime ale_linters/cpp/cpplint.vim
+
+Execute(cpplint warnings from included files should be parsed correctly):
+
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 5,
+  \     'col': 0,
+  \     'text': ' Estra space after ( in function call [whitespace/parents] [4]',
+  \     'type': 'W',
+  \   },
+  \   {
+  \     'lnum': 120,
+  \     'col': 0,
+  \     'text': ' At least two spaces is best between code and comments  [whitespace/comments] [2]',
+  \     'type': 'W',
+  \   },
+  \ ],
+  \ ale#handlers#cpplint#HandleCppLintFormat(347, [
+  \   'test.cpp:5:  Estra space after ( in function call [whitespace/parents] [4]',
+  \   'keymap_keys.hpp:120:  At least two spaces is best between code and comments  [whitespace/comments] [2]',
+  \ ])
+
+After:
+  call ale#linter#Reset()


### PR DESCRIPTION
Added note to `README.md`, `doc/ale.txt` and `doc/ale-cpp.txt`.

This will handle the simplest case running `cpplint` with default options.
Marking everything as warning; this gives good starting point :)