### PR TITLE
Add support for SwiftFormat as a fixer

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ name. That seems to be the fairest way to arrange this table.
 | SML | [smlnj](http://www.smlnj.org/) |
 | Stylus | [stylelint](https://github.com/stylelint/stylelint) |
 | SQL | [sqlint](https://github.com/purcell/sqlint) |
-| Swift | [swiftlint](https://swift.org/) |
+| Swift | [swiftlint](https://github.com/realm/SwiftLint) |
 | Tcl | [nagelfar](http://nagelfar.sourceforge.net)|
 | Texinfo | [proselint](http://proselint.com/)|
 | Text^ | [proselint](http://proselint.com/), [vale](https://github.com/ValeLint/vale) |

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ name. That seems to be the fairest way to arrange this table.
 | SML | [smlnj](http://www.smlnj.org/) |
 | Stylus | [stylelint](https://github.com/stylelint/stylelint) |
 | SQL | [sqlint](https://github.com/purcell/sqlint) |
-| Swift | [swiftlint](https://github.com/realm/SwiftLint) |
+| Swift | [swiftlint](https://github.com/realm/SwiftLint), [swiftformat](https://github.com/nicklockwood/SwiftFormat) |
 | Tcl | [nagelfar](http://nagelfar.sourceforge.net)|
 | Texinfo | [proselint](http://proselint.com/)|
 | Text^ | [proselint](http://proselint.com/), [vale](https://github.com/ValeLint/vale) |

--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -72,6 +72,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['css', 'sass', 'scss', 'stylus'],
 \       'description': 'Fix stylesheet files using stylelint --fix.',
 \   },
+\   'swiftformat': {
+\       'function': 'ale#fixers#swiftformat#Fix',
+\       'suggested_filetypes': ['swift'],
+\       'description': 'Apply SwiftFormat to a file.',
+\   },
 \}
 
 " Reset the function registry to the default entries.

--- a/autoload/ale/fixers/swiftformat.vim
+++ b/autoload/ale/fixers/swiftformat.vim
@@ -1,0 +1,25 @@
+" Author: gfontenot (Gordon Fontenot) <gordon@fonten.io>
+" Description: Integration of SwiftFormat with ALE.
+
+call ale#Set('swift_swiftformat_executable', 'swiftformat')
+call ale#Set('swift_swiftformat_use_global', 0)
+call ale#Set('swift_swiftformat_options', '')
+
+function! ale#fixers#swiftformat#GetExecutable(buffer) abort
+    return ale#node#FindExecutable(a:buffer, 'swift_swiftformat', [
+    \   'Pods/SwiftFormat/CommandLineTool/swiftformat',
+    \   'ios/Pods/SwiftFormat/CommandLineTool/swiftformat',
+    \   'swiftformat',
+    \])
+endfunction
+
+function! ale#fixers#swiftformat#Fix(buffer) abort
+    let l:options = ale#Var(a:buffer, 'swift_swiftformat_options')
+
+    return {
+    \   'read_temporary_file': 1,
+    \   'command': ale#Escape(ale#fixers#swiftformat#GetExecutable(a:buffer))
+    \       . ' %t'
+    \       . ' ' . l:options,
+    \}
+endfunction

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -224,7 +224,7 @@ The following languages and tools are supported.
 * SML: 'smlnj'
 * Stylus: 'stylelint'
 * SQL: 'sqlint'
-* Swift: 'swiftlint'
+* Swift: 'swiftlint', 'swiftformat'
 * Texinfo: 'proselint'
 * Text: 'proselint', 'vale'
 * TypeScript: 'eslint', 'tslint', 'tsserver', 'typecheck'

--- a/test/fixers/test_swiftformat_fixer_callback.vader
+++ b/test/fixers/test_swiftformat_fixer_callback.vader
@@ -1,0 +1,38 @@
+Before:
+  Save g:ale_swift_swiftformat_executable
+
+  " Use an invalid global executable, so we don't match it.
+  let g:ale_swift_swiftformat_executable = 'xxxinvalid'
+
+  call ale#test#SetDirectory('/testplugin/test/fixers')
+  silent cd ..
+  silent cd command_callback
+  let g:dir = getcwd()
+
+After:
+  Restore
+
+  call ale#test#RestoreDirectory()
+
+Execute(The swiftformat callback should return the correct default values):
+  call ale#test#SetFilename('swift_paths/dummy.swift')
+
+  AssertEqual
+  \ {
+  \   'read_temporary_file': 1,
+  \   'command': ale#Escape(g:ale_swift_swiftformat_executable)
+  \     . ' %t ',
+  \ },
+  \ ale#fixers#swiftformat#Fix(bufnr(''))
+
+Execute(The swiftformat callback should include any additional options):
+  call ale#test#SetFilename('swift_paths/dummy.swift')
+  let g:ale_swift_swiftformat_options = '--some-option'
+
+  AssertEqual
+  \ {
+  \   'read_temporary_file': 1,
+  \   'command': ale#Escape(g:ale_swift_swiftformat_executable)
+  \     . ' %t --some-option',
+  \ },
+  \ ale#fixers#swiftformat#Fix(bufnr(''))


### PR DESCRIPTION
SwiftFormat is a tool that can be used to format Swift files. This commit
adds support for using SwiftFormat as a fixer from ALE. It looks for
executables in the Pods directory, then the Pods directory for a React
Native project, then finally falls back to the globally installed instance
if neither of those were found.

https://github.com/nicklockwood/SwiftFormat