### PR TITLE
Add SyntaxErl linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ name. That seems to be the fairest way to arrange this table.
 | Elixir | [credo](https://github.com/rrrene/credo), [dogma](https://github.com/lpil/dogma) |
 | Elm | [elm-make](https://github.com/elm-lang/elm-make) |
 | Erb | [erb](https://github.com/jeremyevans/erubi) |
-| Erlang | [erlc](http://erlang.org/doc/man/erlc.html) |
+| Erlang | [erlc](http://erlang.org/doc/man/erlc.html), [SyntaxErl](https://github.com/ten0s/syntaxerl) |
 | Fortran | [gcc](https://gcc.gnu.org/) |
 | FusionScript | [fusion-lint](https://github.com/RyanSquared/fusionscript) |
 | Go | [gofmt -e](https://golang.org/cmd/gofmt/), [go vet](https://golang.org/cmd/vet/), [golint](https://godoc.org/github.com/golang/lint), [gometalinter](https://github.com/alecthomas/gometalinter), [go build](https://golang.org/cmd/go/), [gosimple](https://github.com/dominikh/go-tools/tree/master/cmd/gosimple), [staticcheck](https://github.com/dominikh/go-tools/tree/master/cmd/staticcheck) |

--- a/ale_linters/erlang/syntaxerl.vim
+++ b/ale_linters/erlang/syntaxerl.vim
@@ -1,0 +1,38 @@
+" Author: Dmitri Vereshchagin <dmitri.vereshchagin@gmail.com>
+" Description: SyntaxErl linter for Erlang files
+
+call ale#Set('erlang_syntaxerl_executable', 'syntaxerl')
+
+
+function! ale_linters#erlang#syntaxerl#GetExecutable(buffer) abort
+    return ale#Var(a:buffer, 'erlang_syntaxerl_executable')
+endfunction
+
+
+function! ale_linters#erlang#syntaxerl#GetCommand(buffer) abort
+    return ale_linters#erlang#syntaxerl#GetExecutable(a:buffer) . ' %t'
+endfunction
+
+
+function! ale_linters#erlang#syntaxerl#Handle(buffer, lines) abort
+    let l:pattern = '\v\C:(\d+):( warning:)? (.+)'
+    let l:loclist = []
+
+    for l:match in ale#util#GetMatches(a:lines, l:pattern)
+        call add(l:loclist, {
+        \   'lnum': l:match[1] + 0,
+        \   'text': l:match[3],
+        \   'type': empty(l:match[2]) ? 'E' : 'W',
+        \})
+    endfor
+
+    return l:loclist
+endfunction
+
+
+call ale#linter#Define('erlang', {
+\   'name': 'syntaxerl',
+\   'executable_callback': 'ale_linters#erlang#syntaxerl#GetExecutable',
+\   'command_callback': 'ale_linters#erlang#syntaxerl#GetCommand',
+\   'callback': 'ale_linters#erlang#syntaxerl#Handle',
+\})

--- a/doc/ale-erlang.txt
+++ b/doc/ale-erlang.txt
@@ -14,5 +14,16 @@ g:ale_erlang_erlc_options                           *g:ale_erlang_erlc_options*
   or `-pa`.
 
 
+-------------------------------------------------------------------------------
+syntaxerl                                                *ale-erlang-syntaxerl*
+
+g:ale_erlang_syntaxerl_executable           *g:ale_erlang_syntaxerl_executable*
+                                            *b:ale_erlang_syntaxerl_executable*
+  Type: |String|
+  Default: `'syntaxerl'`
+
+  This variable can be changed to specify the syntaxerl executable.
+
+
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -33,6 +33,7 @@ CONTENTS                                                         *ale-contents*
       cmakelint...........................|ale-cmake-cmakelint|
     erlang................................|ale-erlang-options|
       erlc................................|ale-erlang-erlc|
+      syntaxerl...........................|ale-erlang-syntaxerl|
     fortran...............................|ale-fortran-options|
       gcc.................................|ale-fortran-gcc|
     fusionscript..........................|ale-fuse-options|

--- a/test/handler/test_syntaxerl_handler.vader
+++ b/test/handler/test_syntaxerl_handler.vader
@@ -1,0 +1,24 @@
+Before:
+  runtime ale_linters/erlang/syntaxerl.vim
+
+After:
+  call ale#linter#Reset()
+
+Execute:
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 42,
+  \     'text': "syntax error before: ','",
+  \     'type': 'E',
+  \   },
+  \   {
+  \     'lnum': 42,
+  \     'text': 'function foo/0 is unused',
+  \     'type': 'W',
+  \   },
+  \ ],
+  \ ale_linters#erlang#syntaxerl#Handle(42, [
+  \   "/tmp/v2wDixk/1/module.erl:42: syntax error before: ','",
+  \   '/tmp/v2wDixk/2/module.erl:42: warning: function foo/0 is unused',
+  \ ])


### PR DESCRIPTION
These changes add [SyntaxErl][1] integration.  SyntaxErl is a syntax checker tool for Erlang.

[1]: https://github.com/ten0s/syntaxerl