### PR TITLE
Add g:ale_highlight_expand

### DIFF
--- a/autoload/ale/highlight.vim
+++ b/autoload/ale/highlight.vim
@@ -31,10 +31,10 @@ function! ale#highlight#CreatePositions(line, col, end_line, end_col) abort
         " If only a single character would be highlighted, and there's an
         " expand expression, apply it to increase the amount of text that
         " would be highlighted.
-        if g:ale_highlight_expand != '0' && a:col == a:end_col
+        if g:ale_highlight_expand !=# '0' && a:col == a:end_col
             let l:line = getline(a:line)
-            let l:endWord = match(l:line, g:ale_highlight_expand, a:col)
-            return [[[a:line, a:col, max([l:endWord, a:end_col]) - a:col + 1]]]
+            let l:expand_end = match(l:line, g:ale_highlight_expand, a:col)
+            return [[[a:line, a:col, max([l:expand_end, a:end_col]) - a:col + 1]]]
         endif
 
         " For single lines, just return the one position.

--- a/autoload/ale/highlight.vim
+++ b/autoload/ale/highlight.vim
@@ -31,7 +31,7 @@ function! ale#highlight#CreatePositions(line, col, end_line, end_col) abort
         " If only a single character would be highlighted, and there's an
         " expand expression, apply it to increase the amount of text that
         " would be highlighted.
-        if g:ale_highlight_expand !=# '0' && a:col == a:end_col
+        if g:ale_highlight_expand isnot# 0 && a:col == a:end_col
             let l:line = getline(a:line)
             let l:expand_end = match(l:line, g:ale_highlight_expand, a:col)
             return [[[a:line, a:col, max([l:expand_end, a:end_col]) - a:col + 1]]]

--- a/autoload/ale/highlight.vim
+++ b/autoload/ale/highlight.vim
@@ -28,6 +28,15 @@ let s:MAX_COL_SIZE = 1073741824 " pow(2, 30)
 
 function! ale#highlight#CreatePositions(line, col, end_line, end_col) abort
     if a:line >= a:end_line
+        " If only a single character would be highlighted, and there's an
+        " expand expression, apply it to increase the amount of text that
+        " would be highlighted.
+        if g:ale_highlight_expand != '0' && a:col == a:end_col
+            let l:line = getline(a:line)
+            let l:endWord = match(l:line, g:ale_highlight_expand, a:col)
+            return [[[a:line, a:col, max([l:endWord, a:end_col]) - a:col + 1]]]
+        endif
+
         " For single lines, just return the one position.
         return [[[a:line, a:col, a:end_col - a:col + 1]]]
     endif

--- a/plugin/ale.vim
+++ b/plugin/ale.vim
@@ -125,6 +125,7 @@ call ale#Set('change_sign_column_color', 0)
 
 " This flag can be set to 0 to disable setting error highlights.
 let g:ale_set_highlights = get(g:, 'ale_set_highlights', has('syntax'))
+let g:ale_highlight_expand = get(g:, 'ale_highlight_expand', 0)
 
 " These variables dictate what sign is used to indicate errors and warnings.
 call ale#Set('sign_error', '>>')


### PR DESCRIPTION
I don't like having the sign column, so I only use highlighting.

Some linters however only return 1 character which will be highlighted -
easy to miss when you don't have a sign column:

<img src=https://i.imgur.com/t0Et5zJ.png></img>

This pull request adds a `g:ale_highlight_expand` configuration,
allowing you to specify a regular expression used to highlight additional characters.

In this example I used `let g:ale_highlight_expand = '\>'`

<img src=https://i.imgur.com/gAepLAd.png></img>

Much better.

The expression gets applied when only a single character would be
highlighted and is disabled by default.

I don't really know any vimscript, but hopefully I didn't mess it up too bad.
