### PR TITLE
Add checkmake (#866)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ formatting.
 | LaTeX | [chktex](http://www.nongnu.org/chktex/), [lacheck](https://www.ctan.org/pkg/lacheck), [proselint](http://proselint.com/) |
 | LLVM | [llc](https://llvm.org/docs/CommandGuide/llc.html) |
 | Lua | [luacheck](https://github.com/mpeterv/luacheck) |
+| Make | [checkmake](https://github.com/mrtazz/checkmake) |
 | Markdown | [mdl](https://github.com/mivok/markdownlint), [proselint](http://proselint.com/), [vale](https://github.com/ValeLint/vale), [remark-lint](https://github.com/wooorm/remark-lint) !! |
 | MATLAB | [mlint](https://www.mathworks.com/help/matlab/ref/mlint.html) |
 | Nim | [nim check](https://nim-lang.org/docs/nimc.html) !! |

--- a/ale_linters/make/checkmake.vim
+++ b/ale_linters/make/checkmake.vim
@@ -1,0 +1,24 @@
+" Author: aurieh - https://github.com/aurieh
+
+function! ale_linters#make#checkmake#Handle(buffer, lines) abort
+    let l:pattern = '\v^(\d+):(.+):(.+)$'
+    let l:output = []
+
+    for l:match in ale#util#GetMatches(a:lines, l:pattern)
+        let l:text = l:match[2] . ': ' . l:match[3]
+        call add(l:output, {
+        \    'bufnr': a:buffer,
+        \    'lnum': l:match[1] + 0,
+        \    'type': 'E',
+        \    'text': l:text,
+        \})
+    endfor
+    return l:output
+endfunction
+
+call ale#linter#Define('make', {
+\   'name': 'checkmake',
+\   'executable': 'checkmake',
+\   'command': 'checkmake %s --format="{{.LineNumber}}:{{.Rule}}:{{.Violation}}"',
+\   'callback': 'ale_linters#make#checkmake#Handle',
+\})

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -261,6 +261,7 @@ Notes:
 * LaTeX (tex): `chktex`, `lacheck`, `proselint`
 * LLVM: `llc`
 * Lua: `luacheck`
+* Make: `checkmake`
 * Markdown: `mdl`, `proselint`, `vale`, `remark-lint`
 * MATLAB: `mlint`
 * Nim: `nim check`!!

--- a/test/handler/test_checkmake_handler.vader
+++ b/test/handler/test_checkmake_handler.vader
@@ -1,0 +1,19 @@
+Execute(Parsing checkmake errors should work):
+  runtime ale_linters/make/checkmake.vim
+  silent file Makefile
+
+  AssertEqual
+  \ [
+  \   {
+  \      'bufnr': 42,
+  \      'lnum': 1,
+  \      'type': 'E',
+  \      'text': 'woops: an error has occurred',
+  \   }
+  \ ],
+  \ ale_linters#make#checkmake#Handle(42, [
+  \   'This shouldnt match',
+  \   '1:woops:an error has occurred',
+  \ ])
+After:
+  call  ale#linter#Reset()


### PR DESCRIPTION
Adds checkmake linter for `make` file type.
One annoying thing is that checkmake, for some reason, uses DOS line endings (`\r\n`), so vim displays `^M` in quickfix/loclist. Should I just substitute it?