### PR TITLE
Add cpplint for cpp

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ name. That seems to be the fairest way to arrange this table.
 | Bash | [-n flag](https://www.gnu.org/software/bash/manual/bash.html#index-set), [shellcheck](https://www.shellcheck.net/) |
 | Bourne Shell | [-n flag](http://linux.die.net/man/1/sh), [shellcheck](https://www.shellcheck.net/) |
 | C | [cppcheck](http://cppcheck.sourceforge.net), [gcc](https://gcc.gnu.org/), [clang](http://clang.llvm.org/)|
-| C++ (filetype cpp) | [clang](http://clang.llvm.org/), [clangtidy](http://clang.llvm.org/extra/clang-tidy/), [cppcheck](http://cppcheck.sourceforge.net), [cpplint](https://github.com/cpplint/cpplint), [gcc](https://gcc.gnu.org/)|
+| C++ (filetype cpp) | [clang](http://clang.llvm.org/), [clangtidy](http://clang.llvm.org/extra/clang-tidy/), [cppcheck](http://cppcheck.sourceforge.net), [cpplint](https://github.com/google/styleguide), [gcc](https://gcc.gnu.org/)|
 | C# | [mcs](http://www.mono-project.com/docs/about-mono/languages/csharp/) |
 | Chef | [foodcritic](http://www.foodcritic.io/) |
 | CMake | [cmakelint](https://github.com/richq/cmake-lint) |

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ name. That seems to be the fairest way to arrange this table.
 | Bash | [-n flag](https://www.gnu.org/software/bash/manual/bash.html#index-set), [shellcheck](https://www.shellcheck.net/) |
 | Bourne Shell | [-n flag](http://linux.die.net/man/1/sh), [shellcheck](https://www.shellcheck.net/) |
 | C | [cppcheck](http://cppcheck.sourceforge.net), [gcc](https://gcc.gnu.org/), [clang](http://clang.llvm.org/)|
-| C++ (filetype cpp) | [clang](http://clang.llvm.org/), [clangtidy](http://clang.llvm.org/extra/clang-tidy/), [cppcheck](http://cppcheck.sourceforge.net), [gcc](https://gcc.gnu.org/)|
+| C++ (filetype cpp) | [clang](http://clang.llvm.org/), [clangtidy](http://clang.llvm.org/extra/clang-tidy/), [cppcheck](http://cppcheck.sourceforge.net), [cpplint](https://github.com/cpplint/cpplint), [gcc](https://gcc.gnu.org/)|
 | C# | [mcs](http://www.mono-project.com/docs/about-mono/languages/csharp/) |
 | Chef | [foodcritic](http://www.foodcritic.io/) |
 | CMake | [cmakelint](https://github.com/richq/cmake-lint) |

--- a/ale_linters/cpp/cpplint.vim
+++ b/ale_linters/cpp/cpplint.vim
@@ -14,8 +14,8 @@ function! ale_linters#cpp#cpplint#HandleCpplintFormat(buffer, lines) abort
         let l:match = matchlist(l:line, l:pattern)
         if !empty(l:match)
             call add(l:output, {
-                        \'text': match[3] . ' ' . match[4],
-                        \'lnum': match[2] + 0,
+                        \'text': l:match[3] . ' ' . l:match[4],
+                        \'lnum': l:match[2] + 0,
                         \'col': 0,
                         \'type': 'W',
                         \})

--- a/ale_linters/cpp/cpplint.vim
+++ b/ale_linters/cpp/cpplint.vim
@@ -1,0 +1,44 @@
+let g:ale_cpp_cpplint_filter = get(g:, 'ale_cpp_cpplint_filter', [])
+let g:ale_cpp_cpplint_verbose = get(g:, 'ale_cpp_cpplint_verbose', 1)
+let g:ale_cpp_cpplint_linelength = get(g:, 'ale_cpp_cpplint_linelength', 80)
+
+function! ale_linters#cpp#cpplint#HandleCpplintFormat(buffer, lines) abort
+    let l:pattern = '^\(.\+\):\(\d\+\):\s\(.\+\)\s\(\[.\+\]\)\s\(\[.\+\]\)$'
+    let l:output = []
+    for l:line in a:lines
+        let l:match = matchlist(l:line, l:pattern)
+        if !empty(l:match)
+            call add(l:output, {
+                        \'text': match[3] . ' ' . match[4],
+                        \'lnum': match[2] + 0,
+                        \'col': 0,
+                        \'type': 'W',
+                        \})
+        endif
+    endfor
+    return l:output
+endfunction
+
+function! s:to_option(key, value)
+    if empty(a:value)
+        return ''
+    endif
+
+    return '--' . a:key . '=' . a:value
+endfunction
+
+function! ale_linters#cpp#cpplint#GetCommand(buffer) abort
+    let l:filter = s:to_option('filter', join(ale#Var(a:buffer, 'cpp_cpplint_filter'), ','))
+    let l:verbose = s:to_option('verbose', ale#Var(a:buffer, 'cpp_cpplint_verbose'))
+    let l:linelength = s:to_option('linelength', ale#Var(a:buffer, 'cpp_cpplint_linelength'))
+    return 'cpplint --quiet ' . l:filter . ' ' . l:verbose . ' ' . l:linelength . ' -'
+endfunction
+
+call ale#linter#Define('cpp', {
+\   'name': 'cpplint',
+\   'output_stream': 'stderr',
+\   'executable': 'cpplint',
+\   'callback': 'ale_linters#cpp#cpplint#HandleCpplintFormat',
+\   'command_callback': 'ale_linters#cpp#cpplint#GetCommand',
+\})
+

--- a/ale_linters/cpp/cpplint.vim
+++ b/ale_linters/cpp/cpplint.vim
@@ -2,6 +2,7 @@
 " Description: cpplint linter for c files
 
 
+let g:ale_cpp_cpplint_options = get(g:, 'ale_cpp_cpplint_options', '')
 let g:ale_cpp_cpplint_filter = get(g:, 'ale_cpp_cpplint_filter', [])
 let g:ale_cpp_cpplint_verbose = get(g:, 'ale_cpp_cpplint_verbose', 1)
 let g:ale_cpp_cpplint_linelength = get(g:, 'ale_cpp_cpplint_linelength', 80)
@@ -32,10 +33,12 @@ function! s:to_option(key, value)
 endfunction
 
 function! ale_linters#cpp#cpplint#GetCommand(buffer) abort
+    let l:options = ale#Var(a:buffer, 'cpp_cpplint_options')
     let l:filter = s:to_option('filter', join(ale#Var(a:buffer, 'cpp_cpplint_filter'), ','))
     let l:verbose = s:to_option('verbose', ale#Var(a:buffer, 'cpp_cpplint_verbose'))
     let l:linelength = s:to_option('linelength', ale#Var(a:buffer, 'cpp_cpplint_linelength'))
-    return 'cpplint --quiet ' . l:filter . ' ' . l:verbose . ' ' . l:linelength . ' -'
+    return 'cpplint --quiet ' . l:options . ' ' . l:filter 
+                \ . ' ' . l:verbose . ' ' . l:linelength . ' -'
 endfunction
 
 call ale#linter#Define('cpp', {

--- a/ale_linters/cpp/cpplint.vim
+++ b/ale_linters/cpp/cpplint.vim
@@ -1,3 +1,7 @@
+" Author: odanado <odan3240@gmail.com>
+" Description: cpplint linter for c files
+
+
 let g:ale_cpp_cpplint_filter = get(g:, 'ale_cpp_cpplint_filter', [])
 let g:ale_cpp_cpplint_verbose = get(g:, 'ale_cpp_cpplint_verbose', 1)
 let g:ale_cpp_cpplint_linelength = get(g:, 'ale_cpp_cpplint_linelength', 80)

--- a/doc/ale-cpp.txt
+++ b/doc/ale-cpp.txt
@@ -71,6 +71,14 @@ g:ale_cpp_gcc_options                                   *g:ale_cpp_gcc_options*
 
 -------------------------------------------------------------------------------
 cpplint                                                       *ale-cpp-cpplint*
+g:ale_cpp_cpplint_options                           *g:ale_cpp_cpplint_options*
+                                                    *b:ale_cpp_cpplint_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be changed to modify flags given to cpplint.
+
+
 g:ale_cpp_cpplint_filter                             *g:ale_cpp_cpplint_filter*
                                                      *b:ale_cpp_cpplint_filter*
   Type: |Array|

--- a/doc/ale-cpp.txt
+++ b/doc/ale-cpp.txt
@@ -70,4 +70,38 @@ g:ale_cpp_gcc_options                                   *g:ale_cpp_gcc_options*
 
 
 -------------------------------------------------------------------------------
+cpplint                                                       *ale-cpp-cpplint*
+g:ale_cpp_cpplint_filter                             *g:ale_cpp_cpplint_filter*
+                                                     *b:ale_cpp_cpplint_filter*
+  Type: |Array|
+  Default: `[]`
+
+  This variable can be set to change the filter option of cpplint. All filters
+  can be seen in _ERROR_CATEGORIES of a source code.
+  https://github.com/google/styleguide/blob/gh-pages/cpplint/cpplint.py
+
+  "-FOO" and "FOO" means "do not print categories that start with FOO".
+  "+FOO" means "do print categories that start with FOO".
+
+
+g:ale_cpp_cpplint_verbose                           *g:ale_cpp_cpplint_verbose*
+                                                    *b:ale_cpp_cpplint_verbose*
+  Type: |Number|
+  Default: `1`
+
+  This variable can be set to change the verbose option of cpplint. The large
+  number, the less a printed message.
+
+  Specify a number 0-5 to restrict errors to certain verbosity levels.
+
+
+g:ale_cpp_cpplint_linelength                     *g:ale_cpp_cpplint_linelength*
+                                                 *b:ale_cpp_cpplint_linelength*
+  Type: |Number| 
+  Default: `80`
+
+  This variable can be set to change the linelength option of cpplint.
+  This is the allowed line length for the project.
+
+-------------------------------------------------------------------------------
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -119,7 +119,7 @@ The following languages and tools are supported.
 * Bash: 'shell' (-n flag), 'shellcheck'
 * Bourne Shell: 'shell' (-n flag), 'shellcheck'
 * C: 'cppcheck', 'gcc', 'clang'
-* C++ (filetype cpp): 'clang', 'clangtidy', 'cppcheck', 'gcc'
+* C++ (filetype cpp): 'clang', 'clangtidy', 'cppcheck', 'cpplint', 'gcc'
 * C#: 'mcs'
 * Chef: 'foodcritic'
 * CMake: 'cmakelint'


### PR DESCRIPTION
[cpplint](https://github.com/google/styleguide/tree/gh-pages/cpplint) is a lint tool to check that c++ file follows [Google's C++ style guide](https://google.github.io/styleguide/cppguide.html).