### PR TITLE
Use $VIRTUAL_ENV environment variable when present.

### DIFF
--- a/autoload/ale/python.vim
+++ b/autoload/ale/python.vim
@@ -71,7 +71,7 @@ function! ale#python#FindVirtualenv(buffer) abort
         endfor
     endfor
 
-    return ''
+    return $VIRTUAL_ENV
 endfunction
 
 " Run an executable check for Python scripts.

--- a/test/test_python_virtualenv.vader
+++ b/test/test_python_virtualenv.vader
@@ -1,0 +1,12 @@
+Before:
+  Save $VIRTUAL_ENV
+  let $VIRTUAL_ENV = "/opt/example/"
+
+After:
+  Restore
+
+Execute(ale#python#FindVirtualenv falls back to $VIRTUAL_ENV when no directories match):
+  AssertEqual
+  \  ale#python#FindVirtualenv(bufnr('%')),
+  \  '/opt/example/',
+  \  'Expected VIRTUAL_ENV environment variable to be used, but it was not'


### PR DESCRIPTION
This modifies the virtualenv detection to use the $VIRTUAL_ENV variable when it is in the environment. I'm not sure what other cases exist, so I left the other code as a fallback.

I will totally write tests if this looks like a reasonable suggestion, but I don't know the test language so don't want to figure it out if this doesn't look useful.

Thanks for the dope plugin! ❤️ 