### PR TITLE
Added filename keys for go linters

### DIFF
--- a/ale_linters/go/gobuild.vim
+++ b/ale_linters/go/gobuild.vim
@@ -44,13 +44,6 @@ function! ale_linters#go#gobuild#Handler(buffer, lines) abort
     let l:output = []
 
     for l:match in ale_linters#go#gobuild#GetMatches(a:lines)
-        "
-        " Get the list of parent paths from the current filename
-        let l:paths = ale#path#Upwards(expand('#' . a:buffer . ':p'))
-        " Only see errors from this package (directory), ignore errors from imported packages
-        if !l:dir is# l:paths[1]
-            continue
-        endif
 
         echom l:match[1]
         call add(l:output, {

--- a/ale_linters/go/gobuild.vim
+++ b/ale_linters/go/gobuild.vim
@@ -44,8 +44,6 @@ function! ale_linters#go#gobuild#Handler(buffer, lines) abort
     let l:output = []
 
     for l:match in ale_linters#go#gobuild#GetMatches(a:lines)
-
-        echom l:match[1]
         call add(l:output, {
         \   'filename': ale#path#GetAbsPath(l:dir, l:match[1]),
         \   'lnum': l:match[2] + 0,

--- a/ale_linters/go/gobuild.vim
+++ b/ale_linters/go/gobuild.vim
@@ -1,4 +1,5 @@
-" Author: Joshua Rubin <joshua@rubixconsulting.com>, Ben Reedy <https://github.com/breed808>
+" Author: Joshua Rubin <joshua@rubixconsulting.com>, Ben Reedy <https://github.com/breed808>,
+" Jeff Willette <jrwillette88@gmail.com>
 " Description: go build for Go files
 
 " inspired by work from dzhou121 <dzhou121@gmail.com>
@@ -39,15 +40,21 @@ function! ale_linters#go#gobuild#GetMatches(lines) abort
 endfunction
 
 function! ale_linters#go#gobuild#Handler(buffer, lines) abort
+    let l:dir = expand('#' . a:buffer . ':p:h')
     let l:output = []
 
     for l:match in ale_linters#go#gobuild#GetMatches(a:lines)
-        " Omit errors from imported go packages
-        if !ale#path#IsBufferPath(a:buffer, l:match[1])
+        "
+        " Get the list of parent paths from the current filename
+        let l:paths = ale#path#Upwards(expand('#' . a:buffer . ':p'))
+        " Only see errors from this package (directory), ignore errors from imported packages
+        if !l:dir is# l:paths[1]
             continue
         endif
 
+        echom l:match[1]
         call add(l:output, {
+        \   'filename': ale#path#GetAbsPath(l:dir, l:match[1]),
         \   'lnum': l:match[2] + 0,
         \   'col': l:match[3] + 0,
         \   'text': l:match[4],

--- a/ale_linters/go/gometalinter.vim
+++ b/ale_linters/go/gometalinter.vim
@@ -1,4 +1,4 @@
-" Author: Ben Reedy <https://github.com/breed808>
+" Author: Ben Reedy <https://github.com/breed808>, Jeff Willette <jrwillette88@gmail.com>
 " Description: Adds support for the gometalinter suite for Go files
 
 call ale#Set('go_gometalinter_options', '')
@@ -14,7 +14,6 @@ function! ale_linters#go#gometalinter#GetCommand(buffer) abort
     let l:options = ale#Var(a:buffer, 'go_gometalinter_options')
 
     return ale#Escape(l:executable)
-    \   . ' --include=' . ale#Escape('^' . ale#util#EscapePCRE(l:filename))
     \   . (!empty(l:options) ? ' ' . l:options : '')
     \   . ' ' . ale#Escape(fnamemodify(l:filename, ':h'))
 endfunction
@@ -25,11 +24,15 @@ function! ale_linters#go#gometalinter#GetMatches(lines) abort
     return ale#util#GetMatches(a:lines, l:pattern)
 endfunction
 
+" TODO: fix for gometalinter and then go build and any other go fixers that need it
+
 function! ale_linters#go#gometalinter#Handler(buffer, lines) abort
+    let l:dir = expand('#' . a:buffer . ':p:h')
     let l:output = []
 
     for l:match in ale_linters#go#gometalinter#GetMatches(a:lines)
         call add(l:output, {
+        \   'filename': ale#path#GetAbsPath(l:dir, l:match[1]),
         \   'lnum': l:match[2] + 0,
         \   'col': l:match[3] + 0,
         \   'type': tolower(l:match[4]) is# 'warning' ? 'W' : 'E',

--- a/ale_linters/go/gometalinter.vim
+++ b/ale_linters/go/gometalinter.vim
@@ -24,8 +24,6 @@ function! ale_linters#go#gometalinter#GetMatches(lines) abort
     return ale#util#GetMatches(a:lines, l:pattern)
 endfunction
 
-" TODO: fix for gometalinter and then go build and any other go fixers that need it
-
 function! ale_linters#go#gometalinter#Handler(buffer, lines) abort
     let l:dir = expand('#' . a:buffer . ':p:h')
     let l:output = []

--- a/test/command_callback/test_gometalinter_command_callback.vader
+++ b/test/command_callback/test_gometalinter_command_callback.vader
@@ -22,7 +22,6 @@ Execute(The gometalinter callback should return the right defaults):
   \ ale_linters#go#gometalinter#GetExecutable(bufnr(''))
   AssertEqual
   \ ale#Escape('gometalinter')
-  \   . ' --include=' . ale#Escape('^' . ale#util#EscapePCRE(expand('%')))
   \   . ' ' . ale#Escape(getcwd()),
   \ ale_linters#go#gometalinter#GetCommand(bufnr(''))
 
@@ -34,7 +33,6 @@ Execute(The gometalinter callback should use a configured executable):
   \ ale_linters#go#gometalinter#GetExecutable(bufnr(''))
   AssertEqual
   \ ale#Escape('something else')
-  \   . ' --include=' . ale#Escape('^' . ale#util#EscapePCRE(expand('%')))
   \   . ' ' . ale#Escape(getcwd()),
   \ ale_linters#go#gometalinter#GetCommand(bufnr(''))
 
@@ -43,7 +41,6 @@ Execute(The gometalinter callback should use configured options):
 
   AssertEqual
   \ ale#Escape('gometalinter')
-  \   . ' --include=' . ale#Escape('^' . ale#util#EscapePCRE(expand('%')))
   \   . ' --foobar'
   \   . ' ' . ale#Escape(getcwd()),
   \ ale_linters#go#gometalinter#GetCommand(bufnr(''))

--- a/test/handler/test_gobuild_handler.vader
+++ b/test/handler/test_gobuild_handler.vader
@@ -37,6 +37,7 @@ Execute (The gobuild handler should handle relative paths correctly):
   \     'col': 0,
   \     'text': 'missing argument for Printf("%s"): format reads arg 2, have only 1 args',
   \     'type': 'E',
+  \     'filename': '/foo/bar/baz.go',
   \   },
   \ ],
   \ ale_linters#go#gobuild#Handler(bufnr(''), [

--- a/test/handler/test_gobuild_handler.vader
+++ b/test/handler/test_gobuild_handler.vader
@@ -28,7 +28,7 @@ Execute (The gobuild handler should handle names with spaces):
   \ ]), 'v:val[1:4]')
 
 Execute (The gobuild handler should handle relative paths correctly):
-  silent file! /foo/bar/baz.go
+  call ale#test#SetFilename('app/test.go')
 
   AssertEqual
   \ [
@@ -37,9 +37,9 @@ Execute (The gobuild handler should handle relative paths correctly):
   \     'col': 0,
   \     'text': 'missing argument for Printf("%s"): format reads arg 2, have only 1 args',
   \     'type': 'E',
-  \     'filename': '/foo/bar/baz.go',
+  \     'filename': ale#path#Winify(expand('%:p:h') . '/test.go'),
   \   },
   \ ],
   \ ale_linters#go#gobuild#Handler(bufnr(''), [
-  \   'baz.go:27: missing argument for Printf("%s"): format reads arg 2, have only 1 args',
+  \   'test.go:27: missing argument for Printf("%s"): format reads arg 2, have only 1 args',
   \ ])

--- a/test/handler/test_gometalinter_handler.vader
+++ b/test/handler/test_gometalinter_handler.vader
@@ -30,7 +30,7 @@ Execute (The gometalinter handler should handle names with spaces):
   \ ]), 'v:val[1:5]')
 
 Execute (The gometalinter handler should handle relative paths correctly):
-  silent file /foo/bar/baz.go
+  call ale#test#SetFilename('app/test.go')
 
   AssertEqual
   \ [
@@ -39,17 +39,17 @@ Execute (The gometalinter handler should handle relative paths correctly):
   \     'col': 3,
   \     'text': 'expected ''package'', found ''IDENT'' gibberish (staticcheck)',
   \     'type': 'W',
-  \     'filename': '/foo/bar/baz.go',
+  \     'filename': ale#path#Winify(expand('%:p:h') . '/test.go'),
   \   },
   \   {
   \     'lnum': 37,
   \     'col': 5,
   \     'text': 'expected ''package'', found ''IDENT'' gibberish (golint)',
   \     'type': 'E',
-  \     'filename': '/foo/bar/baz.go',
+  \     'filename': ale#path#Winify(expand('%:p:h') . '/test.go'),
   \   },
   \ ],
   \ ale_linters#go#gometalinter#Handler(bufnr(''), [
-  \   'baz.go:12:3:warning: expected ''package'', found ''IDENT'' gibberish (staticcheck)',
-  \   'baz.go:37:5:error: expected ''package'', found ''IDENT'' gibberish (golint)',
+  \   'test.go:12:3:warning: expected ''package'', found ''IDENT'' gibberish (staticcheck)',
+  \   'test.go:37:5:error: expected ''package'', found ''IDENT'' gibberish (golint)',
   \ ])

--- a/test/handler/test_gometalinter_handler.vader
+++ b/test/handler/test_gometalinter_handler.vader
@@ -39,12 +39,14 @@ Execute (The gometalinter handler should handle relative paths correctly):
   \     'col': 3,
   \     'text': 'expected ''package'', found ''IDENT'' gibberish (staticcheck)',
   \     'type': 'W',
+  \     'filename': '/foo/bar/baz.go',
   \   },
   \   {
   \     'lnum': 37,
   \     'col': 5,
   \     'text': 'expected ''package'', found ''IDENT'' gibberish (golint)',
   \     'type': 'E',
+  \     'filename': '/foo/bar/baz.go',
   \   },
   \ ],
   \ ale_linters#go#gometalinter#Handler(bufnr(''), [


### PR DESCRIPTION
- reference #653 - add filename keys to existing linters (https://github.com/w0rp/ale/issues/653#issuecomment-323542811)

- added filename keys to gobuild and gometalinter

- removed --include `filename` option on gometalinter to get all errors from current
package

- added name to the authors lists
