### PR TITLE
Adds an option to pass additional arguments to the verilog/verilator …

### DIFF
--- a/ale_linters/verilog/verilator.vim
+++ b/ale_linters/verilog/verilator.vim
@@ -1,6 +1,11 @@
 " Author: Masahiro H https://github.com/mshr-h
 " Description: verilator for verilog files
 
+" Set this option to change Verilator lint options
+if !exists('g:ale_verilog_verilator_options')
+    let g:ale_verilog_verilator_options = ''
+endif
+
 function! ale_linters#verilog#verilator#GetCommand(buffer) abort
     let l:filename = tempname() . '_verilator_linted.v'
 
@@ -8,7 +13,9 @@ function! ale_linters#verilog#verilator#GetCommand(buffer) abort
     call ale#engine#ManageFile(a:buffer, l:filename)
     call writefile(getbufline(a:buffer, 1, '$'), l:filename)
 
-    return 'verilator --lint-only -Wall -Wno-DECLFILENAME ' . ale#Escape(l:filename)
+    return 'verilator --lint-only -Wall -Wno-DECLFILENAME '
+    \   . ale#Var(a:buffer, 'verilog_verilator_options') .' '
+    \   . ale#Escape(l:filename)
 endfunction
 
 function! ale_linters#verilog#verilator#Handle(buffer, lines) abort

--- a/doc/ale-verilog.txt
+++ b/doc/ale-verilog.txt
@@ -3,7 +3,7 @@ ALE Verilog/SystemVerilog Integration                     *ale-verilog-options*
 
 
 -------------------------------------------------------------------------------
-ALE can use tow diffent linters for Verilog HDL:
+ALE can use two different linters for Verilog HDL:
 
   iverilog:
     Using `iverilog -t null -Wall`
@@ -11,7 +11,7 @@ ALE can use tow diffent linters for Verilog HDL:
   verilator
     Using `verilator --lint-only -Wall`
 
-By default both 'verilog' and 'systemverilog' filetypes are checked.
+By default, both 'verilog' and 'systemverilog' filetypes are checked.
 
 You can limit 'systemverilog' files to be checked using only 'verilator' by
 defining 'g:ale_linters' variable:

--- a/doc/ale-verilog.txt
+++ b/doc/ale-verilog.txt
@@ -1,0 +1,43 @@
+===============================================================================
+ALE Verilog/SystemVerilog Integration                     *ale-verilog-options*
+
+
+-------------------------------------------------------------------------------
+ALE can use tow diffent linters for Verilog HDL:
+
+  iverilog:
+    Using `iverilog -t null -Wall`
+
+  verilator
+    Using `verilator --lint-only -Wall`
+
+By default both 'verilog' and 'systemverilog' filetypes are checked.
+
+You can limit 'systemverilog' files to be checked using only 'verilator' by
+defining 'g:ale_linters' variable:
+>
+    au FileType systemverilog
+    \ let g:ale_linters = {'systemverilog' : ['verilator'],}
+<
+
+-------------------------------------------------------------------------------
+iverilog                                                 *ale-verilog-iverilog*
+
+  No additional options
+
+
+-------------------------------------------------------------------------------
+verilator                                               *ale-verilog-verilator*
+
+g:ale_verilog_verilator_options               *g:ale_verilog_verilator_options*
+                                              *b:ale_verilog_verilator_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be changed to modify 'verilator' command arguments
+
+  For example `'-sv --default-language "1800-2012"'` if you want to enable
+  SystemVerilog parsing and select the 2012 version of the language.
+
+-------------------------------------------------------------------------------
+  vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -100,6 +100,9 @@ CONTENTS                                                         *ale-contents*
       eslint..............................|ale-typescript-eslint|
       tslint..............................|ale-typescript-tslint|
       tsserver............................|ale-typescript-tsserver|
+    verilog/systemverilog.................|ale-verilog-options|
+      iverilog............................|ale-verilog-iverilog|
+      verilator...........................|ale-verilog-verilator|
     vim...................................|ale-vim-options|
       vint................................|ale-vim-vint|
     xml...................................|ale-xml-options|

--- a/test/test_verilog_verilator_options.vader
+++ b/test/test_verilog_verilator_options.vader
@@ -1,0 +1,25 @@
+Before:
+  Save g:ale_verilog_verilator_options
+  let g:ale_verilog_verilator_options = ''
+
+After:
+  Restore
+  call ale#linter#Reset()
+
+Execute(Set Verilog Verilator linter additional options to `-sv --default-language "1800-2012"`):
+  runtime! ale_linters/verilog/verilator.vim
+
+  " Additional args for the linter
+  let g:ale_verilog_verilator_options = '-sv --default-language "1800-2012"'
+
+  call ale#Lint()
+
+  let g:run_cmd = ale_linters#verilog#verilator#GetCommand(bufnr(''))
+  let g:matched = match(g:run_cmd, '\s' . g:ale_verilog_verilator_options . '\s')
+
+  " match returns -1 if not found
+  AssertNotEqual
+  \   g:matched ,
+  \   -1 ,
+  \  'Additionnal arguments not found in the run command'
+


### PR DESCRIPTION
Add an option to pass additional arguments to verilator when linting verilog/systemverilog files.
Thus we can specify, for example, the "dialect" or filter some particular warnings.
I have also added a doc file.