### PR TITLE
Perlcritic column number and rule names

### DIFF
--- a/ale_linters/perl/perlcritic.vim
+++ b/ale_linters/perl/perlcritic.vim
@@ -1,9 +1,13 @@
 " Author: Vincent Lequertier <https://github.com/SkySymbol>
 " Description: This file adds support for checking perl with perl critic
 
+if !exists('g:ale_perl_perlcritic_showrules')
+    let g:ale_perl_perlcritic_showrules = 0
+endif
+
 function! ale_linters#perl#perlcritic#GetCommand(buffer) abort
     let l:critic_verbosity = '%l:%c %m\n'
-    if exists('g:ale_perl_perlcritic_showrules')
+    if g:ale_perl_perlcritic_showrules
         let l:critic_verbosity = '%l:%c %m [%p]\n'
     endif
 

--- a/ale_linters/perl/perlcritic.vim
+++ b/ale_linters/perl/perlcritic.vim
@@ -1,6 +1,16 @@
 " Author: Vincent Lequertier <https://github.com/SkySymbol>
 " Description: This file adds support for checking perl with perl critic
 
+function! ale_linters#perl#perlcritic#GetCommand(buffer) abort
+    let l:critic_verbosity = '%l:%c %m\n'
+    if exists('g:ale_perl_perlcritic_showrules')
+        let l:critic_verbosity = '%l:%c %m [%p]\n'
+    endif
+
+    return "perlcritic --verbose '". l:critic_verbosity . "' --nocolor"
+endfunction
+
+
 function! ale_linters#perl#perlcritic#Handle(buffer, lines) abort
     let l:pattern = '\(\d\+\):\(\d\+\) \(.\+\)'
     let l:output = []
@@ -20,6 +30,6 @@ call ale#linter#Define('perl', {
 \   'name': 'perlcritic',
 \   'executable': 'perlcritic',
 \   'output_stream': 'stdout',
-\   'command': "perlcritic --verbose '%l:%c %m\n' --nocolor",
+\   'command_callback': 'ale_linters#perl#perlcritic#GetCommand',
 \   'callback': 'ale_linters#perl#perlcritic#Handle',
 \})

--- a/ale_linters/perl/perlcritic.vim
+++ b/ale_linters/perl/perlcritic.vim
@@ -2,13 +2,14 @@
 " Description: This file adds support for checking perl with perl critic
 
 function! ale_linters#perl#perlcritic#Handle(buffer, lines) abort
-    let l:pattern = '\(.\+\) at \(.\+\) line \(\d\+\)'
+    let l:pattern = '\(\d\+\):\(\d\+\) \(.\+\)'
     let l:output = []
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)
         call add(l:output, {
-        \   'text': l:match[1],
-        \   'lnum': l:match[3],
+        \   'lnum': l:match[1],
+        \   'col': l:match[2],
+        \   'text': l:match[3],
         \})
     endfor
 
@@ -19,6 +20,6 @@ call ale#linter#Define('perl', {
 \   'name': 'perlcritic',
 \   'executable': 'perlcritic',
 \   'output_stream': 'stdout',
-\   'command': 'perlcritic --verbose 3 --nocolor',
+\   'command': "perlcritic --verbose '%l:%c %m\n' --nocolor",
 \   'callback': 'ale_linters#perl#perlcritic#Handle',
 \})

--- a/doc/ale-perl.txt
+++ b/doc/ale-perl.txt
@@ -23,4 +23,16 @@ g:ale_perl_perl_options                               *g:ale_perl_perl_options*
 
 
 -------------------------------------------------------------------------------
+perlcritic                                                *ale-perl-perlcritic*
+
+g:ale_perl_perlcritic_showrules               *g:ale_perl_perlcritic_showrules*
+
+  Type: |Number|
+  Default: 0
+
+  Controls whether perlcritic rule names are shown after the error message.
+  Defaults to off to reduce length of message.
+
+
+-------------------------------------------------------------------------------
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -63,6 +63,7 @@ CONTENTS                                                         *ale-contents*
       merlin..............................|ale-ocaml-merlin|
     perl..................................|ale-perl-options|
       perl................................|ale-perl-perl|
+      perlcritic..........................|ale-perl-perlcritic|
     php...................................|ale-php-options|
       phpcs...............................|ale-php-phpcs|
       phpmd...............................|ale-php-phpmd|

--- a/test/test_perlcritic_showrules.vader
+++ b/test/test_perlcritic_showrules.vader
@@ -1,0 +1,16 @@
+Execute(no g:ale_perl_perlcritic_showrules):
+  silent noautocmd new testfile.pl
+
+  let g:ale_perl_perlcritic_showrules = 0
+
+  AssertEqual
+  \ "perlcritic --verbose '". '%l:%c %m\n' . "' --nocolor",
+  \ ale_linters#perl#perlcritic#GetCommand(bufnr(''))
+
+  let g:ale_perl_perlcritic_showrules = 1
+
+  AssertEqual
+  \ "perlcritic --verbose '". '%l:%c %m [%p]\n' . "' --nocolor",
+  \ ale_linters#perl#perlcritic#GetCommand(bufnr(''))
+
+  :q


### PR DESCRIPTION
This Adds the column number for perlcritic linting errors.
It also adds a config option to display the perlcritic rule name for each error.

<!--
When creating new pull requests, please consider the following.

* Read the Contributing guide linked above first.
* If you are adding a new linter, remember to update the README.md file and
  doc/ale.txt first.
* If you add or modify a function for converting error lines into loclist items
  that ALE can work with, please add Vader tests for them. Look at existing
  tests in the test/handler directory, etc.
* If you add or modify a function for computing a command line string for
  running a command, please add Vader tests for that.
* Generally try and cover anything with Vader tests, although some things just
  can't be tested with Vader, or at least they can be hard to test. Consider
  breaking up your code so that some parts can be tested, and generally open up
  a discussion about it.
* Have fun!
-->
