### PR TITLE
fix typo `RUBUCOP` --> `RUBOCOP` for slim lint

### DIFF
--- a/ale_linters/slim/slimlint.vim
+++ b/ale_linters/slim/slimlint.vim
@@ -6,15 +6,15 @@ function! ale_linters#slim#slimlint#GetCommand(buffer) abort
 
     let l:rubocop_config = ale#path#FindNearestFile(a:buffer, '.rubocop.yml')
 
-    " Set SLIM_LINT_RUBUCOP_CONF variable as it is needed for slim-lint to
+    " Set SLIM_LINT_RUBOCOP_CONF variable as it is needed for slim-lint to
     " pick up the rubocop config.
     "
     " See https://github.com/sds/slim-lint/blob/master/lib/slim_lint/linter/README.md#rubocop
     if !empty(l:rubocop_config)
       if ale#Has('win32')
-        let l:command = 'set SLIM_LINT_RUBUCOP_CONF=' . ale#Escape(l:rubocop_config) . ' && ' . l:command
+        let l:command = 'set SLIM_LINT_RUBOCOP_CONF=' . ale#Escape(l:rubocop_config) . ' && ' . l:command
       else
-        let l:command = 'SLIM_LINT_RUBUCOP_CONF=' . ale#Escape(l:rubocop_config) . ' ' . l:command
+        let l:command = 'SLIM_LINT_RUBOCOP_CONF=' . ale#Escape(l:rubocop_config) . ' ' . l:command
       endif
     endif
 

--- a/test/command_callback/test_slimlint_command_callback.vader
+++ b/test/command_callback/test_slimlint_command_callback.vader
@@ -22,7 +22,7 @@ Execute(The command should have the .rubocop.yml prepended as an env var if one 
   call ale#test#SetFilename('../slimlint-test-files/subdir/file.slim')
 
   AssertEqual
-  \ 'SLIM_LINT_RUBUCOP_CONF=''/testplugin/test/slimlint-test-files/.rubocop.yml'' ' . g:default_command,
+  \ 'SLIM_LINT_RUBOCOP_CONF=''/testplugin/test/slimlint-test-files/.rubocop.yml'' ' . g:default_command,
   \ ale_linters#slim#slimlint#GetCommand(bufnr(''))
 
 Execute(The command should have the .rubocop.yml prepended as an env var if one exists on win32):
@@ -31,5 +31,5 @@ Execute(The command should have the .rubocop.yml prepended as an env var if one 
   let g:ale_has_override['win32'] = 1
 
   AssertEqual
-  \ 'set SLIM_LINT_RUBUCOP_CONF=''/testplugin/test/slimlint-test-files/.rubocop.yml'' && ' . g:default_command,
+  \ 'set SLIM_LINT_RUBOCOP_CONF=''/testplugin/test/slimlint-test-files/.rubocop.yml'' && ' . g:default_command,
   \ ale_linters#slim#slimlint#GetCommand(bufnr(''))


### PR DESCRIPTION
this actually makes 6ebd8f355c974cb6b7c5d5aff20603c8c4b38feb work

... looks through all that refactoring a typo slipped in, sorry!