### PR TITLE
Include location list end column for rust lint

### DIFF
--- a/autoload/ale/handlers/rust.vim
+++ b/autoload/ale/handlers/rust.vim
@@ -10,7 +10,7 @@ endif
 " returns: a list [lnum, col] with the location of the error or []
 function! s:FindErrorInExpansion(span, file_name) abort
     if a:span.file_name ==# a:file_name
-        return [a:span.line_start, a:span.byte_start, a:span.byte_end]
+        return [a:span.line_start, a:span.line_end, a:span.byte_start, a:span.byte_end]
     endif
 
     if !empty(a:span.expansion)
@@ -52,6 +52,7 @@ function! ale#handlers#rust#HandleRustErrorsForFile(buffer, full_filename, lines
             \)
                 call add(l:output, {
                 \   'lnum': l:span.line_start,
+                \   'end_lnum': l:span.line_end,
                 \   'col': l:span.byte_start,
                 \   'end_col': l:span.byte_end,
                 \   'text': l:error.message,
@@ -65,8 +66,9 @@ function! ale#handlers#rust#HandleRustErrorsForFile(buffer, full_filename, lines
                 if !empty(l:root_cause)
                     call add(l:output, {
                     \   'lnum': l:root_cause[0],
-                    \   'col': l:root_cause[1],
-                    \   'end_col': l:root_cause[2],
+                    \   'end_lnum': l:root_cause[1],
+                    \   'col': l:root_cause[2],
+                    \   'end_col': l:root_cause[3],
                     \   'text': l:error.message,
                     \   'type': toupper(l:error.level[0]),
                     \})

--- a/autoload/ale/handlers/rust.vim
+++ b/autoload/ale/handlers/rust.vim
@@ -10,7 +10,7 @@ endif
 " returns: a list [lnum, col] with the location of the error or []
 function! s:FindErrorInExpansion(span, file_name) abort
     if a:span.file_name ==# a:file_name
-        return [a:span.line_start, a:span.byte_start]
+        return [a:span.line_start, a:span.byte_start, a:span.byte_end]
     endif
 
     if !empty(a:span.expansion)
@@ -53,6 +53,7 @@ function! ale#handlers#rust#HandleRustErrorsForFile(buffer, full_filename, lines
                 call add(l:output, {
                 \   'lnum': l:span.line_start,
                 \   'col': l:span.byte_start,
+                \   'end_col': l:span.byte_end,
                 \   'text': l:error.message,
                 \   'type': toupper(l:error.level[0]),
                 \})
@@ -65,6 +66,7 @@ function! ale#handlers#rust#HandleRustErrorsForFile(buffer, full_filename, lines
                     call add(l:output, {
                     \   'lnum': l:root_cause[0],
                     \   'col': l:root_cause[1],
+                    \   'end_col': l:root_cause[2],
                     \   'text': l:error.message,
                     \   'type': toupper(l:error.level[0]),
                     \})

--- a/test/handler/test_rust_handler.vader
+++ b/test/handler/test_rust_handler.vader
@@ -3,14 +3,18 @@ Execute(The Rust handler should handle rustc output):
   \ [
   \   {
   \     'lnum': 15,
+  \     'end_lnum': 15,
   \     'type': 'E',
   \     'col': 418,
+  \     'end_col': 421,
   \     'text': 'expected one of `.`, `;`, `?`, `}`, or an operator, found `for`',
   \   },
   \   {
   \      'lnum': 13,
+  \      'end_lnum': 13,
   \      'type': 'E',
   \      'col': 407,
+  \      'end_col': 410,
   \      'text': 'no method named `wat` found for type `std::string::String` in the current scope',
   \   },
   \ ],
@@ -28,14 +32,18 @@ Execute(The Rust handler should handle cargo output):
   \ [
   \   {
   \     'lnum': 15,
+  \     'end_lnum': 15,
   \     'type': 'E',
   \     'col': 11505,
+  \     'end_col': 11508,
   \     'text': 'expected one of `.`, `;`, `?`, `}`, or an operator, found `for`',
   \   },
   \   {
   \     'lnum': 13,
+  \     'end_lnum': 13,
   \     'type': 'E',
   \     'col': 11494,
+  \     'end_col': 11497,
   \     'text': 'no method named `wat` found for type `std::string::String` in the current scope',
   \   },
   \ ],


### PR DESCRIPTION
Fixes #599.

I've updated the tests in `test/handler/test_rust_handler.vader` by extracting the encountered values from the failed tests. Where does `src/playpen.rs` come from?