### PR TITLE
Add checkstyle linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ name. That seems to be the fairest way to arrange this table.
 | Handlebars | [ember-template-lint](https://github.com/rwjblue/ember-template-lint) |
 | Haskell | [ghc](https://www.haskell.org/ghc/), [hlint](https://hackage.haskell.org/package/hlint), [hdevtools](https://hackage.haskell.org/package/hdevtools) |
 | HTML | [HTMLHint](http://htmlhint.com/), [proselint](http://proselint.com/), [tidy](http://www.html-tidy.org/) |
-| Java | [javac](http://www.oracle.com/technetwork/java/javase/downloads/index.html) |
+| Java | [checkstyle](http://checkstyle.sourceforge.net), [javac](http://www.oracle.com/technetwork/java/javase/downloads/index.html) |
 | JavaScript | [eslint](http://eslint.org/), [jscs](http://jscs.info/), [jshint](http://jshint.com/), [flow](https://flowtype.org/), [standard](http://standardjs.com/), [xo](https://github.com/sindresorhus/xo)
 | JSON | [jsonlint](http://zaa.ch/jsonlint/) |
 | Kotlin | [kotlinc](https://kotlinlang.org) see `:help ale-integration-kotlin` for configuration instructions

--- a/ale_linters/java/checkstyle.vim
+++ b/ale_linters/java/checkstyle.vim
@@ -1,0 +1,46 @@
+" Author: Devon Meunier <devon.meunier@gmail.com>
+" Description: checkstyle for Java files
+
+function! ale_linters#java#checkstyle#Handle(buffer, lines) abort
+    let l:patterns = [
+        \ '\v\[(WARN|ERROR)\] .*:(\d+):(\d+): (.*)',
+        \ '\v\[(WARN|ERROR)\] .*:(\d+): (.*)',
+        \]
+    let l:output = []
+
+    for l:match in ale#util#GetMatches(a:lines, l:patterns)
+        let l:args = {
+        \   'lnum': l:match[2] + 0,
+        \   'type': l:match[1] =~? 'WARN' ? 'W' : 'E'
+        \ }
+
+        let l:col = l:match[3] + 0
+        if l:col > 0
+            let l:args['col'] = l:col
+            let l:args['text'] = l:match[4]
+        else
+            let l:args['text'] = l:match[3]
+        endif
+
+        call add(l:output, l:args)
+    endfor
+
+    return l:output
+endfunction
+
+function! ale_linters#java#checkstyle#GetCommand(buffer) abort
+    return 'checkstyle '
+    \ . ale#Var(a:buffer, 'java_checkstyle_options')
+    \ . ' %t'
+endfunction
+
+if !exists('g:ale_java_checkstyle_options')
+    let g:ale_java_checkstyle_options = '-c /google_checks.xml'
+endif
+
+call ale#linter#Define('java', {
+\   'name': 'checkstyle',
+\   'executable': 'checkstyle',
+\   'command_callback': 'ale_linters#java#checkstyle#GetCommand',
+\   'callback': 'ale_linters#java#checkstyle#Handle',
+\})

--- a/doc/ale-java.txt
+++ b/doc/ale-java.txt
@@ -3,6 +3,18 @@ ALE Java Integration                                         *ale-java-options*
 
 
 -------------------------------------------------------------------------------
+checkstyle                                                ale-java-checkstyle
+
+g:ale_java_checkstyle_options                   g:ale_java_checkstyle_options
+                                                b:ale_java_checkstyle_options
+
+  Type: String
+  Default: '-c /google_checks.xml'
+
+  This variable can be changed to modify flags given to checkstyle.
+
+
+-------------------------------------------------------------------------------
 javac                                                          *ale-java-javac*
 
 g:ale_java_javac_classpath                         *g:ale_java_javac_classpath*

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -39,6 +39,7 @@ CONTENTS                                                         *ale-contents*
       htmlhint............................|ale-html-htmlhint|
       tidy................................|ale-html-tidy|
     java..................................|ale-java-options|
+      checkstyle..........................|ale-java-checkstyle|
       javac...............................|ale-java-javac|
     javascript............................|ale-javascript-options|
       eslint..............................|ale-javascript-eslint|

--- a/test/handler/test_checkstyle_handler.vader
+++ b/test/handler/test_checkstyle_handler.vader
@@ -1,0 +1,21 @@
+Execute(The checkstyle handler should parse lines correctly):
+  runtime ale_linters/java/checkstyle.vim
+
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 101,
+  \     'text': "'method def rcurly' has incorrect indentation level 4, expected level should be 2. [Indentation]",
+  \     'type': 'W',
+  \   },
+  \   {
+  \     'lnum': 63,
+  \     'col': 3,
+  \     'text': "Missing a Javadoc comment. [JavadocMethod]",
+  \     'type': 'W',
+  \   },
+  \ ],
+  \ ale_linters#java#checkstyle#Handle(666, [
+  \   "[WARN] whatever:101: 'method def rcurly' has incorrect indentation level 4, expected level should be 2. [Indentation]",
+  \   "[WARN] whatever:63:3: Missing a Javadoc comment. [JavadocMethod]",
+  \ ])


### PR DESCRIPTION
I put this together based off of the rubocop linter. Checkstyle doesn't actually accept stdin, I'm not sure if that's a problem?

Closes #550 