### PR TITLE
Passthrough eslint config to prettier-eslint

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ name. That seems to be the fairest way to arrange this table.
 | HTML | [HTMLHint](http://htmlhint.com/), [proselint](http://proselint.com/), [tidy](http://www.html-tidy.org/) |
 | Idris | [idris](http://www.idris-lang.org/) |
 | Java | [checkstyle](http://checkstyle.sourceforge.net), [javac](http://www.oracle.com/technetwork/java/javase/downloads/index.html) |
-| JavaScript | [eslint](http://eslint.org/), [jscs](http://jscs.info/), [jshint](http://jshint.com/), [flow](https://flowtype.org/), [standard](http://standardjs.com/), [prettier](https://github.com/prettier/prettier) (and `prettier-eslint`, `prettier-standard`), [xo](https://github.com/sindresorhus/xo)
+| JavaScript | [eslint](http://eslint.org/), [jscs](http://jscs.info/), [jshint](http://jshint.com/), [flow](https://flowtype.org/), [standard](http://standardjs.com/), [prettier](https://github.com/prettier/prettier) (and `prettier-eslint` > 4.2.0, `prettier-standard`), [xo](https://github.com/sindresorhus/xo)
 | JSON | [jsonlint](http://zaa.ch/jsonlint/) |
 | Kotlin | [kotlinc](https://kotlinlang.org), [ktlint](https://ktlint.github.io) see `:help ale-integration-kotlin` for configuration instructions
 | LaTeX | [chktex](http://www.nongnu.org/chktex/), [lacheck](https://www.ctan.org/pkg/lacheck), [proselint](http://proselint.com/) |

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ name. That seems to be the fairest way to arrange this table.
 | HTML | [HTMLHint](http://htmlhint.com/), [proselint](http://proselint.com/), [tidy](http://www.html-tidy.org/) |
 | Idris | [idris](http://www.idris-lang.org/) |
 | Java | [checkstyle](http://checkstyle.sourceforge.net), [javac](http://www.oracle.com/technetwork/java/javase/downloads/index.html) |
-| JavaScript | [eslint](http://eslint.org/), [jscs](http://jscs.info/), [jshint](http://jshint.com/), [flow](https://flowtype.org/), [standard](http://standardjs.com/), [prettier](https://github.com/prettier/prettier) (and `prettier-eslint` > 4.2.0, `prettier-standard`), [xo](https://github.com/sindresorhus/xo)
+| JavaScript | [eslint](http://eslint.org/), [jscs](http://jscs.info/), [jshint](http://jshint.com/), [flow](https://flowtype.org/), [standard](http://standardjs.com/), [prettier](https://github.com/prettier/prettier) (and `prettier-eslint` >= 4.2.0, `prettier-standard`), [xo](https://github.com/sindresorhus/xo)
 | JSON | [jsonlint](http://zaa.ch/jsonlint/) |
 | Kotlin | [kotlinc](https://kotlinlang.org), [ktlint](https://ktlint.github.io) see `:help ale-integration-kotlin` for configuration instructions
 | LaTeX | [chktex](http://www.nongnu.org/chktex/), [lacheck](https://www.ctan.org/pkg/lacheck), [proselint](http://proselint.com/) |

--- a/autoload/ale/fixers/prettier_eslint.vim
+++ b/autoload/ale/fixers/prettier_eslint.vim
@@ -24,6 +24,7 @@ endfunction
 call ale#Set('javascript_prettier_eslint_executable', 'prettier-eslint')
 call ale#Set('javascript_prettier_eslint_use_global', 0)
 call ale#Set('javascript_prettier_eslint_options', '')
+call ale#Set('javascript_prettier_eslint_legacy', 0)
 
 function! ale#fixers#prettier_eslint#GetExecutable(buffer) abort
     return ale#node#FindExecutable(a:buffer, 'javascript_prettier_eslint', [
@@ -37,10 +38,15 @@ function! ale#fixers#prettier_eslint#Fix(buffer, lines) abort
     let l:executable = ale#fixers#prettier_eslint#GetExecutable(a:buffer)
     let l:config = s:FindConfig(a:buffer)
 
+    let l:eslint_config_option = ' --eslint-config-path ' . ale#Escape(l:config)
+    if ale#Var(a:buffer, 'javascript_prettier_eslint_legacy')
+      let l:eslint_config_option = ''
+    endif
+
     return {
     \   'command': ale#Escape(l:executable)
     \       . ' %t'
-    \       . ' --eslint-config-path ' . ale#Escape(l:config)
+    \       . l:eslint_config_option
     \       . ' ' . l:options
     \       . ' --write',
     \   'read_temporary_file': 1,

--- a/doc/ale-javascript.txt
+++ b/doc/ale-javascript.txt
@@ -80,17 +80,6 @@ g:ale_javascript_prettier_use_global     *g:ale_javascript_prettier_use_global*
 ===============================================================================
 prettier-eslint                                *ale-javascript-prettier-eslint*
 
-ALE supports `prettier-eslint` for easy integration with projects, but it is
-not recommended for new projects. ALE instead recommends configuring
-|g:ale_fixers| to run `'prettier'` and `'eslint'` in a sequence like so: >
-
-  let g:ale_fixers = {'javascript': ['prettier', 'eslint']}
-<
-
-This is because `prettier-eslint` cannot be configured to use the ESLint
-configuration file for input given via stdin, which is how ALE integrates with
-the tool.
-
 g:ale_javascript_prettier_eslint_executable
                                   *g:ale_javascript_prettier_eslint_executable*
                                   *b:ale_javascript_prettier_eslint_executable*

--- a/doc/ale-javascript.txt
+++ b/doc/ale-javascript.txt
@@ -80,6 +80,11 @@ g:ale_javascript_prettier_use_global     *g:ale_javascript_prettier_use_global*
 ===============================================================================
 prettier-eslint                                *ale-javascript-prettier-eslint*
 
+ALE supports `prettier-eslint` >= 4.2.0. Using lower version is not recommended
+because it cannot be configured to use the ESLint configuration file for input
+given via stdin. However ALE could be set up on your own risk with older
+versions with |g:ale_javascript_prettier_eslint_legacy|
+
 g:ale_javascript_prettier_eslint_executable
                                   *g:ale_javascript_prettier_eslint_executable*
                                   *b:ale_javascript_prettier_eslint_executable*
@@ -105,6 +110,14 @@ g:ale_javascript_prettier_eslint_use_global
   Default: `0`
 
   See |ale-integrations-local-executables|
+
+g:ale_javascript_prettier_eslint_legacy
+                                  *g:ale_javascript_prettier_eslint_legacy*
+                                  *b:ale_javascript_prettier_eslint_legacy*
+  Type: |Number|
+  Default: `0`
+
+  Fallback option for `prettier-eslint` < 4.2.0
 
 
 ===============================================================================

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -195,7 +195,7 @@ The following languages and tools are supported.
 * HTML: 'HTMLHint', 'proselint', 'tidy'
 * Idris: 'idris'
 * Java: 'javac'
-* JavaScript: 'eslint', 'jscs', 'jshint', 'flow', 'prettier', 'prettier-eslint', 'xo'
+* JavaScript: 'eslint', 'jscs', 'jshint', 'flow', 'prettier', 'prettier-eslint' > 4.2.0, 'xo'
 * JSON: 'jsonlint'
 * Kotlin: 'kotlinc'
 * LaTeX (tex): 'chktex', 'lacheck', 'proselint'

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -195,7 +195,7 @@ The following languages and tools are supported.
 * HTML: 'HTMLHint', 'proselint', 'tidy'
 * Idris: 'idris'
 * Java: 'javac'
-* JavaScript: 'eslint', 'jscs', 'jshint', 'flow', 'prettier', 'prettier-eslint' > 4.2.0, 'xo'
+* JavaScript: 'eslint', 'jscs', 'jshint', 'flow', 'prettier', 'prettier-eslint' >= 4.2.0, 'xo'
 * JSON: 'jsonlint'
 * Kotlin: 'kotlinc'
 * LaTeX (tex): 'chktex', 'lacheck', 'proselint'


### PR DESCRIPTION
closes #853 
- [x] depends on https://github.com/prettier/prettier-eslint-cli/pull/91
- [x] update the documentation to indicate the minimum supported version
- [x] fallback option (legacy)