### PR TITLE
erb, erubis: Redirect file into first command.

### DIFF
--- a/ale_linters/eruby/erb.vim
+++ b/ale_linters/eruby/erb.vim
@@ -11,7 +11,7 @@ function! ale_linters#eruby#erb#GetCommand(buffer) abort
     " Rails-flavored eRuby does not comply with the standard as understood by
     " ERB, so we'll have to do some substitution. This does not reduce the
     " effectiveness of the linter—the translated code is still evaluated.
-    return 'ruby -r erb -e ' . ale#Escape('puts ERB.new($stdin.read.gsub(%{<%=},%{<%}), nil, %{-}).src') . ' | ruby -c'
+    return 'ruby -r erb -e ' . ale#Escape('puts ERB.new($stdin.read.gsub(%{<%=},%{<%}), nil, %{-}).src') . '< %t | ruby -c'
 endfunction
 
 call ale#linter#Define('eruby', {

--- a/ale_linters/eruby/erubis.vim
+++ b/ale_linters/eruby/erubis.vim
@@ -11,7 +11,7 @@ function! ale_linters#eruby#erubis#GetCommand(buffer) abort
     " Rails-flavored eRuby does not comply with the standard as understood by
     " Erubis, so we'll have to do some substitution. This does not reduce the
     " effectiveness of the linter—the translated code is still evaluated.
-    return 'ruby -r erubis -e ' . ale#Escape('puts Erubis::Eruby.new($stdin.read.gsub(%{<%=},%{<%})).src') . ' | ruby -c'
+    return 'ruby -r erubis -e ' . ale#Escape('puts Erubis::Eruby.new($stdin.read.gsub(%{<%=},%{<%})).src') . '< %t | ruby -c'
 endfunction
 
 call ale#linter#Define('eruby', {

--- a/test/command_callback/test_erb_command_callback.vader
+++ b/test/command_callback/test_erb_command_callback.vader
@@ -17,5 +17,5 @@ Execute(Executable should filter invalid eRuby when inside a Rails project):
   call ale#test#SetFilename('../ruby_fixtures/valid_rails_app/app/views/my_great_view.html.erb')
 
   AssertEqual
-  \ 'ruby -r erb -e ' . ale#Escape('puts ERB.new($stdin.read.gsub(%{<%=},%{<%}), nil, %{-}).src') . ' | ruby -c',
+  \ 'ruby -r erb -e ' . ale#Escape('puts ERB.new($stdin.read.gsub(%{<%=},%{<%}), nil, %{-}).src') . '< %t | ruby -c',
   \ ale_linters#eruby#erb#GetCommand(bufnr(''))

--- a/test/command_callback/test_erubis_command_callback.vader
+++ b/test/command_callback/test_erubis_command_callback.vader
@@ -17,5 +17,5 @@ Execute(Executable should filter invalid eRuby when inside a Rails project):
   call ale#test#SetFilename('../ruby_fixtures/valid_rails_app/app/views/my_great_view.html.erb')
 
   AssertEqual
-  \ 'ruby -r erubis -e ' . ale#Escape('puts Erubis::Eruby.new($stdin.read.gsub(%{<%=},%{<%})).src') . ' | ruby -c',
+  \ 'ruby -r erubis -e ' . ale#Escape('puts Erubis::Eruby.new($stdin.read.gsub(%{<%=},%{<%})).src') . '< %t | ruby -c',
   \ ale_linters#eruby#erubis#GetCommand(bufnr(''))


### PR DESCRIPTION
The previous version relied on a zsh-specific behavior where
`<filename` after a pipe could redirect to the first command. This
is the standard way to do it.