### PR TITLE
Add original filename to SyntaxErl command

### DIFF
--- a/ale_linters/erlang/syntaxerl.vim
+++ b/ale_linters/erlang/syntaxerl.vim
@@ -10,7 +10,7 @@ endfunction
 
 
 function! ale_linters#erlang#syntaxerl#GetCommand(buffer) abort
-    return ale_linters#erlang#syntaxerl#GetExecutable(a:buffer) . ' %t'
+    return ale_linters#erlang#syntaxerl#GetExecutable(a:buffer) . ' -b %s %t'
 endfunction
 
 

--- a/test/command_callback/test_erlang_syntaxerl_command_callback.vader
+++ b/test/command_callback/test_erlang_syntaxerl_command_callback.vader
@@ -17,10 +17,10 @@ Execute (Get SyntaxErl executable):
   AssertEqual '/yet/another/syntaxerl', ale_linters#erlang#syntaxerl#GetExecutable(bufnr(''))
 
 Execute (Get SyntaxErl command line):
-  AssertEqual 'syntaxerl %t', ale_linters#erlang#syntaxerl#GetCommand(bufnr(''))
+  AssertEqual 'syntaxerl -b %s %t', ale_linters#erlang#syntaxerl#GetCommand(bufnr(''))
 
   let g:ale_erlang_syntaxerl_executable = '/some/other/syntaxerl'
-  AssertEqual '/some/other/syntaxerl %t', ale_linters#erlang#syntaxerl#GetCommand(bufnr(''))
+  AssertEqual '/some/other/syntaxerl -b %s %t', ale_linters#erlang#syntaxerl#GetCommand(bufnr(''))
 
   let b:ale_erlang_syntaxerl_executable = '/yet/another/syntaxerl'
-  AssertEqual '/yet/another/syntaxerl %t', ale_linters#erlang#syntaxerl#GetCommand(bufnr(''))
+  AssertEqual '/yet/another/syntaxerl -b %s %t', ale_linters#erlang#syntaxerl#GetCommand(bufnr(''))

--- a/test/command_callback/test_erlang_syntaxerl_command_callback.vader
+++ b/test/command_callback/test_erlang_syntaxerl_command_callback.vader
@@ -1,0 +1,26 @@
+Before:
+  Save g:ale_erlang_syntaxerl_executable
+  unlet! g:ale_erlang_syntaxerl_executable b:ale_erlang_syntaxerl_executable
+  runtime ale_linters/erlang/syntaxerl.vim
+
+After:
+  call ale#linter#Reset()
+  Restore g:ale_erlang_syntaxerl_executable
+
+Execute (Get SyntaxErl executable):
+  AssertEqual 'syntaxerl', ale_linters#erlang#syntaxerl#GetExecutable(bufnr(''))
+
+  let g:ale_erlang_syntaxerl_executable = '/some/other/syntaxerl'
+  AssertEqual '/some/other/syntaxerl', ale_linters#erlang#syntaxerl#GetExecutable(bufnr(''))
+
+  let b:ale_erlang_syntaxerl_executable = '/yet/another/syntaxerl'
+  AssertEqual '/yet/another/syntaxerl', ale_linters#erlang#syntaxerl#GetExecutable(bufnr(''))
+
+Execute (Get SyntaxErl command line):
+  AssertEqual 'syntaxerl %t', ale_linters#erlang#syntaxerl#GetCommand(bufnr(''))
+
+  let g:ale_erlang_syntaxerl_executable = '/some/other/syntaxerl'
+  AssertEqual '/some/other/syntaxerl %t', ale_linters#erlang#syntaxerl#GetCommand(bufnr(''))
+
+  let b:ale_erlang_syntaxerl_executable = '/yet/another/syntaxerl'
+  AssertEqual '/yet/another/syntaxerl %t', ale_linters#erlang#syntaxerl#GetCommand(bufnr(''))

--- a/test/handler/test_syntaxerl_handler.vader
+++ b/test/handler/test_syntaxerl_handler.vader
@@ -4,7 +4,7 @@ Before:
 After:
   call ale#linter#Reset()
 
-Execute:
+Execute (Handle SyntaxErl output):
   AssertEqual
   \ [
   \   {
@@ -18,7 +18,7 @@ Execute:
   \     'type': 'W',
   \   },
   \ ],
-  \ ale_linters#erlang#syntaxerl#Handle(42, [
+  \ ale_linters#erlang#syntaxerl#Handle(bufnr(''), [
   \   "/tmp/v2wDixk/1/module.erl:42: syntax error before: ','",
   \   '/tmp/v2wDixk/2/module.erl:42: warning: function foo/0 is unused',
   \ ])


### PR DESCRIPTION
This little change adds original filename to SyntaxErl command. It makes linting with SyntaxErl much more clever.

It's all thanks to @urbanserj's changes in SyntaxErl 😇