### PR TITLE
Add ocaml-language-server for OCaml and ReasonML

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ formatting.
 | nroff | [proselint](http://proselint.com/), [write-good](https://github.com/btford/write-good)|
 | Objective-C | [clang](http://clang.llvm.org/) |
 | Objective-C++ | [clang](http://clang.llvm.org/) |
-| OCaml | [merlin](https://github.com/the-lambda-church/merlin) see `:help ale-ocaml-merlin` for configuration instructions |
+| OCaml | [merlin](https://github.com/the-lambda-church/merlin) see `:help ale-ocaml-merlin` for configuration instructions, [ols](https://github.com/freebroccolo/ocaml-language-server) |
 | Perl | [perl -c](https://perl.org/), [perl-critic](https://metacpan.org/pod/Perl::Critic) |
 | PHP | [hack](http://hacklang.org/), [hackfmt](https://github.com/facebook/flow/tree/master/hack/hackfmt), [langserver](https://github.com/felixfbecker/php-language-server), [phan](https://github.com/phan/phan) see `:help ale-php-phan` to instructions, [php -l](https://secure.php.net/), [phpcs](https://github.com/squizlabs/PHP_CodeSniffer), [phpmd](https://phpmd.org), [phpstan](https://github.com/phpstan/phpstan), [phpcbf](https://github.com/squizlabs/PHP_CodeSniffer) |
 | Pod | [proselint](http://proselint.com/), [write-good](https://github.com/btford/write-good) |
@@ -129,7 +129,7 @@ formatting.
 | Puppet | [puppet](https://puppet.com), [puppet-lint](https://puppet-lint.com) |
 | Python | [autopep8](https://github.com/hhatto/autopep8), [flake8](http://flake8.pycqa.org/en/latest/), [isort](https://github.com/timothycrosley/isort), [mypy](http://mypy-lang.org/), [pycodestyle](https://github.com/PyCQA/pycodestyle), [pyls](https://github.com/palantir/python-language-server), [pylint](https://www.pylint.org/) !!, [yapf](https://github.com/google/yapf) |
 | R | [lintr](https://github.com/jimhester/lintr) |
-| ReasonML | [merlin](https://github.com/the-lambda-church/merlin) see `:help ale-integration-reason-merlin` for configuration instructions, [refmt](https://github.com/reasonml/reason-cli) |
+| ReasonML | [merlin](https://github.com/the-lambda-church/merlin) see `:help ale-integration-reason-merlin` for configuration instructions, [ols](https://github.com/freebroccolo/ocaml-language-server), [refmt](https://github.com/reasonml/reason-cli) |
 | reStructuredText | [proselint](http://proselint.com/), [rstcheck](https://github.com/myint/rstcheck), [write-good](https://github.com/btford/write-good) |
 | RPM spec | [rpmlint](https://github.com/rpm-software-management/rpmlint) (disabled by default; see `:help ale-integration-spec`) |
 | Ruby | [brakeman](http://brakemanscanner.org/) !!, [rails_best_practices](https://github.com/flyerhzm/rails_best_practices) !!, [reek](https://github.com/troessner/reek), [rubocop](https://github.com/bbatsov/rubocop), [ruby](https://www.ruby-lang.org) |

--- a/ale_linters/ocaml/ols.vim
+++ b/ale_linters/ocaml/ols.vim
@@ -1,0 +1,14 @@
+" Author: Michael Jungo <michaeljungo92@gmail.com>
+" Description: A language server for OCaml
+
+call ale#Set('ocaml_ols_executable', 'ocaml-language-server')
+call ale#Set('ocaml_ols_use_global', 0)
+
+call ale#linter#Define('ocaml', {
+\   'name': 'ols',
+\   'lsp': 'stdio',
+\   'executable_callback': 'ale#handlers#ols#GetExecutable',
+\   'command_callback': 'ale#handlers#ols#GetCommand',
+\   'language_callback': 'ale#handlers#ols#GetLanguage',
+\   'project_root_callback': 'ale#handlers#ols#GetProjectRoot',
+\})

--- a/ale_linters/reason/ols.vim
+++ b/ale_linters/reason/ols.vim
@@ -1,0 +1,14 @@
+" Author: Michael Jungo <michaeljungo92@gmail.com>
+" Description: A language server for Reason
+
+call ale#Set('reason_ols_executable', 'ocaml-language-server')
+call ale#Set('reason_ols_use_global', 0)
+
+call ale#linter#Define('reason', {
+\   'name': 'ols',
+\   'lsp': 'stdio',
+\   'executable_callback': 'ale#handlers#ols#GetExecutable',
+\   'command_callback': 'ale#handlers#ols#GetCommand',
+\   'language_callback': 'ale#handlers#ols#GetLanguage',
+\   'project_root_callback': 'ale#handlers#ols#GetProjectRoot',
+\})

--- a/autoload/ale/handlers/ols.vim
+++ b/autoload/ale/handlers/ols.vim
@@ -1,0 +1,25 @@
+" Author: Michael Jungo <michaeljungo92@gmail.com>
+" Description: Handlers for the OCaml language server
+
+function! ale#handlers#ols#GetExecutable(buffer) abort
+    let l:ols_setting = ale#handlers#ols#GetLanguage(a:buffer) . '_ols'
+    return ale#node#FindExecutable(a:buffer, l:ols_setting, [
+    \   'node_modules/.bin/ocaml-language-server',
+    \])
+endfunction
+
+function! ale#handlers#ols#GetCommand(buffer) abort
+    let l:executable = ale#handlers#ols#GetExecutable(a:buffer)
+
+    return ale#node#Executable(a:buffer, l:executable) . ' --stdio'
+endfunction
+
+function! ale#handlers#ols#GetLanguage(buffer) abort
+    return getbufvar(a:buffer, '&filetype')
+endfunction
+
+function! ale#handlers#ols#GetProjectRoot(buffer) abort
+    let l:merlin_file = ale#path#FindNearestFile(a:buffer, '.merlin')
+
+    return !empty(l:merlin_file) ? fnamemodify(l:merlin_file, ':h') : ''
+endfunction

--- a/autoload/ale/lsp.vim
+++ b/autoload/ale/lsp.vim
@@ -83,9 +83,8 @@ function! ale#lsp#CreateMessageData(message) abort
     let l:is_notification = a:message[0]
 
     let l:obj = {
-    \   'id': v:null,
-    \   'jsonrpc': '2.0',
     \   'method': a:message[1],
+    \   'jsonrpc': '2.0',
     \}
 
     if !l:is_notification

--- a/doc/ale-ocaml.txt
+++ b/doc/ale-ocaml.txt
@@ -10,6 +10,28 @@ merlin                                                       *ale-ocaml-merlin*
   detailed instructions
   (https://github.com/the-lambda-church/merlin/wiki/vim-from-scratch).
 
+===============================================================================
+ols                                                             *ale-ocaml-ols*
+
+  The `ocaml-language-server` is the engine that powers OCaml and ReasonML
+  editor support using the Language Server Protocol. See the installation
+  instructions:
+  https://github.com/freebroccolo/ocaml-language-server#installation
+
+g:ale_ocaml_ols_executable                         *g:ale_ocaml_ols_executable*
+                                                   *b:ale_ocaml_ols_executable*
+  Type: |String|
+  Default: `'ocaml-language-server'`
+
+  This variable can be set to change the executable path for `ols`.
+
+g:ale_ocaml_ols_use_global                         *g:ale_ocaml_ols_use_global*
+                                                   *b:ale_ocaml_ols_use_global*
+  Type: |String|
+  Default: `0`
+
+  This variable can be set to `1` to always use the globally installed
+  executable. See also |ale-integrations-local-executables|.
 
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-reasonml.txt
+++ b/doc/ale-reasonml.txt
@@ -11,6 +11,29 @@ merlin                                                    *ale-reasonml-merlin*
   (https://github.com/the-lambda-church/merlin/wiki/vim-from-scratch).
 
 ===============================================================================
+ols                                                          *ale-reasonml-ols*
+
+  The `ocaml-language-server` is the engine that powers OCaml and ReasonML
+  editor support using the Language Server Protocol. See the installation
+  instructions:
+  https://github.com/freebroccolo/ocaml-language-server#installation
+
+g:ale_reason_ols_executable                       *g:ale_reason_ols_executable*
+                                                  *b:ale_reason_ols_executable*
+  Type: |String|
+  Default: `'ocaml-language-server'`
+
+  This variable can be set to change the executable path for `ols`.
+
+g:ale_reason_ols_use_global                       *g:ale_reason_ols_use_global*
+                                                  *b:ale_reason_ols_use_global*
+  Type: |String|
+  Default: `0`
+
+  This variable can be set to `1` to always use the globally installed
+  executable. See also |ale-integrations-local-executables|.
+
+===============================================================================
 refmt                                                      *ale-reasonml-refmt*
 
 g:ale_reasonml_refmt_executable               *g:ale_reasonml_refmt_executable*

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -120,6 +120,7 @@ CONTENTS                                                         *ale-contents*
       clang...............................|ale-objcpp-clang|
     ocaml.................................|ale-ocaml-options|
       merlin..............................|ale-ocaml-merlin|
+      ols.................................|ale-ocaml-ols|
     perl..................................|ale-perl-options|
       perl................................|ale-perl-perl|
       perlcritic..........................|ale-perl-perlcritic|
@@ -153,6 +154,7 @@ CONTENTS                                                         *ale-contents*
       lintr...............................|ale-r-lintr|
     reasonml..............................|ale-reasonml-options|
       merlin..............................|ale-reasonml-merlin|
+      ols.................................|ale-reasonml-ols|
       refmt...............................|ale-reasonml-refmt|
     restructuredtext......................|ale-restructuredtext-options|
       write-good..........................|ale-restructuredtext-write-good|
@@ -306,7 +308,7 @@ Notes:
 * nroff: `proselint`, `write-good`
 * Objective-C: `clang`
 * Objective-C++: `clang`
-* OCaml: `merlin` (see |ale-ocaml-merlin|)
+* OCaml: `merlin` (see |ale-ocaml-merlin|), `ols`
 * Perl: `perl -c`, `perl-critic`
 * PHP: `hack`, `hackfmt`, `langserver`, `phan`, `php -l`, `phpcs`, `phpmd`, `phpstan`, `phpcbf`
 * Pod: `proselint`, `write-good`
@@ -315,7 +317,7 @@ Notes:
 * Puppet: `puppet`, `puppet-lint`
 * Python: `autopep8`, `flake8`, `isort`, `mypy`, `pycodestyle`, `pyls`, `pylint`!!, `yapf`
 * R: `lintr`
-* ReasonML: `merlin`, `refmt`
+* ReasonML: `merlin`, `ols`, `refmt`
 * reStructuredText: `proselint`, `rstcheck`, `write-good`
 * RPM spec: `rpmlint`
 * Ruby: `brakeman`, `rails_best_practices`!!, `reek`, `rubocop`, `ruby`

--- a/test/lsp/test_lsp_connections.vader
+++ b/test/lsp/test_lsp_connections.vader
@@ -26,7 +26,7 @@ Execute(ale#lsp#CreateMessageData() should create an appropriate message):
       \ [
       \   1,
       \   "Content-Length: 79\r\n\r\n"
-      \   . '{"id": 1, "jsonrpc": "2.0", "method": "someMethod", "params": {"foo": "barÜ"}}',
+      \   . '{"method": "someMethod", "jsonrpc": "2.0", "id": 1, "params": {"foo": "barÜ"}}',
       \ ],
       \ ale#lsp#CreateMessageData([0, 'someMethod', {'foo': 'barÜ'}])
       " Check again to ensure that we use the next ID.
@@ -34,7 +34,7 @@ Execute(ale#lsp#CreateMessageData() should create an appropriate message):
       \ [
       \   2,
       \   "Content-Length: 79\r\n\r\n"
-      \   . '{"id": 2, "jsonrpc": "2.0", "method": "someMethod", "params": {"foo": "barÜ"}}',
+      \   . '{"method": "someMethod", "jsonrpc": "2.0", "id": 2, "params": {"foo": "barÜ"}}',
       \ ],
       \ ale#lsp#CreateMessageData([0, 'someMethod', {'foo': 'barÜ'}])
     else
@@ -42,14 +42,14 @@ Execute(ale#lsp#CreateMessageData() should create an appropriate message):
       \ [
       \   1,
       \   "Content-Length: 71\r\n\r\n"
-      \   . '{"id":1,"jsonrpc":"2.0","method":"someMethod","params":{"foo":"barÜ"}}',
+      \   . '{"method":"someMethod","jsonrpc":"2.0","id":1,"params":{"foo":"barÜ"}}',
       \ ],
       \ ale#lsp#CreateMessageData([0, 'someMethod', {'foo': 'barÜ'}])
       AssertEqual
       \ [
       \   2,
       \   "Content-Length: 71\r\n\r\n"
-      \   . '{"id":2,"jsonrpc":"2.0","method":"someMethod","params":{"foo":"barÜ"}}',
+      \   . '{"method":"someMethod","jsonrpc":"2.0","id":2,"params":{"foo":"barÜ"}}',
       \ ],
       \ ale#lsp#CreateMessageData([0, 'someMethod', {'foo': 'barÜ'}])
     endif
@@ -60,7 +60,7 @@ Execute(ale#lsp#CreateMessageData() should create messages without params):
       \ [
       \   1,
       \   "Content-Length: 56\r\n\r\n"
-      \   . '{"id": 1, "jsonrpc": "2.0", "method": "someOtherMethod"}',
+      \   . '{"method": "someOtherMethod", "jsonrpc": "2.0", "id": 1}',
       \ ],
       \ ale#lsp#CreateMessageData([0, 'someOtherMethod'])
     else
@@ -68,7 +68,7 @@ Execute(ale#lsp#CreateMessageData() should create messages without params):
       \ [
       \   1,
       \   "Content-Length: 51\r\n\r\n"
-      \   . '{"id":1,"jsonrpc":"2.0","method":"someOtherMethod"}',
+      \   . '{"method":"someOtherMethod","jsonrpc":"2.0","id":1}',
       \ ],
       \ ale#lsp#CreateMessageData([0, 'someOtherMethod'])
     endif
@@ -78,30 +78,30 @@ Execute(ale#lsp#CreateMessageData() should create notifications):
       AssertEqual
       \ [
       \   0,
-      \   "Content-Length: 60\r\n\r\n"
-      \   . '{"id": null, "jsonrpc": "2.0", "method": "someNotification"}',
+      \   "Content-Length: 48\r\n\r\n"
+      \   . '{"method": "someNotification", "jsonrpc": "2.0"}',
       \ ],
       \ ale#lsp#CreateMessageData([1, 'someNotification'])
       AssertEqual
       \ [
       \   0,
-      \   "Content-Length: 86\r\n\r\n"
-      \   . '{"id": null, "jsonrpc": "2.0", "method": "someNotification", "params": {"foo": "bar"}}',
+      \   "Content-Length: 74\r\n\r\n"
+      \   . '{"method": "someNotification", "jsonrpc": "2.0", "params": {"foo": "bar"}}',
       \ ],
       \ ale#lsp#CreateMessageData([1, 'someNotification', {'foo': 'bar'}])
     else
       AssertEqual
       \ [
       \   0,
-      \   "Content-Length: 55\r\n\r\n"
-      \   . '{"id":null,"jsonrpc":"2.0","method":"someNotification"}',
+      \   "Content-Length: 45\r\n\r\n"
+      \   . '{"method":"someNotification","jsonrpc":"2.0"}',
       \ ],
       \ ale#lsp#CreateMessageData([1, 'someNotification'])
       AssertEqual
       \ [
       \   0,
-      \   "Content-Length: 78\r\n\r\n"
-      \   . '{"id":null,"jsonrpc":"2.0","method":"someNotification","params":{"foo":"bar"}}',
+      \   "Content-Length: 68\r\n\r\n"
+      \   . '{"method":"someNotification","jsonrpc":"2.0","params":{"foo":"bar"}}',
       \ ],
       \ ale#lsp#CreateMessageData([1, 'someNotification', {'foo': 'bar'}])
     endif


### PR DESCRIPTION
[ocaml-language-server](https://github.com/freebroccolo/ocaml-language-server) provides editor support for OCaml and Reason using the Language Server Protocol.

I had to remove the `id` field on the request object, because technically a notification must not have an `id`, which is different from `id: null` (present, but `null`).

From [JSON-RPC 2.0 Specification - Notification](http://www.jsonrpc.org/specification#notification)

> **4.1 Notification**
> A Notification is a Request object without an "id" member. [...]

And [JSON-RPC 2.0 Specification - Request object](http://www.jsonrpc.org/specification#request_object):

> **id**
> An identifier established by the Client that MUST contain a String, Number, or NULL value if included. If it is not included it is assumed to be a notification. The value SHOULD normally not be Null [1] and Numbers SHOULD NOT contain fractional parts [2]
>
> [...]
>
> [1] The use of Null as a value for the id member in a Request object is discouraged, because this specification uses a value of Null for Responses with an unknown id. Also, because JSON-RPC 1.0 uses an id value of Null for Notifications this could cause confusion in handling.

ocaml-language-server is built with [vscode-languageserver](https://github.com/Microsoft/vscode-languageserver-node), which is very strict about this and does not accept notifications with an `id`, even if it's `null`.

After removing `'id': v:null`, Vim reorders the fields to `{"method": "someMethod", "jsonrpc": "2.0"}` for whatever reason, so I swapped them in the source to avoid confusion. The order only affects the tests.

For the record:

```vim
echo {'id': v:null, 'jsonrpc': '2.0', 'method': 'someMethod'}
" => {'id': v:null, 'jsonrpc': '2.0', 'method': 'someMethod'}

echo {'jsonrpc': '2.0', 'method': 'someMethod'}
" => {'method': 'someMethod', 'jsonrpc': '2.0'}

echo {'jsonrpc': '2.0', 'method': 'someMethod', 'id': v:null}
" => {'method': 'someMethod', 'jsonrpc': '2.0', 'id': v:null}
```