### PR TITLE
Fix #1145 added `gometalinter_lint_dir` option

### DIFF
--- a/ale_linters/go/gometalinter.vim
+++ b/ale_linters/go/gometalinter.vim
@@ -3,6 +3,7 @@
 
 call ale#Set('go_gometalinter_options', '')
 call ale#Set('go_gometalinter_executable', 'gometalinter')
+call ale#Set('go_gometalinter_lint_dir', 1)
 
 function! ale_linters#go#gometalinter#GetExecutable(buffer) abort
     return ale#Var(a:buffer, 'go_gometalinter_executable')
@@ -12,8 +13,16 @@ function! ale_linters#go#gometalinter#GetCommand(buffer) abort
     let l:executable = ale_linters#go#gometalinter#GetExecutable(a:buffer)
     let l:filename = expand('#' . a:buffer)
     let l:options = ale#Var(a:buffer, 'go_gometalinter_options')
+    let l:lint_dir = ale#Var(a:buffer, 'go_gometalinter_lint_dir')
+
+    if l:lint_dir
+        return ale#Escape(l:executable)
+        \   . (!empty(l:options) ? ' ' . l:options : '')
+        \   . ' ' . ale#Escape(fnamemodify(l:filename, ':h'))
+    endif
 
     return ale#Escape(l:executable)
+    \   . ' --include=' . ale#Escape('^' . ale#util#EscapePCRE(l:filename))
     \   . (!empty(l:options) ? ' ' . l:options : '')
     \   . ' ' . ale#Escape(fnamemodify(l:filename, ':h'))
 endfunction

--- a/test/command_callback/test_gometalinter_command_callback.vader
+++ b/test/command_callback/test_gometalinter_command_callback.vader
@@ -1,9 +1,11 @@
 Before:
   Save b:ale_go_gometalinter_executable
   Save b:ale_go_gometalinter_options
+  Save b:ale_go_gometalinter_lint_dir
 
   let b:ale_go_gometalinter_executable = 'gometalinter'
   let b:ale_go_gometalinter_options = ''
+  let b:ale_go_gometalinter_lint_dir = 1
 
   runtime ale_linters/go/gometalinter.vim
 
@@ -42,5 +44,14 @@ Execute(The gometalinter callback should use configured options):
   AssertEqual
   \ ale#Escape('gometalinter')
   \   . ' --foobar'
+  \   . ' ' . ale#Escape(getcwd()),
+  \ ale_linters#go#gometalinter#GetCommand(bufnr(''))
+
+Execute(The gometalinter callback should pass `--include` when `lint_dir` is set to 0):
+  let b:ale_go_gometalinter_lint_dir = 0
+
+  AssertEqual
+  \ ale#Escape('gometalinter')
+  \   . ' --include=' . ale#Escape('^' . ale#util#EscapePCRE(expand('%')))
   \   . ' ' . ale#Escape(getcwd()),
   \ ale_linters#go#gometalinter#GetCommand(bufnr(''))


### PR DESCRIPTION
- added an option to lint only the current file with gometalinter
- added command_callback test to test the option

EDIT: I will add docs for the new option, but just wanted to get some input on the changes first
<!--
READ THIS: Before creating a pull request, please consider the following first.

* The most important thing you can do is write tests. Code without tests
  probably doesn't work, and will almost certainly stop working later on. Pull
  requests without tests probably won't be accepted, although there are some
  exceptions.
* Read the Contributing guide linked above first.
* If you are adding a new linter, remember to update the README.md file and
  doc/ale.txt first.
* If you add or modify a function for converting error lines into loclist items
  that ALE can work with, please add Vader tests for them. Look at existing
  tests in the test/handler directory, etc.
* If you add or modify a function for computing a command line string for
  running a command, please add Vader tests for that.
* Generally try and cover anything with Vader tests, although some things just
  can't be tested with Vader, or at least they can be hard to test. Consider
  breaking up your code so that some parts can be tested, and generally open up
  a discussion about it.
* Have fun!
-->
