### PR TITLE
Add support for tslint rules directory option

### DIFF
--- a/ale_linters/typescript/tslint.vim
+++ b/ale_linters/typescript/tslint.vim
@@ -55,6 +55,7 @@ function! ale_linters#typescript#tslint#BuildLintCommand(buffer) abort
     return ale_linters#typescript#tslint#GetExecutable(a:buffer)
     \   . ' --format json'
     \   . l:tslint_config_option
+    \   . l:tslint_rules_option
     \   . ' %t'
 endfunction
 

--- a/ale_linters/typescript/tslint.vim
+++ b/ale_linters/typescript/tslint.vim
@@ -45,7 +45,7 @@ function! ale_linters#typescript#tslint#BuildLintCommand(buffer) abort
     let l:tslint_config_option = !empty(l:tslint_config_path)
     \   ? ' -c ' . ale#Escape(l:tslint_config_path)
     \   : ''
-    
+
     let l:tslint_rules_dir = ale#Var(a:buffer, 'typescript_tslint_rules_dir')
 
     let l:tslint_rules_option = !empty(l:tslint_rules_dir)

--- a/ale_linters/typescript/tslint.vim
+++ b/ale_linters/typescript/tslint.vim
@@ -3,6 +3,7 @@
 
 call ale#Set('typescript_tslint_executable', 'tslint')
 call ale#Set('typescript_tslint_config_path', '')
+call ale#Set('typescript_tslint_rules_dir', '')
 call ale#Set('typescript_tslint_use_global', 0)
 
 function! ale_linters#typescript#tslint#GetExecutable(buffer) abort
@@ -44,6 +45,12 @@ function! ale_linters#typescript#tslint#BuildLintCommand(buffer) abort
     let l:tslint_config_option = !empty(l:tslint_config_path)
     \   ? ' -c ' . ale#Escape(l:tslint_config_path)
     \   : ''
+    
+    let l:tslint_rules_dir = ale#Var(a:buffer, 'typescript_tslint_rules_dir')
+
+    let l:tslint_rules_option = !empty(l:tslint_rules_dir)
+    \  ? ' -r ' . ale#Escape(l:tslint_rules_dir)
+    \  : ''
 
     return ale_linters#typescript#tslint#GetExecutable(a:buffer)
     \   . ' --format json'

--- a/ale_linters/typescript/tslint.vim
+++ b/ale_linters/typescript/tslint.vim
@@ -1,4 +1,4 @@
-" Author: Prashanth Chandra https://github.com/prashcr
+" Author: Prashanth Chandra <https://github.com/prashcr>, Jonathan Clem <https://jclem.net>
 " Description: tslint for TypeScript files
 
 call ale#Set('typescript_tslint_executable', 'tslint')

--- a/doc/ale-typescript.txt
+++ b/doc/ale-typescript.txt
@@ -28,6 +28,14 @@ g:ale_typescript_tslint_config_path       *g:ale_typescript_tslint_config_path*
 
   ALE will first discover the tslint.json path in an ancestor directory. If no
   such path exists, this variable will be used instead.
+  
+  
+g:ale_typescript_tslint_rules_dir         *g:ale_typescript_tslint_rules_dir*
+                                          *b:ale_typescript_tslint_rules_dir*
+  Type: |String|
+  Default: `''`
+
+  If this variable is set, ALE will use it as the rules directory for tslint.
 
 
 g:ale_typescript_tslint_use_global         *g:ale_typescript_tslint_use_global*


### PR DESCRIPTION
This adds support for the `-r`, or rules directory, option to the tslint linter.