### PR TITLE
Allow overriding rubocop executable.

### DIFF
--- a/ale_linters/ruby/rubocop.vim
+++ b/ale_linters/ruby/rubocop.vim
@@ -25,14 +25,19 @@ function! ale_linters#ruby#rubocop#Handle(buffer, lines) abort
 endfunction
 
 function! ale_linters#ruby#rubocop#GetCommand(buffer) abort
-    return ale#Var(a:buffer, 'ruby_rubocop_executable')
+    let l:unescaped = ale#Var(a:buffer, 'ruby_rubocop_executable')
+    let l:executable = ale#Escape(l:unescaped)
+    if l:unescaped =~? 'bundle$'
+        let l:executable = l:executable . ' exec rubocop'
+    endif
+    return l:executable
     \   . ' --format emacs --force-exclusion '
     \   . ale#Var(a:buffer, 'ruby_rubocop_options')
     \   . ' --stdin ' . bufname(a:buffer)
 endfunction
 
 function! ale_linters#ruby#rubocop#GetExecutable(buffer) abort
-    let l:executable = split(ale#Var(a:buffer, 'ruby_rubocop_executable'))[0]
+    let l:executable = ale#Var(a:buffer, 'ruby_rubocop_executable')
     if executable(l:executable)
         return l:executable
     endif

--- a/ale_linters/ruby/rubocop.vim
+++ b/ale_linters/ruby/rubocop.vim
@@ -25,9 +25,17 @@ function! ale_linters#ruby#rubocop#Handle(buffer, lines) abort
 endfunction
 
 function! ale_linters#ruby#rubocop#GetCommand(buffer) abort
-    return 'rubocop --format emacs --force-exclusion '
+    return ale#Var(a:buffer, 'ruby_rubocop_executable')
+    \   . ' --format emacs --force-exclusion '
     \   . ale#Var(a:buffer, 'ruby_rubocop_options')
     \   . ' --stdin ' . bufname(a:buffer)
+endfunction
+
+function! ale_linters#ruby#rubocop#GetExecutable(buffer) abort
+    let l:executable = split(ale#Var(a:buffer, 'ruby_rubocop_executable'))[0]
+    if executable(l:executable)
+        return l:executable
+    endif
 endfunction
 
 " Set this option to change Rubocop options.
@@ -36,9 +44,13 @@ if !exists('g:ale_ruby_rubocop_options')
     let g:ale_ruby_rubocop_options = ''
 endif
 
+if !exists('g:ale_ruby_rubocop_executable')
+    let g:ale_ruby_rubocop_executable = 'rubocop'
+endif
+
 call ale#linter#Define('ruby', {
 \   'name': 'rubocop',
-\   'executable': 'rubocop',
+\   'executable_callback': 'ale_linters#ruby#rubocop#GetExecutable',
 \   'command_callback': 'ale_linters#ruby#rubocop#GetCommand',
 \   'callback': 'ale_linters#ruby#rubocop#Handle',
 \})

--- a/doc/ale-ruby.txt
+++ b/doc/ale-ruby.txt
@@ -37,6 +37,15 @@ g:ale_ruby_reek_show_wiki_link                 *g:ale_ruby_reek_show_wiki_link*
 -------------------------------------------------------------------------------
 rubocop                                                      *ale-ruby-rubocop*
 
+g:ale_ruby_rubocop_executable                   g:ale_ruby_rubocop_executable
+                                                b:ale_ruby_rubocop_executable
+  Type: String
+  Default: 'rubocop'
+
+  Override the invoked rubocop binary. This is useful for running rubocop
+  from binstubs or a bundle.
+
+
 g:ale_ruby_rubocop_options                         *g:ale_ruby_rubocop_options*
                                                    *b:ale_ruby_rubocop_options*
   Type: |String|

--- a/test/command_callback/test_rubocop_command_callback.vader
+++ b/test/command_callback/test_rubocop_command_callback.vader
@@ -3,27 +3,17 @@ Before:
 
 Execute(Executable should default to rubocop):
   AssertEqual
-  \ 'rubocop --format emacs --force-exclusion  --stdin ''dummy.py''',
+  \ '''rubocop'' --format emacs --force-exclusion  --stdin ''dummy.py''',
   \ ale_linters#ruby#rubocop#GetCommand(bufnr(''))
 
 Execute(Should be able to set a custom executable):
   let g:ale_ruby_rubocop_executable = 'bin/rubocop'
   AssertEqual
-  \ 'bin/rubocop --format emacs --force-exclusion  --stdin ''dummy.py''',
+  \ '''bin/rubocop'' --format emacs --force-exclusion  --stdin ''dummy.py''',
   \ ale_linters#ruby#rubocop#GetCommand(bufnr(''))
 
-Execute(Custom executables should not be escaped):
-  let g:ale_ruby_rubocop_executable = 'bundle exec rubocop'
+Execute(Setting bundle appends 'exec rubocop'):
+  let g:ale_ruby_rubocop_executable = 'path to/bundle'
   AssertEqual
-  \ 'bundle exec rubocop --format emacs --force-exclusion  --stdin ''dummy.py''',
+  \ '''path to/bundle'' exec rubocop --format emacs --force-exclusion  --stdin ''dummy.py''',
   \ ale_linters#ruby#rubocop#GetCommand(bufnr(''))
-
-Execute(Executable callback should return the first token of the executable):
-  let g:ale_ruby_rubocop_executable = 'bundle exec rubocop'
-  AssertEqual
-  \ 'bundle',
-  \ ale_linters#ruby#rubocop#GetExecutable(bufnr(''))
-  let g:ale_ruby_rubocop_executable = 'bin/rubocop'
-  AssertEqual
-  \ 'bin/rubocop',
-  \ ale_linters#ruby#rubocop#GetExecutable(bufnr(''))

--- a/test/command_callback/test_rubocop_command_callback.vader
+++ b/test/command_callback/test_rubocop_command_callback.vader
@@ -1,0 +1,29 @@
+Before:
+  runtime ale_linters/ruby/rubocop.vim
+
+Execute(Executable should default to rubocop):
+  AssertEqual
+  \ 'rubocop --format emacs --force-exclusion  --stdin ''dummy.py''',
+  \ ale_linters#ruby#rubocop#GetCommand(bufnr(''))
+
+Execute(Should be able to set a custom executable):
+  let g:ale_ruby_rubocop_executable = 'bin/rubocop'
+  AssertEqual
+  \ 'bin/rubocop --format emacs --force-exclusion  --stdin ''dummy.py''',
+  \ ale_linters#ruby#rubocop#GetCommand(bufnr(''))
+
+Execute(Custom executables should not be escaped):
+  let g:ale_ruby_rubocop_executable = 'bundle exec rubocop'
+  AssertEqual
+  \ 'bundle exec rubocop --format emacs --force-exclusion  --stdin ''dummy.py''',
+  \ ale_linters#ruby#rubocop#GetCommand(bufnr(''))
+
+Execute(Executable callback should return the first token of the executable):
+  let g:ale_ruby_rubocop_executable = 'bundle exec rubocop'
+  AssertEqual
+  \ 'bundle',
+  \ ale_linters#ruby#rubocop#GetExecutable(bufnr(''))
+  let g:ale_ruby_rubocop_executable = 'bin/rubocop'
+  AssertEqual
+  \ 'bin/rubocop',
+  \ ale_linters#ruby#rubocop#GetExecutable(bufnr(''))


### PR DESCRIPTION
Rubocop configuration can get pretty hairy, to the point that you actually want one per-project rather than a global rubocop. The two standard ways for the ruby ecosystem to handle this is either through binstubs (eg. `bin/rubocop`) or bundler `bundle exec rubocop`.