### PR TITLE
Update test scripts to work on OS X

### DIFF
--- a/test/script/check-supported-tools-tables
+++ b/test/script/check-supported-tools-tables
@@ -30,30 +30,30 @@ readme_section_size="$( \
 # shellcheck disable=SC2003
 readme_end_line="$(expr "$readme_start_line" + "$readme_section_size")"
 
-doc_file="$(mktemp)"
-readme_file="$(mktemp)"
+doc_file="$(mktemp -t doc.XXXXXXXX)"
+readme_file="$(mktemp -t readme.XXXXXXXX)"
 
 sed -n "$ale_help_start_line,$ale_help_end_line"p doc/ale.txt \
     | grep '\* .*: ' \
     | sed 's/^*//' \
-    | sed 's/[`!^]\|([^)]*)//g' \
+    | sed 's/[`!^]//g;s/([^)]*)//g' \
     | sed 's/ *\([,:]\)/\1/g' \
     | sed 's/  */ /g' \
-    | sed 's/^ *\| *$//g' \
+    | sed 's/^ *//;s/ *$//' \
     | sed 's/^/ /' \
     > "$doc_file"
 
 sed -n "$readme_start_line,$readme_end_line"p README.md \
     | grep '| .* |' \
-    | sed '/^| Language\|^| ---/d' \
+    | sed '/^| Language/d;/^| ---/d' \
     | sed 's/^|//' \
-    | sed 's/ \?|/:/' \
-    | sed 's/[`!^|]\|([^)]*)//g' \
-    | sed 's/\[\|\]//g' \
-    | sed 's/see[^,]*\(,\|$\)/\1/g' \
+    | sed 's/ \{0,1\}|/:/' \
+    | sed 's/[`!^|]//g;s/([^)]*)//g' \
+    | sed 's/\[//g;s/\]//g' \
+    | sed 's/see[^,]*//g' \
     | sed 's/ *\([,:]\)/\1/g' \
     | sed 's/  */ /g' \
-    | sed 's/^ *\| *$//g' \
+    | sed 's/^ *//;s/ *$//' \
     | sed 's/^/ /' \
     | sed 's/ *-n flag//g' \
     > "$readme_file"

--- a/test/script/check-toc
+++ b/test/script/check-toc
@@ -23,18 +23,19 @@ tagged_toc_file="$(mktemp -t ale.txt.XXXXXXXX)"
 sorted_toc_file="$(mktemp -t sorted-ale.txt.XXXXXXXX)"
 
 sed -n "$toc_start_line,$toc_end_line"p doc/ale.txt \
-    | sed 's/^    \( *[^.]\+\)\.\+|\(.\+\)|/\1, \2/' \
+    | sed 's/^    \( *[^.][^.]*\)\.\.*|\(..*\)|/\1, \2/' \
     > "$toc_file"
 
 # Get all of the doc files in a natural sorted order.
-doc_files="$(/bin/ls -1v doc | grep ^ale- | sed 's/^/doc\//' | paste -sd ' ')"
+doc_files="$(/bin/ls -1v doc | grep ^ale- | sed 's/^/doc\//' | paste -sd ' ' -)"
 
 # shellcheck disable=SC2086
 grep -h 'ale-.*-options\|^[a-z].*\*ale-.*\*$' $doc_files \
     | sed 's/^/  /' \
     | sed 's/ALE Shell Integration/ALE sh Integration/' \
-    | sed 's/  ALE \(.*\) Integration/\L\1/' \
-    | sed 's/ *\*\(.\+\)\*$/, \1/' \
+    | sed 's/  ALE \(.*\) Integration/\1/' \
+    | sed 's/ *\*\(..*\)\*$/, \1/' \
+    | tr '[:upper:]' '[:lower:]' \
     | sed 's/objective-c/objc/' \
     | sed 's/c++/cpp/' \
     > "$heading_file"
@@ -62,7 +63,7 @@ while read -r; do
 done < "$toc_file"
 
 # Sort the sections and sub-sections and remove the tags.
-sort -h "$tagged_toc_file" | sed 's/[0-9]\+ //' > "$sorted_toc_file"
+sort -sn "$tagged_toc_file" | sed 's/[0-9][0-9]* //' > "$sorted_toc_file"
 
 echo 'Check for bad ToC sorting:'
 echo


### PR DESCRIPTION
There were a couple of issues
 - `paste` requires a file argument
 - `mktemp` requires a pattern argument
 - `sort` doesn't support `-h`, but `-n` is enough for sorting on numbers, and `-s` was introduced to perform a stable sort instead.

The main issues were that BSD `sed` does not support:
 - Alternation (`\|`) - solved by splitting to multiple patterns
 - Bound shortcuts (`x\+`, `x\?`) - solved by replacing with `xx*` and `x\{0,1\}` respectively
 - Lower-casing (`\L`) - solved by piping through `tr` instead (this will lowercase everything and not only the integration names, but I assumed that wasn't too much of an issue, as a portable alternative for the selective downcasing would be much more involved).
