### PR TITLE
Ember-template-lint handler: properly handle template parsing errors.

### DIFF
--- a/ale_linters/handlebars/embertemplatelint.vim
+++ b/ale_linters/handlebars/embertemplatelint.vim
@@ -26,13 +26,23 @@ function! ale_linters#handlebars#embertemplatelint#Handle(buffer, lines) abort
     let l:file_errors = values(l:input_json)[0]
 
     for l:error in l:file_errors
-        call add(l:output, {
-        \   'bufnr': a:buffer,
-        \   'lnum': l:error.line,
-        \   'col': l:error.column,
-        \   'text': l:error.rule . ': ' . l:error.message,
-        \   'type': l:error.severity == 1 ? 'W' : 'E',
-        \})
+        if has_key(l:error, 'fatal')
+            call add(l:output, {
+            \   'bufnr': a:buffer,
+            \   'lnum': 1,
+            \   'col': 1,
+            \   'text': l:error.message,
+            \   'type': l:error.severity == 1 ? 'W' : 'E',
+            \})
+        else
+            call add(l:output, {
+            \   'bufnr': a:buffer,
+            \   'lnum': l:error.line,
+            \   'col': l:error.column,
+            \   'text': l:error.rule . ': ' . l:error.message,
+            \   'type': l:error.severity == 1 ? 'W' : 'E',
+            \})
+        endif
     endfor
 
     return l:output

--- a/test/handler/test_embertemplatelint_handler.vader
+++ b/test/handler/test_embertemplatelint_handler.vader
@@ -46,6 +46,33 @@ Execute(The ember-template-lint handler should parse lines correctly):
   \ ],
   \ ale_linters#handlebars#embertemplatelint#Handle(347, input_lines)
 
+Execute(The ember-template-lint handler should handle template parsing error correctly):
+  let input_lines = split('{
+  \ "/ember-project/app/templates/application.hbs": [
+  \   {
+  \     "fatal": true,
+  \     "moduleId": "app/templates/application",
+  \     "message": "Parse error on line 5 ...",
+  \     "line": 1,
+  \     "column": 1,
+  \     "source": "Error: Parse error on line 5 ...",
+  \     "severity": 2
+  \   }
+  \ ]
+  \ }', '\n')
+
+  AssertEqual
+  \ [
+  \   {
+  \     'bufnr': 347,
+  \     'lnum': 1,
+  \     'col': 1,
+  \     'text': 'Parse error on line 5 ...',
+  \     'type': 'E',
+  \   },
+  \ ],
+  \ ale_linters#handlebars#embertemplatelint#Handle(347, input_lines)
+
 Execute(The ember-template-lint handler should handle no lint errors/warnings):
   AssertEqual
   \ [


### PR DESCRIPTION
Properly handle template parsing errors as returned by [ember-template-lint](https://github.com/rwjblue/ember-template-lint) - test case included.