### PR TITLE
nim: optionally check original file instead of a buffer copy

### DIFF
--- a/ale_linters/nim/nimcheck.vim
+++ b/ale_linters/nim/nimcheck.vim
@@ -54,7 +54,7 @@ function! ale_linters#nim#nimcheck#GetCommand(buffer) abort
         \   . ' --threads:on --verbosity:0 --colors:off --listFullPaths %t'
     else
         return 'nim check'
-        \   . ' --threads:on --verbosity:0 --colors:off --listFullPaths %s'
+        \   . ' --verbosity:0 --colors:off --listFullPaths %s'
     endif
 endfunction
 

--- a/ale_linters/nim/nimcheck.vim
+++ b/ale_linters/nim/nimcheck.vim
@@ -1,6 +1,9 @@
 " Author: Baabelfish
 " Description: Typechecking for nim files
 
+let g:ale_nim_make_copy =
+\   get(g:, 'ale_nim_make_copy', '0')
+
 function! ale_linters#nim#nimcheck#Handle(buffer, lines) abort
     let l:buffer_filename = fnamemodify(bufname(a:buffer), ':p:t')
     let l:pattern = '^\(.\+\.nim\)(\(\d\+\), \(\d\+\)) \(.\+\)'
@@ -44,10 +47,15 @@ endfunction
 
 
 function! ale_linters#nim#nimcheck#GetCommand(buffer) abort
-    let l:directory = ale#Escape(fnamemodify(bufname(a:buffer), ':p:h'))
+    if ale#Var(a:buffer, 'nim_make_copy')
+        let l:directory = ale#Escape(fnamemodify(bufname(a:buffer), ':p:h'))
 
-    return 'nim check --path:' . l:directory
-    \   . ' --threads:on --verbosity:0 --colors:off --listFullPaths %t'
+        return 'nim check --path:' . l:directory
+        \   . ' --threads:on --verbosity:0 --colors:off --listFullPaths %t'
+    else
+        return 'nim check'
+        \   . ' --threads:on --verbosity:0 --colors:off --listFullPaths %s'
+    endif
 endfunction
 
 

--- a/doc/ale-nim.txt
+++ b/doc/ale-nim.txt
@@ -1,0 +1,19 @@
+===============================================================================
+ALE Nim Integration                                           *ale-nim-options*
+
+
+-------------------------------------------------------------------------------
+Global Options
+
+g:ale_nim_make_copy                                       *g:ale_nim_make_copy*
+                                                          *b:ale_nim_make_copy*
+  Type: |Number|
+  Default: `0`
+
+  This variable controls whether or not ALE will make a temporary copy of the
+  buffer (in `'/tmp/foo/bar/your_file.nim'`), in order to run `'nim check'` on
+  buffer change, not just on save.
+  
+  In order to enable this behavior, set this variable to `1`. It's disabled by
+  default because it will only work if the file doesn't depend on some
+  project/file specific `nim.cfg`.


### PR DESCRIPTION
Most Nim projects have a project/file-specific "nim.cfg" which is ignored when running "nim check" on a copy in an unrelated temp dir.

This pull request implements an option to switch between original file and temporary copy checking, defaulting to the former which is guaranteed to always work properly.

<!--
When creating new pull requests, please consider the following.

* Read the Contributing guide linked above first.
* If you are adding a new linter, remember to update the README.md file and
  doc/ale.txt first.
* If you add or modify a function for converting error lines into loclist items
  that ALE can work with, please add Vader tests for them. Look at existing
  tests in the test/handler directory, etc.
* If you add or modify a function for computing a command line string for
  running a command, please add Vader tests for that.
* Generally try and cover anything with Vader tests, although some things just
  can't be tested with Vader, or at least they can be hard to test. Consider
  breaking up your code so that some parts can be tested, and generally open up
  a discussion about it.
* Have fun!
-->
