### PR TITLE
Fix for Crystal support

### DIFF
--- a/ale_linters/crystal/crystal.vim
+++ b/ale_linters/crystal/crystal.vim
@@ -1,4 +1,4 @@
-" Author: Jordan Andree <https://github.com/jordanandree>
+" Author: Jordan Andree <https://github.com/jordanandree>, David Alexander <opensource@thelonelyghost.com>
 " Description: This file adds support for checking Crystal with crystal build
 
 function! ale_linters#crystal#crystal#Handle(buffer, lines) abort
@@ -24,7 +24,7 @@ function! ale_linters#crystal#crystal#Handle(buffer, lines) abort
 endfunction
 
 function! ale_linters#crystal#crystal#GetCommand(buffer) abort
-    let l:crystal_cmd = 'crystal build -f json --no-codegen -o '
+    let l:crystal_cmd = 'crystal build -f json --no-codegen --no-color -o '
     let l:crystal_cmd .= ale#Escape(g:ale#util#nul_file)
     let l:crystal_cmd .= ' %s'
 

--- a/autoload/ale.vim
+++ b/autoload/ale.vim
@@ -1,4 +1,4 @@
-" Author: w0rp <devw0rp@gmail.com>
+" Author: w0rp <devw0rp@gmail.com>, David Alexander <opensource@thelonelyghost.com>
 " Description: Primary code path for the plugin
 "   Manages execution of linters when requested by autocommands
 
@@ -86,6 +86,11 @@ function! ale#Lint(...) abort
     if has_key(s:should_lint_file_for_buffer, l:buffer)
         unlet s:should_lint_file_for_buffer[l:buffer]
         let l:should_lint_file = 1
+    endif
+
+    " Don't lint files if the file does not exist
+    if l:should_lint_file && filereadable(expand('#' . l:buffer . ':p'))
+      let l:should_lint_file = 0
     endif
 
     " Initialise the buffer information if needed.

--- a/autoload/ale.vim
+++ b/autoload/ale.vim
@@ -85,12 +85,8 @@ function! ale#Lint(...) abort
     " Check if we previously requested checking the file.
     if has_key(s:should_lint_file_for_buffer, l:buffer)
         unlet s:should_lint_file_for_buffer[l:buffer]
-        let l:should_lint_file = 1
-    endif
-
-    " Don't lint files if the file does not exist
-    if l:should_lint_file && filereadable(expand('#' . l:buffer . ':p'))
-      let l:should_lint_file = 0
+        " Lint files if they exist.
+        let l:should_lint_file = filereadable(expand('#' . l:buffer . ':p'))
     endif
 
     " Initialise the buffer information if needed.


### PR DESCRIPTION
Fixes #650.

If the linter requires the target file (e.g., `lint_file` attribute is set), skip the linting for that file if it does not yet exist. This can happen if you open vim at a location for a new file and the buffer for that file has not been written out to disk yet.

Also includes a fix for Crystal compiler output defaulting to colorized output now, which should be removed for display in the vim output.