### PR TITLE
Add ruby fixer using `rubocop --auto-correct`

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -42,6 +42,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['python'],
 \       'description': 'Fix Python files with yapf.',
 \   },
+\   'rubocop': {
+\       'function': 'ale#fixers#rubocop#Fix',
+\       'suggested_filetypes': ['ruby'],
+\       'description': 'Fix ruby files with rubocop --auto-correct.',
+\   },
 \}
 
 " Reset the function registry to the default entries.

--- a/autoload/ale/fixers/rubocop.vim
+++ b/autoload/ale/fixers/rubocop.vim
@@ -1,9 +1,35 @@
-function! ale#fixers#rubocop#Fix(buffer) abort
-  let l:executable = ale_linters#ruby#rubocop#GetExecutable(a:buffer)
+" Set this option to change Rubocop options.
+if !exists('g:ale_ruby_rubocop_options')
+    " let g:ale_ruby_rubocop_options = '--lint'
+    let g:ale_ruby_rubocop_options = ''
+endif
 
-  return {
-  \   'command': ale#Escape(l:executable)
-  \       . ' --auto-correct %t',
-  \   'read_temporary_file': 1,
-  \}
+if !exists('g:ale_ruby_rubocop_executable')
+    let g:ale_ruby_rubocop_executable = 'rubocop'
+endif
+
+function! ale#fixers#rubocop#GetExecutable(buffer) abort
+    return ale#Var(a:buffer, 'ruby_rubocop_executable')
+endfunction
+
+function! ale#fixers#rubocop#GetCommand(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'ruby_rubocop_executable')
+    let l:exec_args = l:executable =~? 'bundle$'
+    \   ? ' exec rubocop'
+    \   : ''
+
+    return ale#Escape(l:executable) . l:exec_args
+    \   . ' --format emacs --force-exclusion '
+    \   . ale#Var(a:buffer, 'ruby_rubocop_options')
+    \   . ' --stdin ' . bufname(a:buffer)
+endfunction
+
+function! ale#fixers#rubocop#Fix(buffer) abort
+    let l:command = ale#fixers#rubocop#GetCommand(a:buffer)
+
+    return {
+    \   'command': ale#Escape(l:command)
+    \       . ' --auto-correct %t',
+    \   'read_temporary_file': 1,
+    \}
 endfunction

--- a/autoload/ale/fixers/rubocop.vim
+++ b/autoload/ale/fixers/rubocop.vim
@@ -2,8 +2,8 @@ function! ale#fixers#rubocop#Fix(buffer) abort
   let l:executable = ale_linters#ruby#rubocop#GetExecutable(a:buffer)
 
   return {
-        \   'command': ale#Escape(l:executable)
-        \       . ' --auto-correct %t',
-        \   'read_temporary_file': 1,
-        \}
+  \   'command': ale#Escape(l:executable)
+  \       . ' --auto-correct %t',
+  \   'read_temporary_file': 1,
+  \}
 endfunction

--- a/autoload/ale/fixers/rubocop.vim
+++ b/autoload/ale/fixers/rubocop.vim
@@ -19,17 +19,13 @@ function! ale#fixers#rubocop#GetCommand(buffer) abort
     \   : ''
 
     return ale#Escape(l:executable) . l:exec_args
-    \   . ' --format emacs --force-exclusion '
-    \   . ale#Var(a:buffer, 'ruby_rubocop_options')
-    \   . ' --stdin ' . bufname(a:buffer)
+    \   . ' --auto-correct %t'
+
 endfunction
 
 function! ale#fixers#rubocop#Fix(buffer) abort
-    let l:command = ale#fixers#rubocop#GetCommand(a:buffer)
-
     return {
-    \   'command': ale#Escape(l:command)
-    \       . ' --auto-correct %t',
+    \   'command': ale#fixers#rubocop#GetCommand(a:buffer),
     \   'read_temporary_file': 1,
     \}
 endfunction

--- a/autoload/ale/fixers/rubocop.vim
+++ b/autoload/ale/fixers/rubocop.vim
@@ -1,0 +1,11 @@
+function! ale#fixers#rubocop#Fix(buffer) abort
+  let l:executable = ale_linters#ruby#rubocop#GetExecutable(a:buffer)
+
+  echo l:executable
+
+  return {
+        \   'command': ale#Escape(l:executable)
+        \       . ' --auto-correct %t',
+        \   'read_temporary_file': 1,
+        \}
+endfunction

--- a/autoload/ale/fixers/rubocop.vim
+++ b/autoload/ale/fixers/rubocop.vim
@@ -1,8 +1,6 @@
 function! ale#fixers#rubocop#Fix(buffer) abort
   let l:executable = ale_linters#ruby#rubocop#GetExecutable(a:buffer)
 
-  echo l:executable
-
   return {
         \   'command': ale#Escape(l:executable)
         \       . ' --auto-correct %t',

--- a/test/fixers/test_rubocop_fixer_callback.vader
+++ b/test/fixers/test_rubocop_fixer_callback.vader
@@ -23,7 +23,6 @@ Execute(The rubocop callback should return the correct default values):
 
   AssertEqual
   \ {'read_temporary_file': 1,
-  \  'command': '''''\''''' . g:ale_ruby_rubocop_executable . '''\'''' '
-  \      . '--format emacs --force-exclusion  --stdin ' . g:dir
-  \      . '/ruby_paths/dummy.rb'' --auto-correct %t' },
+  \  'command': "'" . g:ale_ruby_rubocop_executable . "' "
+  \      . '--auto-correct %t' },
   \ ale#fixers#rubocop#Fix(bufnr(''))

--- a/test/fixers/test_rubocop_fixer_callback.vader
+++ b/test/fixers/test_rubocop_fixer_callback.vader
@@ -1,0 +1,29 @@
+Before:
+  Save g:ale_ruby_rubocop_executable
+
+  " Use an invalid global executable, so we don't match it.
+  let g:ale_ruby_rubocop_executable = 'xxxinvalid'
+
+  silent! execute 'cd /testplugin/test/command_callback'
+  silent cd ..
+  silent cd command_callback
+  let g:dir = getcwd()
+
+After:
+  Restore
+
+  silent execute 'cd ' . fnameescape(g:dir)
+  " Set the file to something else,
+  " or we'll cause issues when running other tests
+  silent file 'dummy.rb'
+  unlet! g:dir
+
+Execute(The rubocop callback should return the correct default values):
+  silent execute 'file ' . fnameescape(g:dir . '/ruby_paths/dummy.rb')
+
+  AssertEqual
+  \ {'read_temporary_file': 1,
+  \  'command': '''''\''''' . g:ale_ruby_rubocop_executable . '''\'''' '
+  \      . '--format emacs --force-exclusion  --stdin ' . g:dir
+  \      . '/ruby_paths/dummy.rb'' --auto-correct %t' },
+  \ ale#fixers#rubocop#Fix(bufnr(''))


### PR DESCRIPTION
This does seem to work as expected, but I was not able to create a vader test for this. Maybe someone familiar with the test env can give me some advice?

Here was my attempt:

```vader
Before:
  Save g:ale_fixers

After:
  Restore

Given ruby(Ruby code with bad indentation):
  def inc(x)
      x + 1
  end

Execute(Fix the file):
  let g:ale_fixers = {'ruby': ['rubocop']}
  ALEFix

Expect ruby(Ruby code with correct indentation):
  def inc(x)
    x + 1
  end
```

This fails with the following error:

```
  Starting Vader: /testplugin/test/fixers/test_rubocop_fixer.vader
    (1/1) [  GIVEN] Ruby code with bad indentation
    (1/1) [EXECUTE] Fix the file
    (1/1) [ EXPECT] (X) Ruby code with correct indentation
      - Expected:
          def inc(x)
            x + 1
          end
      - Got:
          def inc(x)
              x + 1
          end
  Success/Total: 0/1
```

But the fixer does run when used with actual code in an editor.