### PR TITLE
go: Remove `staticcheck` and `go build` defaults

### DIFF
--- a/autoload/ale/linter.vim
+++ b/autoload/ale/linter.vim
@@ -23,7 +23,7 @@ let s:default_ale_linter_aliases = {
 " rpmlint is disabled by default because it can result in code execution.
 let s:default_ale_linters = {
 \   'csh': ['shell'],
-\   'go': ['go build', 'gofmt', 'golint', 'gosimple', 'go vet', 'staticcheck'],
+\   'go': ['gofmt', 'golint', 'go vet'],
 \   'help': [],
 \   'rust': ['cargo'],
 \   'spec': [],

--- a/doc/ale-go.txt
+++ b/doc/ale-go.txt
@@ -5,13 +5,20 @@ ALE Go Integration                                            *ale-go-options*
 -------------------------------------------------------------------------------
 Integration Information
 
-The `gometalinter` linter is disabled by default, and all other Go linters
-supported by ALE are enabled by default. To enable `gometalinter`, update
-|g:ale_linters| as appropriate:
+The `gometalinter` linter is disabled by default. ALE enables `gofmt`,
+`golint` and `go vet` by default. It also supports `staticcheck`, `go
+build` and `gosimple`.
+
+To enable `gometalinter`, update |g:ale_linters| as appropriate:
 >
   " Enable all of the linters you want for Go.
   let g:ale_linters = {'go': ['gometalinter', 'gofmt']}
 <
+A possible configuration is to enable `gometalinter` and `gofmt` but paired
+with the `--fast` option, set by |g:ale_go_metalinter_options|. This gets you
+the benefit of running a number of linters, more than ALE would by default,
+while ensuring it doesn't run any linters known to be slow or resource
+intensive.
 
 -------------------------------------------------------------------------------
 gometalinter                                             *ale-go-gometalinter*
@@ -23,6 +30,11 @@ g:ale_go_gometalinter_options                  *g:ale_go_gometalinter_options*
 
   This variable can be changed to alter the command-line arguments to the
   gometalinter invocation.
+
+Since `gometalinter` runs a number of linters that can consume a lot of
+resources it's recommended to set this option to a value of `--fast` if you
+use `gometalinter` as one of the linters in |g:ale_linters|. This disables a
+number of linters known to be slow or consume a lot of resources.
 
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #594.

I've opted to just remove `go build` and `staticcheck` from the default linters right now to ensure things stay snappy. A `go build` of a larger project can take quite some time. I thought about changing the default according to the configuration I showed in #594 but that seemed more risky as it's a larger departure from the current behaviour which risks more easily breaking on people.

I've updated the documentation to reflect the change and added a comment about using `gometalinter` instead with the `--fast` flag.