### PR TITLE
ale_fix_on_save, accept list of extensions instead of a boolean

### DIFF
--- a/autoload/ale.vim
+++ b/autoload/ale.vim
@@ -178,3 +178,17 @@ function! ale#Escape(str) abort
 
     return shellescape (a:str)
 endfunction
+
+" Parses the ale_fix_on_save value, before it was a number. If 0 returns `[]`,
+" if 1 returns `['*']`
+function! ale#ParseFixOnSave(value) abort
+    if type(a:value) == type(0)
+        if a:value == 0
+            return []
+        elseif a:value == 1
+            return ['*']
+        endif
+    endif
+
+    return a:value
+endfunction

--- a/autoload/ale/events.vim
+++ b/autoload/ale/events.vim
@@ -3,7 +3,7 @@
 function! ale#events#SaveEvent() abort
     let l:should_lint = g:ale_enabled && g:ale_lint_on_save
 
-    if g:ale_fix_on_save
+    if !empty(g:ale_fix_on_save)
         let l:will_fix = ale#fix#Fix('save_file')
         let l:should_lint = l:should_lint && !l:will_fix
     endif

--- a/autoload/ale/fix.vim
+++ b/autoload/ale/fix.vim
@@ -45,7 +45,7 @@ function! ale#fix#ApplyQueuedFixes() abort
     endif
 
     if l:data.should_save
-        let l:should_lint = g:ale_fix_on_save
+        let l:should_lint = !empty(g:ale_fix_on_save)
     else
         let l:should_lint = l:data.changes_made
     endif

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -313,14 +313,27 @@ g:ale_fixers                                                     *g:ale_fixers*
 
 g:ale_fix_on_save                                           *g:ale_fix_on_save*
 
-  Type: |Number|
-  Default: `0`
+  Type: |List|
+  Default: `[]`
 
-  When set to 1, ALE will fix files when they are saved.
+  List of file extensions which ALE will fix when they are saved.
 
-  If |g:ale_lint_on_save| is set to 1, files will be checked with linters
-  after files are fixed, only when the buffer is open, or re-opened. Changes
-  to the file will saved to the file on disk.
+  If |g:ale_lint_on_save| is set, files will be checked with linters after
+  files are fixed, only when the buffer is open, or re-opened. Changes to the
+  file will saved to the file on disk.
+
+  Only files with an extension matching one of the list, will be fixed on
+  save.
+
+  For example, if you wish to fix only python and javascript files, you could
+  set the following: >
+
+  let g:ale_fix_on_save_extensions = ['js', 'py']
+<
+  You can set the value to ['*'] to match any extension.
+
+  For backwards compatibility it also supports the values 0 and 1. 0 is like
+  setting the value to [], and 1 has the same effect than setting it to ['*']
 
 
 g:ale_history_enabled                                   *g:ale_history_enabled*

--- a/plugin/ale.vim
+++ b/plugin/ale.vim
@@ -60,6 +60,11 @@ let g:ale_filetype_blacklist = ['nerdtree', 'unite', 'tags']
 " This Dictionary configures which linters are enabled for which languages.
 let g:ale_linters = get(g:, 'ale_linters', {})
 
+" This List configures which fixers are executed on save.
+" For compatibility reasons (before the variable was a Number) we check for 0
+" and 1 values
+let g:ale_fix_on_save = ale#ParseFixOnSave(get(g:, 'ale_fix_on_save', []))
+
 " This Dictionary configures which functions will be used for fixing problems.
 let g:ale_fixers = get(g:, 'ale_fixers', {})
 
@@ -226,8 +231,11 @@ function! ALEInitAuGroups() abort
 
     augroup ALERunOnSaveGroup
         autocmd!
-        if (g:ale_enabled && g:ale_lint_on_save) || g:ale_fix_on_save
+        if (g:ale_enabled && g:ale_lint_on_save)
             autocmd BufWrite * call ale#events#SaveEvent()
+        elseif !empty(g:ale_fix_on_save)
+            let l:files = join(map(copy(g:ale_fix_on_save), '"*." . v:val'), ',')
+            execute 'autocmd BufWrite '. (l:files ==# '*.*' ? '*' : l:files ) . ' call ale#events#SaveEvent()'
         endif
     augroup END
 
@@ -250,7 +258,7 @@ function! ALEInitAuGroups() abort
     augroup END
 
     if !g:ale_enabled
-        if !g:ale_fix_on_save
+        if empty(g:ale_fix_on_save)
             augroup! ALERunOnSaveGroup
         endif
 

--- a/test/test_ale_init_au_groups.vader
+++ b/test/test_ale_init_au_groups.vader
@@ -22,7 +22,7 @@ Before:
         let l:header = get(l:event_name_corrections, l:header, l:header)
       elseif !empty(l:header)
         call add(l:matches, join(split(l:header . l:line)))
-        let l:header = ''
+        "let l:header = ''
       endif
     endfor
 
@@ -140,13 +140,13 @@ Execute (g:ale_lint_on_filetype_changed = 1 should bind FileType, and required b
 
 Execute (g:ale_lint_on_save = 0 should bind no events):
   let g:ale_lint_on_save = 0
-  let g:ale_fix_on_save = 0
+  let g:ale_fix_on_save = ale#ParseFixOnSave(0)
 
   AssertEqual [], CheckAutocmd('ALERunOnSaveGroup')
 
-Execute (g:ale_lint_on_save = 1 should bind no events):
+Execute (g:ale_lint_on_save = 1 should bind events):
   let g:ale_lint_on_save = 1
-  let g:ale_fix_on_save = 0
+  let g:ale_fix_on_save = ale#ParseFixOnSave(0)
 
   AssertEqual [
   \ 'BufWritePre * call ale#events#SaveEvent()',
@@ -154,16 +154,42 @@ Execute (g:ale_lint_on_save = 1 should bind no events):
 
 Execute (g:ale_lint_on_save = 0 and g:ale_fix_on_save = 1 should bind events):
   let g:ale_lint_on_save = 0
-  let g:ale_fix_on_save = 1
+  let g:ale_fix_on_save = ale#ParseFixOnSave(1)
 
   AssertEqual [
   \ 'BufWritePre * call ale#events#SaveEvent()',
   \], CheckAutocmd('ALERunOnSaveGroup')
 
+Execute (g:ale_lint_on_save = 0 and g:ale_fix_on_save = ['*'] should bind events):
+  let g:ale_lint_on_save = 0
+  let g:ale_fix_on_save = ale#ParseFixOnSave(['*'])
+
+  AssertEqual [
+  \ 'BufWritePre * call ale#events#SaveEvent()',
+  \], CheckAutocmd('ALERunOnSaveGroup')
+
+Execute (g:ale_lint_on_save = 0 and g:ale_fix_on_save = ['js', 'py'] should bind events):
+  let g:ale_lint_on_save = 0
+  let g:ale_fix_on_save = ale#ParseFixOnSave(['js', 'py'])
+
+  AssertEqual [
+  \ 'BufWritePre *.js call ale#events#SaveEvent()',
+  \ 'BufWritePre *.py call ale#events#SaveEvent()',
+  \], CheckAutocmd('ALERunOnSaveGroup')
+
 Execute (g:ale_fix_on_save = 1 should bind events even when ALE is disabled):
   let g:ale_enabled = 0
   let g:ale_lint_on_save = 0
-  let g:ale_fix_on_save = 1
+  let g:ale_fix_on_save = ale#ParseFixOnSave(1)
+
+  AssertEqual [
+  \ 'BufWritePre * call ale#events#SaveEvent()',
+  \], CheckAutocmd('ALERunOnSaveGroup')
+
+Execute (g:ale_fix_on_save = ['*'] should bind events even when ALE is disabled):
+  let g:ale_enabled = 0
+  let g:ale_lint_on_save = 0
+  let g:ale_fix_on_save = ale#ParseFixOnSave(['*'])
 
   AssertEqual [
   \ 'BufWritePre * call ale#events#SaveEvent()',


### PR DESCRIPTION
I would like to fix on save only some files, e.g. I want to fix automatically on save javascript files, but I want to manually execute the fixers for python files.

Currently `g:ale_fix_on_save` accepts 0 or 1. This PR proposes to accept a list of extensions, e.g.: `['js', 'py']` to fix on save only some files. If you want to maintain the old behavior and fix on save all the files, you could  set `g:ale_fix_on_save` to `['*']`. For backwards compatibility, `g:ale_fix_on_save` still accepts 0 and 1, which is the same that setting it to `[]` or `['*']`

<!--
When creating new pull requests, please consider the following.

* Read the Contributing guide linked above first.
* If you are adding a new linter, remember to update the README.md file and
  doc/ale.txt first.
* If you add or modify a function for converting error lines into loclist items
  that ALE can work with, please add Vader tests for them. Look at existing
  tests in the test/handler directory, etc.
* If you add or modify a function for computing a command line string for
  running a command, please add Vader tests for that.
* Generally try and cover anything with Vader tests, although some things just
  can't be tested with Vader, or at least they can be hard to test. Consider
  breaking up your code so that some parts can be tested, and generally open up
  a discussion about it.
* Have fun!
-->
