### PR TITLE
add support for remark-lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ formatting.
 | LaTeX | [chktex](http://www.nongnu.org/chktex/), [lacheck](https://www.ctan.org/pkg/lacheck), [proselint](http://proselint.com/) |
 | LLVM | [llc](https://llvm.org/docs/CommandGuide/llc.html) |
 | Lua | [luacheck](https://github.com/mpeterv/luacheck) |
-| Markdown | [mdl](https://github.com/mivok/markdownlint), [proselint](http://proselint.com/), [vale](https://github.com/ValeLint/vale) |
+| Markdown | [mdl](https://github.com/mivok/markdownlint), [proselint](http://proselint.com/), [vale](https://github.com/ValeLint/vale), [remark-lint](https://github.com/wooorm/remark-lint) !! |
 | MATLAB | [mlint](https://www.mathworks.com/help/matlab/ref/mlint.html) |
 | Nim | [nim check](https://nim-lang.org/docs/nimc.html) !! |
 | nix | [nix-instantiate](http://nixos.org/nix/manual/#sec-nix-instantiate) |

--- a/ale_linters/markdown/remark_lint.vim
+++ b/ale_linters/markdown/remark_lint.vim
@@ -1,0 +1,28 @@
+" Author rhysd https://rhysd.github.io/
+" Description: remark-lint for Markdown files
+
+function! ale_linters#markdown#remark_lint#Handle(buffer, lines) abort
+    " matches: '  1:4  warning  Incorrect list-item indent: add 1 space  list-item-indent  remark-lint'
+    let l:pattern = '^ \+\(\d\+\):\(\d\+\)  \(warning\|error\)  \(.\+\)$'
+    let l:output = []
+
+    for l:match in ale#util#GetMatches(a:lines, l:pattern)
+        call add(l:output, {
+        \   'lnum': l:match[1] + 0,
+        \   'col': l:match[2] + 0,
+        \   'type': l:match[3] is# 'error' ? 'E' : 'W',
+        \   'text': l:match[4],
+        \})
+    endfor
+
+    return l:output
+endfunction
+
+call ale#linter#Define('markdown', {
+\   'name': 'remark-lint',
+\   'executable': 'remark',
+\   'command': 'remark --no-stdout --no-color %s',
+\   'callback': 'ale_linters#markdown#remark_lint#Handle',
+\   'lint_file': 1,
+\   'output_stream': 'stderr',
+\})

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -259,7 +259,7 @@ Notes:
 * LaTeX (tex): `chktex`, `lacheck`, `proselint`
 * LLVM: `llc`
 * Lua: `luacheck`
-* Markdown: `mdl`, `proselint`, `vale`
+* Markdown: `mdl`, `proselint`, `vale`, `remark-lint`
 * MATLAB: `mlint`
 * Nim: `nim check`!!
 * nix: `nix-instantiate`

--- a/test/handler/test_remark_lint_handler.vader
+++ b/test/handler/test_remark_lint_handler.vader
@@ -1,0 +1,27 @@
+Before:
+  runtime ale_linters/markdown/remark_lint.vim
+
+Execute(Warning and error messages should be handled correctly):
+  AssertEqual
+  \ [
+  \   {
+  \      'lnum': 1,
+  \      'col': 4,
+  \      'type': 'W',
+  \      'text': 'Incorrect list-item indent: add 1 space  list-item-indent  remark-lint',
+  \   },
+  \   {
+  \      'lnum': 3,
+  \      'col': 5,
+  \      'type': 'E',
+  \      'text': 'Incorrect list-item indent: remove 1 space  list-item-indent  remark-lint',
+  \   },
+  \ ],
+  \ ale_linters#markdown#remark_lint#Handle(1, [
+  \   'foo.md',
+  \   '  1:4  warning  Incorrect list-item indent: add 1 space  list-item-indent  remark-lint',
+  \   '  3:5  error  Incorrect list-item indent: remove 1 space  list-item-indent  remark-lint',
+  \   '',
+  \   '⚠ 1 warnings',
+  \   '✘ 1 errors',
+  \])


### PR DESCRIPTION
<!--
READ THIS: Before creating a pull request, please consider the following first.

* The most important thing you can do is write tests. Code without tests
  probably doesn't work, and will almost certainly stop working later on. Pull
  requests without tests probably won't be accepted, although there are some
  exceptions.
* Read the Contributing guide linked above first.
* If you are adding a new linter, remember to update the README.md file and
  doc/ale.txt first.
* If you add or modify a function for converting error lines into loclist items
  that ALE can work with, please add Vader tests for them. Look at existing
  tests in the test/handler directory, etc.
* If you add or modify a function for computing a command line string for
  running a command, please add Vader tests for that.
* Generally try and cover anything with Vader tests, although some things just
  can't be tested with Vader, or at least they can be hard to test. Consider
  breaking up your code so that some parts can be tested, and generally open up
  a discussion about it.
* Have fun!
-->
I added support for [remark-lint](https://github.com/wooorm/remark-lint) to ale. It is a linter for markdown. I marked this linter as existing file only because stdin or temporary file is not available. remark-lint assumes `.remarkrc` config file put in the same or any parent directory as target markdown source file.
