### PR TITLE
Drop "only master branch" travis restriction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@
 sudo: required
 services:
     - docker
-branches:
-    only:
-        - master
 language: python
 script: |
     ./run-tests


### PR DESCRIPTION
I get that one may want to restrict where travis runs (resource contentions,
reserving travis runs for master, etc), but this makes it difficult for others
to enable travis on their forks -- unless they're willing to do all their work
on master.

Would you be amenable to this change?  Or, in the alternative, creating a
[white/black list](https://docs.travis-ci.com/user/customizing-the-build/#Building-Specific-Branches)
to allow for a broader range of branches?


<!--
When creating new pull requests, please consider the following.

* Read the Contributing guide linked above first.
* If you are adding a new linter, remember to update the README.md file and
  doc/ale.txt first.
* If you add or modify a function for converting error lines into loclist items
  that ALE can work with, please add Vader tests for them. Look at existing
  tests in the test/handler directory, etc.
* If you add or modify a function for computing a command line string for
  running a command, please add Vader tests for that.
* Generally try and cover anything with Vader tests, although some things just
  can't be tested with Vader, or at least they can be hard to test. Consider
  breaking up your code so that some parts can be tested, and generally open up
  a discussion about it.
* Have fun!
-->