### PR TITLE
add 'output_stream': 'stderr', let golint work

### DIFF
--- a/ale_linters/go/golint.vim
+++ b/ale_linters/go/golint.vim
@@ -3,6 +3,7 @@
 
 call ale#linter#Define('go', {
 \   'name': 'golint',
+\   'output_stream': 'stderr',
 \   'executable': 'golint',
 \   'command': 'golint %t',
 \   'callback': 'ale#handlers#unix#HandleAsWarning',


### PR DESCRIPTION
have tested, without output_stream line, golint do not work
