### PR TITLE
make prettier options enabled

### DIFF
--- a/autoload/ale/handlers/prettier.vim
+++ b/autoload/ale/handlers/prettier.vim
@@ -18,7 +18,7 @@ function! ale#handlers#prettier#Fix(buffer, lines) abort
     return {
     \   'command': ale#Escape(ale#handlers#prettier#GetExecutable(a:buffer))
     \       . ' %t'
-    \       . ' ' . ale#Escape(l:options)
+    \       . ' ' . l:options
     \       . ' --write',
     \   'read_temporary_file': 1,
     \}

--- a/autoload/ale/handlers/prettier_eslint.vim
+++ b/autoload/ale/handlers/prettier_eslint.vim
@@ -18,7 +18,7 @@ function! ale#handlers#prettier_eslint#Fix(buffer, lines) abort
     return {
     \   'command': ale#Escape(ale#handlers#prettier_eslint#GetExecutable(a:buffer))
     \       . ' %t'
-    \       . ' ' . ale#Escape(l:options)
+    \       . ' ' . l:options
     \       . ' --write',
     \   'read_temporary_file': 1,
     \}


### PR DESCRIPTION
Just moving from neomake to ale for linting javascript.
I love how It's fast and no-brainer to use!

One thing though, seems that ale#Escape make prettier's options unusable.
Here's a tiny patch for it.

Thanks for you great work.
