### PR TITLE
Use Rubocop config also when linting

### DIFF
--- a/ale_linters/ruby/rubocop.vim
+++ b/ale_linters/ruby/rubocop.vim
@@ -6,10 +6,13 @@ function! ale_linters#ruby#rubocop#GetCommand(buffer) abort
     let l:exec_args = l:executable =~? 'bundle$'
     \   ? ' exec rubocop'
     \   : ''
+    let l:config = ale#path#FindNearestFile(a:buffer, '.rubocop.yml')
+    let l:options = ale#Var(a:buffer, 'ruby_rubocop_options')
 
     return ale#Escape(l:executable) . l:exec_args
+    \   . (!empty(l:config) ? ' --config ' . ale#Escape(l:config) : '')
+    \   . (!empty(l:options) ? ' ' . l:options : '')
     \   . ' --format json --force-exclusion '
-    \   . ale#Var(a:buffer, 'ruby_rubocop_options')
     \   . ' --stdin ' . ale#Escape(expand('#' . a:buffer . ':p'))
 endfunction
 

--- a/test/command_callback/test_rubocop_command_callback.vader
+++ b/test/command_callback/test_rubocop_command_callback.vader
@@ -37,3 +37,23 @@ Execute(Setting bundle appends 'exec rubocop'):
   \   . ' --format json --force-exclusion  --stdin '
   \   . ale#Escape(ale#path#Winify(g:dir . '/dummy.rb')),
   \ ale_linters#ruby#rubocop#GetCommand(bufnr(''))
+
+Execute(Should include configuration files):
+  call ale#test#SetFilename('ruby_paths/with_config/dummy.rb')
+
+  AssertEqual
+  \ ale#Escape('rubocop')
+  \   . ' --config ' . ale#Escape(ale#path#Winify(g:dir . '/ruby_paths/with_config/.rubocop.yml'))
+  \   . ' --format json --force-exclusion  --stdin '
+  \   . ale#Escape(ale#path#Winify(g:dir . '/ruby_paths/with_config/dummy.rb')),
+  \ ale_linters#ruby#rubocop#GetCommand(bufnr(''))
+
+Execute(Should include custom rubocop options):
+  let g:ale_ruby_rubocop_options = '--except Lint/Debugger'
+
+  AssertEqual
+  \ ale#Escape('rubocop')
+  \   . ' --except Lint/Debugger'
+  \   . ' --format json --force-exclusion  --stdin '
+  \   . ale#Escape(ale#path#Winify(g:dir . '/dummy.rb')),
+  \ ale_linters#ruby#rubocop#GetCommand(bufnr(''))


### PR DESCRIPTION
This fixes the same problem as in #732 but for linters, and while doing so aligns the option generation for the linter with how the Rubocop fixer works.