### PR TITLE
Make executable and options configurable for hdevtools

### DIFF
--- a/ale_linters/haskell/hdevtools.vim
+++ b/ale_linters/haskell/hdevtools.vim
@@ -1,9 +1,22 @@
-" Author: rob-b
+" Author: rob-b, Takano Akio <tak@anoak.io>
 " Description: hdevtools for Haskell files
+
+call ale#Set('haskell_hdevtools_executable', 'hdevtools')
+call ale#Set('haskell_hdevtools_options', '-g -Wall')
+
+function! ale_linters#haskell#hdevtools#GetExecutable(buffer) abort
+    return ale#Var(a:buffer, 'haskell_hdevtools_executable')
+endfunction
+
+function! ale_linters#haskell#hdevtools#GetCommand(buffer) abort
+    return ale#Escape(ale_linters#haskell#hdevtools#GetExecutable(a:buffer))
+        \ . ' check ' . ale#Var(a:buffer, 'haskell_hdevtools_options')
+        \ . ' -p %s %t'
+endfunction
 
 call ale#linter#Define('haskell', {
 \   'name': 'hdevtools',
-\   'executable': 'hdevtools',
-\   'command': 'hdevtools check -g -Wall -p %s %t',
+\   'executable_callback': 'ale_linters#haskell#hdevtools#GetExecutable',
+\   'command_callback': 'ale_linters#haskell#hdevtools#GetCommand',
 \   'callback': 'ale#handlers#haskell#HandleGHCFormat',
 \})

--- a/doc/ale-haskell.txt
+++ b/doc/ale-haskell.txt
@@ -13,4 +13,22 @@ g:ale_haskell_stack_build_options           *g:ale_haskell_stack_build_options*
   programs will be slower unless you separately rebuild them outside of ALE.
 
 ===============================================================================
+hdevtools                                               *ale-haskell-hdevtools*
+
+g:ale_haskell_hdevtools_executable         *g:ale_haskell_hdevtools_executable*
+                                           *b:ale_haskell_hdevtools_executable*
+  Type: |String|
+  Default: `'hdevtools'`
+
+  This variable can be changed to use a different executable for hdevtools.
+
+
+g:ale_haskell_hdevtools_options               *g:ale_haskell_hdevtools_options*
+                                              *b:ale_haskell_hdevtools_options*
+  Type: |String|
+  Default: `'-g -Wall'`
+
+  This variable can be changed to modify flags given to hdevtools.
+
+===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/test/command_callback/test_haskell_hdevtools_command_callbacks.vader
+++ b/test/command_callback/test_haskell_hdevtools_command_callbacks.vader
@@ -1,0 +1,37 @@
+Before:
+  Save g:ale_haskell_hdevtools_executable
+  Save g:ale_haskell_hdevtools_options
+
+  unlet! g:ale_haskell_hdevtools_executable
+  unlet! b:ale_haskell_hdevtools_executable
+  unlet! g:ale_haskell_hdevtools_options
+  unlet! b:ale_haskell_hdevtools_options
+
+  runtime ale_linters/haskell/hdevtools.vim
+
+  let b:command_tail = ' check -g -Wall -p %s %t'
+
+After:
+  Restore
+  unlet! b:command_tail
+  unlet! b:ale_haskell_hdevtools_executable
+  unlet! b:ale_haskell_hdevtools_options
+  call ale#linter#Reset()
+
+Execute(The executable should be configurable):
+  AssertEqual 'hdevtools', ale_linters#haskell#hdevtools#GetExecutable(bufnr(''))
+
+  let b:ale_haskell_hdevtools_executable = 'foobar'
+
+  AssertEqual 'foobar', ale_linters#haskell#hdevtools#GetExecutable(bufnr(''))
+
+Execute(The executable should be used in the command):
+  AssertEqual
+  \ ale#Escape('hdevtools') . b:command_tail,
+  \ ale_linters#haskell#hdevtools#GetCommand(bufnr(''))
+
+  let b:ale_haskell_hdevtools_executable = 'foobar'
+
+  AssertEqual
+  \ ale#Escape('foobar') . b:command_tail,
+  \ ale_linters#haskell#hdevtools#GetCommand(bufnr(''))


### PR DESCRIPTION
This patch adds the two configuration variables, `g:ale_haskell_hdevtools_executable` and `g:ale_haskell_hdevtools_options`.