### PR TITLE
windows compatible warning match pattern for erlc

### DIFF
--- a/ale_linters/erlang/erlc.vim
+++ b/ale_linters/erlang/erlc.vim
@@ -17,7 +17,7 @@ function! ale_linters#erlang#erlc#Handle(buffer, lines) abort
     " error.erl:4: variable 'B' is unbound
     " error.erl:3: Warning: function main/0 is unused
     " error.erl:4: Warning: variable 'A' is unused
-    let l:pattern = '\v^([^:]+):(\d+): (Warning: )?(.+)$'
+    let l:pattern = '\v\C:(\d+): (Warning: )?(.+)$'
 
     " parse_transforms are a special case. The error message does not indicate a location:
     " error.erl: undefined parse transform 'some_parse_transform'
@@ -56,9 +56,9 @@ function! ale_linters#erlang#erlc#Handle(buffer, lines) abort
             continue
         endif
 
-        let l:line = l:match[2]
-        let l:warning_or_text = l:match[3]
-        let l:text = l:match[4]
+        let l:line = l:match[1]
+        let l:warning_or_text = l:match[2]
+        let l:text = l:match[3]
 
         " If this file is a header .hrl, ignore the following expected messages:
         " - 'no module definition'

--- a/ale_linters/erlang/erlc.vim
+++ b/ale_linters/erlang/erlc.vim
@@ -17,7 +17,7 @@ function! ale_linters#erlang#erlc#Handle(buffer, lines) abort
     " error.erl:4: variable 'B' is unbound
     " error.erl:3: Warning: function main/0 is unused
     " error.erl:4: Warning: variable 'A' is unused
-    let l:pattern = '\v\C:(\d+): (Warning: )?(.+)$'
+    let l:pattern = '\v^([a-zA-Z]?:?[^:]+):(\d+): (Warning: )?(.+)$'
 
     " parse_transforms are a special case. The error message does not indicate a location:
     " error.erl: undefined parse transform 'some_parse_transform'
@@ -56,9 +56,9 @@ function! ale_linters#erlang#erlc#Handle(buffer, lines) abort
             continue
         endif
 
-        let l:line = l:match[1]
-        let l:warning_or_text = l:match[2]
-        let l:text = l:match[3]
+        let l:line = l:match[2]
+        let l:warning_or_text = l:match[3]
+        let l:text = l:match[4]
 
         " If this file is a header .hrl, ignore the following expected messages:
         " - 'no module definition'


### PR DESCRIPTION
The pattern did search for lines starting with ([^:]+) as the filename,
however under windows, the file name erlc ouputs is like:
c:/Users/user/AppData/Local/Temp/XXX.tmp/file.erl
Simplifying the patters as it is done for the syntaxerl checker avoids
the issue.

I haven't found tests for this part, and I'm not proficient enough in vader to add a new one from scratch, but I can work on it provided some guidance.

<!--
READ THIS: Before creating a pull request, please consider the following first.

* The most important thing you can do is write tests. Code without tests
  probably doesn't work, and will almost certainly stop working later on. Pull
  requests without tests probably won't be accepted, although there are some
  exceptions.
* Read the Contributing guide linked above first.
* If you are adding a new linter, remember to update the README.md file and
  doc/ale.txt first.
* If you add or modify a function for converting error lines into loclist items
  that ALE can work with, please add Vader tests for them. Look at existing
  tests in the test/handler directory, etc.
* If you add or modify a function for computing a command line string for
  running a command, please add Vader tests for that.
* Generally try and cover anything with Vader tests, although some things just
  can't be tested with Vader, or at least they can be hard to test. Consider
  breaking up your code so that some parts can be tested, and generally open up
  a discussion about it.
* Have fun!
-->
