### PR TITLE
adds fixer support for hfmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ formatting.
 | GraphQL | [gqlint](https://github.com/happylinks/gqlint) |
 | Haml | [haml-lint](https://github.com/brigade/haml-lint) |
 | Handlebars | [ember-template-lint](https://github.com/rwjblue/ember-template-lint) |
-| Haskell | [ghc](https://www.haskell.org/ghc/), [stack-ghc](https://haskellstack.org/), [stack-build](https://haskellstack.org/) !!, [ghc-mod](https://github.com/DanielG/ghc-mod), [stack-ghc-mod](https://github.com/DanielG/ghc-mod), [hlint](https://hackage.haskell.org/package/hlint), [hdevtools](https://hackage.haskell.org/package/hdevtools) |
+| Haskell | [ghc](https://www.haskell.org/ghc/), [stack-ghc](https://haskellstack.org/), [stack-build](https://haskellstack.org/) !!, [ghc-mod](https://github.com/DanielG/ghc-mod), [stack-ghc-mod](https://github.com/DanielG/ghc-mod), [hlint](https://hackage.haskell.org/package/hlint), [hdevtools](https://hackage.haskell.org/package/hdevtools), [hfmt](https://github.com/danstiner/hfmt) |
 | HTML | [HTMLHint](http://htmlhint.com/), [proselint](http://proselint.com/), [tidy](http://www.html-tidy.org/) |
 | Idris | [idris](http://www.idris-lang.org/) |
 | Java | [checkstyle](http://checkstyle.sourceforge.net), [javac](http://www.oracle.com/technetwork/java/javase/downloads/index.html) |

--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -107,6 +107,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['typescript'],
 \       'description': 'Fix typescript files with tslint --fix.',
 \   },
+\   'hfmt': {
+\       'function': 'ale#fixers#hfmt#Fix',
+\       'suggested_filetypes': ['haskell'],
+\       'description': 'Fix Haskell files with hfmt.',
+\   },
 \}
 
 " Reset the function registry to the default entries.

--- a/autoload/ale/fixers/hfmt.vim
+++ b/autoload/ale/fixers/hfmt.vim
@@ -1,0 +1,16 @@
+" Author: zack <zack@kourouma.me>
+" Description: Integration of hfmt with ALE.
+
+call ale#Set('haskell_hfmt_executable', 'hfmt')
+
+function! ale#fixers#hfmt#Fix(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'haskell_hfmt_executable')
+
+    return {
+    \   'command': ale#Escape(l:executable)
+    \       . ' -w'
+    \       . ' %t',
+    \   'read_temporary_file': 1,
+    \}
+endfunction
+

--- a/doc/ale-haskell.txt
+++ b/doc/ale-haskell.txt
@@ -21,6 +21,16 @@ g:ale_haskell_hdevtools_options               *g:ale_haskell_hdevtools_options*
   This variable can be changed to modify flags given to hdevtools.
 
 ===============================================================================
+hfmt                                                         *ale-haskell-hfmt*
+
+g:ale_haskell_hfmt_executable                   *g:ale_haskell_hfmt_executable*
+                                                *b:ale_haskell_hfmt_executable*
+  Type: |String|
+  Default: `'hfmt'`
+
+  This variable can be changed to use a different executable for hfmt.
+
+===============================================================================
 stack-build                                           *ale-haskell-stack-build*
 
 g:ale_haskell_stack_build_options           *g:ale_haskell_stack_build_options*

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -69,9 +69,9 @@ CONTENTS                                                         *ale-contents*
     handlebars............................|ale-handlebars-options|
       ember-template-lint.................|ale-handlebars-embertemplatelint|
     haskell...............................|ale-haskell-options|
+      hfmt................................|ale-haskell-hfmt|
       hdevtools...........................|ale-haskell-hdevtools|
       stack-build.........................|ale-haskell-stack-build|
-      hfmt................................|ale-haskell-hfmt|
     html..................................|ale-html-options|
       htmlhint............................|ale-html-htmlhint|
       tidy................................|ale-html-tidy|

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -71,7 +71,7 @@ CONTENTS                                                         *ale-contents*
     haskell...............................|ale-haskell-options|
       hdevtools...........................|ale-haskell-hdevtools|
       stack-build.........................|ale-haskell-stack-build|
-      hfmt................................|ale-go-hfmt|
+      hfmt................................|ale-haskell-hfmt|
     html..................................|ale-html-options|
       htmlhint............................|ale-html-htmlhint|
       tidy................................|ale-html-tidy|

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -69,8 +69,8 @@ CONTENTS                                                         *ale-contents*
     handlebars............................|ale-handlebars-options|
       ember-template-lint.................|ale-handlebars-embertemplatelint|
     haskell...............................|ale-haskell-options|
-      hfmt................................|ale-haskell-hfmt|
       hdevtools...........................|ale-haskell-hdevtools|
+      hfmt................................|ale-haskell-hfmt|
       stack-build.........................|ale-haskell-stack-build|
     html..................................|ale-html-options|
       htmlhint............................|ale-html-htmlhint|

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -71,6 +71,7 @@ CONTENTS                                                         *ale-contents*
     haskell...............................|ale-haskell-options|
       hdevtools...........................|ale-haskell-hdevtools|
       stack-build.........................|ale-haskell-stack-build|
+      hfmt................................|ale-go-hfmt|
     html..................................|ale-html-options|
       htmlhint............................|ale-html-htmlhint|
       tidy................................|ale-html-tidy|
@@ -251,7 +252,7 @@ Notes:
 * GraphQL: `gqlint`
 * Haml: `haml-lint`
 * Handlebars: `ember-template-lint`
-* Haskell: `ghc`, `stack-ghc`, `stack-build`!!, `ghc-mod`, `stack-ghc-mod`, `hlint`, `hdevtools`
+* Haskell: `ghc`, `stack-ghc`, `stack-build`!!, `ghc-mod`, `stack-ghc-mod`, `hlint`, `hdevtools`, `hfmt`
 * HTML: `HTMLHint`, `proselint`, `tidy`
 * Idris: `idris`
 * Java: `checkstyle`, `javac`

--- a/test/fixers/test_hfmt_fixer_callback.vader
+++ b/test/fixers/test_hfmt_fixer_callback.vader
@@ -1,0 +1,24 @@
+Before:
+  Save g:ale_haskell_hfmt_executable
+
+  " Use an invalid global executable, so we don't match it.
+  let g:ale_haskell_hfmt_executable = 'xxxinvalid'
+
+  call ale#test#SetDirectory('/testplugin/test/fixers')
+
+After:
+  Restore
+
+  call ale#test#RestoreDirectory()
+
+Execute(The hfmt callback should return the correct default values):
+  call ale#test#SetFilename('../haskell_files/testfile.hs')
+
+  AssertEqual
+  \ {
+  \   'read_temporary_file': 1,
+  \   'command': ale#Escape('xxxinvalid')
+  \     . ' -w'
+  \     . ' %t',
+  \ },
+  \ ale#fixers#hfmt#Fix(bufnr(''))


### PR DESCRIPTION
added a fixer for haskell files using [hfmt](https://github.com/danstiner/hfmt)

hfmt is a tool for formatting Haskell programs. Currently it is simply a gofmt style wrapper of the excellent tools [hlint](https://github.com/ndmitchell/hlint/blob/master/README.md), [hindent](https://github.com/commercialhaskell/hindent#readme), and [stylish-haskell](https://github.com/jaspervdj/stylish-haskell#readme).

i didn't include the options since they're mostly for different kinds of print output. 