### PR TITLE
#955 Add vale linter for mail files

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ formatting.
 | LaTeX | [chktex](http://www.nongnu.org/chktex/), [lacheck](https://www.ctan.org/pkg/lacheck), [proselint](http://proselint.com/) |
 | LLVM | [llc](https://llvm.org/docs/CommandGuide/llc.html) |
 | Lua | [luacheck](https://github.com/mpeterv/luacheck) |
-| Mail | [proselint](http://proselint.com/) |
+| Mail | [proselint](http://proselint.com/), [vale](https://github.com/ValeLint/vale) |
 | Make | [checkmake](https://github.com/mrtazz/checkmake) |
 | Markdown | [mdl](https://github.com/mivok/markdownlint), [proselint](http://proselint.com/), [vale](https://github.com/ValeLint/vale), [remark-lint](https://github.com/wooorm/remark-lint) !! |
 | MATLAB | [mlint](https://www.mathworks.com/help/matlab/ref/mlint.html) |

--- a/ale_linters/mail/vale.vim
+++ b/ale_linters/mail/vale.vim
@@ -1,0 +1,9 @@
+" Author: chew-z https://github.com/chew-z
+" Description: vale for Markdown files
+
+call ale#linter#Define('mail', {
+\   'name': 'vale',
+\   'executable': 'vale',
+\   'command': 'vale --output=line %t',
+\   'callback': 'ale#handlers#unix#HandleAsWarning',
+\})

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -266,7 +266,7 @@ Notes:
 * LaTeX (tex): `chktex`, `lacheck`, `proselint`
 * LLVM: `llc`
 * Lua: `luacheck`
-* Mail: `proselint`
+* Mail: `proselint`, `vale`
 * Make: `checkmake`
 * Markdown: `mdl`, `proselint`, `vale`, `remark-lint`
 * MATLAB: `mlint`


### PR DESCRIPTION
This is a very simple pull to add Vale lint to mail files. I didn't see any tests for the other file types using proselint (asciidoc, rst, etc.), so I didn't add any here either.