### PR TITLE
Add all possible config files for prettier

### DIFF
--- a/autoload/ale/fixers/prettier.vim
+++ b/autoload/ale/fixers/prettier.vim
@@ -10,6 +10,10 @@ call ale#Set('javascript_prettier_options', '')
 function! s:FindConfig(buffer) abort
     for l:filename in [
     \   '.prettierrc',
+    \   '.prettierrc.json',
+    \   '.prettierrc.yaml',
+    \   '.prettierrc.yml',
+    \   '.prettierrc.js',
     \   'prettier.config.js',
     \   'package.json',
     \ ]


### PR DESCRIPTION
Prettier uses cosmiconfig, and therefore it is possible to add different
extensions to the config file. More information can be found here:
https://github.com/prettier/prettier#configuration-file.

