### PR TITLE
✏️ Fix link to stylelint styled-components

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ If you configure ALE options correctly in your vimrc file, and install
 the right tools, you can check JSX files with stylelint and eslint.
 
 First, install eslint and install stylelint with
-[https://github.com/styled-components/stylelint-processor-styled-components](stylelint-processor-styled-components).
+[stylelint-processor-styled-components](https://github.com/styled-components/stylelint-processor-styled-components).
 
 Supposing you have installed both tools correctly, configure your .jsx files so
 `jsx` is included in the filetype. You can use an `autocmd` for this.


### PR DESCRIPTION
Fix link, currently it leads to https://github.com/w0rp/ale/blob/master/stylelint-processor-styled-components.