### PR TITLE
Skip invalid signs

### DIFF
--- a/autoload/ale/sign.vim
+++ b/autoload/ale/sign.vim
@@ -114,7 +114,14 @@ function! s:GroupLoclistItems(loclist) abort
             call add(l:grouped_items, [])
         endif
 
-        call add(l:grouped_items[-1], l:obj)
+        try
+          if l:obj.lnum > 1
+            call add(l:grouped_items[-1], l:obj)
+          endif
+        catch
+          echom 'skipping invalid sign'
+        finally
+        endtry
         let l:last_lnum = l:obj.lnum
     endfor
 


### PR DESCRIPTION
Kotlinc was reporting some warnings about the classpath it was being called with. These didn't have line numbers associated with them so a line number of -1 was used when attempting to add the sign which caused an error. I've added a handler around the code that adds the sign so invalid signs will no longer prevent valid signs from being added. The loclist is still populated with errors/ warnings that cannot be added as signs. There might be a more efficient way to do this, I'm not overly familiar with vimscript.

<!--
When creating new pull requests, please consider the following.

* Read the Contributing guide linked above first.
* If you are adding a new linter, remember to update the README.md file and
  doc/ale.txt first.
* If you add or modify a function for converting error lines into loclist items
  that ALE can work with, please add Vader tests for them. Look at existing
  tests in the test/handler directory, etc.
* If you add or modify a function for computing a command line string for
  running a command, please add Vader tests for that.
* Generally try and cover anything with Vader tests, although some things just
  can't be tested with Vader, or at least they can be hard to test. Consider
  breaking up your code so that some parts can be tested, and generally open up
  a discussion about it.
* Have fun!
-->
