### PR TITLE
Suppress warning about .eslintignore'd file

### DIFF
--- a/autoload/ale/handlers/eslint.vim
+++ b/autoload/ale/handlers/eslint.vim
@@ -82,6 +82,10 @@ function! ale#handlers#eslint#Handle(buffer, lines) abort
         let l:type = 'Error'
         let l:text = l:match[3]
 
+        if l:text == 'File ignored because of a matching ignore pattern. Use "--no-ignore" to override.'
+            continue
+        endif
+
         " Take the error type from the output if available.
         if !empty(l:match[4])
             let l:type = split(l:match[4], '/')[0]

--- a/autoload/ale/handlers/eslint.vim
+++ b/autoload/ale/handlers/eslint.vim
@@ -82,7 +82,7 @@ function! ale#handlers#eslint#Handle(buffer, lines) abort
         let l:type = 'Error'
         let l:text = l:match[3]
 
-        if l:text == 'File ignored because of a matching ignore pattern. Use "--no-ignore" to override.'
+        if l:text is# 'File ignored because of a matching ignore pattern. Use "--no-ignore" to override.'
             continue
         endif
 

--- a/autoload/ale/handlers/eslint.vim
+++ b/autoload/ale/handlers/eslint.vim
@@ -4,6 +4,7 @@
 call ale#Set('javascript_eslint_options', '')
 call ale#Set('javascript_eslint_executable', 'eslint')
 call ale#Set('javascript_eslint_use_global', 0)
+call ale#Set('javascript_eslint_suppress_eslintignore', 0)
 
 function! ale#handlers#eslint#GetExecutable(buffer) abort
     return ale#node#FindExecutable(a:buffer, 'javascript_eslint', [
@@ -82,8 +83,10 @@ function! ale#handlers#eslint#Handle(buffer, lines) abort
         let l:type = 'Error'
         let l:text = l:match[3]
 
-        if l:text is# 'File ignored because of a matching ignore pattern. Use "--no-ignore" to override.'
-            continue
+        if ale#Var(a:buffer, 'javascript_eslint_suppress_eslintignore')
+            if l:text is# 'File ignored because of a matching ignore pattern. Use "--no-ignore" to override.'
+                continue
+            endif
         endif
 
         " Take the error type from the output if available.

--- a/doc/ale-javascript.txt
+++ b/doc/ale-javascript.txt
@@ -50,6 +50,16 @@ g:ale_javascript_eslint_use_global         *g:ale_javascript_eslint_use_global*
   See |ale-integrations-local-executables|
 
 
+g:ale_javascript_eslint_suppress_eslintignore
+                                *g:ale_javascript_eslint_suppress_eslintignore*
+                                *b:ale_javascript_eslint_suppress_eslintignore*
+  Type: |Number|
+  Default: `0`
+
+  This variable can be set to disable the warning that linting is disabled on
+  the current file due to being covered by `.eslintignore`.
+
+
 ===============================================================================
 prettier                                              *ale-javascript-prettier*
 

--- a/test/eslint-test-files/eslintignore/ignored.js
+++ b/test/eslint-test-files/eslintignore/ignored.js
@@ -1,0 +1,1 @@
+var foo = "bar";

--- a/test/test_eslint_suppress_eslintignore.vader
+++ b/test/test_eslint_suppress_eslintignore.vader
@@ -1,0 +1,38 @@
+Before:
+  Save g:ale_javascript_eslint_suppress_eslintignore
+
+  call ale#test#SetDirectory('/testplugin/test')
+
+  runtime ale_linters/javascript/eslint.vim
+
+After:
+  Restore
+
+  call ale#test#RestoreDirectory()
+  call ale#linter#Reset()
+
+Execute(eslint should warn about ignored file):
+  call ale#test#SetFilename('eslint-test-files/eslintignore/ignore.js')
+
+  AssertEqual
+  \ [{
+  \    'lnum': 0,
+  \    'col': 0,
+  \    'type': 'W',
+  \    'text': 'File ignored because of a matching ignore pattern. Use "--no-ignore" to override. [Warning]'
+  \ }],
+  \ ale#handlers#eslint#Handle(347, [
+  \  '/path/to/some/ignored.js:0:0: File ignored because of a matching ignore pattern. Use "--no-ignore" to override. [Warning]',
+  \ ])
+
+
+Execute(eslint should not warn about ignored file when configured):
+  let g:ale_javascript_eslint_suppress_eslintignore = 1
+
+  call ale#test#SetFilename('eslint-test-files/eslintignore/ignore.js')
+
+  AssertEqual
+  \ [],
+  \ ale#handlers#eslint#Handle(347, [
+  \  '/path/to/some/ignored.js:0:0: File ignored because of a matching ignore pattern. Use "--no-ignore" to override. [Warning]',
+  \ ])


### PR DESCRIPTION
`eslint` currently issues a warning when a file has been excluded by `.eslintignore`. Ale sees this warning and renders it, which is somewhat pointless and annoying. This change suppresses that warning, which makes it easier to focus on actual lint errors on the file exposed by other linters, e.g. `tslint`

I don't really care for how fragile this implementation is, but I couldn't find any flags that I could pass to eslint (either directly or via its config file) to prevent them from showing up at all. Most suggestions I found on github and SO said to use `--quiet`, but that will remove *all* warnings which is not desirable.