### PR TITLE
Add shfmt fixer for sh files

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ formatting.
 | Ansible | [ansible-lint](https://github.com/willthames/ansible-lint) |
 | AsciiDoc | [proselint](http://proselint.com/), [write-good](https://github.com/btford/write-good)|
 | Awk | [gawk](https://www.gnu.org/software/gawk/)|
-| Bash | shell [-n flag](https://www.gnu.org/software/bash/manual/bash.html#index-set), [shellcheck](https://www.shellcheck.net/) |
-| Bourne Shell | shell [-n flag](http://linux.die.net/man/1/sh), [shellcheck](https://www.shellcheck.net/) |
+| Bash | shell [-n flag](https://www.gnu.org/software/bash/manual/bash.html#index-set), [shellcheck](https://www.shellcheck.net/), [shfmt](https://github.com/mvdan/sh) |
+| Bourne Shell | shell [-n flag](http://linux.die.net/man/1/sh), [shellcheck](https://www.shellcheck.net/), [shfmt](https://github.com/mvdan/sh) |
 | C | [cppcheck](http://cppcheck.sourceforge.net), [cpplint](https://github.com/google/styleguide/tree/gh-pages/cpplint), [gcc](https://gcc.gnu.org/), [clang](http://clang.llvm.org/), [clangtidy](http://clang.llvm.org/extra/clang-tidy/) !!, [clang-format](https://clang.llvm.org/docs/ClangFormat.html)|
 | C++ (filetype cpp) | [clang](http://clang.llvm.org/), [clangcheck](http://clang.llvm.org/docs/ClangCheck.html) !!, [clangtidy](http://clang.llvm.org/extra/clang-tidy/) !!, [cppcheck](http://cppcheck.sourceforge.net), [cpplint](https://github.com/google/styleguide/tree/gh-pages/cpplint) !!, [gcc](https://gcc.gnu.org/), [clang-format](https://clang.llvm.org/docs/ClangFormat.html)|
 | CUDA | [nvcc](http://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html) |

--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -132,6 +132,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['reason'],
 \       'description': 'Fix ReasonML files with refmt.',
 \   },
+\   'shfmt': {
+\       'function': 'ale#fixers#shfmt#Fix',
+\       'suggested_filetypes': ['sh'],
+\       'description': 'Fix sh files with shfmt.',
+\   },
 \}
 
 " Reset the function registry to the default entries.

--- a/autoload/ale/fixers/shfmt.vim
+++ b/autoload/ale/fixers/shfmt.vim
@@ -11,7 +11,7 @@ function! ale#fixers#shfmt#Fix(buffer) abort
 
     return {
     \   'command': ale#Escape(l:executable)
-    \       . ' ' . l:options,
+    \       . (empty(l:options) ? '' : ' ' . l:options)
     \}
 
 endfunction

--- a/autoload/ale/fixers/shfmt.vim
+++ b/autoload/ale/fixers/shfmt.vim
@@ -1,0 +1,17 @@
+scriptencoding utf-8
+" Author: Simon Bugert <simon.bugert@gmail.com>
+" Description: Fix sh files with shfmt.
+
+call ale#Set('sh_shfmt_executable', 'shfmt')
+call ale#Set('sh_shfmt_options', '')
+
+function! ale#fixers#shfmt#Fix(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'sh_shfmt_executable')
+    let l:options = ale#Var(a:buffer, 'sh_shfmt_options')
+
+    return {
+    \   'command': ale#Escape(l:executable)
+    \       . ' ' . l:options,
+    \}
+
+endfunction

--- a/doc/ale-sh.txt
+++ b/doc/ale-sh.txt
@@ -58,4 +58,15 @@ g:ale_sh_shellcheck_exclusions                 *g:ale_sh_shellcheck_exclusions*
 <
 
 ===============================================================================
+shfmt                                                            *ale-sh-shfmt*
+
+g:ale_sh_shfmt_options                                 *g:ale_sh_shfmt_options*
+                                                       *b:ale_sh_shfmt_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be set to pass additional options to the shfmt fixer.
+
+
+===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -173,6 +173,7 @@ CONTENTS                                                         *ale-contents*
     sh....................................|ale-sh-options|
       shell...............................|ale-sh-shell|
       shellcheck..........................|ale-sh-shellcheck|
+      shfmt...............................|ale-sh-shfmt|
     sml...................................|ale-sml-options|
       smlnj...............................|ale-sml-smlnj|
     solidity..............................|ale-solidity-options|
@@ -256,8 +257,8 @@ Notes:
 * Ansible: `ansible-lint`
 * AsciiDoc: `proselint`, `write-good`
 * Awk: `gawk`
-* Bash: `shell` (-n flag), `shellcheck`
-* Bourne Shell: `shell` (-n flag), `shellcheck`
+* Bash: `shell` (-n flag), `shellcheck`, `shfmt`
+* Bourne Shell: `shell` (-n flag), `shellcheck`, `shfmt`
 * C: `cppcheck`, `cpplint`!!, `gcc`, `clang`, `clangtidy`!!, `clang-format`
 * C++ (filetype cpp): `clang`, `clangcheck`!!, `clangtidy`!!, `cppcheck`, `cpplint`!!, `gcc`, `clang-format`
 * CUDA: `nvcc`!!

--- a/test/fixers/test_shfmt_fixer_callback.vader
+++ b/test/fixers/test_shfmt_fixer_callback.vader
@@ -1,0 +1,24 @@
+Before:
+  Save g:ale_sh_shfmt_executable
+  Save g:ale_sh_shfmt_options
+
+  " Use an invalid global executable, so we don't match it.
+  let g:ale_sh_shfmt_executable = 'xxxinvalid'
+  let g:ale_sh_shfmt_options = ''
+
+Execute(The shfmt callback should return the correct default values):
+  AssertEqual
+  \ {
+  \   'command': ale#Escape('xxxinvalid'),
+  \ },
+  \ ale#fixers#shfmt#Fix(bufnr(''))
+
+Execute(The shfmt callback should include custom shfmt options):
+  let g:ale_sh_shfmt_options = '--some-option'
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape(g:ale_sh_shfmt_executable)
+  \     . ' --some-option',
+  \ },
+  \ ale#fixers#shfmt#Fix(bufnr(''))


### PR DESCRIPTION
<!--
READ THIS: Before creating a pull request, please consider the following first.

* The most important thing you can do is write tests. Code without tests
  probably doesn't work, and will almost certainly stop working later on. Pull
  requests without tests probably won't be accepted, although there are some
  exceptions.
* Read the Contributing guide linked above first.
* If you are adding a new linter, remember to update the README.md file and
  doc/ale.txt first.
* If you add or modify a function for converting error lines into loclist items
  that ALE can work with, please add Vader tests for them. Look at existing
  tests in the test/handler directory, etc.
* If you add or modify a function for computing a command line string for
  running a command, please add Vader tests for that.
* Generally try and cover anything with Vader tests, although some things just
  can't be tested with Vader, or at least they can be hard to test. Consider
  breaking up your code so that some parts can be tested, and generally open up
  a discussion about it.
* Have fun!
-->
I added support for fixing sh files with [shftm](https://github.com/mvdan/sh).
shfmt can also lint files but I have not yet added this feature.

Also, this PR lacks tests. Are there already shell test files in the repo? I guess I would need some assistance for writing tests.
