### PR TITLE
Fix Elm linter for Windows (resolves #980)

### DIFF
--- a/ale_linters/elm/make.vim
+++ b/ale_linters/elm/make.vim
@@ -71,11 +71,11 @@ function! ale_linters#elm#make#GetCommand(buffer) abort
 
     " The elm-make compiler, at the time of this writing, uses '/dev/null' as
     " a sort of flag to tell the compiler not to generate an output file,
-    " which is why this is hard coded here.
+    " which is why this is hard coded here. It does not use NUL on Windows.
     " Source: https://github.com/elm-lang/elm-make/blob/master/src/Flags.hs
     let l:elm_cmd = ale#Escape(l:elm_exe)
     \   . ' --report=json'
-    \   . ' --output=' . ale#Escape(g:ale#util#nul_file)
+    \   . ' --output=/dev/null'
 
     return l:dir_set_cmd . ' ' . l:elm_cmd . ' %t'
 endfunction


### PR DESCRIPTION
Looks like elm-make only respects `/dev/null`, even on Windows. The person
who wrote this linter maybe did not test it on Windows, and wrote the
code in the way you would expect to be solid by using `NUL` on Windows.
However it seems elm-make is not actually making use of `/dev/null` but
rather using it as a form of flag. Ironically this seems to be what is
already described in the comments; I added some clarification.

Let me know if you think this should be tested with Vader. I looked at the existing tests and thought about it and decided it would really just be "test that I wrote what I wrote" and that wasn't worth it.