### PR TITLE
Be more explicit about the effect of `g:..._perlcritic_profile = ''`

### DIFF
--- a/doc/ale-perl.txt
+++ b/doc/ale-perl.txt
@@ -44,7 +44,12 @@ g:ale_perl_perlcritic_profile                    *g:ale_perl_perlcritic_profile*
   parent directory, etc, until it finds one.  If no matching file is found, no
   profile is passed to perlcritic.
 
-  Set to an empty string to disable using a profile.
+  Set to an empty string to disable passing a specific profile to perlcritic
+  with the `'--profile'` option.
+
+  To prevent perlcritic from using any profile, set this variable to an empty
+  string and pass `'--no-profile'`to perlcritic via the
+  |g:ale_perl_perlcritic_options| variable.
 
 
 g:ale_perl_perlcritic_options                    *g:ale_perl_perlcritic_options*


### PR DESCRIPTION
<!--
When creating new pull requests, please consider the following.

* Read the Contributing guide linked above first.
* If you are adding a new linter, remember to update the README.md file and
  doc/ale.txt first.
* If you add or modify a function for converting error lines into loclist items
  that ALE can work with, please add Vader tests for them. Look at existing
  tests in the test/handler directory, etc.
* If you add or modify a function for computing a command line string for
  running a command, please add Vader tests for that.
* Generally try and cover anything with Vader tests, although some things just
  can't be tested with Vader, or at least they can be hard to test. Consider
  breaking up your code so that some parts can be tested, and generally open up
  a discussion about it.
* Have fun!
-->

Just to prevent any confusion, the documentation now explicitly states
that setting `g:ale_perl_perlcritic_profile` to an empty string merely
disables passing an explicit profile to `perlcritic` and does not cause
`--no-profile` to be set.