### PR TITLE
Modifications to location_list open behavior

### DIFF
--- a/autoload/ale/list.vim
+++ b/autoload/ale/list.vim
@@ -90,33 +90,35 @@ function! s:SetListsImpl(timer_id, buffer, loclist) abort
     "
     " We'll check if the current buffer's List is not empty here, so the
     " window will only be opened if the current buffer has problems.
-    if s:ShouldOpen(a:buffer) && !empty(a:loclist)
-        let l:winnr = winnr()
-        let l:mode = mode()
-        let l:reset_visual_selection = l:mode is? 'v' || l:mode is# "\<c-v>"
-        let l:reset_character_selection = l:mode is? 's' || l:mode is# "\<c-s>"
+    let l:winnr = winnr()
+    let l:mode = mode()
+    let l:reset_visual_selection = l:mode is? 'v' || l:mode is# "\<c-v>"
+    let l:reset_character_selection = l:mode is? 's' || l:mode is# "\<c-s>"
 
-        if g:ale_set_quickfix
-            if !ale#list#IsQuickfixOpen()
-                silent! execute 'copen ' . str2nr(ale#Var(a:buffer, 'list_window_size'))
-            endif
-        elseif g:ale_set_loclist
+    if g:ale_set_quickfix
+        if !ale#list#IsQuickfixOpen()
+            silent! execute 'copen ' . str2nr(ale#Var(a:buffer, 'list_window_size'))
+        endif
+    elseif g:ale_set_loclist
+        if !empty(a:loclist)
             silent! execute 'lopen ' . str2nr(ale#Var(a:buffer, 'list_window_size'))
+        else
+            silent! execute 'lopen 1'
         endif
+    endif
 
-        " If focus changed, restore it (jump to the last window).
-        if l:winnr isnot# winnr()
-            wincmd p
-        endif
+    " If focus changed, restore it (jump to the last window).
+    if l:winnr isnot# winnr()
+        wincmd p
+    endif
 
-        if l:reset_visual_selection || l:reset_character_selection
-            " If we were in a selection mode before, select the last selection.
-            normal! gv
+    if l:reset_visual_selection || l:reset_character_selection
+        " If we were in a selection mode before, select the last selection.
+        normal! gv
 
-            if l:reset_character_selection
-                " Switch back to Select mode, if we were in that.
-                normal! "\<c-g>"
-            endif
+        if l:reset_character_selection
+            " Switch back to Select mode, if we were in that.
+            normal! "\<c-g>"
         endif
     endif
 
@@ -162,7 +164,10 @@ function! s:CloseWindowIfNeeded(buffer) abort
             let l:win_id = s:BufWinId(a:buffer)
 
             if g:ale_set_loclist && empty(getloclist(l:win_id))
-                lclose
+                " Disable lclose because when 'close', have a 1 row location
+                " list
+
+                "lclose
             endif
         endif
     " Ignore 'Cannot close last window' errors.

--- a/autoload/ale/list.vim
+++ b/autoload/ale/list.vim
@@ -101,7 +101,12 @@ function! s:SetListsImpl(timer_id, buffer, loclist) abort
         endif
     elseif g:ale_set_loclist
         if !empty(a:loclist)
-            silent! execute 'lopen ' . str2nr(ale#Var(a:buffer, 'list_window_size'))
+            " Set list_window_size to be up to list_window_size parameter
+            let l:lheight = len(a:loclist)
+            if l:lheight > ale#Var(a:buffer, 'list_window_size')
+                let l:lheight = ale#Var(a:buffer, 'list_window_size')
+            endif
+            silent! execute 'lopen ' . str2nr(l:lheight)
         else
             silent! execute 'lopen 1'
         endif


### PR DESCRIPTION
I put 2 related commits together:

[(1)](https://github.com/w0rp/ale/commit/40bf9a05763bbde4eb6d29b28413cab2b8bc6fcd): I use `ale` constantly but found the constant opening/closing of the quickfix/location_list to be annoying (which is, ironically, only because it's so fast async that it caught my semicolon errors before I could type them!). This modification along with the existing param to keeping the sign gutter open makes it a lot less jumpy.

[(2)](https://github.com/w0rp/ale/commit/ee4c53a3c5ed5b49c75da169cdb21b6ed1e20a5c): This makes the error menu change height to fit the number of errors, up to a max_height parameter (it uses the existing `list_window_size` which defaults to 10 max).

I thought a cool addition to # 2 would be to make the last item of the quickfix/location_list menu be "..." so the user knows there are more errors but since this is my first vimscript project, didn't know how to change that

I can make the necessary changes to the quickfix menu as well but thought I would get location_list feedback first

I really enjoy ale, it makes me 100x faster at catching bugs. Thanks so much for making it

----

I'll be happy to fix the tests but don't know how to best integrate it (if at all).

In my mind, there would be another parameter to enable the responsive-height. I don't know if anyone wants the always-open location_list, in which case, it just live on my fork