### PR TITLE
Fix bug with ALEPrevious for blank lines.

### DIFF
--- a/autoload/ale/loclist_jumping.vim
+++ b/autoload/ale/loclist_jumping.vim
@@ -32,7 +32,7 @@ function! ale#loclist_jumping#FindNearest(direction, wrap) abort
         \   {
         \       'bufnr': bufnr(''),
         \       'lnum': l:item.lnum,
-        \       'col': min([max([l:item.col, 1]), len(getline(l:item.lnum))]),
+        \       'col': min([max([l:item.col, 1]), max([len(getline(l:item.lnum)), 1])]),
         \   },
         \   l:search_item
         \)

--- a/test/test_loclist_jumping.vader
+++ b/test/test_loclist_jumping.vader
@@ -32,6 +32,7 @@ After:
 Given foobar (Some imaginary filetype):
   12345678
   12345678
+  
 
 Execute(loclist jumping should jump correctly when not wrapping):
   AssertEqual [2, 1], TestJump('before', 0, [2, 2])
@@ -74,3 +75,12 @@ Execute(We shouldn't move when jumping to the first item where there are none):
   let g:ale_buffer_info[bufnr('%')].loclist = []
 
   AssertEqual [1, 6], TestJump(0, 0, [1, 6])
+
+Execute(We should be able to jump when the error line is blank):
+  call add(g:ale_buffer_info[bufnr('%')].loclist, {'bufnr': bufnr(''), 'lnum': 3, 'col': 1})
+
+  AssertEqual 0, len(getline(3))
+  AssertEqual [2, 8], TestJump('before', 0, [3, 1])
+  AssertEqual [2, 8], TestJump('before', 1, [3, 1])
+  AssertEqual [3, 1], TestJump('after', 0, [3, 1])
+  AssertEqual [1, 2], TestJump('after', 1, [3, 1])


### PR DESCRIPTION
ALEPrevious (as well as ALEPreviousWrap) does not work if there is an
error in empty line like 'W391: blank line at end of file' in python.

<!--
READ THIS: Before creating a pull request, please consider the following first.

* The most important thing you can do is write tests. Code without tests
  probably doesn't work, and will almost certainly stop working later on.
* Read the Contributing guide linked above first.
* If you are adding a new linter, remember to update the README.md file and
  doc/ale.txt first.
* If you add or modify a function for converting error lines into loclist items
  that ALE can work with, please add Vader tests for them. Look at existing
  tests in the test/handler directory, etc.
* If you add or modify a function for computing a command line string for
  running a command, please add Vader tests for that.
* Generally try and cover anything with Vader tests, although some things just
  can't be tested with Vader, or at least they can be hard to test. Consider
  breaking up your code so that some parts can be tested, and generally open up
  a discussion about it.
* Have fun!
-->
