### PR TITLE
Show errors from other files for ghc (#653)

### DIFF
--- a/autoload/ale/engine.vim
+++ b/autoload/ale/engine.vim
@@ -177,6 +177,7 @@ function! s:HandleExit(job_id, exit_code) abort
     let l:output = l:job_info.output
     let l:buffer = l:job_info.buffer
     let l:next_chain_index = l:job_info.next_chain_index
+    let l:wd = l:job_info.wd
 
     if g:ale_history_enabled
         call ale#history#SetExitCode(l:buffer, a:job_id, a:exit_code)
@@ -208,7 +209,7 @@ function! s:HandleExit(job_id, exit_code) abort
         call ale#history#RememberOutput(l:buffer, a:job_id, l:output[:])
     endif
 
-    let l:loclist = ale#util#GetFunction(l:linter.callback)(l:buffer, l:output)
+    let l:loclist = ale#util#GetFunction(l:linter.callback)(l:buffer, l:output, l:wd)
 
     call s:HandleLoclist(l:linter.name, l:buffer, l:loclist)
 endfunction
@@ -552,6 +553,7 @@ function! s:RunJob(options) abort
         \   'buffer': l:buffer,
         \   'output': [],
         \   'next_chain_index': l:next_chain_index,
+        \   'wd': getcwd(),
         \}
     endif
 

--- a/autoload/ale/handlers/haskell.vim
+++ b/autoload/ale/handlers/haskell.vim
@@ -31,10 +31,6 @@ function! ale#handlers#haskell#HandleGHCFormat(buffer, lines) abort
             continue
         endif
 
-        if !ale#path#IsBufferPath(a:buffer, l:match[1])
-            continue
-        endif
-
         let l:errors = matchlist(l:match[4], '\v([wW]arning|[eE]rror): ?(.*)')
 
         if len(l:errors) > 0
@@ -52,6 +48,7 @@ function! ale#handlers#haskell#HandleGHCFormat(buffer, lines) abort
         endif
 
         call add(l:output, {
+        \   'filename': ale#path#Simplify(getcwd() . '/' . l:match[1]),
         \   'lnum': l:match[2] + 0,
         \   'col': l:match[3] + 0,
         \   'text': l:text,

--- a/autoload/ale/handlers/haskell.vim
+++ b/autoload/ale/handlers/haskell.vim
@@ -1,7 +1,7 @@
 " Author: w0rp <devw0rp@gmail.com>
 " Description: Error handling for the format GHC outputs.
 
-function! ale#handlers#haskell#HandleGHCFormat(buffer, lines) abort
+function! ale#handlers#haskell#HandleGHCFormat(buffer, lines, wd) abort
     " Look for lines like the following.
     "
     "Appoint/Lib.hs:8:1: warning:
@@ -48,7 +48,7 @@ function! ale#handlers#haskell#HandleGHCFormat(buffer, lines) abort
         endif
 
         call add(l:output, {
-        \   'filename': ale#path#Simplify(getcwd() . '/' . l:match[1]),
+        \   'filename': ale#path#GetAbsPath(a:wd, l:match[1]),
         \   'lnum': l:match[2] + 0,
         \   'col': l:match[3] + 0,
         \   'text': l:text,

--- a/test/handler/test_ghc_handler.vader
+++ b/test/handler/test_ghc_handler.vader
@@ -4,6 +4,7 @@ Execute(The ghc handler should handle hdevtools output):
   AssertEqual
   \ [
   \   {
+  \     'filename': simplify(getcwd() . '/foo.hs'),
   \     'lnum': 147,
   \     'type': 'W',
   \     'col': 62,
@@ -22,12 +23,14 @@ Execute(The ghc handler should handle ghc 8 output):
   AssertEqual
   \ [
   \   {
+  \     'filename': simplify(getcwd() . '/src/Appoint/Lib.hs'),
   \     'lnum': 6,
   \     'type': 'E',
   \     'col': 1,
   \     'text': 'Failed to load interface for ‘GitHub.Data’ Use -v to see a list of the files searched for.',
   \   },
   \   {
+  \     'filename': simplify(getcwd() . '/src/Appoint/Lib.hs'),
   \     'lnum': 7,
   \     'type': 'W',
   \     'col': 1,
@@ -51,18 +54,21 @@ Execute(The ghc handler should handle ghc 7 output):
   AssertEqual
   \ [
   \   {
+  \     'filename': simplify(getcwd() . '/src/Main.hs'),
   \     'lnum': 168,
   \     'type': 'E',
   \     'col': 1,
   \     'text': 'parse error (possibly incorrect indentation or mismatched brackets)',
   \   },
   \   {
+  \     'filename': simplify(getcwd() . '/src/Main.hs'),
   \     'lnum': 84,
   \     'col': 1,
   \     'type': 'W',
   \     'text': 'Top-level binding with no type signature:^@  myLayout :: Choose Tall (Choose (Mirror Tall) Full) a',
   \   },
   \   {
+  \     'filename': simplify(getcwd() . '/src/Main.hs'),
   \     'lnum': 94,
   \     'col': 5,
   \     'type': 'E',

--- a/test/handler/test_ghc_mod_handler.vader
+++ b/test/handler/test_ghc_mod_handler.vader
@@ -4,18 +4,28 @@ Execute(HandleGhcFormat should handle ghc-mod problems):
   AssertEqual
   \ [
   \   {
+  \     'filename': simplify(getcwd() . '/check2.hs'),
   \     'lnum': 2,
   \     'col': 1,
   \     'type': 'E',
   \     'text': 'Failed to load interface for ‘Missing’Use -v to see a list of the files searched for.',
   \   },
   \   {
+  \     'filename': simplify(getcwd() . '/check2.hs'),
   \     'lnum': 2,
   \     'col': 1,
   \     'type': 'E',
   \     'text': 'Suggestion: Use camelCaseFound:  my_variable = ...Why not:  myVariable = ...',
   \   },
   \   {
+  \     'filename': simplify(getcwd() . '/check2.hs'),
+  \     'lnum': 6,
+  \     'col': 1,
+  \     'type': 'W',
+  \     'text': 'Eta reduceFound:  myFunc x = succ xWhy not:  myFunc = succ',
+  \   },
+  \   {
+  \     'filename': simplify(getcwd() . '/xxx.hs'),
   \     'lnum': 6,
   \     'col': 1,
   \     'type': 'W',


### PR DESCRIPTION
GHC-based linters (including `hdevtools` and `ghc-mod`) may generate errors about files imported from the current file. This patch adds support for them.