### PR TITLE
phpcs: include sniff code in message

### DIFF
--- a/ale_linters/php/phpcs.vim
+++ b/ale_linters/php/phpcs.vim
@@ -29,11 +29,12 @@ function! ale_linters#php#phpcs#Handle(buffer, lines) abort
     " Matches against lines like the following:
     "
     " /path/to/some-filename.php:18:3: error - Line indented incorrectly; expected 4 spaces, found 2 (Generic.WhiteSpace.ScopeIndent.IncorrectExact)
-    let l:pattern = '^.*:\(\d\+\):\(\d\+\): \(.\+\) - \(.\+\) \(\(.\+\)\)$'
+    let l:pattern = '^.*:\(\d\+\):\(\d\+\): \(.\+\) - \(.\+\) (\(.\+\))$'
     let l:output = []
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)
-        let l:text = l:match[4]
+        let l:code = l:match[5]
+        let l:text = l:match[4] . ' (' . l:code . ')'
         let l:type = l:match[3]
 
         call add(l:output, {

--- a/test/test_phpcs_include_code.vader
+++ b/test/test_phpcs_include_code.vader
@@ -1,0 +1,7 @@
+Execute(errors should include code):
+  AssertEqual
+  \ [{'lnum': 18, 'col': 3, 'type': 'E', 'text': 'Line indented incorrectly; expected 4 spaces, found 2 (Generic.WhiteSpace.ScopeIndent.IncorrectExact)'}],
+  \ ale_linters#php#phpcs#Handle(bufnr(''), [
+  \ '/path/to/some-filename.php:18:3: error - Line indented incorrectly; expected 4 spaces, found 2 (Generic.WhiteSpace.ScopeIndent.IncorrectExact)',
+  \ ])
+


### PR DESCRIPTION
When troubleshooting phpcs warnings/errors, it is often helpful to know the exact "sniff code" that represents that notice (eg: `Generic.Files.LowercasedFilename.NotFound`), but the default implementation of the ALE phpcs module hides that code, and just prints the text part of the message.

This PR includes the sniff code in the message instead.

## Screenshots

Current behavior:
![phpcs-without-code](https://user-images.githubusercontent.com/2036909/31747462-04df929c-b43b-11e7-95de-d6b6a9fb550b.png)

With this change
![phpcs-with-code](https://user-images.githubusercontent.com/2036909/31747469-0d7ec256-b43b-11e7-8aeb-35f7d9f41794.png)
