### PR TITLE
add joker handler for clojure

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ formatting.
 | CUDA | [nvcc](http://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html) |
 | C# | [mcs](http://www.mono-project.com/docs/about-mono/languages/csharp/) see:`help ale-cs-mcs` for details, [mcsc](http://www.mono-project.com/docs/about-mono/languages/csharp/) !! see:`help ale-cs-mcsc` for details and configuration|
 | Chef | [foodcritic](http://www.foodcritic.io/) |
+| Clojure | [joker](https://github.com/candid82/joker) |
 | CMake | [cmakelint](https://github.com/richq/cmake-lint) |
 | CoffeeScript | [coffee](http://coffeescript.org/), [coffeelint](https://www.npmjs.com/package/coffeelint) |
 | Crystal | [crystal](https://crystal-lang.org/) !! |

--- a/ale_linters/clojure/joker.vim
+++ b/ale_linters/clojure/joker.vim
@@ -1,0 +1,32 @@
+" Author: Nic West <nicwest@mailbox.org>
+" Description: linter for clojure using joker https://github.com/candid82/joker
+
+function! ale_linters#clojure#joker#HandleJokerFormat(buffer, lines) abort
+    " output format
+    " <filename>:<line>:<column>: <issue type>: <message>
+    let l:pattern = '\v^[a-zA-Z]?:?[^:]+:(\d+):(\d+):? ((Read error|Parse error|Parse warning|Exception): ?(.+))$'
+    let l:output = []
+
+    for l:match in ale#util#GetMatches(a:lines, l:pattern)
+        let l:type = 'E'
+        if l:match[4] is? 'Parse warning'
+          let l:type = 'W'
+        endif
+        call add(l:output, {
+        \   'lnum': l:match[1] + 0,
+        \   'col': l:match[2] + 0,
+        \   'text': l:match[3],
+        \   'type': l:type,
+        \})
+    endfor
+
+    return l:output
+endfunction
+
+call ale#linter#Define('clojure', {
+\   'name': 'joker',
+\   'output_stream': 'stderr',
+\   'executable': 'joker',
+\   'command': 'joker --lint %t',
+\   'callback': 'ale_linters#clojure#joker#HandleJokerFormat',
+\})

--- a/doc/ale-clojure.txt
+++ b/doc/ale-clojure.txt
@@ -1,0 +1,21 @@
+===============================================================================
+ALE Clojure Integration                                   *ale-clojure-options*
+
+
+===============================================================================
+joker                                                       *ale-clojure-joker*
+
+Joker is a small Clojure interpreter and linter written in Go.
+
+https://github.com/candid82/joker
+
+Linting options are not configurable by ale, but instead are controlled by a
+`.joker` file in same directory as the file (or current working directory if
+linting stdin), a parent directory relative to the file, or the users home
+directory.
+
+see https://github.com/candid82/joker#linter-mode for more information.
+
+===============================================================================
+  vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:
+

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -29,6 +29,8 @@ CONTENTS                                                         *ale-contents*
       gcc.................................|ale-c-gcc|
     chef..................................|ale-chef-options|
       foodcritic..........................|ale-chef-foodcritic|
+    clojure...............................|ale-clojure-options|
+      joker...............................|ale-clojure-joker|
     cmake.................................|ale-cmake-options|
       cmakelint...........................|ale-cmake-cmakelint|
     cpp...................................|ale-cpp-options|
@@ -271,6 +273,7 @@ Notes:
 * CUDA: `nvcc`!!
 * C#: `mcs`, `mcsc`!!
 * Chef: `foodcritic`
+* Clojure: `joker`
 * CMake: `cmakelint`
 * CoffeeScript: `coffee`, `coffeelint`
 * Crystal: `crystal`!!

--- a/test/handler/test_clojure_joker_handler.vader
+++ b/test/handler/test_clojure_joker_handler.vader
@@ -1,0 +1,75 @@
+Before:
+  runtime ale_linters/clojure/joker.vim
+
+After:
+  call ale#linter#Reset()
+
+Execute(the clojure joker handler should be able to handle errors):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 123,
+  \     'col': 44,
+  \     'type': 'E',
+  \     'text': 'Read error: Unexpected )',
+  \   },
+  \ ],
+  \ ale_linters#clojure#joker#HandleJokerFormat(0, [
+  \   'test.clj:123:44: Read error: Unexpected )',
+  \ ])
+
+Execute(the clojure joker handler should be able to handle warnings):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 654,
+  \     'col': 321,
+  \     'type': 'W',
+  \     'text': 'Parse warning: let form with empty body',
+  \   }
+  \ ],
+  \ ale_linters#clojure#joker#HandleJokerFormat(0, [
+  \   'test.clj:654:321: Parse warning: let form with empty body'
+  \ ])
+
+Execute(the clojure joker handler should be able to handle exceptions):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 123,
+  \     'col': 321,
+  \     'type': 'E',
+  \     'text': 'Exception: something horrible happen',
+  \   }
+  \ ],
+  \ ale_linters#clojure#joker#HandleJokerFormat(0, [
+  \   'test.clj:123:321: Exception: something horrible happen'
+  \ ])
+
+Execute(the clojure joker handler should be able to handle errors from stdin):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 16,
+  \     'col': 1,
+  \     'type': 'E',
+  \     'text': 'Read error: Unexpected )',
+  \   },
+  \ ],
+  \ ale_linters#clojure#joker#HandleJokerFormat(0, [
+  \   '<stdin>:16:1: Read error: Unexpected )',
+  \ ])
+
+Execute(the clojure joker handler should be able to handle windows files):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 123,
+  \     'col': 44,
+  \     'type': 'E',
+  \     'text': 'Read error: Unexpected )',
+  \   }
+  \ ],
+  \ ale_linters#clojure#joker#HandleJokerFormat(0, [
+  \   'C:\my\operating\system\is\silly\core.clj:123:44: Read error: Unexpected )',
+  \ ])


### PR DESCRIPTION
Adds new linter for clojure using joker

https://github.com/candid82/joker

I haven't tested with clojurescript, edn, or joker (the dialect of clojure implemented by the joker interpreter), but the linter mode appears to support all three in addition to clojure (although it might need a option or something for handling files from stdin)

can I just add that this is the nicest vim plugin that I have ever worked on, really clear and easy to use API's, guidelines, tests, etc! 

fixes #975
ref #544 #1040

<!--
READ THIS: Before creating a pull request, please consider the following first.

* The most important thing you can do is write tests. Code without tests
  probably doesn't work, and will almost certainly stop working later on. Pull
  requests without tests probably won't be accepted, although there are some
  exceptions.
* Read the Contributing guide linked above first.
* If you are adding a new linter, remember to update the README.md file and
  doc/ale.txt first.
* If you add or modify a function for converting error lines into loclist items
  that ALE can work with, please add Vader tests for them. Look at existing
  tests in the test/handler directory, etc.
* If you add or modify a function for computing a command line string for
  running a command, please add Vader tests for that.
* Generally try and cover anything with Vader tests, although some things just
  can't be tested with Vader, or at least they can be hard to test. Consider
  breaking up your code so that some parts can be tested, and generally open up
  a discussion about it.
* Have fun!
-->
