### PR TITLE
Perlcritic: All issues are warnings

### DIFF
--- a/ale_linters/perl/perlcritic.vim
+++ b/ale_linters/perl/perlcritic.vim
@@ -61,6 +61,7 @@ function! ale_linters#perl#perlcritic#Handle(buffer, lines) abort
         \   'lnum': l:match[1],
         \   'col': l:match[2],
         \   'text': l:match[3],
+        \   'type': 'W'
         \})
     endfor
 

--- a/test/handler/test_perlcritic_handler.vader
+++ b/test/handler/test_perlcritic_handler.vader
@@ -1,0 +1,20 @@
+Before:
+  runtime ale_linters/perl/perlcritic.vim
+
+After:
+  call ale#linter#Reset()
+
+Execute(The Perl::Critic handler should create all issues as warnings):
+  AssertEqual
+  \  [
+  \    {
+  \      'lnum': '21',
+  \      'col': '17',
+  \      'text': 'Regular expression without "/m" flag',
+  \      'type': 'W',
+  \    }
+  \  ],
+  \  ale_linters#perl#perlcritic#Handle(99, [
+  \      '21:17 Regular expression without "/m" flag'
+  \  ])
+


### PR DESCRIPTION
Perlcritic is a style checker, not a syntax validator.

This change was originally proposed by @RsrchBoy in https://github.com/w0rp/ale/pull/784.