### PR TITLE
remove --parser flag from prettier fixer

### DIFF
--- a/autoload/ale/fixers/prettier.vim
+++ b/autoload/ale/fixers/prettier.vim
@@ -1,5 +1,6 @@
 " Author: tunnckoCore (Charlike Mike Reagent) <mameto2011@gmail.com>,
-"         w0rp <devw0rp@gmail.com>, morhetz (Pavel Pertsev) <morhetz@gmail.com>
+"         w0rp <devw0rp@gmail.com>, morhetz (Pavel Pertsev) <morhetz@gmail.com>,
+"         Ahmed El Gabri <@ahmedelgabri>
 " Description: Integration of Prettier with ALE.
 
 call ale#Set('javascript_prettier_executable', 'prettier')
@@ -42,22 +43,7 @@ function! ale#fixers#prettier#Fix(buffer) abort
     let l:config = s:FindConfig(a:buffer)
     let l:use_config = ale#Var(a:buffer, 'javascript_prettier_use_local_config')
                 \ && !empty(l:config)
-    let l:filetype = getbufvar(a:buffer, '&filetype')
-
-    " Append the --parser flag depending on the current filetype (unless it's
-    " already set in g:javascript_prettier_options).
-    if match(l:options, '--parser') == -1
-        if l:filetype is# 'typescript'
-            let l:parser = 'typescript'
-        elseif l:filetype =~# 'css\|scss\|less'
-            let l:parser = 'postcss'
-        elseif l:filetype is# 'json'
-            let l:parser = 'json'
-        else
-            let l:parser = 'babylon'
-        endif
-        let l:options = (!empty(l:options) ? l:options . ' ' : '') . '--parser ' . l:parser
-    endif
+    let l:options = (!empty(l:options) ? l:options : '')
 
     return {
     \   'command': ale#Escape(ale#fixers#prettier#GetExecutable(a:buffer))

--- a/test/fixers/test_prettier_fixer_callback.vader
+++ b/test/fixers/test_prettier_fixer_callback.vader
@@ -24,7 +24,6 @@ Execute(The prettier callback should return the correct default values):
   \   'read_temporary_file': 1,
   \   'command': ale#Escape(g:ale_javascript_prettier_executable)
   \     . ' %t'
-  \     . ' --parser babylon'
   \     . ' --write',
   \ },
   \ ale#fixers#prettier#Fix(bufnr(''))
@@ -38,7 +37,6 @@ Execute(The prettier callback should include configuration files when the option
   \   'read_temporary_file': 1,
   \   'command': ale#Escape(g:ale_javascript_prettier_executable)
   \     . ' %t'
-  \     . ' --parser babylon'
   \     . ' --config ' . ale#Escape(ale#path#Winify(g:dir .  '/../prettier-test-files/with_config/.prettierrc'))
   \     . ' --write',
   \ },
@@ -53,7 +51,7 @@ Execute(The prettier callback should include custom prettier options):
   \   'read_temporary_file': 1,
   \   'command': ale#Escape(g:ale_javascript_prettier_executable)
   \     . ' %t'
-  \     . ' --no-semi --parser babylon'
+  \     . ' --no-semi'
   \     . ' --config ' . ale#Escape(ale#path#Winify(g:dir .  '/../prettier-test-files/with_config/.prettierrc'))
   \     . ' --write',
   \ },
@@ -68,7 +66,6 @@ Execute(Append '--parser typescript' for filetype=typescript):
   \   'read_temporary_file': 1,
   \   'command': ale#Escape(g:ale_javascript_prettier_executable)
   \     . ' %t'
-  \     . ' --parser typescript'
   \     . ' --write',
   \ },
   \ ale#fixers#prettier#Fix(bufnr(''))
@@ -82,7 +79,6 @@ Execute(Append '--parser json' for filetype=json):
   \   'read_temporary_file': 1,
   \   'command': ale#Escape(g:ale_javascript_prettier_executable)
   \     . ' %t'
-  \     . ' --parser json'
   \     . ' --write',
   \ },
   \ ale#fixers#prettier#Fix(bufnr(''))
@@ -96,7 +92,6 @@ Execute(Append '--parser postcss' for filetype=scss):
   \   'read_temporary_file': 1,
   \   'command': ale#Escape(g:ale_javascript_prettier_executable)
   \     . ' %t'
-  \     . ' --parser postcss'
   \     . ' --write',
   \ },
   \ ale#fixers#prettier#Fix(bufnr(''))
@@ -110,7 +105,6 @@ Execute(Append '--parser postcss' for filetype=css):
   \   'read_temporary_file': 1,
   \   'command': ale#Escape(g:ale_javascript_prettier_executable)
   \     . ' %t'
-  \     . ' --parser postcss'
   \     . ' --write',
   \ },
   \ ale#fixers#prettier#Fix(bufnr(''))
@@ -124,7 +118,6 @@ Execute(Append '--parser postcss' for filetype=less):
   \   'read_temporary_file': 1,
   \   'command': ale#Escape(g:ale_javascript_prettier_executable)
   \     . ' %t'
-  \     . ' --parser postcss'
   \     . ' --write',
   \ },
   \ ale#fixers#prettier#Fix(bufnr(''))


### PR DESCRIPTION
Prettier will infer the parser based on the file name https://github.com/prettier/prettier/issues/3190#issuecomment-342532165, so no need for the parser flag. 

And since prettier now supports Markdown & GraphQL this list will just grow & needs to be maintained manually which is not good thing.