### PR TITLE
Do not change 'runtimepath'

### DIFF
--- a/plugin/ale.vim
+++ b/plugin/ale.vim
@@ -32,9 +32,6 @@ if !s:has_features
     finish
 endif
 
-" Add the after directory to the runtimepath
-let &runtimepath .= ',' . expand('<sfile>:p:h:h') . '/after'
-
 " Set this flag so that other plugins can use it, like airline.
 let g:loaded_ale = 1
 

--- a/test/vimrc
+++ b/test/vimrc
@@ -6,9 +6,9 @@ let g:ale_set_lists_synchronously = 1
 " Load builtin plugins
 " We need this because run_vim.sh sets -i NONE
 if has('win32')
-    set runtimepath=$VIM/vimfiles,$VIMRUNTIME,$VIM/vimfiles/after,C:\vader,C:\testplugin
+    set runtimepath=C:\testplugin,C:\vader,$VIM/vimfiles,$VIMRUNTIME,$VIM/vimfiles/after,C:\testplugin\after
 else
-    set runtimepath=/home/vim,$VIM/vimfiles,$VIMRUNTIME,$VIM/vimfiles/after,/testplugin,/vader
+    set runtimepath=/testplugin,/vader,/home/vim,$VIM/vimfiles,$VIMRUNTIME,$VIM/vimfiles/after,/testplugin/after
 endif
 
 " The following is just an example


### PR DESCRIPTION
A plugin must not change 'runtimepath' implicitly.
It is plugin manager's work.
