### PR TITLE
Use rubocop's JSON output format (resolves #339)

### DIFF
--- a/ale_linters/ruby/rubocop.vim
+++ b/ale_linters/ruby/rubocop.vim
@@ -23,9 +23,11 @@ function! ale_linters#ruby#rubocop#Handle(buffer, lines) abort
     let l:output = []
 
     for l:error in l:errors['files'][0]['offenses']
+        let l:start_col = l:error['location']['column'] + 0
         call add(l:output, {
         \   'lnum': l:error['location']['line'] + 0,
-        \   'col': l:error['location']['column'] + 0,
+        \   'col': l:start_col,
+        \   'end_col': l:start_col + l:error['location']['length'] - 1,
         \   'text': l:error['message'],
         \   'type': ale_linters#ruby#rubocop#GetType(l:error['severity']),
         \})

--- a/ale_linters/ruby/rubocop.vim
+++ b/ale_linters/ruby/rubocop.vim
@@ -1,5 +1,5 @@
-" Author: ynonp - https://github.com/ynonp
-" Description: rubocop for Ruby files
+" Author: ynonp - https://github.com/ynonp, Eddie Lebow https://github.com/elebow
+" Description: RuboCop, a code style analyzer for Ruby files
 
 function! ale_linters#ruby#rubocop#GetCommand(buffer) abort
     let l:executable = ale#handlers#rubocop#GetExecutable(a:buffer)
@@ -8,32 +8,47 @@ function! ale_linters#ruby#rubocop#GetCommand(buffer) abort
     \   : ''
 
     return ale#Escape(l:executable) . l:exec_args
-    \   . ' --format emacs --force-exclusion '
+    \   . ' --format json --force-exclusion '
     \   . ale#Var(a:buffer, 'ruby_rubocop_options')
     \   . ' --stdin ' . bufname(a:buffer)
 endfunction
 
 function! ale_linters#ruby#rubocop#Handle(buffer, lines) abort
-    " Matches patterns line the following:
-    "
-    " <path>:83:29: C: Prefer single-quoted strings when you don't
-    " need string interpolation or special symbols.
-    let l:pattern = '\v:(\d+):(\d+): (.): (.+)'
+    if len(a:lines) == 0
+      return []
+    endif
+
+    let l:errors = json_decode(a:lines[0])
+
     let l:output = []
 
-    for l:match in ale#util#GetMatches(a:lines, l:pattern)
-        let l:text = l:match[4]
-        let l:type = l:match[3]
-
+    for l:error in l:errors['files'][0]['offenses']
         call add(l:output, {
-        \   'lnum': l:match[1] + 0,
-        \   'col': l:match[2] + 0,
-        \   'text': l:text,
-        \   'type': index(['F', 'E'], l:type) != -1 ? 'E' : 'W',
+        \   'lnum': l:error['location']['line'] + 0,
+        \   'col': l:error['location']['column'] + 0,
+        \   'text': l:error['message'],
+        \   'type': s:GetType(l:error['severity']),
         \})
     endfor
 
     return l:output
+endfunction
+
+function! s:GetType(severity) abort
+    if a:severity ==? 'refactor'
+      return 'W'
+    elseif a:severity ==? 'convention'
+      return 'W'
+    elseif a:severity ==? 'warning'
+      return 'W'
+    elseif a:severity ==? 'error'
+      return 'E'
+    elseif a:severity ==? 'fatal'
+      return 'E'
+    else
+      echo 'Rubocop offense type unrecognized by ALE: ' + severity
+      return ''
+    endif
 endfunction
 
 call ale#linter#Define('ruby', {

--- a/ale_linters/ruby/rubocop.vim
+++ b/ale_linters/ruby/rubocop.vim
@@ -46,7 +46,7 @@ function! ale_linters#ruby#rubocop#GetType(severity) abort
     elseif a:severity ==? 'fatal'
       return 'E'
     else
-      echo 'Rubocop offense type unrecognized by ALE: ' + severity
+      echo 'Rubocop offense type unrecognized by ALE: ' + a:severity
       return ''
     endif
 endfunction

--- a/ale_linters/ruby/rubocop.vim
+++ b/ale_linters/ruby/rubocop.vim
@@ -27,14 +27,14 @@ function! ale_linters#ruby#rubocop#Handle(buffer, lines) abort
         \   'lnum': l:error['location']['line'] + 0,
         \   'col': l:error['location']['column'] + 0,
         \   'text': l:error['message'],
-        \   'type': s:GetType(l:error['severity']),
+        \   'type': ale_linters#ruby#rubocop#GetType(l:error['severity']),
         \})
     endfor
 
     return l:output
 endfunction
 
-function! s:GetType(severity) abort
+function! ale_linters#ruby#rubocop#GetType(severity) abort
     if a:severity ==? 'refactor'
       return 'W'
     elseif a:severity ==? 'convention'

--- a/test/command_callback/test_rubocop_command_callback.vader
+++ b/test/command_callback/test_rubocop_command_callback.vader
@@ -3,17 +3,17 @@ Before:
 
 Execute(Executable should default to rubocop):
   AssertEqual
-  \ '''rubocop'' --format emacs --force-exclusion  --stdin ''dummy.py''',
+  \ '''rubocop'' --format json --force-exclusion  --stdin ''dummy.py''',
   \ ale_linters#ruby#rubocop#GetCommand(bufnr(''))
 
 Execute(Should be able to set a custom executable):
   let g:ale_ruby_rubocop_executable = 'bin/rubocop'
   AssertEqual
-  \ '''bin/rubocop'' --format emacs --force-exclusion  --stdin ''dummy.py''',
+  \ '''bin/rubocop'' --format json --force-exclusion  --stdin ''dummy.py''',
   \ ale_linters#ruby#rubocop#GetCommand(bufnr(''))
 
 Execute(Setting bundle appends 'exec rubocop'):
   let g:ale_ruby_rubocop_executable = 'path to/bundle'
   AssertEqual
-  \ '''path to/bundle'' exec rubocop --format emacs --force-exclusion  --stdin ''dummy.py''',
+  \ '''path to/bundle'' exec rubocop --format json --force-exclusion  --stdin ''dummy.py''',
   \ ale_linters#ruby#rubocop#GetCommand(bufnr(''))

--- a/test/handler/test_rubocop_handler.vader
+++ b/test/handler/test_rubocop_handler.vader
@@ -6,24 +6,28 @@ Execute(The rubocop handler should parse lines correctly):
   \   {
   \     'lnum': 83,
   \     'col': 29,
+  \     'end_col': 35,
   \     'text': 'Prefer single-quoted strings...',
   \     'type': 'W',
   \   },
   \   {
   \     'lnum': 12,
   \     'col': 2,
+  \     'end_col': 2,
   \     'text': 'Some error',
   \     'type': 'E',
   \   },
   \   {
   \     'lnum': 10,
   \     'col': 5,
+  \     'end_col': 12,
   \     'text': 'Regular warning',
   \     'type': 'W',
   \   },
   \   {
   \     'lnum': 11,
   \     'col': 1,
+  \     'end_col': 1,
   \     'text': 'Another error',
   \     'type': 'E',
   \   },

--- a/test/handler/test_rubocop_handler.vader
+++ b/test/handler/test_rubocop_handler.vader
@@ -29,11 +29,7 @@ Execute(The rubocop handler should parse lines correctly):
   \   },
   \ ],
   \ ale_linters#ruby#rubocop#Handle(347, [
-  \   'This line should be ignored completely',
-  \   'whatever:83:29: C: Prefer single-quoted strings...',
-  \   'whatever:12:2: F: Some error',
-  \   'whatever:10:5: W: Regular warning',
-  \   'whatever:11:1: E: Another error',
+  \     '{"metadata":{"rubocop_version":"0.47.1","ruby_engine":"ruby","ruby_version":"2.1.5","ruby_patchlevel":"273","ruby_platform":"x86_64-linux-gnu"},"files":[{"path":"my_great_file.rb","offenses":[{"severity":"convention","message":"Prefer single-quoted strings...","cop_name":"Style/SomeCop","corrected":false,"location":{"line":83,"column":29,"length":7}},{"severity":"fatal","message":"Some error","cop_name":"Style/SomeOtherCop","corrected":false,"location":{"line":12,"column":2,"length":1}},{"severity":"warning","message":"Regular warning","cop_name":"Style/WarningCop","corrected":false,"location":{"line":10,"column":5,"length":8}},{"severity":"error","message":"Another error","cop_name":"Style/SpaceBeforeBlockBraces","corrected":false,"location":{"line":11,"column":1,"length":1}}]}],"summary":{"offense_count":4,"target_file_count":1,"inspected_file_count":1}}'
   \ ])
 
 After:


### PR DESCRIPTION
Rubocop's emacs formatter seems to have changed format in some
not-so-ancient version. The JSON formatter should provide a more stable
interface than parsing lines with a regex.

The JSON formatter was introduced in mid-2013, so it should be safe to
assume available in any reasonably-modern environment. The oldest
currently-supported version of ruby (according to ruby-lang.org) was
not supported by rubocop until 2014.