### PR TITLE
Correctly resolve temp files on macOS

### DIFF
--- a/autoload/ale/path.vim
+++ b/autoload/ale/path.vim
@@ -73,6 +73,7 @@ endfunction
 function! ale#path#IsTempName(filename) abort
     let l:prefix_list = [
     \   $TMPDIR,
+    \   resolve($TMPDIR),
     \   '/run/user',
     \]
 


### PR DESCRIPTION
On macOS, the `$TMPDIR` is in `/var`. However, `/var -> /private/var`.
This means that fully resolved temp filenames weren't always getting
checked against the proper prefix in `IsTempFile`.

This was affecting some of the Haskell plugins, though I'm sure it could
have affected any program that resolved past the generated `$TMPDIR/foo`
and wound up at a different filename.