### PR TITLE
Support using relative paths in commands, and add an option for flow to use them

### DIFF
--- a/autoload/ale/engine.vim
+++ b/autoload/ale/engine.vim
@@ -476,11 +476,17 @@ function! ale#engine#FormatCommand(buffer, command) abort
     " with an ugly string.
     let l:command = substitute(l:command, '%%', '<<PERCENTS>>', 'g')
 
-    " Replace all %s occurences in the string with the name of the current
-    " file.
+    " Replace all %s occurences in the string with the absolute path of the
+    " current file.
     if l:command =~# '%s'
         let l:filename = fnamemodify(bufname(a:buffer), ':p')
         let l:command = substitute(l:command, '%s', '\=shellescape(l:filename)', 'g')
+    endif
+
+    " Replace all %r occurences with the relative path of the current file
+    if l:command =~# '%r'
+        let l:filename = fnamemodify(bufname(a:buffer), ':.')
+        let l:command = substitute(l:command, '%r', '\=shellescape(l:filename)', 'g')
     endif
 
     if l:command =~# '%t'


### PR DESCRIPTION
I wanted to open this to get feedback on if this approach is something that could be accepted, and if so I'll write tests for it to get this merged.

This exposes a `%r` interpolation variable for commands, which will fill in the relative path instead of absolute.

My use case is that I use docker in development, and for more intensive linting tools like flow (which needs to have a large part of my js build environment, have all node_modules installed, etc.) it's nice to install all of that once in my docker environment, rather than setting it up both on my host machine and in docker.

The paths in my docker env are different i.e. not nested in `/Users/username`, but with relative paths it works fine (I have a tiny wrapper script that I set as `g:ale_javascript_flow_executable` which proxies the command from Ale into my running dev docker container, though I think there's also a `flow ide`  command that I haven't looked much into that could potentially be used in the future and would likely still need relative paths coming from the editor).
