### PR TITLE
Added filename key for `go build` linter

### DIFF
--- a/ale_linters/go/gobuild.vim
+++ b/ale_linters/go/gobuild.vim
@@ -1,4 +1,5 @@
-" Author: Joshua Rubin <joshua@rubixconsulting.com>, Ben Reedy <https://github.com/breed808>
+" Author: Joshua Rubin <joshua@rubixconsulting.com>, Ben Reedy <https://github.com/breed808>,
+" Jeff Willette <jrwillette88@gmail.com>
 " Description: go build for Go files
 
 " inspired by work from dzhou121 <dzhou121@gmail.com>
@@ -39,15 +40,12 @@ function! ale_linters#go#gobuild#GetMatches(lines) abort
 endfunction
 
 function! ale_linters#go#gobuild#Handler(buffer, lines) abort
+    let l:dir = expand('#' . a:buffer . ':p:h')
     let l:output = []
 
     for l:match in ale_linters#go#gobuild#GetMatches(a:lines)
-        " Omit errors from imported go packages
-        if !ale#path#IsBufferPath(a:buffer, l:match[1])
-            continue
-        endif
-
         call add(l:output, {
+        \   'filename': ale#path#GetAbsPath(l:dir, l:match[1]),
         \   'lnum': l:match[2] + 0,
         \   'col': l:match[3] + 0,
         \   'text': l:match[4],

--- a/test/handler/test_gobuild_handler.vader
+++ b/test/handler/test_gobuild_handler.vader
@@ -28,7 +28,7 @@ Execute (The gobuild handler should handle names with spaces):
   \ ]), 'v:val[1:4]')
 
 Execute (The gobuild handler should handle relative paths correctly):
-  silent file! /foo/bar/baz.go
+  call ale#test#SetFilename('app/test.go')
 
   AssertEqual
   \ [
@@ -37,8 +37,9 @@ Execute (The gobuild handler should handle relative paths correctly):
   \     'col': 0,
   \     'text': 'missing argument for Printf("%s"): format reads arg 2, have only 1 args',
   \     'type': 'E',
+  \     'filename': ale#path#Winify(expand('%:p:h') . '/test.go'),
   \   },
   \ ],
   \ ale_linters#go#gobuild#Handler(bufnr(''), [
-  \   'baz.go:27: missing argument for Printf("%s"): format reads arg 2, have only 1 args',
+  \   'test.go:27: missing argument for Printf("%s"): format reads arg 2, have only 1 args',
   \ ])


### PR DESCRIPTION
- Re: f224ce8a377bbb3a0deb78b98fdc6c43555791e2

- The issues that prompted the above commit which reverted changes made to `go build` and
`gometalinter` seemed to suggest that the main issue was with gometalinter and that
changes should be put into different commits so they are independent of each other

- This commit reinstates the changes to the `go build` linter which seem to be uncontested
and it also seems absolutely necessary to show errors from all files in the package which
may have caused a build failure.

<!--
READ THIS: Before creating a pull request, please consider the following first.

* The most important thing you can do is write tests. Code without tests
  probably doesn't work, and will almost certainly stop working later on. Pull
  requests without tests probably won't be accepted, although there are some
  exceptions.
* Read the Contributing guide linked above first.
* If you are adding a new linter, remember to update the README.md file and
  doc/ale.txt first.
* If you add or modify a function for converting error lines into loclist items
  that ALE can work with, please add Vader tests for them. Look at existing
  tests in the test/handler directory, etc.
* If you add or modify a function for computing a command line string for
  running a command, please add Vader tests for that.
* Generally try and cover anything with Vader tests, although some things just
  can't be tested with Vader, or at least they can be hard to test. Consider
  breaking up your code so that some parts can be tested, and generally open up
  a discussion about it.
* Have fun!
-->
