### PR TITLE
Fix OCaml helptag name to match readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ formatting.
 | nroff | [proselint](http://proselint.com/)|
 | Objective-C | [clang](http://clang.llvm.org/) |
 | Objective-C++ | [clang](http://clang.llvm.org/) |
-| OCaml | [merlin](https://github.com/the-lambda-church/merlin) see `:help ale-integration-ocaml-merlin` for configuration instructions
+| OCaml | [merlin](https://github.com/the-lambda-church/merlin) see `:help ale-ocaml-merlin` for configuration instructions
 | Perl | [perl -c](https://perl.org/), [perl-critic](https://metacpan.org/pod/Perl::Critic) |
 | PHP | [hack](http://hacklang.org/), [langserver](https://github.com/felixfbecker/php-language-server), [php -l](https://secure.php.net/), [phpcs](https://github.com/squizlabs/PHP_CodeSniffer), [phpmd](https://phpmd.org), [phpstan](https://github.com/phpstan/phpstan), [phpcbf](https://github.com/squizlabs/PHP_CodeSniffer) |
 | Pod | [proselint](http://proselint.com/)|

--- a/doc/ale-ocaml.txt
+++ b/doc/ale-ocaml.txt
@@ -3,7 +3,7 @@ ALE OCaml Integration                                       *ale-ocaml-options*
 
 
 ===============================================================================
-merlin                                                       *ale-ocaml-merlin*
+merlin                                                      *ale-integration-ocaml-merlin*
 
   To use merlin linter for OCaml source code you need to make sure Merlin for
   Vim is correctly configured. See the corresponding Merlin wiki page for

--- a/doc/ale-ocaml.txt
+++ b/doc/ale-ocaml.txt
@@ -3,7 +3,7 @@ ALE OCaml Integration                                       *ale-ocaml-options*
 
 
 ===============================================================================
-merlin                                                      *ale-integration-ocaml-merlin*
+merlin                                                       *ale-ocaml-merlin*
 
   To use merlin linter for OCaml source code you need to make sure Merlin for
   Vim is correctly configured. See the corresponding Merlin wiki page for


### PR DESCRIPTION
The readme states for OCaml completion 'merlin see :help ale-integration-ocaml-merlin for configuration instructions'

This helptag didn't work, so I've fixed it.