### PR TITLE
Add erubis linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ name. That seems to be the fairest way to arrange this table.
 | Dockerfile | [hadolint](https://github.com/lukasmartinelli/hadolint) |
 | Elixir | [credo](https://github.com/rrrene/credo), [dogma](https://github.com/lpil/dogma) |
 | Elm | [elm-make](https://github.com/elm-lang/elm-make) |
-| Erb | [erb](https://github.com/jeremyevans/erubi) |
+| Erb | [erb](https://github.com/jeremyevans/erubi), [erubis](https://github.com/kwatch/erubis) |
 | Erlang | [erlc](http://erlang.org/doc/man/erlc.html), [SyntaxErl](https://github.com/ten0s/syntaxerl) |
 | Fortran | [gcc](https://gcc.gnu.org/) |
 | FusionScript | [fusion-lint](https://github.com/RyanSquared/fusionscript) |

--- a/ale_linters/eruby/erubis.vim
+++ b/ale_linters/eruby/erubis.vim
@@ -1,0 +1,11 @@
+" Author: Jake Zimmerman <jake@zimmerman.io>
+" Description: eruby checker using `erubis`, instead of `erb`
+
+call ale#linter#Define('eruby', {
+\   'name': 'erubis',
+\   'executable': 'erubis',
+\   'output_stream': 'stderr',
+\   'command': 'erubis -x %t | ruby -c',
+\   'callback': 'ale#handlers#ruby#HandleSyntaxErrors',
+\})
+

--- a/doc/ale-eruby.txt
+++ b/doc/ale-eruby.txt
@@ -1,0 +1,17 @@
+===============================================================================
+ALE Eruby Integration                                       *ale-eruby-options*
+
+There are two linters for `eruby` files:
+
+- `erubylint`
+- `erubis`
+
+If you don't know which one your project uses, it's probably `erb`.
+To selectively enable one or the other, see |g:ale_linters|.
+
+(Note that ALE already disables linters if the executable for that linter is
+not found; thus, there's probably no need to disable one of these if you're
+using the other one.)
+
+===============================================================================
+  vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -36,6 +36,7 @@ CONTENTS                                                         *ale-contents*
     erlang................................|ale-erlang-options|
       erlc................................|ale-erlang-erlc|
       syntaxerl...........................|ale-erlang-syntaxerl|
+    eruby.................................|ale-eruby-options|
     fortran...............................|ale-fortran-options|
       gcc.................................|ale-fortran-gcc|
     fusionscript..........................|ale-fuse-options|


### PR DESCRIPTION
This linter works largely the same as the existing `erubylint` linter,
except it works with `erubis` instead of `erb` as the driving command.