### PR TITLE
	 Default flake8 to --format=default

### DIFF
--- a/ale_linters/python/flake8.vim
+++ b/ale_linters/python/flake8.vim
@@ -80,6 +80,7 @@ function! ale_linters#python#flake8#GetCommand(buffer, version_output) abort
     \   : ''
 
     let l:options = ale#Var(a:buffer, 'python_flake8_options')
+    \   . ' --format=default'
 
     return ale#Escape(ale_linters#python#flake8#GetExecutable(a:buffer))
     \   . (!empty(l:options) ? ' ' . l:options : '')

--- a/test/command_callback/test_flake8_command_callback.vader
+++ b/test/command_callback/test_flake8_command_callback.vader
@@ -19,23 +19,23 @@ Execute(The flake8 callbacks should return the correct default values):
   \ '''flake8'' --version',
   \ ale_linters#python#flake8#VersionCheck(bufnr(''))
   AssertEqual
-  \ '''flake8'' --stdin-display-name %s -',
+  \ '''flake8''  --format=default --stdin-display-name %s -',
   \ ale_linters#python#flake8#GetCommand(bufnr(''), ['3.0.0'])
   " Try with older versions.
   call ale_linters#python#flake8#ClearVersionCache()
   AssertEqual
-  \ '''flake8'' -',
+  \ '''flake8''  --format=default -',
   \ ale_linters#python#flake8#GetCommand(bufnr(''), ['2.9.9'])
 
 Execute(The flake8 command callback should let you set options):
   let g:ale_python_flake8_options = '--some-option'
 
   AssertEqual
-  \ '''flake8'' --some-option --stdin-display-name %s -',
+  \ '''flake8'' --some-option --format=default --stdin-display-name %s -',
   \ ale_linters#python#flake8#GetCommand(bufnr(''), ['3.0.4'])
   call ale_linters#python#flake8#ClearVersionCache()
   AssertEqual
-  \ '''flake8'' --some-option -',
+  \ '''flake8'' --some-option --format=default -',
   \ ale_linters#python#flake8#GetCommand(bufnr(''), ['2.9.9'])
 
 Execute(You should be able to set a custom executable and it should be escaped):
@@ -48,7 +48,7 @@ Execute(You should be able to set a custom executable and it should be escaped):
   \ '''executable with spaces'' --version',
   \ ale_linters#python#flake8#VersionCheck(bufnr(''))
   AssertEqual
-  \ '''executable with spaces'' --stdin-display-name %s -',
+  \ '''executable with spaces''  --format=default --stdin-display-name %s -',
   \ ale_linters#python#flake8#GetCommand(bufnr(''), ['3.0.0'])
 
 Execute(The flake8 callbacks should detect virtualenv directories):
@@ -62,7 +62,7 @@ Execute(The flake8 callbacks should detect virtualenv directories):
   \ ale_linters#python#flake8#VersionCheck(bufnr(''))
   AssertEqual
   \   '''' . g:dir . '/python_paths/with_virtualenv/env/bin/flake8'''
-  \   . ' --stdin-display-name %s -',
+  \   . '  --format=default --stdin-display-name %s -',
   \ ale_linters#python#flake8#GetCommand(bufnr(''), ['3.0.0'])
 
 Execute(The FindProjectRoot should detect the project root directory for namespace package via Manifest.in):
@@ -114,7 +114,7 @@ Execute(Using `python -m flake8` should be supported for running flake8):
   \ '''python'' -m flake8 --version',
   \ ale_linters#python#flake8#VersionCheck(bufnr(''))
   AssertEqual
-  \ '''python'' -m flake8 --some-option -',
+  \ '''python'' -m flake8 --some-option --format=default -',
   \ ale_linters#python#flake8#GetCommand(bufnr(''), ['2.9.9'])
 
   call ale_linters#python#flake8#ClearVersionCache()
@@ -129,5 +129,5 @@ Execute(Using `python -m flake8` should be supported for running flake8):
   \ '''python'' -m flake8 --version',
   \ ale_linters#python#flake8#VersionCheck(bufnr(''))
   AssertEqual
-  \ '''python''   -m flake8 --some-option -',
+  \ '''python''   -m flake8 --some-option --format=default -',
   \ ale_linters#python#flake8#GetCommand(bufnr(''), ['2.9.9'])


### PR DESCRIPTION
EDIT: The solution to this problem has changed, scroll down further in this PR and look at the diffs

`let g:ale_python_flake8_options = '--format=pylint'` will cause Ale to not properly parse the error message. As an example, consider file asdf.py

```python
def asdf:
```

```
bash-3.2$ flake8 --format=pylint asdf.py
asdf.py:1: [E999] SyntaxError: invalid syntax
bash-3.2$ flake8 --format=default asdf.py
asdf.py:1:9: E999 SyntaxError: invalid syntax
```
The issue here is the `pylint` format will include the square brackets around the error number, e.g `[E999]` vs `E999`. The regex setup for parsing the code for flake8 won't be able to properly parse this and won't show the error message. I added an optional opening/closing square brackets in the `pattern` to allow for this regex to catch this type of format as well.

I'm still a bit iffy on the test cases
