### PR TITLE
Add ale_fix_on_save and ale_fixers to debug output

### DIFF
--- a/autoload/ale/debugging.vim
+++ b/autoload/ale/debugging.vim
@@ -7,6 +7,8 @@ let s:global_variable_list = [
 \    'ale_echo_msg_format',
 \    'ale_echo_msg_warning_str',
 \    'ale_enabled',
+\    'ale_fix_on_save',
+\    'ale_fixers',
 \    'ale_keep_list_window_open',
 \    'ale_lint_delay',
 \    'ale_lint_on_enter',

--- a/test/test_ale_info.vader
+++ b/test/test_ale_info.vader
@@ -19,6 +19,8 @@ Before:
   \  'let g:ale_echo_msg_format = ''%s''',
   \  'let g:ale_echo_msg_warning_str = ''Warning''',
   \  'let g:ale_enabled = 1',
+  \  'let g:ale_fix_on_save = 0',
+  \  'let g:ale_fixers = {}',
   \  'let g:ale_keep_list_window_open = 0',
   \  'let g:ale_lint_delay = 200',
   \  'let g:ale_lint_on_enter = 1',


### PR DESCRIPTION
While trying to debug why I can't get fixers to work - I noticed that these global variables weren't included in the output of `ALEInfo`