### PR TITLE
[kotlin::kotlinc] Fix wrong filename escape

### DIFF
--- a/ale_linters/kotlin/kotlinc.vim
+++ b/ale_linters/kotlin/kotlinc.vim
@@ -46,8 +46,9 @@ function! ale_linters#kotlin#kotlinc#GetCommand(buffer, import_paths) abort
 
     " If the config file is enabled and readable, source it
     if ale#Var(a:buffer, 'kotlin_kotlinc_enable_config')
-        if filereadable(expand(ale#Var(a:buffer, 'kotlin_kotlinc_config_file'), 1))
-            execute 'source ' . expand(ale#Var(a:buffer, 'kotlin_kotlinc_config_file'), 1)
+        let l:conffile = fnameescape(expand(ale#Var(a:buffer, 'kotlin_kotlinc_config_file'), 1))
+        if filereadable(l:conffile)
+            execute 'source ' . l:conffile
         endif
     endif
 

--- a/ale_linters/kotlin/kotlinc.vim
+++ b/ale_linters/kotlin/kotlinc.vim
@@ -47,7 +47,7 @@ function! ale_linters#kotlin#kotlinc#GetCommand(buffer, import_paths) abort
     " If the config file is enabled and readable, source it
     if ale#Var(a:buffer, 'kotlin_kotlinc_enable_config')
         if filereadable(expand(ale#Var(a:buffer, 'kotlin_kotlinc_config_file'), 1))
-            execute 'source ' . ale#Escape(expand(ale#Var(a:buffer, 'kotlin_kotlinc_config_file'), 1))
+            execute 'source ' . expand(ale#Var(a:buffer, 'kotlin_kotlinc_config_file'), 1)
         endif
     endif
 


### PR DESCRIPTION
Removes escaping when sourcing configuration file