### PR TITLE
Brakeman: Remove unused cache var from tests

### DIFF
--- a/autoload/ale/cursor.vim
+++ b/autoload/ale/cursor.vim
@@ -24,7 +24,7 @@ function! s:EchoWithShortMess(setting, message) abort
         " Turn shortmess on or off.
         if a:setting ==# 'on'
             setlocal shortmess+=T
-            " echomsg is neede for the message to get truncated and appear in
+            " echomsg is needed for the message to get truncated and appear in
             " the message history.
             exec "norm! :echomsg a:message\n"
         elseif a:setting ==# 'off'

--- a/test/handler/test_brakeman_handler.vader
+++ b/test/handler/test_brakeman_handler.vader
@@ -5,7 +5,6 @@ Before:
     cd ../ruby_fixtures/valid_rails_app/app/models
 
     runtime ale_linters/ruby/brakeman.vim
-    call setbufvar(0, 'ruby_brakeman_rails_root_cached', '')
 
 After:
     " Switch back to whatever directory it was that we started on.


### PR DESCRIPTION
Caching of the Rails application root was used in an initial version of the Brakeman handler, but was removed before merging. This must have slipped by.

Also fixes a typo in a comment elsewhere.