### PR TITLE
Add end columns on php linter

### DIFF
--- a/ale_linters/php/php.vim
+++ b/ale_linters/php/php.vim
@@ -4,17 +4,23 @@
 function! ale_linters#php#php#Handle(buffer, lines) abort
     " Matches patterns like the following:
     "
-    " PHP Parse error:  syntax error, unexpected ';', expecting ']' in - on line 15
+    " Parse error:  syntax error, unexpected ';', expecting ']' in - on line 15
     let l:pattern = '\v^%(Fatal|Parse) error:\s+(.+unexpected ''(.+)%(expecting.+)@<!''.*|.+) in - on line (\d+)'
-
     let l:output = []
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)
-        call add(l:output, {
+        let l:col = empty(l:match[2]) ? 0 : stridx(getline(l:match[3]), l:match[2]) + 1
+        let l:obj = {
         \   'lnum': l:match[3] + 0,
-        \   'col': empty(l:match[2]) ? 0 : stridx(getline(l:match[3]), l:match[2]) + 1,
+        \   'col': l:col,
         \   'text': l:match[1],
-        \})
+        \}
+
+        if l:col != 0
+            let l:obj.end_col = l:col + strlen(l:match[2]) - 1
+        endif
+
+        call add(l:output, l:obj)
     endfor
 
     return l:output

--- a/test/handler/test_php_handler.vader
+++ b/test/handler/test_php_handler.vader
@@ -14,21 +14,25 @@ Execute(The php handler should calculate column numbers):
   \   {
   \     'lnum': 1,
   \     'col': 5,
+  \     'end_col': 5,
   \     'text': "syntax error, unexpected ';', expecting ']'",
   \   },
   \   {
   \     'lnum': 2,
   \     'col': 13,
+  \     'end_col': 13,
   \     'text': "syntax error, unexpected '/', expecting function (T_FUNCTION) or const (T_CONST)",
   \   },
   \   {
   \     'lnum': 3,
   \     'col': 5,
+  \     'end_col': 5,
   \     'text': "syntax error, unexpected ')'",
   \   },
   \   {
   \     'lnum': 4,
   \     'col': 8,
+  \     'end_col': 12,
   \     'text': "syntax error, unexpected ''bar'' (T_CONSTANT_ENCAPSED_STRING), expecting ']'",
   \   },
   \ ],

--- a/test/handler/test_php_handler.vader
+++ b/test/handler/test_php_handler.vader
@@ -1,3 +1,6 @@
+Before:
+  runtime ale_linters/php/php.vim
+
 Given (Some invalid lines of PHP):
   [foo;]
   class Foo { / }
@@ -5,9 +8,7 @@ Given (Some invalid lines of PHP):
   ['foo' 'bar']
   function count() {}
 
-Execute(The php handler should parse lines correctly):
-  runtime ale_linters/php/php.vim
-
+Execute(The php handler should calculate column numbers):
   AssertEqual
   \ [
   \   {
@@ -30,6 +31,25 @@ Execute(The php handler should parse lines correctly):
   \     'col': 8,
   \     'text': "syntax error, unexpected ''bar'' (T_CONSTANT_ENCAPSED_STRING), expecting ']'",
   \   },
+  \ ],
+  \ ale_linters#php#php#Handle(347, [
+  \   "This line should be ignored completely",
+  \   "Parse error:  syntax error, unexpected ';', expecting ']' in - on line 1",
+  \   "Parse error:  syntax error, unexpected '/', expecting function (T_FUNCTION) or const (T_CONST) in - on line 2",
+  \   "Parse error:  syntax error, unexpected ')' in - on line 3",
+  \   "Parse error:  syntax error, unexpected ''bar'' (T_CONSTANT_ENCAPSED_STRING), expecting ']' in - on line 4",
+  \ ])
+
+Execute (The php handler should ignore lines starting with 'PHP Parse error'):
+  AssertEqual
+  \ [],
+  \ ale_linters#php#php#Handle(347, [
+  \   "PHP Parse error:  syntax error, This line should be ignored completely in - on line 1",
+  \ ])
+
+Execute (The php handler should parse lines without column indication):
+  AssertEqual
+  \ [
   \   {
   \     'lnum': 5,
   \     'col': 0,
@@ -47,15 +67,10 @@ Execute(The php handler should parse lines correctly):
   \   },
   \ ],
   \ ale_linters#php#php#Handle(347, [
-  \   'This line should be ignored completely',
-  \   "PHP Parse error:  syntax error, This line should be ignored completely in - on line 1",
-  \   "Parse error:  syntax error, unexpected ';', expecting ']' in - on line 1",
-  \   "Parse error:  syntax error, unexpected '/', expecting function (T_FUNCTION) or const (T_CONST) in - on line 2",
-  \   "Parse error:  syntax error, unexpected ')' in - on line 3",
-  \   "Parse error:  syntax error, unexpected ''bar'' (T_CONSTANT_ENCAPSED_STRING), expecting ']' in - on line 4",
+  \   "This line should be ignored completely",
   \   "Fatal error:  Cannot redeclare count() in - on line 5",
-  \   'Parse error:  syntax error, unexpected end of file in - on line 21',
-  \   'Parse error: Invalid numeric literal in - on line 47',
+  \   "Parse error:  syntax error, unexpected end of file in - on line 21",
+  \   "Parse error: Invalid numeric literal in - on line 47",
   \ ])
 
 After:


### PR DESCRIPTION
This adds support for `end_col` on the php linter. I did it like the linter for eslint, so `end_col` is only added when it can be calculated.