### PR TITLE
Allow Perl::Critic issues to be displayed as warnings or errors

### DIFF
--- a/ale_linters/perl/perlcritic.vim
+++ b/ale_linters/perl/perlcritic.vim
@@ -13,6 +13,9 @@ let g:ale_perl_perlcritic_options =
 let g:ale_perl_perlcritic_showrules =
 \   get(g:, 'ale_perl_perlcritic_showrules', 0)
 
+let g:ale_perl_perlcritic_display_mode =
+\   get(g:, 'ale_perl_perlcritic_display_mode', 'E')
+
 function! ale_linters#perl#perlcritic#GetExecutable(buffer) abort
     return ale#Var(a:buffer, 'perl_perlcritic_executable')
 endfunction
@@ -61,6 +64,7 @@ function! ale_linters#perl#perlcritic#Handle(buffer, lines) abort
         \   'lnum': l:match[1],
         \   'col': l:match[2],
         \   'text': l:match[3],
+        \   'type': ale#Var(a:buffer, 'perl_perlcritic_display_mode'),
         \})
     endfor
 

--- a/doc/ale-perl.txt
+++ b/doc/ale-perl.txt
@@ -70,5 +70,13 @@ g:ale_perl_perlcritic_showrules               *g:ale_perl_perlcritic_showrules*
   Defaults to off to reduce length of message.
 
 
+g:ale_perl_perlcritic_display_mode          g:ale_perl_perlcritic_display_mode
+
+  Type: String
+  Default: E
+
+  Controls whether perlcritic issues are displayed as errors (E) or warnings
+  (W). Defaults to "E" in order to preserve the default behaviour.
+
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/test/test_perlcritic_linter.vader
+++ b/test/test_perlcritic_linter.vader
@@ -12,9 +12,11 @@ Before:
   Save g:ale_perl_perlcritic_options
   Save g:ale_perl_perlcritic_executable
   Save g:ale_perl_perlcritic_showrules
+  Save g:ale_perl_perlcritic_display_mode
   silent! unlet g:ale_perl_perlcritic_options
   silent! unlet g:ale_perl_perlcritic_executable
   silent! unlet g:ale_perl_perlcritic_showrules
+  silent! unlet g:ale_perl_perlcritic_display_mode
   let g:ale_perl_perlcritic_profile  = ''
 
   " enable loading inside test container
@@ -28,6 +30,7 @@ After:
   silent! unlet b:ale_perl_perlcritic_options
   silent! unlet b:ale_perl_perlcritic_executable
   silent! unlet b:ale_perl_perlcritic_showrules
+  silent! unlet b:ale_perl_perlcritic_display_mode
 
 
 Execute(no g:ale_perl_perlcritic_showrules):


### PR DESCRIPTION
This is the result of a little Twitter poll:

https://twitter.com/olafalders/status/898594830707679232

Basically, I don't want Perl::Critic violations to display as errors since they're generally not going to prevent my code from compiling.  If I'm whipping up a quick script, I just want to deal with the compilation errors etc first.

I tweaked the Vader tests slightly, but I didn't add a test for the new functionality because it wasn't clear to me how to do this.  I'm happy to add a test if you think it's necessary and can possibly point me at some prior art.

As far as the name of the new option, I can happily rename that as well.  Again, I wasn't sure if there's a different plugin that already does this and has a naming convention which I should follow.