### PR TITLE
Support project's local phpcs installation

### DIFF
--- a/ale_linters/php/phpcs.vim
+++ b/ale_linters/php/phpcs.vim
@@ -14,12 +14,14 @@ function! ale_linters#php#phpcs#GetExecutable(buffer) abort
 endfunction
 
 function! ale_linters#php#phpcs#GetCommand(buffer) abort
+    let l:executable = ale_linters#php#phpcs#GetExecutable(a:buffer)
+
     let l:standard = ale#Var(a:buffer, 'php_phpcs_standard')
     let l:standard_option = !empty(l:standard)
     \   ? '--standard=' . l:standard
     \   : ''
 
-    return ale_linters#php#phpcs#GetExecutable(a:buffer)
+    return ale#Escape(l:executable)
     \   . ' -s --report=emacs --stdin-path=%s ' . l:standard_option
 endfunction
 

--- a/ale_linters/php/phpcs.vim
+++ b/ale_linters/php/phpcs.vim
@@ -3,13 +3,22 @@
 
 let g:ale_php_phpcs_standard = get(g:, 'ale_php_phpcs_standard', '')
 
+function! ale_linters#php#phpcs#GetExecutable(buffer) abort
+    return ale#path#ResolveLocalPath(
+    \   a:buffer,
+    \   'vendor/bin/phpcs',
+    \   'phpcs'
+    \)
+endfunction
+
 function! ale_linters#php#phpcs#GetCommand(buffer) abort
     let l:standard = ale#Var(a:buffer, 'php_phpcs_standard')
     let l:standard_option = !empty(l:standard)
     \   ? '--standard=' . l:standard
     \   : ''
 
-    return 'phpcs -s --report=emacs --stdin-path=%s ' . l:standard_option
+    return ale_linters#php#phpcs#GetExecutable(a:buffer)
+    \   . ' -s --report=emacs --stdin-path=%s ' . l:standard_option
 endfunction
 
 function! ale_linters#php#phpcs#Handle(buffer, lines) abort
@@ -36,7 +45,7 @@ endfunction
 
 call ale#linter#Define('php', {
 \   'name': 'phpcs',
-\   'executable': 'phpcs',
+\   'executable_callback': 'ale_linters#php#phpcs#GetExecutable',
 \   'command_callback': 'ale_linters#php#phpcs#GetCommand',
 \   'callback': 'ale_linters#php#phpcs#Handle',
 \})

--- a/ale_linters/php/phpcs.vim
+++ b/ale_linters/php/phpcs.vim
@@ -1,4 +1,4 @@
-" Author: jwilliams108 <https://github.com/jwilliams108>
+" Author: jwilliams108 <https://github.com/jwilliams108>, Eric Stern <https://github.com/firehed>
 " Description: phpcs for PHP files
 
 let g:ale_php_phpcs_standard = get(g:, 'ale_php_phpcs_standard', '')

--- a/ale_linters/php/phpcs.vim
+++ b/ale_linters/php/phpcs.vim
@@ -3,12 +3,14 @@
 
 let g:ale_php_phpcs_standard = get(g:, 'ale_php_phpcs_standard', '')
 
+call ale#Set('php_phpcs_executable', 'phpcs')
+call ale#Set('php_phpcs_use_global', 0)
+
 function! ale_linters#php#phpcs#GetExecutable(buffer) abort
-    return ale#path#ResolveLocalPath(
-    \   a:buffer,
+    return ale#node#FindExecutable(a:buffer, 'php_phpcs', [
     \   'vendor/bin/phpcs',
     \   'phpcs'
-    \)
+    \])
 endfunction
 
 function! ale_linters#php#phpcs#GetCommand(buffer) abort

--- a/test/test_phpcs_executable_detection.vader
+++ b/test/test_phpcs_executable_detection.vader
@@ -1,0 +1,45 @@
+Before:
+  let g:ale_php_phpcs_executable = 'phpcs_test'
+
+  silent! cd /testplugin/test
+  let g:dir = getcwd()
+
+  runtime ale_linters/php/phpcs.vim
+
+After:
+  let g:ale_php_phpcs_executable = 'phpcs'
+  let g:ale_php_phpcs_use_global = 0
+
+  silent execute 'cd ' . g:dir
+  unlet! g:dir
+
+  call ale#linter#Reset()
+
+Execute(project with phpcs should use local by default):
+  silent noautocmd new phpcs-test-files/project-with-phpcs/vendor/bin/phpcs
+
+  AssertEqual
+  \ g:dir . '/phpcs-test-files/project-with-phpcs/vendor/bin/phpcs',
+  \ ale_linters#php#phpcs#GetExecutable(bufnr(''))
+
+  :q
+
+Execute(use-global should override local detection):
+  let g:ale_php_phpcs_use_global = 1
+
+  silent noautocmd new phpcs-test-files/project-with-phpcs/vendor/bin/phpcs
+
+  AssertEqual
+  \ 'phpcs_test',
+  \ ale_linters#php#phpcs#GetExecutable(bufnr(''))
+
+  :q
+
+Execute(project without phpcs should use global):
+  silent noautocmd new phpcs-test-files/project-without-phpcs/vendor/bin/phpcs
+
+  AssertEqual
+  \ 'phpcs_test',
+  \ ale_linters#php#phpcs#GetExecutable(bufnr(''))
+
+  :q


### PR DESCRIPTION
This change allows use of the PHPCS linter when installed as a project's dev dependency, instead of only a global install. It firsts checks for `vendor/bin/phpcs` as the executable path before falling back to the previous behavior (`phpcs` anywhere on the $PATH). This is similar to how many Node-based linters work, but with the paths from PHP's Composer.