### PR TITLE
Correctly pass options to cpplint

### DIFF
--- a/ale_linters/cpp/cpplint.vim
+++ b/ale_linters/cpp/cpplint.vim
@@ -1,15 +1,15 @@
 " Author: Dawid Kurek https://github.com/dawikur
 " Description: cpplint for cpp files
 
-if !exists('g:ale_cpp_cpplint_options')
-    let g:ale_cpp_cpplint_options = ''
-endif
+function! ale_linters#cpp#cpplint#GetCommand(buffer) abort
+  return 'cpplint ' . ale#Var(a:buffer, 'cpp_cpplint_options') . ' %s'
+endfunction
 
 call ale#linter#Define('cpp', {
 \   'name': 'cpplint',
 \   'output_stream': 'stderr',
 \   'executable': 'cpplint',
-\   'command': 'cpplint %s',
+\   'command_callback': 'ale_linters#cpp#cpplint#GetCommand',
 \   'callback': 'ale#handlers#cpplint#HandleCppLintFormat',
 \   'lint_file': 1,
 \})

--- a/ale_linters/cpp/cpplint.vim
+++ b/ale_linters/cpp/cpplint.vim
@@ -1,6 +1,10 @@
 " Author: Dawid Kurek https://github.com/dawikur
 " Description: cpplint for cpp files
 
+if !exists('g:ale_cpp_cpplint_options')
+    let g:ale_cpp_cpplint_options = ''
+endif
+
 function! ale_linters#cpp#cpplint#GetCommand(buffer) abort
   return 'cpplint ' . ale#Var(a:buffer, 'cpp_cpplint_options') . ' %s'
 endfunction

--- a/ale_linters/cpp/cpplint.vim
+++ b/ale_linters/cpp/cpplint.vim
@@ -6,7 +6,7 @@ if !exists('g:ale_cpp_cpplint_options')
 endif
 
 function! ale_linters#cpp#cpplint#GetCommand(buffer) abort
-  return 'cpplint ' . ale#Var(a:buffer, 'cpp_cpplint_options') . ' %s'
+    return 'cpplint ' . ale#Var(a:buffer, 'cpp_cpplint_options') . ' %s'
 endfunction
 
 call ale#linter#Define('cpp', {


### PR DESCRIPTION
<!--
When creating new pull requests, please consider the following.

* Read the Contributing guide linked above first.
* If you are adding a new linter, remember to update the README.md file and
  doc/ale.txt first.
* If you add or modify a function for converting error lines into loclist items
  that ALE can work with, please add Vader tests for them. Look at existing
  tests in the test/handler directory, etc.
* If you add or modify a function for computing a command line string for
  running a command, please add Vader tests for that.
* Generally try and cover anything with Vader tests, although some things just
  can't be tested with Vader, or at least they can be hard to test. Consider
  breaking up your code so that some parts can be tested, and generally open up
  a discussion about it.
* Have fun!
-->

The `g:ale_cpp_cpplint_options` variable was being ignored (not used as part of the `cpplint` command). This PR adds a `command_callback` function to add the options to the `cpplint` command string.

I have not added any `vader` tests as this is a fairly minor change. If tests should still be added, I can do so.