### PR TITLE
`lintr` options

### DIFF
--- a/ale_linters/r/lintr.vim
+++ b/ale_linters/r/lintr.vim
@@ -3,7 +3,7 @@
 
 function! ale_linters#r#lintr#GetCommand(buffer) abort
     return ale#path#BufferCdString(a:buffer)
-    \   . 'Rscript -e ' . ale#Escape('lintr::lint(commandArgs(TRUE))') . ' %t'
+    \   . 'Rscript -e ' . ale#Escape('lintr::lint(commandArgs(TRUE), linters = lintr::with_defaults(object_usage_linter = NULL))') . ' %t'
 endfunction
 
 call ale#linter#Define('r', {

--- a/ale_linters/r/lintr.vim
+++ b/ale_linters/r/lintr.vim
@@ -1,9 +1,14 @@
 " Author: Michel Lang <michellang@gmail.com>, w0rp <devw0rp@gmail.com>
 " Description: This file adds support for checking R code with lintr.
 
+let g:ale_r_lintr_options =
+\   get(g:, 'ale_r_lintr_options', 'lintr::with_defaults()')
+" A reasonable alternative default:
+" \   get(g:, 'ale_r_lintr_options', 'lintr::with_defaults(object_usage_linter = NULL)')
+
 function! ale_linters#r#lintr#GetCommand(buffer) abort
     return ale#path#BufferCdString(a:buffer)
-    \   . 'Rscript -e ' . ale#Escape('lintr::lint(commandArgs(TRUE), linters = lintr::with_defaults(object_usage_linter = NULL))') . ' %t'
+    \   . 'Rscript -e ' . ale#Escape('lintr::lint(commandArgs(TRUE)[1], eval(parse(text = commandArgs(TRUE)[2])))') . ' %t' . ' ' . ale#Escape(ale#Var(a:buffer, 'r_lintr_options'))
 endfunction
 
 call ale#linter#Define('r', {


### PR DESCRIPTION
Hi,

I'm not really proficient in VimScript or vader, so I would greatly appreciate if someone could help me write tests for this, but I *think* that I allowed for linters to be set for `lintr` for `R` files. So far it's been working for me (informally), with the following line in my `vimrc`:
```
let·g:ale_r_lintr_options·=·'lintr::with_defaults(object_usage_linter·=·NULL)'
```

Loving ALE so far, Thanks!