### PR TITLE
ESLint --config option causes it to not detect node_modules?

### DIFF
--- a/autoload/ale/fixers/eslint.vim
+++ b/autoload/ale/fixers/eslint.vim
@@ -11,7 +11,7 @@ function! ale#fixers#eslint#Fix(buffer) abort
 
     return {
     \   'command': ale#node#Executable(a:buffer, l:executable)
-    \       . ' --config ' . ale#Escape(l:config)
+    \       . ' -c ' . ale#Escape(l:config)
     \       . ' --fix %t',
     \   'read_temporary_file': 1,
     \}

--- a/test/fixers/test_eslint_fixer_callback.vader
+++ b/test/fixers/test_eslint_fixer_callback.vader
@@ -13,7 +13,7 @@ Execute(The path to eslint.js should be run on Unix):
   \   'read_temporary_file': 1,
   \   'command':
   \     ale#Escape(simplify(g:dir . '/../eslint-test-files/react-app/node_modules/eslint/bin/eslint.js'))
-  \     . ' --config ' . ale#Escape(simplify(g:dir . '/../eslint-test-files/react-app/.eslintrc.js'))
+  \     . ' -c ' . ale#Escape(simplify(g:dir . '/../eslint-test-files/react-app/.eslintrc.js'))
   \     . ' --fix %t',
   \ },
   \ ale#fixers#eslint#Fix(bufnr(''))
@@ -26,7 +26,7 @@ Execute(The lower priority configuration file in a nested directory should be pr
   \   'read_temporary_file': 1,
   \   'command':
   \     ale#Escape(simplify(g:dir . '/../eslint-test-files/react-app/node_modules/eslint/bin/eslint.js'))
-  \     . ' --config ' . ale#Escape(simplify(g:dir . '/../eslint-test-files/react-app/subdir-with-config/.eslintrc'))
+  \     . ' -c ' . ale#Escape(simplify(g:dir . '/../eslint-test-files/react-app/subdir-with-config/.eslintrc'))
   \     . ' --fix %t',
   \ },
   \ ale#fixers#eslint#Fix(bufnr(''))
@@ -39,7 +39,7 @@ Execute(package.json should be used as a last resort):
   \   'read_temporary_file': 1,
   \   'command':
   \     ale#Escape(simplify(g:dir . '/../eslint-test-files/react-app/node_modules/eslint/bin/eslint.js'))
-  \     . ' --config ' . ale#Escape(simplify(g:dir . '/../eslint-test-files/react-app/.eslintrc.js'))
+  \     . ' -c ' . ale#Escape(simplify(g:dir . '/../eslint-test-files/react-app/.eslintrc.js'))
   \     . ' --fix %t',
   \ },
   \ ale#fixers#eslint#Fix(bufnr(''))
@@ -51,7 +51,7 @@ Execute(package.json should be used as a last resort):
   \   'read_temporary_file': 1,
   \   'command':
   \     ale#Escape(simplify(g:dir . '/../eslint-test-files/node_modules/.bin/eslint'))
-  \     . ' --config ' . ale#Escape(simplify(g:dir . '/../eslint-test-files/package.json'))
+  \     . ' -c ' . ale#Escape(simplify(g:dir . '/../eslint-test-files/package.json'))
   \     . ' --fix %t',
   \ },
   \ ale#fixers#eslint#Fix(bufnr(''))


### PR DESCRIPTION
I realize that this probably shouldn't be Ale's problem. It's definitely an upstream issue.

However, there seems to be a bug in eslint that causes the `--config` option to not detect node_modules correctly. The `-c` option, however, works fine.

Fixes #897 