### PR TITLE
Rubocop: handle empty 'files' array in output

### DIFF
--- a/ale_linters/ruby/rubocop.vim
+++ b/ale_linters/ruby/rubocop.vim
@@ -28,6 +28,10 @@ function! ale_linters#ruby#rubocop#Handle(buffer, lines) abort
         \}]
     endtry
 
+    if l:errors['summary']['offense_count'] == 0 || empty(l:errors['files'])
+      return []
+    endif
+
     let l:output = []
 
     for l:error in l:errors['files'][0]['offenses']

--- a/test/handler/test_rubocop_handler.vader
+++ b/test/handler/test_rubocop_handler.vader
@@ -41,6 +41,20 @@ Execute(The rubocop handler should parse lines correctly):
   \     '{"metadata":{"rubocop_version":"0.47.1","ruby_engine":"ruby","ruby_version":"2.1.5","ruby_patchlevel":"273","ruby_platform":"x86_64-linux-gnu"},"files":[{"path":"my_great_file.rb","offenses":[{"severity":"convention","message":"Prefer single-quoted strings...","cop_name":"Style/SomeCop","corrected":false,"location":{"line":83,"column":29,"length":7}},{"severity":"fatal","message":"Some error","cop_name":"Style/SomeOtherCop","corrected":false,"location":{"line":12,"column":2,"length":1}},{"severity":"warning","message":"Regular warning","cop_name":"Style/WarningCop","corrected":false,"location":{"line":10,"column":5,"length":8}},{"severity":"error","message":"Another error","cop_name":"Style/SpaceBeforeBlockBraces","corrected":false,"location":{"line":11,"column":1,"length":1}}]}],"summary":{"offense_count":4,"target_file_count":1,"inspected_file_count":1}}'
   \ ])
 
+Execute(The rubocop handler should handle when files are checked and no offenses are found):
+  AssertEqual
+  \ [],
+  \ ale_linters#ruby#rubocop#Handle(347, [
+  \     '{"metadata":{"rubocop_version":"0.47.1","ruby_engine":"ruby","ruby_version":"2.1.5","ruby_patchlevel":"273","ruby_platform":"x86_64-linux-gnu"},"files":[{"path":"my_great_file.rb","offenses":[]}],"summary":{"offense_count":0,"target_file_count":1,"inspected_file_count":1}}'
+  \ ])
+
+Execute(The rubocop handler should handle when no files are checked):
+  AssertEqual
+  \ [],
+  \ ale_linters#ruby#rubocop#Handle(347, [
+  \     '{"metadata":{"rubocop_version":"0.47.1","ruby_engine":"ruby","ruby_version":"2.1.5","ruby_patchlevel":"273","ruby_platform":"x86_64-linux-gnu"},"files":[],"summary":{"offense_count":0,"target_file_count":0,"inspected_file_count":0}}'
+  \ ])
+
 Execute(Parse errors should be handled for rubocop):
   let g:lines = [
   \ '/my/project/.rubocop.yml: Layout/MultilineOperationIndentation has the wrong namespace - should be Style',


### PR DESCRIPTION
The handler previously assumed there would be at least one entry in the
'files' array in the output JSON. It looks like this in the normal case:

    "files":[{"path":"app/models/image.rb","offenses":[]}]

But if RuboCop's config excludes the specified input files, causing no
files to be linted, the output is emptier:

    "files":[]

This change causes the handler to treat that case correctly, and also
exit early if the reported offense_count is zero.