### PR TITLE
Python `virtualenv` finder behaves badly on Windows

### DIFF
--- a/autoload/ale/python.vim
+++ b/autoload/ale/python.vim
@@ -27,7 +27,7 @@ endfunction
 function! ale#python#FindVirtualenv(buffer) abort
     for l:path in ale#path#Upwards(expand('#' . a:buffer . ':p:h'))
         for l:dirname in ale#Var(a:buffer, 'virtualenv_dir_names')
-            let l:venv_dir = l:path . '/' . l:dirname
+            let l:venv_dir = l:path =~# '/$' ? l:path . l:dirname : l:path . '/' . l:dirname
 
             if filereadable(l:venv_dir . '/bin/activate')
                 return l:venv_dir


### PR DESCRIPTION
### Summary
This is a quick fix to collapse the initial path component `//` into `/` to avoid freezing Vim for several seconds when running Ale in an Windows+MSYS2 environment, also fixing potential (though exotic) issues on other systems.

I end with some thoughts on a more complete solution to fix similar issues in a few other places in the code.


### Problem description
From 65fbf1c and onwards, Vim freezes for a couple of seconds every time Ale triggers Pylint when editing Python files under Windows in an [MSYS2](http://www.msys2.org/) environment. This is the standard environment that e.g. a standard Git installation on Windows uses by default.

The `virtualenv` discovery code in `autoload/ale/python.vim` currently loops through some usual suspects (configurable via `g:ale_virtualenv_dir_names`) when naming virtual environments such as `env`, `.env`, etc., within parent directories of the buffer being edited, and in particular checks if `{virtualenv dir}/bin/activate` exists.

This is very "*nix only" since virtual environments created on Windows actually calls the `bin` subdirectory `Scripts` (why this was chosen boggles the mind, but nevertheless ([`virtualenv`](https://virtualenv.pypa.io/en/stable/userguide/#activate-script), [`venv`](https://docs.python.org/3/library/venv.html#creating-virtual-environments)), which means that the code will never work when a virtual environment has been created with a Windows-native Python installation.

This would just have been a transparent degradation in function with a minimal time penalty, but the `ale#path#Upwards` function returns a list with the `/` entry when running in an MSYS2 environment on Windows. After concatenating paths, `ale#Python#FindVirtualenv` will then check readability of `//env/bin/activate`, `//.env/bin/activate` and so on. The meaning of the `//` path within MSYS2 on Windows is unclear to me, but it might mean the network root or something (analogous to `\\`) -- in any case lookups on `//` are _really_ slow:

    $ time ls //
    ls: reading directory '//': No such file or directory

    real    0m7.561s
    user    0m0.530s
    sys     0m2.324s

So, every attempt at finding a virtual environment on Windows within an MSYS2 environment (which will never succeed using Windows-native Python since scripts are in `Scripts`, not in `bin`) adds a couple of seconds of freezing time for the current Vim session. The default list of possible paths has five entries, which multiplies the issue.

For completeness sake, running it via e.g. GVim on Windows will yield a list of parent directories using Windows-style paths and fail at finding virtual environments as well due to the `Scripts`/`bin` issue, but at least it seems to fail fast.


### Quick workaround
For anyone encountering this, not running with this pull request applied: define `g:ale_virtualenv_dir_names` to be an empty list. In your `vimrc`:

    let g:ale_virtualenv_dir_names = []

This in practice inactivates the virtual environment finding mechanism altogether by looping over an empty list.


### Solution thoughts
One thought would be to not enable the virtual environment finder by default, but I am not sure whether users would want this. Personally I tend to always launch Vim from a session where the project virtual environment is already active which is then inheritied by Pylint if I understand it correctly, but I can imagine that if I within the same Vim session would open a file from another project, this would tend to give incorrect warnings.

Making the path joining smarter than just "concatenate base path and `/bin/activate`" to instead immediately collapse multiple slashes would also solve the freeze issue in a way, I guess, rather by accident. Technically, [a leading `//` is not necessarily equivalent to a leading `/` within POSIX](http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap04.html#tag_04_11) ("A pathname that begins with two successive slashes may be interpreted in an implementation-defined manner") and in this case the code really wants to find a single leading `/`, so this might be a good thing anyway.

This pull request attempts to fix this inline for the specific place that matters for the Pylint issue. However, similar code exists in at least another place in `autoload/ale/python.vim` as well as in `autoload/ale/c.vim`, so either one should duplicate this inline fix in those places or perhaps it should rather be done through a more robust new `os.path.join`-like utility function in `autoload/ale/path.vim`.

To make the virtual environment search work for Windows-native Python installations as well, the finder function should also have to check for `{virtualenv dir}/Scripts/activate`. This would currently break other assumptions made in

* `autoload/ale/fixers/mypy`
* `autoload/ale/fixers/autopep8`
* `autoload/ale/fixers/isort`
* `autoload/ale/fixers/yapf`

that also assume that scripts within virtual environments reside in the `{virtualenv dir}/bin` directory. This has not been addressed at all in this merge request.
