### PR TITLE
Rubocop fixer now uses g:ale_ruby_rubocop_options

### DIFF
--- a/autoload/ale/fixers/rubocop.vim
+++ b/autoload/ale/fixers/rubocop.vim
@@ -7,7 +7,8 @@ function! ale#fixers#rubocop#GetCommand(buffer) abort
 
     return ale#Escape(l:executable) . l:exec_args
     \   . (!empty(l:config) ? ' --config ' . ale#Escape(l:config) : '')
-    \   . ' --auto-correct %t'
+    \   . ' --auto-correct %t '
+    \   . ale#Var(a:buffer, 'ruby_rubocop_options')
 
 endfunction
 

--- a/test/fixers/test_rubocop_fixer_callback.vader
+++ b/test/fixers/test_rubocop_fixer_callback.vader
@@ -21,7 +21,7 @@ Execute(The rubocop callback should return the correct default values):
   \ {
   \   'read_temporary_file': 1,
   \   'command': ale#Escape(g:ale_ruby_rubocop_executable)
-  \     . ' --auto-correct %t',
+  \     . ' --auto-correct %t ',
   \ },
   \ ale#fixers#rubocop#Fix(bufnr(''))
 
@@ -33,6 +33,19 @@ Execute(The rubocop callback should include configuration files):
   \   'read_temporary_file': 1,
   \   'command': ale#Escape(g:ale_ruby_rubocop_executable)
   \     . ' --config ' . ale#Escape(g:dir . '/ruby_paths/with_config/.rubocop.yml')
-  \     . ' --auto-correct %t',
+  \     . ' --auto-correct %t ',
+  \ },
+  \ ale#fixers#rubocop#Fix(bufnr(''))
+
+Execute(The rubocop callback should include custom rubocop options):
+  let g:ale_ruby_rubocop_options = '--except Lint/Debugger'
+  call ale#test#SetFilename('ruby_paths/with_config/dummy.rb')
+
+  AssertEqual
+  \ {
+  \   'read_temporary_file': 1,
+  \   'command': ale#Escape(g:ale_ruby_rubocop_executable)
+  \     . ' --config ' . ale#Escape(g:dir . '/ruby_paths/with_config/.rubocop.yml')
+  \     . ' --auto-correct %t --except Lint/Debugger',
   \ },
   \ ale#fixers#rubocop#Fix(bufnr(''))


### PR DESCRIPTION
This fixes #840, which I just reported

It turns out the fix was really simple. However, I'm unsure how to write tests for this (I'm not all that familiar with Vader). I can try to look into this again later (got no time at the moment), or if someone else wants to take a look at it I'd also appreciate it