### PR TITLE
Improve elm linter

### DIFF
--- a/ale_linters/elm/make.vim
+++ b/ale_linters/elm/make.vim
@@ -21,7 +21,6 @@ function! ale_linters#elm#make#Handle(buffer, lines) abort
 
                 if l:file_is_buffer
                     call add(l:output, {
-                    \    'bufnr': a:buffer,
                     \    'lnum': l:error.region.start.line,
                     \    'col': l:error.region.start.column,
                     \    'type': (l:error.type ==? 'error') ? 'E' : 'W',
@@ -37,9 +36,7 @@ function! ale_linters#elm#make#Handle(buffer, lines) abort
 
     if len(l:unparsed_lines) > 0
         call add(l:output, {
-        \    'bufnr': a:buffer,
-        \    'lnum': 0,
-        \    'col': 0,
+        \    'lnum': 1,
         \    'type': 'E',
         \    'text': l:unparsed_lines[0],
         \    'detail': join(l:unparsed_lines, "\n")

--- a/ale_linters/elm/make.vim
+++ b/ale_linters/elm/make.vim
@@ -5,6 +5,7 @@ function! ale_linters#elm#make#Handle(buffer, lines) abort
     let l:output = []
     let l:is_windows = has('win32')
     let l:temp_dir = l:is_windows ? $TMP : $TMPDIR
+    let l:unparsed_lines = []
     for l:line in a:lines
         if l:line[0] ==# '['
             let l:errors = json_decode(l:line)
@@ -29,8 +30,21 @@ function! ale_linters#elm#make#Handle(buffer, lines) abort
                     \})
                 endif
             endfor
+        elseif l:line !=# 'Successfully generated /dev/null'
+            call add(l:unparsed_lines, l:line)
         endif
     endfor
+
+    if len(l:unparsed_lines) > 0
+        call add(l:output, {
+        \    'bufnr': a:buffer,
+        \    'lnum': 0,
+        \    'col': 0,
+        \    'type': 'E',
+        \    'text': l:unparsed_lines[0],
+        \    'detail': join(l:unparsed_lines, "\n")
+        \})
+    endif
 
     return l:output
 endfunction

--- a/test/handler/test_elmmake_handler.vader
+++ b/test/handler/test_elmmake_handler.vader
@@ -38,6 +38,29 @@ Execute(The elm-make handler should parse lines correctly):
   \   '[{"tag":"TYPE MISMATCH","overview":"error overview 1","subregion":{"start":{"line":406,"column":5},"end":{"line":408,"column":18}},"details":"error details 1","region":{"start":{"line":404,"column":1},"end":{"line":408,"column":18}},"type":"error","file":"' . $TMPDIR . 'Module.elm"},{"tag":"TYPE MISMATCH","overview":"error overview 2","subregion":{"start":{"line":407,"column":12},"end":{"line":407,"column":17}},"details":"error details 2","region":{"start":{"line":406,"column":5},"end":{"line":407,"column":17}},"type":"error","file":"' . $TMPDIR . 'Module.elm"},{"tag":"TYPE MISMATCH","overview":"error overview 3","subregion":{"start":{"line":406,"column":88},"end":{"line":406,"column":93}},"details":"error details 3","region":{"start":{"line":406,"column":5},"end":{"line":406,"column":93}},"type":"error","file":"' . $TMPDIR . 'Module.elm"}]'
   \ ])
 
+Execute(The elm-make handler should put an error on the first line if a line cannot be parsed):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 33,
+  \     'col': 1,
+  \     'type': 'W',
+  \     'text': 'warning overview',
+  \     'detail': "warning overview\n\nwarning details",
+  \   },
+  \   {
+  \     'lnum': 1,
+  \     'type': 'E',
+  \     'text': 'Not JSON',
+  \     'detail': "Not JSON\nAlso not JSON",
+  \   },
+  \ ],
+  \ ale_linters#elm#make#Handle(347, [
+  \   '[{"tag":"unused import","overview":"warning overview","details":"warning details","region":{"start":{"line":33,"column":1},"end":{"line":33,"column":19}},"type":"warning","file":"' . $TMPDIR . 'Module.elm"}]',
+  \   "Not JSON",
+  \   "Also not JSON",
+  \ ])
+
 After:
   unlet! g:config_error_lines
   call ale#linter#Reset()

--- a/test/handler/test_elmmake_handler.vader
+++ b/test/handler/test_elmmake_handler.vader
@@ -1,0 +1,43 @@
+Before:
+  runtime ale_linters/elm/make.vim
+
+Execute(The elm-make handler should parse lines correctly):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 33,
+  \     'col': 1,
+  \     'type': 'W',
+  \     'text': 'warning overview',
+  \     'detail': "warning overview\n\nwarning details",
+  \   },
+  \   {
+  \     'lnum': 404,
+  \     'col': 1,
+  \     'type': 'E',
+  \     'text': 'error overview 1',
+  \     'detail': "error overview 1\n\nerror details 1",
+  \   },
+  \   {
+  \     'lnum': 406,
+  \     'col': 5,
+  \     'type': 'E',
+  \     'text': 'error overview 2',
+  \     'detail': "error overview 2\n\nerror details 2",
+  \   },
+  \   {
+  \     'lnum': 406,
+  \     'col': 5,
+  \     'type': 'E',
+  \     'text': 'error overview 3',
+  \     'detail': "error overview 3\n\nerror details 3",
+  \   },
+  \ ],
+  \ ale_linters#elm#make#Handle(347, [
+  \   '[{"tag":"unused import","overview":"warning overview","details":"warning details","region":{"start":{"line":33,"column":1},"end":{"line":33,"column":19}},"type":"warning","file":"' . $TMPDIR . 'Module.elm"}]',
+  \   '[{"tag":"TYPE MISMATCH","overview":"error overview 1","subregion":{"start":{"line":406,"column":5},"end":{"line":408,"column":18}},"details":"error details 1","region":{"start":{"line":404,"column":1},"end":{"line":408,"column":18}},"type":"error","file":"' . $TMPDIR . 'Module.elm"},{"tag":"TYPE MISMATCH","overview":"error overview 2","subregion":{"start":{"line":407,"column":12},"end":{"line":407,"column":17}},"details":"error details 2","region":{"start":{"line":406,"column":5},"end":{"line":407,"column":17}},"type":"error","file":"' . $TMPDIR . 'Module.elm"},{"tag":"TYPE MISMATCH","overview":"error overview 3","subregion":{"start":{"line":406,"column":88},"end":{"line":406,"column":93}},"details":"error details 3","region":{"start":{"line":406,"column":5},"end":{"line":406,"column":93}},"type":"error","file":"' . $TMPDIR . 'Module.elm"}]'
+  \ ])
+
+After:
+  unlet! g:config_error_lines
+  call ale#linter#Reset()


### PR DESCRIPTION
Currently some elm compiler errors are not returned in json format. An example of this is the case of importing a module that does not exist. The current behavior of the elm-make ale linter is to simply not show an error in this case requiring one to manually run elm-make to figure out what's broken.

This PR adds a fallback. In case of a non-parseable error it takes the error-message as is and attaches it on the first line.