### PR TITLE
Add new Haskell linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ name. That seems to be the fairest way to arrange this table.
 | Go | [gofmt -e](https://golang.org/cmd/gofmt/), [go vet](https://golang.org/cmd/vet/), [golint](https://godoc.org/github.com/golang/lint), [gometalinter](https://github.com/alecthomas/gometalinter), [go build](https://golang.org/cmd/go/), [gosimple](https://github.com/dominikh/go-tools/tree/master/cmd/gosimple), [staticcheck](https://github.com/dominikh/go-tools/tree/master/cmd/staticcheck) |
 | Haml | [haml-lint](https://github.com/brigade/haml-lint)
 | Handlebars | [ember-template-lint](https://github.com/rwjblue/ember-template-lint) |
-| Haskell | [ghc](https://www.haskell.org/ghc/), [ghc-mod](https://github.com/DanielG/ghc-mod), [hlint](https://hackage.haskell.org/package/hlint), [hdevtools](https://hackage.haskell.org/package/hdevtools) |
+| Haskell | [ghc](https://www.haskell.org/ghc/), [stack-ghc](https://haskellstack.org/), [stack-build](https://haskellstack.org/), [ghc-mod](https://github.com/DanielG/ghc-mod), [stack-ghc-mod](https://github.com/DanielG/ghc-mod), [hlint](https://hackage.haskell.org/package/hlint), [hdevtools](https://hackage.haskell.org/package/hdevtools) |
 | HTML | [HTMLHint](http://htmlhint.com/), [proselint](http://proselint.com/), [tidy](http://www.html-tidy.org/) |
 | Java | [checkstyle](http://checkstyle.sourceforge.net), [javac](http://www.oracle.com/technetwork/java/javase/downloads/index.html) |
 | JavaScript | [eslint](http://eslint.org/), [jscs](http://jscs.info/), [jshint](http://jshint.com/), [flow](https://flowtype.org/), [standard](http://standardjs.com/), [prettier](https://github.com/prettier/prettier) (and `prettier-eslint`, `prettier-standard`), [xo](https://github.com/sindresorhus/xo)

--- a/ale_linters/haskell/ghc.vim
+++ b/ale_linters/haskell/ghc.vim
@@ -16,3 +16,12 @@ call ale#linter#Define('haskell', {
 \   'command': 'stack ghc -- -fno-code -v0 %t',
 \   'callback': 'ale#handlers#haskell#HandleGHCFormat',
 \})
+
+call ale#linter#Define('haskell', {
+\   'name': 'stack-build',
+\   'output_stream': 'stderr',
+\   'executable': 'stack',
+\   'command': 'stack build',
+\   'lint_file': 1,
+\   'callback': 'ale#handlers#haskell#HandleGHCFormat',
+\})

--- a/ale_linters/haskell/stack-build.vim
+++ b/ale_linters/haskell/stack-build.vim
@@ -1,0 +1,14 @@
+" Author: Jake Zimmerman <jake@zimmerman.io>
+" Description: Like stack-ghc, but for entire projects
+"
+" Note: Ideally, this would *only* typecheck. Right now, it also does codegen.
+" See <https://github.com/commercialhaskell/stack/issues/977>.
+
+call ale#linter#Define('haskell', {
+\   'name': 'stack-build',
+\   'output_stream': 'stderr',
+\   'executable': 'stack',
+\   'command': 'stack build',
+\   'lint_file': 1,
+\   'callback': 'ale#handlers#haskell#HandleGHCFormat',
+\})

--- a/ale_linters/haskell/stack-ghc.vim
+++ b/ale_linters/haskell/stack-ghc.vim
@@ -1,10 +1,10 @@
 " Author: w0rp <devw0rp@gmail.com>
-" Description: ghc for Haskell files
+" Description: ghc for Haskell files, using Stack
 
 call ale#linter#Define('haskell', {
-\   'name': 'ghc',
+\   'name': 'stack-ghc',
 \   'output_stream': 'stderr',
-\   'executable': 'ghc',
-\   'command': 'ghc -fno-code -v0 %t',
+\   'executable': 'stack',
+\   'command': 'stack ghc -- -fno-code -v0 %t',
 \   'callback': 'ale#handlers#haskell#HandleGHCFormat',
 \})

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -172,7 +172,7 @@ The following languages and tools are supported.
 * FusionScript: 'fusion-lint'
 * Haml: 'hamllint'
 * Handlebars: 'ember-template-lint'
-* Haskell: 'ghc', 'ghc-mod', 'hlint', 'hdevtools'
+* Haskell: 'ghc', 'stack-ghc', 'stack-build', 'ghc-mod', 'stack-ghc-mod', 'hlint', 'hdevtools'
 * HTML: 'HTMLHint', 'proselint', 'tidy'
 * Java: 'javac'
 * JavaScript: 'eslint', 'jscs', 'jshint', 'flow', 'prettier', 'prettier-eslint', 'xo'


### PR DESCRIPTION
This PR adds a new Haskell linter (based on GHC). As such, it can take advantage
of the pre-existing `HandleGHCFormat` function. Also, we update the docs.

- **Add stack-build linter for Haskell**

  The stack-build linter works better than the other two linters when you're
  working with an entire Haskell project. It builds the project entirely and
  reports any errors.

  The other two Haskell GHC linters only work on single files, which can
  result in spurious errors (for example, not being able to find imports).

- **Document all available Haskell linters**