### PR TITLE
Added missing statement about `<Plug>(ale_toggle)` mapping to the documentation

### DIFF
--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -1110,8 +1110,8 @@ ALEEnable                                                           *ALEEnable*
 ALEDisable                                                         *ALEDisable*
 
   Enable or disable ALE, including all of its autocmd events, loclist items,
-  quickfix items, signs, current jobs, etc. Calling this option will change
-  the |g:ale_enabled| variable.
+  quickfix items, signs, current jobs, etc. Executing any of those commands
+  will change the |g:ale_enabled| variable.
 
   For convenience, a plug mapping `<Plug>(ale_toggle)` is defined for |ALEToggle|
   command.

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -1113,6 +1113,9 @@ ALEDisable                                                         *ALEDisable*
   quickfix items, signs, current jobs, etc. Calling this option will change
   the |g:ale_enabled| variable.
 
+  For convenience, a plug mapping `<Plug>(ale_toggle)` is defined for |ALEToggle|
+  command.
+
 
 ALEDetail                                                           *ALEDetail*
 

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -1113,8 +1113,8 @@ ALEDisable                                                         *ALEDisable*
   quickfix items, signs, current jobs, etc. Executing any of those commands
   will change the |g:ale_enabled| variable.
 
-  For convenience, a plug mapping `<Plug>(ale_toggle)` is defined for |ALEToggle|
-  command.
+  For convenience, a plug mapping `<Plug>(ale_toggle)` is defined for the 
+  |ALEToggle| command.
 
 
 ALEDetail                                                           *ALEDetail*


### PR DESCRIPTION
<!--
When creating new pull requests, please consider the following.

* Read the Contributing guide linked above first.
* If you are adding a new linter, remember to update the README.md file and
  doc/ale.txt first.
* If you add or modify a function for converting error lines into loclist items
  that ALE can work with, please add Vader tests for them. Look at existing
  tests in the test/handler directory, etc.
* If you add or modify a function for computing a command line string for
  running a command, please add Vader tests for that.
* Generally try and cover anything with Vader tests, although some things just
  can't be tested with Vader, or at least they can be hard to test. Consider
  breaking up your code so that some parts can be tested, and generally open up
  a discussion about it.
* Have fun!
-->
Also would like to ask why there are no mappings for `:ALEEnable`, `:ALEDisable` and on what basis the mappings are added. For all commands? As someone requests them?

Thank you,
Andrew V 