### PR TITLE
Redpen support for text, asciidoc, reST, LaTeX and Re:VIEW

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ formatting.
 | Tcl | [nagelfar](http://nagelfar.sourceforge.net) !! |
 | Terraform | [tflint](https://github.com/wata727/tflint) |
 | Texinfo | [proselint](http://proselint.com/), [write-good](https://github.com/btford/write-good)|
-| Text^ | [proselint](http://proselint.com/), [vale](https://github.com/ValeLint/vale), [write-good](https://github.com/btford/write-good) |
+| Text^ | [proselint](http://proselint.com/), [vale](https://github.com/ValeLint/vale), [write-good](https://github.com/btford/write-good), [redpen](http://redpen.cc/) |
 | Thrift | [thrift](http://thrift.apache.org/) |
 | TypeScript | [eslint](http://eslint.org/), [prettier](https://github.com/prettier/prettier), [tslint](https://github.com/palantir/tslint), tsserver, typecheck |
 | Verilog | [iverilog](https://github.com/steveicarus/iverilog), [verilator](http://www.veripool.org/projects/verilator/wiki/Intro) |

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ formatting.
 | -------- | ----- |
 | ASM | [gcc](https://gcc.gnu.org) |
 | Ansible | [ansible-lint](https://github.com/willthames/ansible-lint) |
-| AsciiDoc | [proselint](http://proselint.com/), [write-good](https://github.com/btford/write-good)|
+| AsciiDoc | [proselint](http://proselint.com/), [write-good](https://github.com/btford/write-good), [redpen](http://redpen.cc/)|
 | Awk | [gawk](https://www.gnu.org/software/gawk/)|
 | Bash | shell [-n flag](https://www.gnu.org/software/bash/manual/bash.html#index-set), [shellcheck](https://www.shellcheck.net/), [shfmt](https://github.com/mvdan/sh) |
 | Bourne Shell | shell [-n flag](http://linux.die.net/man/1/sh), [shellcheck](https://www.shellcheck.net/), [shfmt](https://github.com/mvdan/sh) |
@@ -109,7 +109,7 @@ formatting.
 | JavaScript | [eslint](http://eslint.org/), [flow](https://flowtype.org/), [jscs](http://jscs.info/), [jshint](http://jshint.com/), [prettier](https://github.com/prettier/prettier), prettier-eslint >= 4.2.0, prettier-standard, [standard](http://standardjs.com/), [xo](https://github.com/sindresorhus/xo)
 | JSON | [jsonlint](http://zaa.ch/jsonlint/), [prettier](https://github.com/prettier/prettier) |
 | Kotlin | [kotlinc](https://kotlinlang.org) !!, [ktlint](https://ktlint.github.io) !! see `:help ale-integration-kotlin` for configuration instructions |
-| LaTeX | [chktex](http://www.nongnu.org/chktex/), [lacheck](https://www.ctan.org/pkg/lacheck), [proselint](http://proselint.com/), [write-good](https://github.com/btford/write-good) |
+| LaTeX | [chktex](http://www.nongnu.org/chktex/), [lacheck](https://www.ctan.org/pkg/lacheck), [proselint](http://proselint.com/), [write-good](https://github.com/btford/write-good), [redpen](http://redpen.cc/) |
 | Less | [lessc](https://www.npmjs.com/package/less), [prettier](https://github.com/prettier/prettier), [stylelint](https://github.com/stylelint/stylelint) |
 | LLVM | [llc](https://llvm.org/docs/CommandGuide/llc.html) |
 | Lua | [luacheck](https://github.com/mpeterv/luacheck) |
@@ -132,7 +132,8 @@ formatting.
 | Python | [autopep8](https://github.com/hhatto/autopep8), [flake8](http://flake8.pycqa.org/en/latest/), [isort](https://github.com/timothycrosley/isort), [mypy](http://mypy-lang.org/), [pycodestyle](https://github.com/PyCQA/pycodestyle), [pyls](https://github.com/palantir/python-language-server), [pylint](https://www.pylint.org/) !!, [yapf](https://github.com/google/yapf) |
 | R | [lintr](https://github.com/jimhester/lintr) |
 | ReasonML | [merlin](https://github.com/the-lambda-church/merlin) see `:help ale-integration-reason-merlin` for configuration instructions, [ols](https://github.com/freebroccolo/ocaml-language-server), [refmt](https://github.com/reasonml/reason-cli) |
-| reStructuredText | [proselint](http://proselint.com/), [rstcheck](https://github.com/myint/rstcheck), [write-good](https://github.com/btford/write-good) |
+| reStructuredText | [proselint](http://proselint.com/), [rstcheck](https://github.com/myint/rstcheck), [write-good](https://github.com/btford/write-good), [redpen](http://redpen.cc/) |
+| Re:VIEW | [redpen](http://redpen.cc/) |
 | RPM spec | [rpmlint](https://github.com/rpm-software-management/rpmlint) (disabled by default; see `:help ale-integration-spec`) |
 | Ruby | [brakeman](http://brakemanscanner.org/) !!, [rails_best_practices](https://github.com/flyerhzm/rails_best_practices) !!, [reek](https://github.com/troessner/reek), [rubocop](https://github.com/bbatsov/rubocop), [ruby](https://www.ruby-lang.org) |
 | Rust |  cargo !! (see `:help ale-integration-rust` for configuration instructions), [rls](https://github.com/rust-lang-nursery/rls), [rustc](https://www.rust-lang.org/), [rustfmt](https://github.com/rust-lang-nursery/rustfmt) |

--- a/ale_linters/asciidoc/redpen.vim
+++ b/ale_linters/asciidoc/redpen.vim
@@ -1,9 +1,9 @@
 " Author: rhysd https://rhysd.github.io
 " Description: Redpen, a proofreading tool (http://redpen.cc)
 
-call ale#linter#Define('markdown', {
+call ale#linter#Define('asciidoc', {
 \   'name': 'redpen',
 \   'executable': 'redpen',
-\   'command': 'redpen -f markdown -r json %t',
+\   'command': 'redpen -f asciidoc -r json %t',
 \   'callback': 'ale#handlers#redpen#HandleRedpenOutput',
 \})

--- a/ale_linters/review/redpen.vim
+++ b/ale_linters/review/redpen.vim
@@ -1,9 +1,9 @@
 " Author: rhysd https://rhysd.github.io
 " Description: Redpen, a proofreading tool (http://redpen.cc)
 
-call ale#linter#Define('markdown', {
+call ale#linter#Define('review', {
 \   'name': 'redpen',
 \   'executable': 'redpen',
-\   'command': 'redpen -f markdown -r json %t',
+\   'command': 'redpen -f review -r json %t',
 \   'callback': 'ale#handlers#redpen#HandleRedpenOutput',
 \})

--- a/ale_linters/rst/redpen.vim
+++ b/ale_linters/rst/redpen.vim
@@ -1,9 +1,9 @@
 " Author: rhysd https://rhysd.github.io
 " Description: Redpen, a proofreading tool (http://redpen.cc)
 
-call ale#linter#Define('markdown', {
+call ale#linter#Define('rst', {
 \   'name': 'redpen',
 \   'executable': 'redpen',
-\   'command': 'redpen -f markdown -r json %t',
+\   'command': 'redpen -f rest -r json %t',
 \   'callback': 'ale#handlers#redpen#HandleRedpenOutput',
 \})

--- a/ale_linters/tex/redpen.vim
+++ b/ale_linters/tex/redpen.vim
@@ -1,9 +1,9 @@
 " Author: rhysd https://rhysd.github.io
 " Description: Redpen, a proofreading tool (http://redpen.cc)
 
-call ale#linter#Define('markdown', {
+call ale#linter#Define('tex', {
 \   'name': 'redpen',
 \   'executable': 'redpen',
-\   'command': 'redpen -f markdown -r json %t',
+\   'command': 'redpen -f latex -r json %t',
 \   'callback': 'ale#handlers#redpen#HandleRedpenOutput',
 \})

--- a/ale_linters/text/redpen.vim
+++ b/ale_linters/text/redpen.vim
@@ -1,0 +1,9 @@
+" Author: rhysd https://rhysd.github.io
+" Description: Redpen, a proofreading tool (http://redpen.cc)
+
+call ale#linter#Define('text', {
+\   'name': 'redpen',
+\   'executable': 'redpen',
+\   'command': 'redpen -f plain -r json %t',
+\   'callback': 'ale#handlers#redpen#HandleRedpenOutput',
+\})

--- a/autoload/ale/handlers/redpen.vim
+++ b/autoload/ale/handlers/redpen.vim
@@ -1,0 +1,29 @@
+" Author: rhysd https://rhysd.github.io
+" Description: Redpen, a proofreading tool (http://redpen.cc)
+
+function! ale#handlers#redpen#HandleRedpenOutput(buffer, lines) abort
+    " Only one file was passed to redpen. So response array has only one
+    " element.
+    let l:res = json_decode(join(a:lines))[0]
+    let l:output = []
+    for l:err in l:res.errors
+        let l:item = {
+        \   'text': l:err.message . ' (' . l:err.validator . ')',
+        \   'type': 'W',
+        \}
+        if has_key(l:err, 'startPosition')
+            let l:item.lnum = l:err.startPosition.lineNum
+            let l:item.col = l:err.startPosition.offset
+            if has_key(l:err, 'endPosition')
+                let l:item.end_lnum = l:err.endPosition.lineNum
+                let l:item.end_col = l:err.endPosition.offset
+            endif
+        else
+            let l:item.lnum = l:err.lineNum
+            let l:item.col = l:err.sentenceStartColumnNum + 1
+        endif
+        call add(l:output, l:item)
+    endfor
+    return l:output
+endfunction
+

--- a/autoload/ale/handlers/redpen.vim
+++ b/autoload/ale/handlers/redpen.vim
@@ -13,7 +13,7 @@ function! ale#handlers#redpen#HandleRedpenOutput(buffer, lines) abort
         \}
         if has_key(l:err, 'startPosition')
             let l:item.lnum = l:err.startPosition.lineNum
-            let l:item.col = l:err.startPosition.offset
+            let l:item.col = l:err.startPosition.offset + 1
             if has_key(l:err, 'endPosition')
                 let l:item.end_lnum = l:err.endPosition.lineNum
                 let l:item.end_col = l:err.endPosition.offset

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -341,7 +341,7 @@ Notes:
 * Tcl: `nagelfar`!!
 * Terraform: `tflint`
 * Texinfo: `proselint`, `write-good`
-* Text^: `proselint`, `vale`, `write-good`
+* Text^: `proselint`, `vale`, `write-good`, `redpen`
 * Thrift: `thrift`
 * TypeScript: `eslint`, `prettier`, `tslint`, `tsserver`, `typecheck`
 * Verilog: `iverilog`, `verilator`

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -264,7 +264,7 @@ Notes:
 
 * ASM: `gcc`
 * Ansible: `ansible-lint`
-* AsciiDoc: `proselint`, `write-good`
+* AsciiDoc: `proselint`, `write-good`, `redpen`
 * Awk: `gawk`
 * Bash: `shell` (-n flag), `shellcheck`, `shfmt`
 * Bourne Shell: `shell` (-n flag), `shellcheck`, `shfmt`
@@ -301,7 +301,7 @@ Notes:
 * JavaScript: `eslint`, `flow`, `jscs`, `jshint`, `prettier`, `prettier-eslint` >= 4.2.0, `prettier-standard`, `standard`, `xo`
 * JSON: `jsonlint`, `prettier`
 * Kotlin: `kotlinc`, `ktlint`
-* LaTeX (tex): `chktex`, `lacheck`, `proselint`, `write-good`
+* LaTeX (tex): `chktex`, `lacheck`, `proselint`, `write-good`, `redpen`
 * Less: `lessc`, `prettier`, `stylelint`
 * LLVM: `llc`
 * Lua: `luacheck`
@@ -324,7 +324,8 @@ Notes:
 * Python: `autopep8`, `flake8`, `isort`, `mypy`, `pycodestyle`, `pyls`, `pylint`!!, `yapf`
 * R: `lintr`
 * ReasonML: `merlin`, `ols`, `refmt`
-* reStructuredText: `proselint`, `rstcheck`, `write-good`
+* reStructuredText: `proselint`, `rstcheck`, `write-good`, `redpen`
+* Re:VIEW: `redpen`
 * RPM spec: `rpmlint`
 * Ruby: `brakeman`, `rails_best_practices`!!, `reek`, `rubocop`, `ruby`
 * Rust: `cargo`!!, `rls`, `rustc` (see |ale-integration-rust|), `rustfmt`

--- a/test/handler/test_redpen_handler.vader
+++ b/test/handler/test_redpen_handler.vader
@@ -22,7 +22,7 @@ Execute(redpen handler should handle errors output):
   \     'type': 'W',
   \   },
   \ ],
-  \ ale_linters#markdown#redpen#HandleErrors(bufnr(''), [
+  \ ale#handlers#redpen#HandleRedpenOutput(bufnr(''), [
   \   '[',
   \   '  {',
   \   '    "document": "test.md",',
@@ -57,7 +57,7 @@ Execute(redpen handler should handle errors output):
 Execute(redpen handler should no error output):
   AssertEqual
   \ [],
-  \ ale_linters#markdown#redpen#HandleErrors(bufnr(''), [
+  \ ale#handlers#redpen#HandleRedpenOutput(bufnr(''), [
   \   '[',
   \   '  {',
   \   '    "document": "test.md",',

--- a/test/handler/test_redpen_handler.vader
+++ b/test/handler/test_redpen_handler.vader
@@ -9,7 +9,7 @@ Execute(redpen handler should handle errors output):
   \ [
   \   {
   \     'lnum': 1,
-  \     'col': 9,
+  \     'col': 10,
   \     'end_lnum': 1,
   \     'end_col': 15,
   \     'text': 'Found possibly misspelled word "plugin". (Spelling)',


### PR DESCRIPTION
<!--
READ THIS: Before creating a pull request, please consider the following first.

* The most important thing you can do is write tests. Code without tests
  probably doesn't work, and will almost certainly stop working later on. Pull
  requests without tests probably won't be accepted, although there are some
  exceptions.
* Read the Contributing guide linked above first.
* If you are adding a new linter, remember to update the README.md file and
  doc/ale.txt first.
* If you add or modify a function for converting error lines into loclist items
  that ALE can work with, please add Vader tests for them. Look at existing
  tests in the test/handler directory, etc.
* If you add or modify a function for computing a command line string for
  running a command, please add Vader tests for that.
* Generally try and cover anything with Vader tests, although some things just
  can't be tested with Vader, or at least they can be hard to test. Consider
  breaking up your code so that some parts can be tested, and generally open up
  a discussion about it.
* Have fun!
-->

Yesterday, I sent a PR for [redpen](http://redpen.cc/) support as markdown linter. And it seems to work well. Today, I added text, asciidoc, reST, LaTeX and Re:VIEW support by redpen.
