### PR TITLE
Add clang-format fixer for C/C++

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ name. That seems to be the fairest way to arrange this table.
 | Awk | [gawk](https://www.gnu.org/software/gawk/)|
 | Bash | [-n flag](https://www.gnu.org/software/bash/manual/bash.html#index-set), [shellcheck](https://www.shellcheck.net/) |
 | Bourne Shell | [-n flag](http://linux.die.net/man/1/sh), [shellcheck](https://www.shellcheck.net/) |
-| C | [cppcheck](http://cppcheck.sourceforge.net), [gcc](https://gcc.gnu.org/), [clang](http://clang.llvm.org/)|
-| C++ (filetype cpp) | [clang](http://clang.llvm.org/), [clangcheck](http://clang.llvm.org/docs/ClangCheck.html), [clangtidy](http://clang.llvm.org/extra/clang-tidy/), [cppcheck](http://cppcheck.sourceforge.net), [cpplint](https://github.com/google/styleguide/tree/gh-pages/cpplint), [gcc](https://gcc.gnu.org/)|
+| C | [cppcheck](http://cppcheck.sourceforge.net), [gcc](https://gcc.gnu.org/), [clang](http://clang.llvm.org/), [clang-format](https://clang.llvm.org/docs/ClangFormat.html)|
+| C++ (filetype cpp) | [clang](http://clang.llvm.org/), [clangcheck](http://clang.llvm.org/docs/ClangCheck.html), [clangtidy](http://clang.llvm.org/extra/clang-tidy/), [cppcheck](http://cppcheck.sourceforge.net), [cpplint](https://github.com/google/styleguide/tree/gh-pages/cpplint), [gcc](https://gcc.gnu.org/), [clang-format](https://clang.llvm.org/docs/ClangFormat.html)|
 | C# | [mcs](http://www.mono-project.com/docs/about-mono/languages/csharp/) |
 | Chef | [foodcritic](http://www.foodcritic.io/) |
 | CMake | [cmakelint](https://github.com/richq/cmake-lint) |

--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -82,6 +82,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['php'],
 \       'description': 'Fix PHP files with phpcbf.',
 \   },
+\   'clang-format': {
+\       'function': 'ale#fixers#clangformat#Fix',
+\       'suggested_filetypes': ['c', 'cpp'],
+\       'description': 'Fix C/C++ files with clang-format.',
+\   },
 \}
 
 " Reset the function registry to the default entries.

--- a/autoload/ale/fixers/clangformat.vim
+++ b/autoload/ale/fixers/clangformat.vim
@@ -1,0 +1,21 @@
+" Author: Peter Renström <renstrom.peter@gmail.com>
+" Description: Fixing C/C++ files with clang-format.
+
+call ale#Set('c_clangformat_executable', 'clang-format')
+call ale#Set('c_clangformat_use_global', 0)
+call ale#Set('c_clangformat_options', '')
+
+function! ale#fixers#clangformat#GetExecutable(buffer) abort
+    return ale#node#FindExecutable(a:buffer, 'c_clangformat', [
+    \   'clang-format',
+    \])
+endfunction
+
+function! ale#fixers#clangformat#Fix(buffer) abort
+    let l:options = ale#Var(a:buffer, 'c_clangformat_options')
+
+    return {
+    \   'command': ale#Escape(ale#fixers#clangformat#GetExecutable(a:buffer))
+    \       . ' ' . l:options,
+    \}
+endfunction

--- a/doc/ale-c.txt
+++ b/doc/ale-c.txt
@@ -60,4 +60,23 @@ g:ale_c_gcc_options                                       *g:ale_c_gcc_options*
 
 
 ===============================================================================
+clang-format                                                *ale-c-clangformat*
+
+g:ale_c_clangformat_executable                 *g:ale_c_clangformat_executable*
+                                               *b:ale_c_clangformat_executable*
+  Type: |String|
+  Default: `'clang-format'`
+
+  This variable can be changed to use a different executable for clang-format.
+
+
+g:ale_c_clangformat_options                       *g:ale_c_clangformat_options*
+                                                  *b:ale_c_clangformat_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be change to modify flags given to clang-format.
+
+
+===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-cpp.txt
+++ b/doc/ale-cpp.txt
@@ -190,4 +190,23 @@ g:ale_cpp_gcc_options                                   *g:ale_cpp_gcc_options*
 
 
 ===============================================================================
+clang-format                                              *ale-cpp-clangformat*
+
+g:ale_c_clangformat_executable                 *g:ale_c_clangformat_executable*
+                                               *b:ale_c_clangformat_executable*
+  Type: |String|
+  Default: `'clang-format'`
+
+  This variable can be changed to use a different executable for clang-format.
+
+
+g:ale_c_clangformat_options                       *g:ale_c_clangformat_options*
+                                                  *b:ale_c_clangformat_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be change to modify flags given to clang-format.
+
+
+===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-cpp.txt
+++ b/doc/ale-cpp.txt
@@ -192,20 +192,8 @@ g:ale_cpp_gcc_options                                   *g:ale_cpp_gcc_options*
 ===============================================================================
 clang-format                                              *ale-cpp-clangformat*
 
-g:ale_c_clangformat_executable                 *g:ale_c_clangformat_executable*
-                                               *b:ale_c_clangformat_executable*
-  Type: |String|
-  Default: `'clang-format'`
-
-  This variable can be changed to use a different executable for clang-format.
-
-
-g:ale_c_clangformat_options                       *g:ale_c_clangformat_options*
-                                                  *b:ale_c_clangformat_options*
-  Type: |String|
-  Default: `''`
-
-  This variable can be change to modify flags given to clang-format.
+See |ale-c-clangformat| for information about the available options.
+Note that the C options are also used for C++.
 
 
 ===============================================================================

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -19,6 +19,7 @@ CONTENTS                                                         *ale-contents*
       clang...............................|ale-c-clang|
       cppcheck............................|ale-c-cppcheck|
       gcc.................................|ale-c-gcc|
+      clang-format........................|ale-c-clangformat|
     chef..................................|ale-chef-options|
       foodcritic..........................|ale-chef-foodcritic|
     cpp...................................|ale-cpp-options|
@@ -28,6 +29,7 @@ CONTENTS                                                         *ale-contents*
       cppcheck............................|ale-cpp-cppcheck|
       cpplint.............................|ale-cpp-cpplint|
       gcc.................................|ale-cpp-gcc|
+      clang-format........................|ale-cpp-clangformat|
     css...................................|ale-css-options|
       stylelint...........................|ale-css-stylelint|
     cmake.................................|ale-cmake-options|
@@ -176,8 +178,8 @@ The following languages and tools are supported.
 * Asciidoc: 'proselint'
 * Bash: 'shell' (-n flag), 'shellcheck'
 * Bourne Shell: 'shell' (-n flag), 'shellcheck'
-* C: 'cppcheck', 'gcc', 'clang'
-* C++ (filetype cpp): 'clang', 'clangtidy', 'cppcheck', 'cpplint', 'gcc'
+* C: 'cppcheck', 'gcc', 'clang', 'clang-format'
+* C++ (filetype cpp): 'clang', 'clangtidy', 'cppcheck', 'cpplint', 'gcc', 'clang-format'
 * C#: 'mcs'
 * Chef: 'foodcritic'
 * CMake: 'cmakelint'

--- a/test/fixers/test_clangformat_fixer_callback.vader
+++ b/test/fixers/test_clangformat_fixer_callback.vader
@@ -1,0 +1,36 @@
+Before:
+  Save g:ale_c_clangformat_executable
+
+  " Use an invalid global executable, so we don't match it.
+  let g:ale_c_clangformat_executable = 'xxxinvalid'
+
+  call ale#test#SetDirectory('/testplugin/test/fixers')
+  silent cd ..
+  silent cd command_callback
+  let g:dir = getcwd()
+
+After:
+  Restore
+
+  call ale#test#RestoreDirectory()
+
+Execute(The clang-format callback should return the correct default values):
+  call ale#test#SetFilename('c_paths/dummy.c')
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape(g:ale_c_clangformat_executable)
+  \       . ' '
+  \ },
+  \ ale#fixers#clangformat#Fix(bufnr(''))
+
+Execute(The clangformat callback should include any additional options):
+  call ale#test#SetFilename('c_paths/dummy.c')
+  let g:ale_c_clangformat_options = '--some-option'
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape(g:ale_c_clangformat_executable)
+  \     . ' --some-option',
+  \ },
+  \ ale#fixers#clangformat#Fix(bufnr(''))


### PR DESCRIPTION
<!--
READ THIS: Before creating a pull request, please consider the following first.

* The most important thing you can do is write tests. Code without tests
  probably doesn't work, and will almost certainly stop working later on. Pull
  requests without tests probably won't be accepted, although there are some
  exceptions.
* Read the Contributing guide linked above first.
* If you are adding a new linter, remember to update the README.md file and
  doc/ale.txt first.
* If you add or modify a function for converting error lines into loclist items
  that ALE can work with, please add Vader tests for them. Look at existing
  tests in the test/handler directory, etc.
* If you add or modify a function for computing a command line string for
  running a command, please add Vader tests for that.
* Generally try and cover anything with Vader tests, although some things just
  can't be tested with Vader, or at least they can be hard to test. Consider
  breaking up your code so that some parts can be tested, and generally open up
  a discussion about it.
* Have fun!
-->

All the paths, variables and functions use "c" instead of "cpp". Not sure what's preferred, or if I should duplicate it?

https://clang.llvm.org/docs/ClangFormat.html