### PR TITLE
Make ghc-mod linter check current buffer

### DIFF
--- a/ale_linters/haskell/ghc-mod.vim
+++ b/ale_linters/haskell/ghc-mod.vim
@@ -4,13 +4,13 @@
 call ale#linter#Define('haskell', {
 \   'name': 'ghc-mod',
 \   'executable': 'ghc-mod',
-\   'command': 'ghc-mod check %t',
+\   'command': 'ghc-mod --map-file %s=%t check %s',
 \   'callback': 'ale#handlers#haskell#HandleGHCFormat',
 \})
 
 call ale#linter#Define('haskell', {
 \   'name': 'stack-ghc-mod',
 \   'executable': 'stack',
-\   'command': 'stack exec ghc-mod check %t',
+\   'command': 'stack exec ghc-mod --map-file %s=%t check %s',
 \   'callback': 'ale#handlers#haskell#HandleGHCFormat',
 \})


### PR DESCRIPTION
Right now ghc-mod linter check temp file instead of current buffer,
which cause the problem that it can't detect cabal file and raise
missing package error.

IP/s: try to look at the test but can't find ghc-mod specific test.

<!--
READ THIS: Before creating a pull request, please consider the following first.

* The most important thing you can do is write tests. Code without tests
  probably doesn't work, and will almost certainly stop working later on.
* Read the Contributing guide linked above first.
* If you are adding a new linter, remember to update the README.md file and
  doc/ale.txt first.
* If you add or modify a function for converting error lines into loclist items
  that ALE can work with, please add Vader tests for them. Look at existing
  tests in the test/handler directory, etc.
* If you add or modify a function for computing a command line string for
  running a command, please add Vader tests for that.
* Generally try and cover anything with Vader tests, although some things just
  can't be tested with Vader, or at least they can be hard to test. Consider
  breaking up your code so that some parts can be tested, and generally open up
  a discussion about it.
* Have fun!
-->
