### PR TITLE
Allow `perlcritic` linter notes to be shown as warnings

### DIFF
--- a/ale_linters/perl/perlcritic.vim
+++ b/ale_linters/perl/perlcritic.vim
@@ -13,6 +13,8 @@ let g:ale_perl_perlcritic_options =
 let g:ale_perl_perlcritic_showrules =
 \   get(g:, 'ale_perl_perlcritic_showrules', 0)
 
+call ale#Set('perl_perlcritic_as_warnings', 0)
+
 function! ale_linters#perl#perlcritic#GetExecutable(buffer) abort
     return ale#Var(a:buffer, 'perl_perlcritic_executable')
 endfunction
@@ -55,12 +57,14 @@ endfunction
 function! ale_linters#perl#perlcritic#Handle(buffer, lines) abort
     let l:pattern = '\(\d\+\):\(\d\+\) \(.\+\)'
     let l:output = []
+    let l:type = ale#Var(a:buffer, 'perl_perlcritic_as_warnings') ? 'W' : 'E'
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)
         call add(l:output, {
         \   'lnum': l:match[1],
         \   'col': l:match[2],
         \   'text': l:match[3],
+        \   'type': l:type,
         \})
     endfor
 

--- a/doc/ale-perl.txt
+++ b/doc/ale-perl.txt
@@ -25,8 +25,8 @@ g:ale_perl_perl_options                               *g:ale_perl_perl_options*
 ===============================================================================
 perlcritic                                                *ale-perl-perlcritic*
 
-g:ale_perl_perlcritic_executable              *g:ale_perl_perlcritic_executable*
-                                              *b:ale_perl_perlcritic_executable*
+g:ale_perl_perlcritic_executable             *g:ale_perl_perlcritic_executable*
+                                             *b:ale_perl_perlcritic_executable*
   Type: |String|
   Default: `'perlcritic'`
 
@@ -34,8 +34,8 @@ g:ale_perl_perlcritic_executable              *g:ale_perl_perlcritic_executable*
   linting perl.
 
 
-g:ale_perl_perlcritic_profile                    *g:ale_perl_perlcritic_profile*
-                                                 *b:ale_perl_perlcritic_profile*
+g:ale_perl_perlcritic_profile                   *g:ale_perl_perlcritic_profile*
+                                                *b:ale_perl_perlcritic_profile*
   Type: |String|
   Default: `'.perlcriticrc'`
 
@@ -52,8 +52,8 @@ g:ale_perl_perlcritic_profile                    *g:ale_perl_perlcritic_profile*
   |g:ale_perl_perlcritic_options| variable.
 
 
-g:ale_perl_perlcritic_options                    *g:ale_perl_perlcritic_options*
-                                                 *b:ale_perl_perlcritic_options*
+g:ale_perl_perlcritic_options                   *g:ale_perl_perlcritic_options*
+                                                *b:ale_perl_perlcritic_options*
   Type: |String|
   Default: `''`
 
@@ -68,6 +68,14 @@ g:ale_perl_perlcritic_showrules               *g:ale_perl_perlcritic_showrules*
 
   Controls whether perlcritic rule names are shown after the error message.
   Defaults to off to reduce length of message.
+
+
+g:ale_perl_perlcritic_as_warnings           *g:ale_perl_perlcritic_as_warnings*
+
+  Type: |Number|
+  Default: 0
+
+  Controls how linting notes are shown: 0 for errors, 1 for warnings.
 
 
 ===============================================================================


### PR DESCRIPTION
<!--
When creating new pull requests, please consider the following.

* Read the Contributing guide linked above first.
* If you are adding a new linter, remember to update the README.md file and
  doc/ale.txt first.
* If you add or modify a function for converting error lines into loclist items
  that ALE can work with, please add Vader tests for them. Look at existing
  tests in the test/handler directory, etc.
* If you add or modify a function for computing a command line string for
  running a command, please add Vader tests for that.
* Generally try and cover anything with Vader tests, although some things just
  can't be tested with Vader, or at least they can be hard to test. Consider
  breaking up your code so that some parts can be tested, and generally open up
  a discussion about it.
* Have fun!
-->

Some of us prefer to take `perlcritic`, well, not literally.  We
introduce a new variable, `g:ale_perl_perlcritic_as_warnings`, that
allows one to change the default handler behaviour from undefined
(effectively shows as errors) to warnings.