### PR TITLE
Workaround to get linting in cpp header files with clangtidy.

### DIFF
--- a/ale_linters/cpp/clangtidy.vim
+++ b/ale_linters/cpp/clangtidy.vim
@@ -1,5 +1,5 @@
 " Author: vdeurzen <tim@kompiler.org>, w0rp <devw0rp@gmail.com>,
-" gagbo <gagbobada@gmail.com>
+" gagbo <gagbobada@gmail.com>, phcerdan <pablo.hernandez.cerdan@outlook.com>
 " Description: clang-tidy linter for cpp files
 
 call ale#Set('cpp_clangtidy_executable', 'clang-tidy')
@@ -9,19 +9,27 @@ call ale#Set('cpp_clangtidy_checks', ['*'])
 " This will disable compile_commands.json detection.
 call ale#Set('cpp_clangtidy_options', '')
 call ale#Set('c_build_dir', '')
+" TODO: This can be common to all clang checkers requiring .cpp files.
+call ale#Set('cpp_clangtidy_header_suffixes', ['h', 'hpp', 'hxx', 'tcc'])
+" Set this option to handle options in case of header files.
+call ale#Set('cpp_clangtidy_header_sourcefile', '')
+" Set this option to set manually what file suffix is consider a header.
+" Set this option to manually set some options for clang-tidy.
 
 function! ale_linters#cpp#clangtidy#GetExecutable(buffer) abort
     return ale#Var(a:buffer, 'cpp_clangtidy_executable')
 endfunction
 
-function! s:GetBuildDirectory(buffer) abort
-    " Don't include build directory for header files, as compile_commands.json
-    " files don't consider headers to be translation units, and provide no
-    " commands for compiling header files.
-    if expand('#' . a:buffer) =~# '\v\.(h|hpp)$'
-        return ''
+function! ale_linters#cpp#clangtidy#IsHeader(buffer) abort
+    let l:search = '\v\.(' . join(ale#Var(a:buffer,'cpp_clangtidy_header_suffixes'), '|') . ')$'
+    if expand('#' . a:buffer) =~# l:search
+        return 1
     endif
 
+    return 0
+endfunction
+
+function! s:GetBuildDirectory(buffer) abort
     let l:build_dir = ale#Var(a:buffer, 'c_build_dir')
 
     " c_build_dir has the priority if defined
@@ -35,17 +43,45 @@ endfunction
 function! ale_linters#cpp#clangtidy#GetCommand(buffer) abort
     let l:checks = join(ale#Var(a:buffer, 'cpp_clangtidy_checks'), ',')
     let l:build_dir = s:GetBuildDirectory(a:buffer)
-
     " Get the extra options if we couldn't find a build directory.
     let l:options = empty(l:build_dir)
-    \   ? ale#Var(a:buffer, 'cpp_clangtidy_options')
-    \   : ''
+                \   ? ale#Var(a:buffer, 'cpp_clangtidy_options')
+                \   : ''
 
-    return ale#Escape(ale_linters#cpp#clangtidy#GetExecutable(a:buffer))
-    \   . (!empty(l:checks) ? ' -checks=' . ale#Escape(l:checks) : '')
-    \   . ' %s'
-    \   . (!empty(l:build_dir) ? ' -p ' . ale#Escape(l:build_dir) : '')
-    \   . (!empty(l:options) ? ' -- ' . l:options : '')
+    if !ale_linters#cpp#clangtidy#IsHeader(a:buffer)
+        return ale#Escape(ale_linters#cpp#clangtidy#GetExecutable(a:buffer))
+        \   . (!empty(l:checks) ? ' -checks=' . ale#Escape(l:checks) : '')
+        \   . ' %s'
+        \   . (!empty(l:build_dir) ? ' -p ' . ale#Escape(l:build_dir) : '')
+        \   . (!empty(l:options) ? ' -- ' . l:options : '')
+    else
+        let l:header_sourcefile = ale#Var(a:buffer, 'cpp_clangtidy_header_sourcefile')
+        " If no specific header options provided by user:
+        " Don't include build directory for header files, as compile_commands.json
+        " files don't consider headers to be translation units, and provide no
+        " commands for compiling header files.
+        " Use the same command as non-header files.
+        if empty(l:header_sourcefile)
+            let l:build_dir = ''
+            let l:options = ale#Var(a:buffer, 'cpp_clangtidy_options')
+            return ale#Escape(ale_linters#cpp#clangtidy#GetExecutable(a:buffer))
+            \   . (!empty(l:checks) ? ' -checks=' . ale#Escape(l:checks) : '')
+            \   . ' %s'
+            \   . (!empty(l:build_dir) ? ' -p ' . ale#Escape(l:build_dir) : '')
+            \   . (!empty(l:options) ? ' -- ' . l:options : '')
+        " If header_sourcefile: Don't use the current buffer as input! The user has to
+        " provide a source file (.cpp) to run the checker on it when editing
+        " the header.
+        " The build_dir is kept if present, the provided source file must be
+        " in the database.
+        else
+            return ale#Escape(ale_linters#cpp#clangtidy#GetExecutable(a:buffer))
+            \   . (!empty(l:checks) ? ' -checks=' . ale#Escape(l:checks) : '')
+            \   . (!empty(l:header_sourcefile) ? ' ' . ale#Escape(l:header_sourcefile) : '')
+            \   . (!empty(l:build_dir) ? ' -p ' . ale#Escape(l:build_dir) : '')
+            \   . (!empty(l:options) ? ' -- ' . l:options : '')
+        endif
+    endif
 endfunction
 
 call ale#linter#Define('cpp', {

--- a/doc/ale-cpp.txt
+++ b/doc/ale-cpp.txt
@@ -132,6 +132,39 @@ g:ale_cpp_clangtidy_options                       *g:ale_cpp_clangtidy_options*
   of the |g:ale_c_build_dir_names| directories of the project tree.
 
 
+g:ale_cpp_clangtidy_header_suffixes        *g:ale_cpp_clangtidy_header_suffixes*
+                                           *b:ale_cpp_clangtidy_header_suffixes*
+  Type: |List|
+  Default: `['h', 'hpp', 'hxx', 'tcc']`
+
+  What suffixes are considered headers.
+
+  Headers could have an extra logic if |g:ale_cpp_clangtidy_header_sourcefile|
+  is set.
+  If |g:ale_cpp_clangtidy_header_sourcefile| is empty, `compile_commands.json`
+  is ignored, even if it exists in |g:ale_c_build_dir_names|.
+
+g:ale_cpp_clangtidy_header_sourcefile      *g:ale_cpp_clangtidy_header_sourcefile*
+                                           *b:ale_cpp_clangtidy_header_sourcefile*
+  Type: |String|
+  Default: `''`
+
+  Headers in cpp are not in the `compile_commands.json`, so it is hard to
+  process them with current tools.
+
+  This option allow the user to choose a source file (a `.cpp`) that uses
+  the current header to get linting.
+
+  The source file can be set locally per buffer with:
+  `let b:ale_cpp_clangtidy_header_sourcefile = '/path/source.cpp'`
+  Or set |g:ale_pattern_options| in a project vimL file.
+  let g:ale_pattern_options = {
+    \   'my_favourite_header\.h$': {
+    \       'ale_linters': {'cpp': ['clangtidy']},
+    \       'ale_cpp_clangtidy_header_sourcefile': '/path/test_header.cpp',
+    \   },
+  \}
+
 ===============================================================================
 cppcheck                                                     *ale-cpp-cppcheck*
 

--- a/test/command_callback/test_clang_tidy_command_callback.vader
+++ b/test/command_callback/test_clang_tidy_command_callback.vader
@@ -9,6 +9,10 @@ Before:
   unlet! b:ale_cpp_clangtidy_checks
   unlet! g:ale_cpp_clangtidy_options
   unlet! b:ale_cpp_clangtidy_options
+  unlet! g:ale_cpp_clangtidy_header_suffixes
+  unlet! b:ale_cpp_clangtidy_header_suffixes
+  unlet! g:ale_cpp_clangtidy_header_sourcefile
+  unlet! b:ale_cpp_clangtidy_header_sourcefile
 
   runtime ale_linters/cpp/clangtidy.vim
 
@@ -19,6 +23,8 @@ After:
   unlet! b:ale_cpp_clangtidy_checks
   unlet! b:ale_cpp_clangtidy_options
   unlet! b:ale_cpp_clangtidy_executable
+  unlet! b:ale_cpp_clangtidy_header_suffixes
+  unlet! b:ale_cpp_clangtidy_header_sourcefile
 
   Restore
   call ale#linter#Reset()
@@ -70,22 +76,42 @@ Execute(The build directory setting should override the options):
   \   . ' -checks=''*'' %s -p ' . ale#Escape('/foo/bar'),
   \ ale_linters#cpp#clangtidy#GetCommand(bufnr(''))
 
-Execute(The build directory should be ignored for header files):
+Execute(The build directory should be ignored for header files with empty header_sourcefile):
   call ale#test#SetFilename('test.h')
 
   let b:ale_c_build_dir = '/foo/bar'
   let b:ale_cpp_clangtidy_options = '-Wall'
+  let b:ale_cpp_clangtidy_header_sourcefile = ''
+  let b:ale_cpp_clangtidy_header_suffixes = ['h', 'hpp', 'hxx']
 
   AssertEqual
   \ ale#Escape('clang-tidy')
   \   . ' -checks=''*'' %s -- -Wall',
   \ ale_linters#cpp#clangtidy#GetCommand(bufnr(''))
   \
-  call ale#test#SetFilename('test.hpp')
 
+  call ale#test#SetFilename('test.hpp')
   AssertEqual
   \ ale#Escape('clang-tidy')
   \   . ' -checks=''*'' %s -- -Wall',
+  \ ale_linters#cpp#clangtidy#GetCommand(bufnr(''))
+
+  call ale#test#SetFilename('test.hxx')
+  AssertEqual
+  \ ale#Escape('clang-tidy')
+  \   . ' -checks=''*'' %s -- -Wall',
+  \ ale_linters#cpp#clangtidy#GetCommand(bufnr(''))
+
+Execute(The header_sourcefile should be used when non-empty, not ignoring build_dir):
+  call ale#test#SetFilename('test.h')
+
+  let b:ale_c_build_dir = '/foo/bar'
+  let b:ale_cpp_clangtidy_options = '-Wall'
+  let b:ale_cpp_clangtidy_header_sourcefile = 'test.cpp'
+
+  AssertEqual
+  \ ale#Escape('clang-tidy')
+  \   . ' -checks=''*'' tests.cpp -p ' . ale#Escape('/foo/bar')',
   \ ale_linters#cpp#clangtidy#GetCommand(bufnr(''))
 
 Execute(The executable should be configurable):


### PR DESCRIPTION
Provide extra logic to handle header files in cpp.
Only using clangtidy, but same workaround will work in other clang checkers.

First, provide a list of headers suffixes:
By default:
let g:cpp_clangtidy_header_suffixes = ['h', 'hpp', 'hxx', 'tcc']
And then, use a variable specific for headers:
let b:cpp_clangtidy_header_sourcefile = ''

This variable should point to a source file (a .cpp) which uses the
current header.
This source file could be set by the user when editing the buffer, with
a simple:
let b:cpp_clangtidy_header_sourcefile

Or set a g:ale_pattern_options in a project vimL file.
let g:ale_pattern_options = {
      \   'my_favourite_header\.h$': {
      \       'ale_linters': {'cpp': ['clangtidy']},
      \       'ale_cpp_clangtidy_header_sourcefile': '/path/test_header.cpp',
      \   },
      \}

Related: #782

I have written vader tests, but not run them.
