### PR TITLE
feat(fixer): add Prettier fixer (using Prettier-ESLint CLI) + docs

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -12,6 +12,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['javascript'],
 \       'description': 'Apply eslint --fix to a file.',
 \   },
+\   'prettier': {
+\       'function': 'ale#handlers#prettier#Fix',
+\       'suggested_filetypes': ['javascript'],
+\       'description': 'Apply prettier (with ESLint integration) to file',
+\   },
 \   'isort': {
 \       'function': 'ale#handlers#python#ISort',
 \       'suggested_filetypes': ['python'],

--- a/autoload/ale/handlers/prettier.vim
+++ b/autoload/ale/handlers/prettier.vim
@@ -1,0 +1,49 @@
+
+" Author: tunnckoCore (Charlike Mike Reagent) <mameto2011@gmail.com>
+" Description: Integration between Prettier and ESLint.
+
+" Here we use `prettier-eslint` intetionally,
+" because from v4 it is direct mirror of `prettier` - mimics
+" it's flags and etc.
+
+let g:ale_javascript_prettier_executable =
+\   get(g:, 'ale_javascript_prettier_executable', 'prettier-eslint')
+
+let g:ale_javascript_prettier_options =
+\   get(g:, 'ale_javascript_prettier_options', '')
+
+function! ale#handlers#prettier#GetExecutable(buffer) abort
+    if ale#Var(a:buffer, 'javascript_prettier_use_global')
+        return ale#Var(a:buffer, 'javascript_prettier_executable')
+    endif
+
+    " Look for the kinds of paths that create-react-app generates first.
+    let l:executable = ale#path#ResolveLocalPath(
+    \   a:buffer,
+    \   'node_modules/prettier-eslint-cli/index.js',
+    \   ''
+    \)
+
+    if !empty(l:executable)
+        return l:executable
+    endif
+
+    return ale#path#ResolveLocalPath(
+    \   a:buffer,
+    \   'node_modules/.bin/prettier-eslint',
+    \   ale#Var(a:buffer, 'javascript_prettier_executable')
+    \)
+endfunction
+
+
+function! ale#handlers#prettier#Fix(buffer, lines) abort
+    let l:options = ale#Var(a:buffer, 'javascript_prettier_options')
+
+    return {
+    \   'command': ale#Escape(ale#handlers#prettier#GetExecutable(a:buffer))
+    \       . ' %t'
+    \       . ' ' . ale#Escape(l:options)
+    \       . ' --write',
+    \   'read_temporary_file': 1,
+    \}
+endfunction

--- a/doc/ale-javascript.txt
+++ b/doc/ale-javascript.txt
@@ -40,6 +40,45 @@ g:ale_javascript_eslint_use_global         *g:ale_javascript_eslint_use_global*
 
 
 -------------------------------------------------------------------------------
+prettier                                              *ale-javascript-prettier*
+
+g:ale_javascript_prettier_executable     *g:ale_javascript_prettier_executable*
+                                         *b:ale_javascript_prettier_executable*
+  Type: |String|
+  Default: `'prettier-eslint'`
+
+  ALE will first discover the prettier-eslint path in an ancestor node_modules
+  directory. If no such path exists, this variable will be used instead.
+
+  This variable can be set to change the path to prettier-eslint or if you want
+  to use the original Prettier CLI.
+
+  If you wish to use only a globally installed version of prettier or
+  prettier-eslint, set the set
+  |g:ale_javascript_prettier_use_global| to `1`.
+
+
+g:ale_javascript_prettier_options             *g:ale_javascript_prettier_options*
+                                            *b:ale_javascript_prettier_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be set to pass additional options to prettier.
+
+
+g:ale_javascript_prettier_use_global       *g:ale_javascript_eslint_use_global*
+                                           *b:ale_javascript_eslint_use_global*
+  Type: |Number|
+  Default: `0`
+
+  This variable controls whether or not ALE will search for a local path for
+  prettier-eslint-cli first. If this variable is set to `1`,
+  then ALE will always use the global version of Prettier or Prettier-ESLint,
+  depending on g:ale_javascript_prettier_executable, in preference to
+  locally installed versions of Prettier / Prettier-ESLint in node_modules.
+
+
+-------------------------------------------------------------------------------
 flow                                                      *ale-javascript-flow*
 
 g:ale_javascript_flow_executable             *g:ale_javascript_flow_executable*


### PR DESCRIPTION
I did a PR to Prettier-ESLint ([merged as v4](https://github.com/prettier/prettier-eslint-cli/releases/tag/v4.0.0)) that made it exact mirror of the original Prettier CLI, so here i just use it for better integration.

If someone don't want it he can just use `g:ale_javascript_prettier_executable = 'prettier'` and it will use the original one.

Docs added too, adapted from ESLint fixer.