### PR TITLE
Fixed stylelint not catching all errors.

### DIFF
--- a/autoload/ale/handlers/css.vim
+++ b/autoload/ale/handlers/css.vim
@@ -42,7 +42,7 @@ function! ale#handlers#css#HandleStyleLintFormat(buffer, lines) abort
     " src/main.css
     "  108:10  ✖  Unexpected leading zero         number-leading-zero
     "  116:20  ✖  Expected a trailing semicolon   declaration-block-trailing-semicolon
-    let l:pattern = '\v^.* (\d+):(\d+) \s+(\S+)\s+ (.*[^ ])\s+([^ ]+)$'
+    let l:pattern = '\v^.* (\d+):(\d+) \s+(\S+)\s+ (.*[^ ])\s+([^ ]+)\s*$'
     let l:output = []
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)


### PR DESCRIPTION
While using stylelint, I noticed that it didn't catch most of the errors, only some of them. When linting one particular file in vim all I got was:
```      
 351:21  ✖  Unexpected shorthand "margin" after "margin-left"              declaration-block-no-shorthand-property-overrides
 351:21  ✖  Unexpected shorthand "margin" after "margin-top"               declaration-block-no-shorthand-property-overrides
 520:1   ✖  Expected no more than 1 empty line(s)                          max-empty-lines
```

The actual output from stylelinter was much longer:
```
  40:9   ✖  Expected empty line before declaration                         declaration-empty-line-before                    
  84:55  ✖  Expected newline after ";" in a multi-line declaration block   declaration-block-semicolon-newline-after        
  84:55  ✖  Unexpected whitespace at end of line                           no-eol-whitespace                                
 101:10  ✖  Expected double colon pseudo-element notation                  selector-pseudo-element-colon-notation           
 143:5   ✖  Expected empty line before rule                                rule-empty-line-before                           
 147:9   ✖  Unexpected duplicate "color"                                   declaration-block-no-duplicate-properties        
 161:5   ✖  Unexpected empty line before closing brace                     block-closing-brace-empty-line-before            
 239:14  ✖  Expected double colon pseudo-element notation                  selector-pseudo-element-colon-notation           
 252:5   ✖  Unexpected empty line before closing brace                     block-closing-brace-empty-line-before            
 256:9   ✖  Unexpected empty line before rule                              rule-empty-line-before                           
 286:13  ✖  Expected empty line before at-rule                             at-rule-empty-line-before                        
 293:34  ✖  Unexpected unit                                                length-zero-no-unit                              
 313:31  ✖  Expected double colon pseudo-element notation                  selector-pseudo-element-colon-notation           
 317:31  ✖  Expected double colon pseudo-element notation                  selector-pseudo-element-colon-notation           
 321:31  ✖  Expected double colon pseudo-element notation                  selector-pseudo-element-colon-notation           
 325:31  ✖  Expected double colon pseudo-element notation                  selector-pseudo-element-colon-notation           
 329:31  ✖  Expected double colon pseudo-element notation                  selector-pseudo-element-colon-notation           
 333:31  ✖  Expected double colon pseudo-element notation                  selector-pseudo-element-colon-notation           
 337:18  ✖  Expected double colon pseudo-element notation                  selector-pseudo-element-colon-notation           
 351:21  ✖  Unexpected shorthand "margin" after "margin-left"              declaration-block-no-shorthand-property-overrides
 351:21  ✖  Unexpected shorthand "margin" after "margin-top"               declaration-block-no-shorthand-property-overrides
 449:99  ✖  Expected single space before "{"                               block-opening-brace-space-before                 
 465:13  ✖  Expected single space before "{"                               block-opening-brace-space-before                 
 500:6   ✖  Expected double colon pseudo-element notation                  selector-pseudo-element-colon-notation           
 520:1   ✖  Expected no more than 1 empty line(s)                          max-empty-lines
```

After some digging I noticed that the regex didn't account for the extra padding in the last column. Apparently the error type is padded to the longest one. I've patched the regex to allow for trailing whitespace and all errors now appear fine when using the stylelint handler.

The change was tested with stylelint 7.10.1. It is a trivial change, which should be safe to merge.