### PR TITLE
Add fusion-lint, documentation, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ name. That seems to be the fairest way to arrange this table.
 | Erb | [erb](https://github.com/jeremyevans/erubi) |
 | Erlang | [erlc](http://erlang.org/doc/man/erlc.html) |
 | Fortran | [gcc](https://gcc.gnu.org/) |
+| FusionScript | [fusion-lint](https://github.com/RyanSquared/fusionscript) |
 | Go | [gofmt -e](https://golang.org/cmd/gofmt/), [go vet](https://golang.org/cmd/vet/), [golint](https://godoc.org/github.com/golang/lint), [gometalinter](https://github.com/alecthomas/gometalinter), [go build](https://golang.org/cmd/go/), [gosimple](https://github.com/dominikh/go-tools/tree/master/cmd/gosimple), [staticcheck](https://github.com/dominikh/go-tools/tree/master/cmd/staticcheck) |
 | Haml | [haml-lint](https://github.com/brigade/haml-lint)
 | Handlebars | [ember-template-lint](https://github.com/rwjblue/ember-template-lint) |

--- a/ale_linters/fuse/fusionlint.vim
+++ b/ale_linters/fuse/fusionlint.vim
@@ -1,0 +1,41 @@
+" Author: RyanSquared <vandor2012@gmail.com>
+" Description: `fusion-lint` linter for FusionScript files
+
+let g:ale_fuse_fusionlint_executable =
+\   get(g:, 'ale_fuse_fusionlint_executable', 'fusion-lint')
+
+let g:ale_fuse_fusionlint_options =
+\   get(g:, 'ale_fuse_fusionlint_options', '')
+
+function! ale_linters#fuse#fusionlint#GetExecutable(buffer) abort
+    return ale#Var(a:buffer, 'fuse_fusionlint_executable')
+endfunction
+
+function! ale_linters#fuse#fusionlint#GetCommand(buffer) abort
+    return ale#Escape(ale_linters#fuse#fusionlint#GetExecutable(a:buffer))
+    \   . ' ' . ale#Var(a:buffer, 'fuse_fusionlint_options')
+    \   . ' --filename %s -i'
+endfunction
+
+function! ale_linters#fuse#fusionlint#Handle(buffer, lines) abort
+    let l:pattern = '^.*:\(\d\+\):\(\d\+\): (\([WE]\)\d\+) \(.\+\)$'
+    let l:output = []
+
+    for l:match in ale#util#GetMatches(a:lines, l:pattern)
+        call add(l:output, {
+        \   'lnum': l:match[1] + 0,
+        \   'col': l:match[2] + 0,
+        \   'text': l:match[4],
+        \   'type': l:match[3],
+        \})
+    endfor
+
+    return l:output
+endfunction
+
+call ale#linter#Define('fuse', {
+\   'name': 'fusionlint',
+\   'executable_callback': 'ale_linters#fuse#fusionlint#GetExecutable',
+\   'command_callback': 'ale_linters#fuse#fusionlint#GetCommand',
+\   'callback': 'ale_linters#fuse#fusionlint#Handle',
+\})

--- a/doc/ale-fuse.txt
+++ b/doc/ale-fuse.txt
@@ -1,0 +1,25 @@
+===============================================================================
+ALE FusionScript Integration                                   *ale-fuse-options*
+
+
+-------------------------------------------------------------------------------
+4.12. fusionlint                                           *ale-fuse-fusionlint*
+
+g:ale_fusion_fusionlint_executable           *g:ale_fuse_fusionlint_executable*
+                                             *b:ale_fuse_fusionlint_executable*
+  Type: |String|
+  Default: `'fusion-lint'`
+
+  This variable can be changed to change the path to fusion-lint.
+
+
+g:ale_fuse_fusionlint_options                   *g:ale_fuse_fusionlint_options*
+                                                *b:ale_fuse_fusionlint_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be set to pass additional options to fusion-lint.
+
+
+-------------------------------------------------------------------------------
+  vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -33,6 +33,8 @@ CONTENTS                                                         *ale-contents*
       erlc................................|ale-erlang-erlc|
     fortran...............................|ale-fortran-options|
       gcc.................................|ale-fortran-gcc|
+		fusionscript..........................ale-fuse-options
+		  fusion-lint.........................ale-fuse-fusionlint
     go....................................|ale-go-options|
       gometalinter........................|ale-go-gometalinter|
     handlebars............................|ale-handlebars-options|
@@ -151,6 +153,7 @@ The following languages and tools are supported.
 * Erlang: 'erlc'
 * Fortran: 'gcc'
 * Go: 'gofmt', 'go vet', 'golint', 'go build', 'gosimple', 'staticcheck'
+* FusionScript: 'fusion-lint'
 * Haml: 'hamllint'
 * Handlebars: 'ember-template-lint'
 * Haskell: 'ghc', 'ghc-mod', 'hlint', 'hdevtools'

--- a/test/command_callback/test_fusionlint_command_callback.vader
+++ b/test/command_callback/test_fusionlint_command_callback.vader
@@ -1,0 +1,24 @@
+Before:
+  runtime ale_linters/fuse/fusionlint.vim
+
+After:
+  call ale#linter#Reset()
+  let g:ale_fuse_fusionlint_options = ''
+  let g:ale_fuse_fusionlint_executable = 'fusion-lint'
+
+Execute(The fuse fusionlint command callback should return the correct default string):
+  AssertEqual '''fusion-lint'' --filename %s -i',
+  \ join(split(ale_linters#fuse#fusionlint#GetCommand(1)))
+
+Execute(The fuse fusionlint command callback should let you set options):
+  let g:ale_fuse_fusionlint_options = '--example-option argument'
+
+  AssertEqual '''fusion-lint'' --example-option argument --filename %s -i',
+  \ join(split(ale_linters#fuse#fusionlint#GetCommand(1)))
+
+Execute(The fusionlint executable should be configurable):
+  let g:ale_fuse_fusionlint_executable = 'util/linter.fuse'
+
+  AssertEqual 'util/linter.fuse', ale_linters#fuse#fusionlint#GetExecutable(1)
+  AssertEqual '''util/linter.fuse'' --filename %s -i',
+  \ join(split(ale_linters#fuse#fusionlint#GetCommand(1)))


### PR DESCRIPTION
<!--
When creating new pull requests, please consider the following.

* Read the Contributing guide linked above first.
* If you are adding a new linter, remember to update the README.md file and
  doc/ale.txt first.
* If you add or modify a function for converting error lines into loclist items
  that ALE can work with, please add Vader tests for them. Look at existing
  tests in the test/handler directory, etc.
* If you add or modify a function for computing a command line string for
  running a command, please add Vader tests for that.
* Generally try and cover anything with Vader tests, although some things just
  can't be tested with Vader, or at least they can be hard to test. Consider
  breaking up your code so that some parts can be tested, and generally open up
  a discussion about it.
* Have fun!
-->

This adds `fusion-lint` to the list of linters, including documentation over options and a test for the command string callback. I'm not able to verify if the tests pass for the callback due to a weird quirk with Vader and UltiSnips; however, extensive manual testing showed they should work.