### PR TITLE
Fix Rubocop when linting a ignored file

### DIFF
--- a/ale_linters/ruby/rubocop.vim
+++ b/ale_linters/ruby/rubocop.vim
@@ -14,19 +14,11 @@ function! ale_linters#ruby#rubocop#GetCommand(buffer) abort
 endfunction
 
 function! ale_linters#ruby#rubocop#Handle(buffer, lines) abort
-    if empty(a:lines)
-        return []
+    if len(a:lines) == 0
+      return []
     endif
 
-    try
-        let l:errors = json_decode(a:lines[0])
-    catch
-        return [{
-        \   'lnum': 1,
-        \   'text': 'rubocop configuration error (type :ALEDetail for more information)',
-        \   'detail': join(a:lines, "\n"),
-        \}]
-    endtry
+    let l:errors = json_decode(a:lines[0])
 
     let l:output = []
 
@@ -59,5 +51,4 @@ call ale#linter#Define('ruby', {
 \   'executable_callback': 'ale#handlers#rubocop#GetExecutable',
 \   'command_callback': 'ale_linters#ruby#rubocop#GetCommand',
 \   'callback': 'ale_linters#ruby#rubocop#Handle',
-\   'output_stream': 'both',
 \})

--- a/ale_linters/ruby/rubocop.vim
+++ b/ale_linters/ruby/rubocop.vim
@@ -14,11 +14,15 @@ function! ale_linters#ruby#rubocop#GetCommand(buffer) abort
 endfunction
 
 function! ale_linters#ruby#rubocop#Handle(buffer, lines) abort
-    if len(a:lines) == 0
-      return []
+    if empty(a:lines)
+        return []
     endif
 
     let l:errors = json_decode(a:lines[0])
+
+    if empty(l:errors['files'])
+        return []
+    endif
 
     let l:output = []
 

--- a/test/handler/test_rubocop_handler.vader
+++ b/test/handler/test_rubocop_handler.vader
@@ -1,6 +1,11 @@
-Execute(The rubocop handler should parse lines correctly):
+Before:
   runtime ale_linters/ruby/rubocop.vim
 
+After:
+  unlet! g:lines
+  call ale#linter#Reset()
+
+Execute(The rubocop handler should parse lines correctly):
   AssertEqual
   \ [
   \   {
@@ -36,5 +41,11 @@ Execute(The rubocop handler should parse lines correctly):
   \     '{"metadata":{"rubocop_version":"0.47.1","ruby_engine":"ruby","ruby_version":"2.1.5","ruby_patchlevel":"273","ruby_platform":"x86_64-linux-gnu"},"files":[{"path":"my_great_file.rb","offenses":[{"severity":"convention","message":"Prefer single-quoted strings...","cop_name":"Style/SomeCop","corrected":false,"location":{"line":83,"column":29,"length":7}},{"severity":"fatal","message":"Some error","cop_name":"Style/SomeOtherCop","corrected":false,"location":{"line":12,"column":2,"length":1}},{"severity":"warning","message":"Regular warning","cop_name":"Style/WarningCop","corrected":false,"location":{"line":10,"column":5,"length":8}},{"severity":"error","message":"Another error","cop_name":"Style/SpaceBeforeBlockBraces","corrected":false,"location":{"line":11,"column":1,"length":1}}]}],"summary":{"offense_count":4,"target_file_count":1,"inspected_file_count":1}}'
   \ ])
 
-After:
-  call ale#linter#Reset()
+Execute(Blank files array should not raise any errors):
+  let g:lines = [
+  \ '{"metadata":{"rubocop_version":"0.48.1","ruby_engine":"ruby","ruby_version":"2.4.1","ruby_patchlevel":"111","ruby_platform":"x86_64-darwin16"},"files":[]}',
+  \]
+
+  AssertEqual
+  \ [],
+  \ ale_linters#ruby#rubocop#Handle(347, g:lines)

--- a/test/handler/test_rubocop_handler.vader
+++ b/test/handler/test_rubocop_handler.vader
@@ -1,11 +1,6 @@
-Before:
+Execute(The rubocop handler should parse lines correctly):
   runtime ale_linters/ruby/rubocop.vim
 
-After:
-  unlet! g:lines
-  call ale#linter#Reset()
-
-Execute(The rubocop handler should parse lines correctly):
   AssertEqual
   \ [
   \   {
@@ -41,19 +36,5 @@ Execute(The rubocop handler should parse lines correctly):
   \     '{"metadata":{"rubocop_version":"0.47.1","ruby_engine":"ruby","ruby_version":"2.1.5","ruby_patchlevel":"273","ruby_platform":"x86_64-linux-gnu"},"files":[{"path":"my_great_file.rb","offenses":[{"severity":"convention","message":"Prefer single-quoted strings...","cop_name":"Style/SomeCop","corrected":false,"location":{"line":83,"column":29,"length":7}},{"severity":"fatal","message":"Some error","cop_name":"Style/SomeOtherCop","corrected":false,"location":{"line":12,"column":2,"length":1}},{"severity":"warning","message":"Regular warning","cop_name":"Style/WarningCop","corrected":false,"location":{"line":10,"column":5,"length":8}},{"severity":"error","message":"Another error","cop_name":"Style/SpaceBeforeBlockBraces","corrected":false,"location":{"line":11,"column":1,"length":1}}]}],"summary":{"offense_count":4,"target_file_count":1,"inspected_file_count":1}}'
   \ ])
 
-Execute(Parse errors should be handled for rubocop):
-  let g:lines = [
-  \ '/my/project/.rubocop.yml: Layout/MultilineOperationIndentation has the wrong namespace - should be Style',
-  \ '/my/project/.rubocop.yml: Layout/AlignHash has the wrong namespace - should be Style',
-  \ '{"metadata":{"rubocop_version":"0.48.1","ruby_engine":"ruby","ruby_version":"2.4.1","ruby_patchlevel":"111","ruby_platform":"x86_64-darwin16"},"files":[]}',
-  \]
-
-  AssertEqual
-  \ [
-  \   {
-  \     'lnum': 1,
-  \     'text': 'rubocop configuration error (type :ALEDetail for more information)',
-  \     'detail': join(g:lines, "\n"),
-  \   },
-  \ ],
-  \ ale_linters#ruby#rubocop#Handle(347, g:lines)
+After:
+  call ale#linter#Reset()


### PR DESCRIPTION
When Rubocop is linting an ignored file, it will output something like this:

```json
{"metadata":{"rubocop_version":"0.48.1","ruby_engine":"ruby","ruby_version":"2.4.1","ruby_patchlevel":"111","ruby_platform":"x86_64-darwin16"},"files":[],"summary":{"offense_count":0,"target_file_count":0,"inspected_file_count":0}}
```

Currently, ale will throw an error because it expects that the `files` key has at least one element in it. I just added this protection condition so it won't try to loop through an invalid array.

This PR also reverts the behavior introduced by 5885954, which is undesirable: whenever rubocop outputs something to stderr, the linter would display an error message, even if the content of the stdout is valid.

For more info, also check my comment [here](https://github.com/w0rp/ale/issues/760#issuecomment-314957246).