### PR TITLE
ALEStyleError or ALEStyleWarning highlights not being removed on highlight update

### DIFF
--- a/autoload/ale/highlight.vim
+++ b/autoload/ale/highlight.vim
@@ -67,7 +67,7 @@ function! s:GetALEMatches() abort
     let l:list = []
 
     for l:match in getmatches()
-        if l:match['group'] ==# 'ALEError' || l:match['group'] ==# 'ALEWarning'
+        if l:match['group'] ==# 'ALEError' || l:match['group'] ==# 'ALEWarning' || l:match['group'] ==# 'ALEStyleError' || l:match['group'] ==# 'ALEStyleWarning'
             call add(l:list, l:match)
         endif
     endfor


### PR DESCRIPTION
While testing out linting a python file with Flake8, I realized highlights from PEP 8 style errors (i.e. E302: expected 2 blank lines, found 1) were not being removed after fixing them. The gutter signs were gone but the highlights remained until the buffer was closed and re-opened.

Did some debugging and found out that a possible cause was GetALEMatches() was not returning the style errors (ALEStyleError) for RemoveHighlights to remove them. Looking through the docs, I think this may extend to ALEStyleWarnings, and maybe ALEInfo? But I am not sure of the intended behavior so maybe this is the wrong place to fix it.

