### PR TITLE
Make options configurable in iverilog

### DIFF
--- a/ale_linters/verilog/iverilog.vim
+++ b/ale_linters/verilog/iverilog.vim
@@ -1,6 +1,14 @@
 " Author: Masahiro H https://github.com/mshr-h
 " Description: iverilog for verilog files
 
+call ale#Set('verilog_iverilog_options', '')
+
+function! ale_linters#verilog#iverilog#GetCommand(buffer) abort
+    return 'iverilog -t null -Wall '
+    \   . ale#Var(a:buffer, 'verilog_iverilog_options')
+    \   . ' %t'
+endfunction
+
 function! ale_linters#verilog#iverilog#Handle(buffer, lines) abort
     " Look for lines like the following.
     "
@@ -30,6 +38,6 @@ call ale#linter#Define('verilog', {
 \   'name': 'iverilog',
 \   'output_stream': 'stderr',
 \   'executable': 'iverilog',
-\   'command': 'iverilog -t null -Wall %t',
+\   'command_callback': 'ale_linters#verilog#iverilog#GetCommand',
 \   'callback': 'ale_linters#verilog#iverilog#Handle',
 \})

--- a/test/test_verilog_iverilog_options.vader
+++ b/test/test_verilog_iverilog_options.vader
@@ -14,11 +14,5 @@ Execute(Set Verilog iverilog linter additional options to `-y.`):
 
   call ale#Lint()
 
-  let g:run_cmd = ale_linters#verilog#iverilog#GetCommand(bufnr(''))
-  let g:matched = match(g:run_cmd, '\s' . g:ale_verilog_iverilog_options . '\s')
-
-  " match returns -1 if not found
-  AssertNotEqual
-  \   g:matched ,
-  \   -1 ,
-  \   'Additionnal arguments not found in the run command'
+  let g:cmd = ale_linters#verilog#iverilog#GetCommand(bufnr(''))
+  AssertEqual g:cmd, 'iverilog -t null -Wall -y. %t',

--- a/test/test_verilog_iverilog_options.vader
+++ b/test/test_verilog_iverilog_options.vader
@@ -1,0 +1,24 @@
+Before:
+  Save g:ale_verilog_iverilog_options
+  let g:ale_verilog_iverilog_options = ''
+
+After:
+  Restore
+  call ale#linter#Reset()
+
+Execute(Set Verilog iverilog linter additional options to `-y.`):
+  runtime! ale_linters/verilog/iverilog.vim
+
+  " Additional args for the linter
+  let g:ale_verilog_iverilog_options = '-y.'
+
+  call ale#Lint()
+
+  let g:run_cmd = ale_linters#verilog#iverilog#GetCommand(bufnr(''))
+  let g:matched = match(g:run_cmd, '\s' . g:ale_verilog_iverilog_options . '\s')
+
+  " match returns -1 if not found
+  AssertNotEqual
+  \   g:matched ,
+  \   -1 ,
+  \   'Additionnal arguments not found in the run command'

--- a/test/test_verilog_iverilog_options.vader
+++ b/test/test_verilog_iverilog_options.vader
@@ -15,4 +15,4 @@ Execute(Set Verilog iverilog linter additional options to `-y.`):
   call ale#Lint()
 
   let g:cmd = ale_linters#verilog#iverilog#GetCommand(bufnr(''))
-  AssertEqual g:cmd, 'iverilog -t null -Wall -y. %t',
+  AssertEqual g:cmd, 'iverilog -t null -Wall -y. %t'


### PR DESCRIPTION
I've inserted the variable `verilog_iverilog_options` into command, which is set to empty by default.
And the test file is altered from `verilog_verilator_options.vader` in the same folder.

<!--
READ THIS: Before creating a pull request, please consider the following first.

* The most important thing you can do is write tests. Code without tests
  probably doesn't work, and will almost certainly stop working later on. Pull
  requests without tests probably won't be accepted, although there are some
  exceptions.
* Read the Contributing guide linked above first.
* If you are adding a new linter, remember to update the README.md file and
  doc/ale.txt first.
* If you add or modify a function for converting error lines into loclist items
  that ALE can work with, please add Vader tests for them. Look at existing
  tests in the test/handler directory, etc.
* If you add or modify a function for computing a command line string for
  running a command, please add Vader tests for that.
* Generally try and cover anything with Vader tests, although some things just
  can't be tested with Vader, or at least they can be hard to test. Consider
  breaking up your code so that some parts can be tested, and generally open up
  a discussion about it.
* Have fun!
-->
