### PR TITLE
Proselint and standard vars

### DIFF
--- a/ale_linters/help/proselint.vim
+++ b/ale_linters/help/proselint.vim
@@ -1,9 +1,4 @@
 " Author: Daniel M. Capella https://github.com/polyzen
 " Description: proselint for Vim help files
 
-call ale#linter#Define('help', {
-\   'name': 'proselint',
-\   'executable': 'proselint',
-\   'command': 'proselint %t',
-\   'callback': 'ale#handlers#unix#HandleAsWarning',
-\})
+call ale#proselint#Define('help')

--- a/autoload/ale/linter/util.vim
+++ b/autoload/ale/linter/util.vim
@@ -1,0 +1,20 @@
+" Author: Chris Weyl <cweyl@alumni.drew.edu>
+
+" This is a collection of utility functions largely aimed at consolidating
+" some common functionality in one place.
+
+function! ale#linter#util#SetStandardVars(linter, executable) abort
+    call ale#Set(a:linter.'_executable', a:executable)
+    call ale#Set(a:linter.'_options', '')
+    return
+endfunction
+
+function! ale#linter#util#GetBufExec(buffer, linter) abort
+    return ale#Var(a:buffer, a:linter.'_executable')
+endfunction
+
+function! ale#linter#util#GetCommand(buffer, linter) abort
+    let l:command = ale#Escape(ale#Var(a:buffer, a:linter.'_executable')) . ' '
+    \  . ale#Var(a:buffer, a:linter.'_options') . ' %t'
+    return l:command
+endfunction

--- a/autoload/ale/proselint.vim
+++ b/autoload/ale/proselint.vim
@@ -1,0 +1,15 @@
+" Author: Chris Weyl <cweyl@alumni.drew.edu>
+" Description: Helper functions for proselint filters
+
+" What: define a standard proselint linter via one function
+function! ale#proselint#Define(filetype) abort
+
+    call ale#linter#util#SetStandardVars(a:filetype.'_proselint', 'proselint')
+
+    call ale#linter#Define(a:filetype, {
+    \   'name':                'proselint',
+    \   'executable_callback': { buffer -> ale#linter#util#GetBufExec(buffer, a:filetype.'_proselint') },
+    \   'command_callback':    { buffer -> ale#linter#util#GetCommand(buffer, a:filetype.'_proselint') },
+    \   'callback':            'ale#handlers#unix#HandleAsWarning',
+    \})
+endfunction

--- a/doc/ale-help.txt
+++ b/doc/ale-help.txt
@@ -1,0 +1,25 @@
+===============================================================================
+ALE Help Integration                                         *ale-help-options*
+
+
+===============================================================================
+help                                                       *ale-help-proselint*
+
+g:ale_help_proselint_executable               *g:ale_help_proselint_executable*
+                                              *b:ale_help_proselint_executable*
+  Type: |String|
+  Default: `'proselint'`
+
+  See |g:ale_{ft}_{name}_executable|.
+
+
+g:ale_help_proselint_options                     *g:ale_help_proselint_options*
+                                                 *b:ale_help_proselint_options*
+  Type: |String|
+  Default: `''`
+
+  See |g:ale_{ft}_{name}_options|.
+
+
+===============================================================================
+  vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -10,6 +10,7 @@ CONTENTS                                                         *ale-contents*
   2. Supported Languages & Tools..........|ale-support|
   3. Global Options.......................|ale-options|
     3.1 Highlights........................|ale-highlights|
+    3.2 "Standard" linter variables.......|ale-standard-linter-variables|
   4. Fixing Problems......................|ale-fix|
   5. Integration Documentation............|ale-integrations|
     asm...................................|ale-asm-options|
@@ -944,6 +945,36 @@ ALEWarningSign                                                 *ALEWarningSign*
   Default: `highlight link ALEWarningSign todo`
 
   The highlight used for warning signs. See |g:ale_set_signs|.
+
+
+-------------------------------------------------------------------------------
+3.2. "Standard" linter variables                *ale-standard-linter-variables*
+
+Some ALE linters use a standard set of variables to control their behaviour,
+most notably the executable used and any additional options to be passed.
+While not universally supported by all linters these are being documented here
+to spare having multiple copies of this documentation copied (and recopied)
+between the linters.
+
+Linters that honor these variables will have them documented in their
+linter-specific help. See, e.g., |g:ale_help_proselint_executable|.
+
+
+g:ale_{ft}_{name}_executable                     *g:ale_{ft}_{name}_executable*
+                                                 *b:ale_{ft}_{name}_executable*
+  Type: |String|
+  Default: `depends on the linter`
+
+  This variable can be changed to modify the executable used for linting.
+
+
+g:ale_{ft}_{name}_options                           *g:ale_{ft}_{name}_options*
+                                                    *b:ale_{ft}_{name}_options*
+  Type: |String|
+  Default: `depends on the linter`
+
+  This variable can be changed to alter the command-line arguments used to
+  invoke the linter.
 
 
 ===============================================================================


### PR DESCRIPTION
This pull request introduces two things:  the concept of a set of "standard linter variables" and functionality, and a central means to define a `proselint` linter.  Both of these come out of work I've been doing to more capably support running linters inside containers, yet are sufficiently generic so as to be generally useful.  This PR is intended to introduce these ideas, and open things up for discussion.

The standard functionality introduced is aimed at making certain common things -- for now, executable and options -- easy.  Using a function like `ale#linter#util#SetStandardVars()` ensures that every calling linter can be expected to have these variables defined, and makes it easy to introduce new variables (e.g. `...image`, `..._use_docker`, etc) without having to go back and touch each linter.

The standard vars introduced here are:

 * `g:ale_{ft}_{linter}_executable`
 * `g:ale_{ft}_{linter}_options`

These variables have been slowly making their way into a significant number of linters, completely independent of this PR.

Documentation of these variables is centralized -- no sense in copy and pasting the same docs everywhere.  Linters using this setup can refer to the general documentation from their specific help text; e.g. the proselint linter converted does just that.

Note that the neovim tests will fail until #806 is merged and the image rebuilt.
