### PR TITLE
feat(options): add ale_fix_* options

### DIFF
--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -393,6 +393,34 @@ g:ale_lint_on_insert_leave                         *g:ale_lint_on_insert_leave*
   This option will make ALE run the linters whenever leaving insert mode when
   it it set to `1` in your vimrc file.
 
+g:ale_fix_on_enter                                       *g:ale_fix_on_enter*
+
+  Type: |Number|
+  Default: `1`
+
+  When this option is set to `1`, the |BufEnter| and |BufRead| events will be
+  used to apply fixers when buffers are first opened. If this is not desired,
+  this variable can be set to `0` in your vimrc file to disable this
+  behaviour.
+
+g:ale_fix_on_save                                         *g:ale_fix_on_save*
+
+  Type: |Number|
+  Default: `1`
+
+  This option will make ALE run the fixers whenever a file is saved when it
+  it set to `1` in your vimrc file. This option can be used in combination
+  with the |g:ale_fix_on_enter| and |g:ale_lint_on_text_changed| options to
+  make ALE only check files after that have been saved, if that is what is
+  desired.
+
+g:ale_fix_on_insert_leave                         *g:ale_fix_on_insert_leave*
+
+  Type: |Number|
+  Default: `0`
+
+  This option will make ALE run the fixers whenever leaving insert mode when
+  it it set to `1` in your vimrc file.
 
 g:ale_linter_aliases                                     *g:ale_linter_aliases*
                                                          *b:ale_linter_aliases*

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -396,7 +396,7 @@ g:ale_lint_on_insert_leave                         *g:ale_lint_on_insert_leave*
 g:ale_fix_on_enter                                       *g:ale_fix_on_enter*
 
   Type: |Number|
-  Default: `1`
+  Default: `0`
 
   When this option is set to `1`, the |BufEnter| and |BufRead| events will be
   used to apply fixers when buffers are first opened. If this is not desired,
@@ -406,7 +406,7 @@ g:ale_fix_on_enter                                       *g:ale_fix_on_enter*
 g:ale_fix_on_save                                         *g:ale_fix_on_save*
 
   Type: |Number|
-  Default: `1`
+  Default: `0`
 
   This option will make ALE run the fixers whenever a file is saved when it
   it set to `1` in your vimrc file. This option can be used in combination

--- a/plugin/ale.vim
+++ b/plugin/ale.vim
@@ -89,6 +89,15 @@ let g:ale_lint_on_save = get(g:, 'ale_lint_on_save', 1)
 " This flag can be set to 1 to enable linting when the filetype is changed.
 let g:ale_lint_on_filetype_changed = get(g:, 'ale_lint_on_filetype_changed', 1)
 
+" This flag can be set to 1 to enable fixing when leaving insert mode.
+let g:ale_fix_on_insert_leave = get(g:, 'ale_fix_on_insert_leave', 0)
+
+" This flag can be set to 0 to disable fixing when the buffer is entered.
+let g:ale_fix_on_enter = get(g:, 'ale_fix_on_enter', 1)
+
+" This flag can be set to 1 to enable fixing when a buffer is written.
+let g:ale_fix_on_save = get(g:, 'ale_fix_on_save', 1)
+
 " This flag may be set to 0 to disable ale. After ale is loaded, :ALEToggle
 " should be used instead.
 let g:ale_enabled = get(g:, 'ale_enabled', 1)
@@ -182,6 +191,11 @@ function! ALEInitAuGroups() abort
         if g:ale_enabled && g:ale_lint_on_enter
             autocmd BufEnter,BufRead * call ale#Queue(300, 'lint_file')
         endif
+
+        autocmd!
+        if g:ale_enabled && g:ale_fix_on_enter
+            autocmd BufEnter,BufRead * call ale#fix#Fix()
+        endif
     augroup END
 
     augroup ALERunOnFiletypeChangeGroup
@@ -204,12 +218,22 @@ function! ALEInitAuGroups() abort
         if g:ale_enabled && g:ale_lint_on_save
             autocmd BufWrite * call ale#Queue(0, 'lint_file')
         endif
+
+        autocmd!
+        if g:ale_enabled && g:ale_fix_on_save
+            autocmd BufWrite * call ale#fix#Fix()
+        endif
     augroup END
 
     augroup ALERunOnInsertLeave
         autocmd!
         if g:ale_enabled && g:ale_lint_on_insert_leave
             autocmd InsertLeave * call ale#Queue(0, 'lint_file')
+        endif
+
+        autocmd!
+        if g:ale_enabled && g:ale_fix_on_insert_leave
+            autocmd InsertLeave * call ale#fix#Fix()
         endif
     augroup END
 

--- a/plugin/ale.vim
+++ b/plugin/ale.vim
@@ -93,10 +93,10 @@ let g:ale_lint_on_filetype_changed = get(g:, 'ale_lint_on_filetype_changed', 1)
 let g:ale_fix_on_insert_leave = get(g:, 'ale_fix_on_insert_leave', 0)
 
 " This flag can be set to 0 to disable fixing when the buffer is entered.
-let g:ale_fix_on_enter = get(g:, 'ale_fix_on_enter', 1)
+let g:ale_fix_on_enter = get(g:, 'ale_fix_on_enter', 0)
 
 " This flag can be set to 1 to enable fixing when a buffer is written.
-let g:ale_fix_on_save = get(g:, 'ale_fix_on_save', 1)
+let g:ale_fix_on_save = get(g:, 'ale_fix_on_save', 0)
 
 " This flag may be set to 0 to disable ale. After ale is loaded, :ALEToggle
 " should be used instead.


### PR DESCRIPTION
Add 3 new options for better control of ALEFix: `ale_fix_on_insert_leave`, `ale_fix_on_save` and `ale_fix_on_enter`. Their defaults are the same as their `ale_lint_*` equivalents.

- ale_fix_on_insert_leave = 0
- ale_fix_on_enter = 1
- ale_fix_on_save = 1

Also added docs.

Sorry, but don't have tests because I'm new to Vim world, can you handle them?