### PR TITLE
Improve performance when using gometalinter

### DIFF
--- a/ale_linters/go/gometalinter.vim
+++ b/ale_linters/go/gometalinter.vim
@@ -6,7 +6,7 @@ if !exists('g:ale_go_gometalinter_options')
 endif
 
 function! ale_linters#go#gometalinter#GetCommand(buffer) abort
-    return 'gometalinter '
+    return 'gometalinter --include=''^' . expand('%:p') . '.*$'' '
     \   . ale#Var(a:buffer, 'go_gometalinter_options')
     \   . ' ' . ale#Escape(fnamemodify(bufname(a:buffer), ':p:h'))
 endfunction
@@ -21,11 +21,6 @@ function! ale_linters#go#gometalinter#Handler(buffer, lines) abort
     let l:output = []
 
     for l:match in ale_linters#go#gometalinter#GetMatches(a:lines)
-        " Omit errors from files other than the one currently open
-        if !ale#path#IsBufferPath(a:buffer, l:match[1])
-            continue
-        endif
-
         call add(l:output, {
         \   'lnum': l:match[2] + 0,
         \   'col': l:match[3] + 0,

--- a/test/handler/test_gometalinter_handler.vader
+++ b/test/handler/test_gometalinter_handler.vader
@@ -51,24 +51,3 @@ Execute (The gometalinter handler should handle relative paths correctly):
   \   'baz.go:12:3:warning: expected ''package'', found ''IDENT'' gibberish (staticcheck)',
   \   'baz.go:37:5:error: expected ''package'', found ''IDENT'' gibberish (golint)',
   \ ])
-
-
-Execute (The gometalinter handler should filter out errors from other files):
-  silent file! /some/path/sql.go
-
-  AssertEqual
-  \ [],
-  \ ale_linters#go#gometalinter#Handler(bufnr(''), [
-  \   '/some/path/interface_implementation_test.go:417::warning: cyclomatic complexity 24 of function testGetUserHeaders() is high (> 10) (gocyclo)',
-  \   '/some/path/sql_helpers.go:38::warning: cyclomatic complexity 11 of function CreateTestUserMetadataDB() is high (> 10) (gocyclo)',
-  \   '/some/path/sql_alpha.go:560:7:warning: ineffectual assignment to err (ineffassign)',
-  \   '/some/path/sql_alpha.go:589:7:warning: ineffectual assignment to err (ineffassign)',
-  \   '/some/path/sql_test.go:124:9:warning: should not use basic type untyped string as key in context.WithValue (golint)',
-  \   '/some/path/interface_implementation_test.go:640::warning: declaration of "cfg" shadows declaration at sql_test.go:21 (vetshadow)',
-  \   '/some/path/sql_helpers.go:55::warning: declaration of "err" shadows declaration at sql_helpers.go:48 (vetshadow)',
-  \   '/some/path/sql_helpers.go:91::warning: declaration of "err" shadows declaration at sql_helpers.go:48 (vetshadow)',
-  \   '/some/path/sql_helpers.go:108::warning: declaration of "err" shadows declaration at sql_helpers.go:48 (vetshadow)',
-  \   '/some/path/user_metadata_db.go:149::warning: declaration of "err" shadows declaration at user_metadata_db.go:140 (vetshadow)',
-  \   '/some/path/user_metadata_db.go:188::warning: declaration of "err" shadows declaration at user_metadata_db.go:179 (vetshadow)',
-  \   '/some/path/queries_alpha.go:62::warning: Potential hardcoded credentials,HIGH,LOW (gas)',
-  \ ])


### PR DESCRIPTION
Before this change when I opened a big project that had 6000+ warnings/errors it took ages to get the actual warnings/errors and it caused my CPU to be busy for quite some time. The call to gometalinter alone took about 24 seconds, but after that vim was struggling as well.

After this change the gometalinter call just takes 2 seconds and nothing noticeable happens with the CPU and/or vim.
