### PR TITLE
Make gometalinter work again

### DIFF
--- a/ale_linters/go/gometalinter.vim
+++ b/ale_linters/go/gometalinter.vim
@@ -10,11 +10,11 @@ endfunction
 
 function! ale_linters#go#gometalinter#GetCommand(buffer) abort
     let l:executable = ale_linters#go#gometalinter#GetExecutable(a:buffer)
-    let l:filename = expand('#' . a:buffer . ':p')
+    let l:filename = expand('#' . a:buffer)
     let l:options = ale#Var(a:buffer, 'go_gometalinter_options')
 
     return ale#Escape(l:executable)
-    \   . ' --include=''^' . l:filename . '.*$'''
+    \   . ' --include=' . ale#Escape(l:filename)
     \   . (!empty(l:options) ? ' ' . l:options : '')
     \   . ' ' . ale#Escape(fnamemodify(l:filename, ':h'))
 endfunction

--- a/test/command_callback/test_gometalinter_command_callback.vader
+++ b/test/command_callback/test_gometalinter_command_callback.vader
@@ -22,7 +22,7 @@ Execute(The gometalinter callback should return the right defaults):
   \ ale_linters#go#gometalinter#GetExecutable(bufnr(''))
   AssertEqual
   \ ale#Escape('gometalinter')
-  \   . ' --include=''^' . expand('%:p') . '.*$'''
+  \   . ' --include=' . ale#Escape(expand('%'))
   \   . ' ' . ale#Escape(getcwd()),
   \ ale_linters#go#gometalinter#GetCommand(bufnr(''))
 
@@ -34,7 +34,7 @@ Execute(The gometalinter callback should use a configured executable):
   \ ale_linters#go#gometalinter#GetExecutable(bufnr(''))
   AssertEqual
   \ ale#Escape('something else')
-  \   . ' --include=''^' . expand('%:p') . '.*$'''
+  \   . ' --include=' . ale#Escape(expand('%'))
   \   . ' ' . ale#Escape(getcwd()),
   \ ale_linters#go#gometalinter#GetCommand(bufnr(''))
 
@@ -43,7 +43,7 @@ Execute(The gometalinter callback should use configured options):
 
   AssertEqual
   \ ale#Escape('gometalinter')
-  \   . ' --include=''^' . expand('%:p') . '.*$'''
+  \   . ' --include=' . ale#Escape(expand('%'))
   \   . ' --foobar'
   \   . ' ' . ale#Escape(getcwd()),
   \ ale_linters#go#gometalinter#GetCommand(bufnr(''))


### PR DESCRIPTION
They changed their logic to use related paths instead of absoluut paths (see [here](https://github.com/alecthomas/gometalinter/commit/a04df08be5899be3c7ad69aa379858dcb660c709#diff-04424ed7c660c10495a54e8d11be89eaR253))

This fixes the linter by also using relative paths…