### PR TITLE
Move dialect setting before user options (shellcheck)

### DIFF
--- a/ale_linters/sh/shellcheck.vim
+++ b/ale_linters/sh/shellcheck.vim
@@ -44,9 +44,9 @@ function! ale_linters#sh#shellcheck#GetCommand(buffer) abort
     let l:dialect = ale_linters#sh#shellcheck#GetDialectArgument(a:buffer)
 
     return ale_linters#sh#shellcheck#GetExecutable(a:buffer)
+    \   . (!empty(l:dialect) ? ' -s ' . l:dialect : '')
     \   . (!empty(l:options) ? ' ' . l:options : '')
     \   . (!empty(l:exclude_option) ? ' -e ' . l:exclude_option : '')
-    \   . (!empty(l:dialect) ? ' -s ' . l:dialect : '')
     \   . ' -f gcc -'
 endfunction
 

--- a/test/command_callback/test_shellcheck_command_callback.vader
+++ b/test/command_callback/test_shellcheck_command_callback.vader
@@ -45,3 +45,12 @@ Execute(The shellcheck command should include the dialect):
   AssertEqual
   \ 'shellcheck -s bash -f gcc -',
   \ ale_linters#sh#shellcheck#GetCommand(bufnr(''))
+
+Execute(The shellcheck command should include the dialect before options and exclusions):
+  let b:is_bash = 1
+  let b:ale_sh_shellcheck_options = '--foobar'
+  let b:ale_sh_shellcheck_exclusions = 'foo,bar'
+
+  AssertEqual
+  \ 'shellcheck -s bash --foobar -e foo,bar -f gcc -',
+  \ ale_linters#sh#shellcheck#GetCommand(bufnr(''))


### PR DESCRIPTION
This PR simply moves the dialect option before the user defined options for the shellcheck linter.

I tried to override the dialect with:

    let g:ale_sh_shellcheck_options = '-s bash'

However, this doesn't work because the dialect discovered by ale is place _after_ the user defined options. This results is `-s bash -s sh`. I certainly think the user should be able to override if they want. With this change the new result is `-s sh -s bash` (shellcheck using the last defined option).