### PR TITLE
Syntaxerl linter feature check

### DIFF
--- a/ale_linters/erlang/syntaxerl.vim
+++ b/ale_linters/erlang/syntaxerl.vim
@@ -2,7 +2,6 @@
 " Description: SyntaxErl linter for Erlang files
 
 call ale#Set('erlang_syntaxerl_executable', 'syntaxerl')
-call ale#Set('erlang_syntaxerl_use_basename', 0)
 
 
 function! ale_linters#erlang#syntaxerl#GetExecutable(buffer) abort
@@ -10,14 +9,16 @@ function! ale_linters#erlang#syntaxerl#GetExecutable(buffer) abort
 endfunction
 
 
-function! ale_linters#erlang#syntaxerl#GetCommand(buffer) abort
-    let l:base_options = ale#Var(a:buffer, 'erlang_syntaxerl_use_basename')
-    \   ? ' -b %s'
-    \   : ''
+function! ale_linters#erlang#syntaxerl#FeatureCheck(buffer) abort
+    return ale_linters#erlang#syntaxerl#GetExecutable(a:buffer) . ' -h'
+endfunction
+
+
+function! ale_linters#erlang#syntaxerl#GetCommand(buffer, output) abort
+    let l:use_b_option = match(a:output, '\C\V-b, --base\>') > -1
 
     return ale_linters#erlang#syntaxerl#GetExecutable(a:buffer)
-    \   . l:base_options
-    \   . ' %t'
+    \   . (l:use_b_option ? ' -b %s %t' : ' %t')
 endfunction
 
 
@@ -40,6 +41,9 @@ endfunction
 call ale#linter#Define('erlang', {
 \   'name': 'syntaxerl',
 \   'executable_callback': 'ale_linters#erlang#syntaxerl#GetExecutable',
-\   'command_callback': 'ale_linters#erlang#syntaxerl#GetCommand',
+\   'command_chain': [
+\       {'callback': 'ale_linters#erlang#syntaxerl#FeatureCheck'},
+\       {'callback': 'ale_linters#erlang#syntaxerl#GetCommand'},
+\   ],
 \   'callback': 'ale_linters#erlang#syntaxerl#Handle',
 \})

--- a/ale_linters/erlang/syntaxerl.vim
+++ b/ale_linters/erlang/syntaxerl.vim
@@ -10,15 +10,14 @@ endfunction
 
 
 function! ale_linters#erlang#syntaxerl#FeatureCheck(buffer) abort
-    return ale_linters#erlang#syntaxerl#GetExecutable(a:buffer) . ' -h'
+    return s:GetEscapedExecutable(a:buffer) . ' -h'
 endfunction
 
 
 function! ale_linters#erlang#syntaxerl#GetCommand(buffer, output) abort
     let l:use_b_option = match(a:output, '\C\V-b, --base\>') > -1
 
-    return ale_linters#erlang#syntaxerl#GetExecutable(a:buffer)
-    \   . (l:use_b_option ? ' -b %s %t' : ' %t')
+    return s:GetEscapedExecutable(a:buffer) . (l:use_b_option ? ' -b %s %t' : ' %t')
 endfunction
 
 
@@ -35,6 +34,11 @@ function! ale_linters#erlang#syntaxerl#Handle(buffer, lines) abort
     endfor
 
     return l:loclist
+endfunction
+
+
+function! s:GetEscapedExecutable(buffer) abort
+    return ale#Escape(ale_linters#erlang#syntaxerl#GetExecutable(a:buffer))
 endfunction
 
 

--- a/doc/ale-erlang.txt
+++ b/doc/ale-erlang.txt
@@ -25,17 +25,5 @@ g:ale_erlang_syntaxerl_executable           *g:ale_erlang_syntaxerl_executable*
   This variable can be changed to specify the syntaxerl executable.
 
 
-g:ale_erlang_syntaxerl_use_basename       *g:ale_erlang_syntaxerl_use_basename*
-                                          *b:ale_erlang_syntaxerl_use_basename*
-  Type: |Number|
-  Default: `0`
-
-  When set to `1`, the `-b` argument for telling SyntaxErl about the path to the
-  file being checked will be used. The argument is only available in newer
-  versions of SyntaxErl.
-
-  This option will be enabled by default in future.
-
-
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/test/command_callback/test_erlang_syntaxerl_command_callback.vader
+++ b/test/command_callback/test_erlang_syntaxerl_command_callback.vader
@@ -25,22 +25,22 @@ Execute (The executable should be correct):
 
 Execute (The executable should be presented in the feature check command):
   let g:ale_erlang_syntaxerl_executable = '/some/other/syntaxerl'
-  AssertEqual '/some/other/syntaxerl -h', ale_linters#erlang#syntaxerl#FeatureCheck(bufnr(''))
+  AssertEqual "'/some/other/syntaxerl' -h", ale_linters#erlang#syntaxerl#FeatureCheck(bufnr(''))
 
   let b:ale_erlang_syntaxerl_executable = '/yet/another/syntaxerl'
-  AssertEqual '/yet/another/syntaxerl -h', ale_linters#erlang#syntaxerl#FeatureCheck(bufnr(''))
+  AssertEqual "'/yet/another/syntaxerl' -h", ale_linters#erlang#syntaxerl#FeatureCheck(bufnr(''))
 
 
 Execute (The executable should be presented in the command):
   let g:ale_erlang_syntaxerl_executable = '/some/other/syntaxerl'
-  AssertEqual '/some/other/syntaxerl %t', ale_linters#erlang#syntaxerl#GetCommand(bufnr(''), [])
+  AssertEqual "'/some/other/syntaxerl' %t", ale_linters#erlang#syntaxerl#GetCommand(bufnr(''), [])
 
   let b:ale_erlang_syntaxerl_executable = '/yet/another/syntaxerl'
-  AssertEqual '/yet/another/syntaxerl %t', ale_linters#erlang#syntaxerl#GetCommand(bufnr(''), [])
+  AssertEqual "'/yet/another/syntaxerl' %t", ale_linters#erlang#syntaxerl#GetCommand(bufnr(''), [])
 
 
 Execute (The -b option should be used when available):
-  AssertEqual 'syntaxerl %t', ale_linters#erlang#syntaxerl#GetCommand(bufnr(''), [
+  AssertEqual "'syntaxerl' %t", ale_linters#erlang#syntaxerl#GetCommand(bufnr(''), [
   \   'Syntax checker for Erlang (0.14.0)',
   \   'Usage: syntaxerl [-d | --debug] <FILENAME>',
   \   '       syntaxerl <-h | --help>',
@@ -48,7 +48,7 @@ Execute (The -b option should be used when available):
   \   '  -h, --help     Show this message',
   \ ])
 
-  AssertEqual 'syntaxerl -b %s %t', ale_linters#erlang#syntaxerl#GetCommand(bufnr(''), [
+  AssertEqual "'syntaxerl' -b %s %t", ale_linters#erlang#syntaxerl#GetCommand(bufnr(''), [
   \   'Syntax checker for Erlang (0.14.0)',
   \   'Usage: syntaxerl [-b | --base <FILENAME>] [-d | --debug] <FILENAME>',
   \   '       syntaxerl <-h | --help>',

--- a/test/command_callback/test_erlang_syntaxerl_command_callback.vader
+++ b/test/command_callback/test_erlang_syntaxerl_command_callback.vader
@@ -1,12 +1,11 @@
 Before:
   Save g:ale_erlang_syntaxerl_executable
-  Save g:ale_erlang_syntaxerl_use_basename
 
   unlet! g:ale_erlang_syntaxerl_executable
   unlet! b:ale_erlang_syntaxerl_executable
-  unlet! b:ale_erlang_syntaxerl_use_basename
 
   runtime ale_linters/erlang/syntaxerl.vim
+
 
 After:
   Restore
@@ -14,7 +13,7 @@ After:
   call ale#linter#Reset()
 
 
-Execute (The SyntaxErl executable should be correct):
+Execute (The executable should be correct):
   AssertEqual 'syntaxerl', ale_linters#erlang#syntaxerl#GetExecutable(bufnr(''))
 
   let g:ale_erlang_syntaxerl_executable = '/some/other/syntaxerl'
@@ -23,17 +22,37 @@ Execute (The SyntaxErl executable should be correct):
   let b:ale_erlang_syntaxerl_executable = '/yet/another/syntaxerl'
   AssertEqual '/yet/another/syntaxerl', ale_linters#erlang#syntaxerl#GetExecutable(bufnr(''))
 
-Execute (The default SyntaxErl command should be correct):
-  AssertEqual 'syntaxerl %t', ale_linters#erlang#syntaxerl#GetCommand(bufnr(''))
 
-Execute (The executable name should be used in the command):
+Execute (The executable should be presented in the feature check command):
   let g:ale_erlang_syntaxerl_executable = '/some/other/syntaxerl'
-  AssertEqual '/some/other/syntaxerl %t', ale_linters#erlang#syntaxerl#GetCommand(bufnr(''))
+  AssertEqual '/some/other/syntaxerl -h', ale_linters#erlang#syntaxerl#FeatureCheck(bufnr(''))
 
   let b:ale_erlang_syntaxerl_executable = '/yet/another/syntaxerl'
-  AssertEqual '/yet/another/syntaxerl %t', ale_linters#erlang#syntaxerl#GetCommand(bufnr(''))
+  AssertEqual '/yet/another/syntaxerl -h', ale_linters#erlang#syntaxerl#FeatureCheck(bufnr(''))
 
-Execute (The basename option should be set when the option is on):
-  let b:ale_erlang_syntaxerl_use_basename = 1
 
-  AssertEqual 'syntaxerl -b %s %t', ale_linters#erlang#syntaxerl#GetCommand(bufnr(''))
+Execute (The executable should be presented in the command):
+  let g:ale_erlang_syntaxerl_executable = '/some/other/syntaxerl'
+  AssertEqual '/some/other/syntaxerl %t', ale_linters#erlang#syntaxerl#GetCommand(bufnr(''), [])
+
+  let b:ale_erlang_syntaxerl_executable = '/yet/another/syntaxerl'
+  AssertEqual '/yet/another/syntaxerl %t', ale_linters#erlang#syntaxerl#GetCommand(bufnr(''), [])
+
+
+Execute (The -b option should be used when available):
+  AssertEqual 'syntaxerl %t', ale_linters#erlang#syntaxerl#GetCommand(bufnr(''), [
+  \   'Syntax checker for Erlang (0.14.0)',
+  \   'Usage: syntaxerl [-d | --debug] <FILENAME>',
+  \   '       syntaxerl <-h | --help>',
+  \   '  -d, --debug    Enable debug output',
+  \   '  -h, --help     Show this message',
+  \ ])
+
+  AssertEqual 'syntaxerl -b %s %t', ale_linters#erlang#syntaxerl#GetCommand(bufnr(''), [
+  \   'Syntax checker for Erlang (0.14.0)',
+  \   'Usage: syntaxerl [-b | --base <FILENAME>] [-d | --debug] <FILENAME>',
+  \   '       syntaxerl <-h | --help>',
+  \   '  -b, --base     Set original filename',
+  \   '  -d, --debug    Enable debug output',
+  \   '  -h, --help     Show this message',
+  \ ])


### PR DESCRIPTION
This replaces `erlang_syntaxerl_use_basename` option with simple feature check based on the help output. I've decided not to use version check since SyntaxErl has no `--version` flag and at the time code in master displays only the previously released version number.