### PR TITLE
Remove -X flag from perl defaults.

### DIFF
--- a/ale_linters/perl/perl.vim
+++ b/ale_linters/perl/perl.vim
@@ -5,7 +5,7 @@ let g:ale_perl_perl_executable =
 \   get(g:, 'ale_perl_perl_executable', 'perl')
 
 let g:ale_perl_perl_options =
-\   get(g:, 'ale_perl_perl_options', '-X -c -Mwarnings -Ilib')
+\   get(g:, 'ale_perl_perl_options', '-c -Mwarnings -Ilib')
 
 function! ale_linters#perl#perl#GetExecutable(buffer) abort
     return ale#Var(a:buffer, 'perl_perl_executable')

--- a/doc/ale-perl.txt
+++ b/doc/ale-perl.txt
@@ -16,7 +16,7 @@ g:ale_perl_perl_executable                         *g:ale_perl_perl_executable*
 g:ale_perl_perl_options                               *g:ale_perl_perl_options*
                                                       *b:ale_perl_perl_options*
   Type: |String|
-  Default: `'-X -c -Mwarnings -Ilib'`
+  Default: `'-c -Mwarnings -Ilib'`
 
   This variable can be changed to alter the command-line arguments to the perl
   invocation.


### PR DESCRIPTION
"-X Disables all warnings regardless of use warnings or $^W".  See
"perldoc perlrun" or http://perldoc.perl.org/perlrun.html

With the current defaults, warnings are squashed.  For example:

$ perl -X -Mwarnings -c -e'BEGIN { 42 + undef }'
-e syntax OK

$ perl -Mwarnings -c -e'BEGIN { 42 + undef }'
Use of uninitialized value in addition (+) at -e line 1.
-e syntax OK

So, it's not clear from the current defaults whether Ale wants to remove
warnings or enable them.  As it stands, it's trying to do both and the
disabling appears to win.

This commit enables warnings by default.

I'm not familiar with Vader, but if this needs some tests, I'm happy to dig in and try to figure that out.
