### PR TITLE
Remove style classification from E999

### DIFF
--- a/ale_linters/python/flake8.vim
+++ b/ale_linters/python/flake8.vim
@@ -136,7 +136,7 @@ function! ale_linters#python#flake8#Handle(buffer, lines) abort
         \   'type': 'W',
         \}
 
-        if l:code[:0] ==# 'F'
+        if l:code[:0] ==# 'F' || l:code ==# 'E999'
             let l:item.type = 'E'
         elseif l:code[:0] ==# 'E'
             let l:item.type = 'E'

--- a/test/handler/test_flake8_handler.vader
+++ b/test/handler/test_flake8_handler.vader
@@ -4,7 +4,7 @@ Before:
 After:
     call ale#linter#Reset()
 
-Execute(The flake8 handler should handle basic warnings):
+Execute(The flake8 handler should handle basic warnings and syntax errors):
   AssertEqual
   \ [
   \   {
@@ -21,10 +21,17 @@ Execute(The flake8 handler should handle basic warnings):
   \     'text': 'W123: some warning',
   \     'sub_type': 'style',
   \   },
+  \   {
+  \     'lnum': 8,
+  \     'col': 3,
+  \     'type': 'E',
+  \     'text': 'E999: SyntaxError: invalid syntax',
+  \   },
   \ ],
   \ ale_linters#python#flake8#Handle(1, [
   \   'stdin:6:6: E111 indentation is not a multiple of four',
   \   'stdin:7:6: W123 some warning',
+  \   'stdin:8:3: E999 SyntaxError: invalid syntax',
   \ ])
 
 Execute(The flake8 handler should set end column indexes should be set for certain errors):


### PR DESCRIPTION
One of the things I noticed when working with Ale and flake8 was that syntax errors were reported as "style errors." I did some digging and noticed this was done in response to #430. Here, w0rp states that he made all error codes that started with "E" and "W" have the `'style'` `subtype`. However, this neglects the E999 error code, [which is documented](http://flake8.pycqa.org/en/latest/user/error-codes.html) as an error code used to report compilation failures. As such, since this is not a stylistic error, and I have added an exception for it in `ale_linters/python/flake8.vim`