### PR TITLE
Added support for goimports fixer

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ formatting.
 | Fortran | [gcc](https://gcc.gnu.org/) |
 | FusionScript | [fusion-lint](https://github.com/RyanSquared/fusionscript) |
 | GLSL | [glslang](https://github.com/KhronosGroup/glslang) |
-| Go | [gofmt](https://golang.org/cmd/gofmt/), [go vet](https://golang.org/cmd/vet/), [golint](https://godoc.org/github.com/golang/lint), [gometalinter](https://github.com/alecthomas/gometalinter) !!, [go build](https://golang.org/cmd/go/) !!, [gosimple](https://github.com/dominikh/go-tools/tree/master/cmd/gosimple) !!, [staticcheck](https://github.com/dominikh/go-tools/tree/master/cmd/staticcheck) !! |
+| Go | [gofmt](https://golang.org/cmd/gofmt/), [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), [golint](https://godoc.org/github.com/golang/lint), [gometalinter](https://github.com/alecthomas/gometalinter) !!, [go build](https://golang.org/cmd/go/) !!, [gosimple](https://github.com/dominikh/go-tools/tree/master/cmd/gosimple) !!, [staticcheck](https://github.com/dominikh/go-tools/tree/master/cmd/staticcheck) !! |
 | GraphQL | [gqlint](https://github.com/happylinks/gqlint) |
 | Haml | [haml-lint](https://github.com/brigade/haml-lint) |
 | Handlebars | [ember-template-lint](https://github.com/rwjblue/ember-template-lint) |

--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -107,6 +107,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['go'],
 \       'description': 'Fix Go files with go fmt.',
 \   },
+\   'goimports': {
+\       'function': 'ale#fixers#goimports#Fix',
+\       'suggested_filetypes': ['go'],
+\       'description': 'Fix Go files imports with go fmt.',
+\   },
 \   'tslint': {
 \       'function': 'ale#fixers#tslint#Fix',
 \       'suggested_filetypes': ['typescript'],

--- a/autoload/ale/fixers/goimports.vim
+++ b/autoload/ale/fixers/goimports.vim
@@ -8,6 +8,10 @@ function! ale#fixers#goimports#Fix(buffer) abort
     let l:executable = ale#Var(a:buffer, 'go_goimports_executable')
     let l:options = ale#Var(a:buffer, 'go_goimports_options')
 
+    if !executable(l:executable)
+        return 0
+    endif
+
     return {
     \   'command': ale#Escape(l:executable)
     \       . ' -l -w'

--- a/autoload/ale/fixers/goimports.vim
+++ b/autoload/ale/fixers/goimports.vim
@@ -1,0 +1,18 @@
+" Author: Jeff Willette <jrwillette88@gmail.com>
+" Description: Integration of goimports with ALE.
+
+call ale#Set('go_goimports_executable', 'goimports')
+call ale#Set('go_goimports_options', '')
+
+function! ale#fixers#goimports#Fix(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'go_goimports_executable')
+    let l:options = ale#Var(a:buffer, 'go_goimports_options')
+
+    return {
+    \   'command': ale#Escape(l:executable)
+    \       . ' -l -w'
+    \       . (empty(l:options) ? '' : ' ' . l:options)
+    \       . ' %t',
+    \   'read_temporary_file': 1,
+    \}
+endfunction

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -287,7 +287,7 @@ Notes:
 * Fortran: `gcc`
 * FusionScript: `fusion-lint`
 * GLSL: glslang
-* Go: `gofmt`, `go vet`, `golint`, `gometalinter`!!, `go build`!!, `gosimple`!!, `staticcheck`!!
+* Go: `gofmt`, `goimports`, `go vet`, `golint`, `gometalinter`!!, `go build`!!, `gosimple`!!, `staticcheck`!!
 * GraphQL: `gqlint`
 * Haml: `haml-lint`
 * Handlebars: `ember-template-lint`

--- a/test/fixers/test_goimports_fixer_callback.vader
+++ b/test/fixers/test_goimports_fixer_callback.vader
@@ -13,28 +13,10 @@ After:
 
   call ale#test#RestoreDirectory()
 
-Execute(The goimports callback should return the correct default values):
+Execute(The goimports callback should return 0 with bad executable):
   call ale#test#SetFilename('../go_files/testfile.go')
 
   AssertEqual
-  \ {
-  \   'read_temporary_file': 1,
-  \   'command': ale#Escape('xxxinvalid')
-  \     . ' -l -w'
-  \     . ' %t',
-  \ },
+  \ 0,
   \ ale#fixers#goimports#Fix(bufnr(''))
 
-Execute(The goimports callback should include custom goimports options):
-  let g:ale_go_goimports_options = "-r '(a) -> a'"
-  call ale#test#SetFilename('../go_files/testfile.go')
-
-  AssertEqual
-  \ {
-  \   'read_temporary_file': 1,
-  \   'command': ale#Escape('xxxinvalid')
-  \     . ' -l -w'
-  \     . ' ' . g:ale_go_goimports_options
-  \     . ' %t',
-  \ },
-  \ ale#fixers#goimports#Fix(bufnr(''))

--- a/test/fixers/test_goimports_fixer_callback.vader
+++ b/test/fixers/test_goimports_fixer_callback.vader
@@ -1,0 +1,40 @@
+Before:
+  Save g:ale_go_goimports_executable
+  Save g:ale_go_goimports_options
+
+  " Use an invalid global executable, so we don't match it.
+  let g:ale_go_goimports_executable = 'xxxinvalid'
+  let g:ale_go_goimports_options = ''
+
+  call ale#test#SetDirectory('/testplugin/test/fixers')
+
+After:
+  Restore
+
+  call ale#test#RestoreDirectory()
+
+Execute(The goimports callback should return the correct default values):
+  call ale#test#SetFilename('../go_files/testfile.go')
+
+  AssertEqual
+  \ {
+  \   'read_temporary_file': 1,
+  \   'command': ale#Escape('xxxinvalid')
+  \     . ' -l -w'
+  \     . ' %t',
+  \ },
+  \ ale#fixers#goimports#Fix(bufnr(''))
+
+Execute(The goimports callback should include custom goimports options):
+  let g:ale_go_goimports_options = "-r '(a) -> a'"
+  call ale#test#SetFilename('../go_files/testfile.go')
+
+  AssertEqual
+  \ {
+  \   'read_temporary_file': 1,
+  \   'command': ale#Escape('xxxinvalid')
+  \     . ' -l -w'
+  \     . ' ' . g:ale_go_goimports_options
+  \     . ' %t',
+  \ },
+  \ ale#fixers#goimports#Fix(bufnr(''))


### PR DESCRIPTION
I tried to follow the precedent that the gofmt fixer laid out, I couldn't find any tests in teh tests file so I wasn't sure if I should write tests or not.

Also, the docs seem to omit some of the options that gofmt has such as setting the executable so I wasn't sure what, if anything to add there.
