### PR TITLE
don't use stdin with tflint

### DIFF
--- a/ale_linters/terraform/tflint.vim
+++ b/ale_linters/terraform/tflint.vim
@@ -46,7 +46,7 @@ function! ale_linters#terraform#tflint#GetCommand(buffer) abort
         let l:cmd .= ' ' . l:opts
     endif
 
-    let l:cmd .= ' -f json'
+    let l:cmd .= ' -f json %t'
 
     return l:cmd
 endfunction

--- a/test/command_callback/test_terraform_tflint_command_callback.vader
+++ b/test/command_callback/test_terraform_tflint_command_callback.vader
@@ -21,12 +21,12 @@ Execute(The default executable should be configurable):
 Execute(The default command should be good):
   let g:ale_terraform_tflint_executable = 'tflint'
   AssertEqual
-  \ ale#Escape('tflint') . ' -f json',
+  \ ale#Escape('tflint') . ' -f json %t',
   \ ale_linters#terraform#tflint#GetCommand(bufnr(''))
 
 Execute(Overriding things should work):
   let g:ale_terraform_tflint_executable = 'fnord'
   let g:ale_terraform_tflint_options = '--whatever'
   AssertEqual
-  \ ale#Escape('fnord') . ' --whatever -f json',
+  \ ale#Escape('fnord') . ' --whatever -f json %t',
   \ ale_linters#terraform#tflint#GetCommand(bufnr(''))

--- a/test/test_tflint_config_detection.vader
+++ b/test/test_tflint_config_detection.vader
@@ -13,6 +13,6 @@ Execute(adjacent config file should be found):
   \   ale#Escape('tflint')
   \   . ' --config '
   \   . ale#Escape(ale#path#Winify(g:dir . '/tflint-test-files/foo/.tflint.hcl'))
-  \   . ' -f json'
+  \   . ' -f json %t'
   \ ),
   \ ale_linters#terraform#tflint#GetCommand(bufnr(''))


### PR DESCRIPTION
whoops. It looks like `tflint` doesn't actually use stdin, it just doesn't complain.

sorry about that