### PR TITLE
Do not complain if Rubocop is displaying warning messages on stderr

### DIFF
--- a/ale_linters/ruby/rubocop.vim
+++ b/ale_linters/ruby/rubocop.vim
@@ -59,5 +59,4 @@ call ale#linter#Define('ruby', {
 \   'executable_callback': 'ale#handlers#rubocop#GetExecutable',
 \   'command_callback': 'ale_linters#ruby#rubocop#GetCommand',
 \   'callback': 'ale_linters#ruby#rubocop#Handle',
-\   'output_stream': 'both',
 \})


### PR DESCRIPTION
This will make Rubocop work even when there are warning messages being outputted to stderr, which does not impact the linting.

## Before:

![screenshot 2017-07-13 13 43 53](https://user-images.githubusercontent.com/962032/28177651-d8e740c8-67d1-11e7-9a41-eb8c8a125ddb.png)

It would stop the linting, even if there's a valid linter output.

## After:

![screenshot 2017-07-13 13 43 39](https://user-images.githubusercontent.com/962032/28177668-e90796c4-67d1-11e7-9e90-db5ed7c9e409.png)

Now it will disconsider any err outputted to stderr.