### PR TITLE
TSLint: distinguish warnings from errors

### DIFF
--- a/ale_linters/typescript/tslint.vim
+++ b/ale_linters/typescript/tslint.vim
@@ -14,19 +14,21 @@ endfunction
 function! ale_linters#typescript#tslint#Handle(buffer, lines) abort
     " Matches patterns like the following:
     "
-    " hello.ts[7, 41]: trailing whitespace
-    " hello.ts[5, 1]: Forbidden 'var' keyword, use 'let' or 'const' instead
-    "
+    " WARNING: hello.ts[113, 6]: Unnecessary semicolon
+    " ERROR: hello.ts[133, 10]: Missing semicolon
+
     let l:ext = '.' . fnamemodify(bufname(a:buffer), ':e')
-    let l:pattern = '.\+' . l:ext . '\[\(\d\+\), \(\d\+\)\]: \(.\+\)'
+    let l:pattern = '\<\(WARNING\|ERROR\)\>: .\+' . l:ext . '\[\(\d\+\), \(\d\+\)\]: \(.\+\)'
     let l:output = []
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)
-        let l:line = l:match[1] + 0
-        let l:column = l:match[2] + 0
-        let l:text = l:match[3]
+        let l:type = l:match[1]
+        let l:line = l:match[2] + 0
+        let l:column = l:match[3] + 0
+        let l:text = l:match[4]
 
         call add(l:output, {
+        \   'type': (l:type ==# 'WARNING' ? 'W' : 'E'),
         \   'lnum': l:line,
         \   'col': l:column,
         \   'text': l:text,

--- a/test/handler/test_tslint_handler.vader
+++ b/test/handler/test_tslint_handler.vader
@@ -1,0 +1,41 @@
+Before:
+  runtime ale_linters/typescript/tslint.vim
+
+Execute(The tslint handler should parse lines correctly):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 235,
+  \     'col': 21,
+  \     'text': 'unused expression, expected an assignment or function call',
+  \     'type': 'W',
+  \   },
+  \   {
+  \     'lnum': 35,
+  \     'col': 6,
+  \     'text': 'Missing semicolon',
+  \     'type': 'E',
+  \   },
+  \   {
+  \     'lnum': 147,
+  \     'col': 10,
+  \     'text': 'Unnecessary semicolon',
+  \     'type': 'W',
+  \   },
+  \   {
+  \     'lnum': 101,
+  \     'col': 25,
+  \     'text': 'Unnecessary trailing comma',
+  \     'type': 'E',
+  \   },
+  \ ],
+  \ ale_linters#typescript#tslint#Handle(347, [
+  \   'This line should be ignored completely',
+  \   'WARNING: hello.ts[235, 21]: unused expression, expected an assignment or function call',
+  \   'ERROR: hello.ts[35, 6]: Missing semicolon',
+  \   'WARNING: hello.ts[147, 10]: Unnecessary semicolon',
+  \   'ERROR: hello.ts[101, 25]: Unnecessary trailing comma'
+  \ ])
+
+After:
+  call ale#linter#Reset()


### PR DESCRIPTION
Currently TSLint linter displays everything as errors. After looking at the source code, I've modified the regex to detect tslint message type so that ALE can show warnings correctly.