### PR TITLE
add option to override TMPDIR from Vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -678,3 +678,27 @@ let g:ale_pattern_options_enabled = 1
 ```
 
 Buffer-local variables for settings always override the global settings.
+
+### 5.xvi. How can I override my TMPDIR setting?
+
+By default, ALE will use whatever your `$TMPDIR` environment variable is set
+to. If it is unset, ALE will default to `/tmp`. However, when you want to
+specifically override your `$TMPDIR` setting for ALE, you can do so in the
+following way:
+
+```vim
+" Override TMPDIR for ALE
+let g:ale_override_tmpdir = '/path/to/tmp'
+```
+
+One of the reasons to do this, is when you run linters in containers, using
+Docker Machine. By default only your home directory is shared with the Docker
+VM, which means `/tmp` or `/var/folders` (MacOS) are never available to a 
+linter inside a container. But if we were to set `$TMPDIR` to something
+inside our home directory, suddenly everything works fine:
+
+```vim
+" Set TMPDIR to subdir of homedir, just for ALE
+let g:ale_override_tmpdir = $HOME.'/.vimtmp'
+```
+

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -1093,6 +1093,21 @@ g:ale_open_list                                               *g:ale_open_list*
   The window size can be configured with |g:ale_list_window_size|.
 
 
+g:ale_override_tmpdir                                   *g:ale_override_tmpdir*
+
+  Type: |String|
+  Default: `{}`
+
+  This option allows one to override the $TMPDIR environment variable. This
+  can be useful when running linters in Docker containers using Docker
+  Machine, where by default '/tmp' (*nix) or '/var/folders' (MacOS) aren't
+  mountable. 
+
+  Example:
+  " Have Vim-specific TMPDIR:
+  let g:ale_override_tmpdir = $HOME.'/.vimtmp'
+
+
 g:ale_pattern_options                                   *g:ale_pattern_options*
 
   Type: |Dictionary|

--- a/plugin/ale.vim
+++ b/plugin/ale.vim
@@ -45,6 +45,12 @@ endif
 " Set this flag so that other plugins can use it, like airline.
 let g:loaded_ale = 1
 
+" Allow overriding of the TMPDIR variable. This is especially useful
+" for running linters in containers using Docker Machine
+if exists('g:ale_override_tmpdir')
+    let $TMPDIR = get(g:, 'ale_override_tmpdir', {})
+endif
+
 " Set the TMPDIR environment variable if it is not set automatically.
 " This can automatically fix some environments.
 if has('unix') && empty($TMPDIR)


### PR DESCRIPTION
Hi,

this is my first attempt ever at contributing to a Vim plugin, so please bear with me 😉 

I ran into the issue that running linters inside Docker containers (using Docker Machine on MacOS) breaks ALE. I traced the issue to the `$TMPDIR` location, which on a Mac is a random dir inside `/var/folders`. However, if you are using Docker Machine, this directory by default can not be made available to a Docker container, so any linter running in a container would fail because of this.

To solve this problem, I introduced a new setting (unset by default), that allows a user to override `TMPDIR` specifically for ALE.

```vim
let g:ale_override_tmpdir = $HOME.'/.vimtmp'
```

If I now run `ALELint` for my Terraform code, it will run TFlint in a container using `$HOME/.vimtmp` as the temporary dir, which is passed to the container, and everything is fine: 

```
(started) ['/usr/local/bin/bash', '-lc', '''tflint'' -f json ''/Users/benny/.vimtmp/vHyo9Sb/35/bastion.tf''']
(finished - exit code 0) ['/usr/local/bin/bash', '-lc', '''tflint'' -f json ''/Users/benny/.vimtmp/vHyo9Sb/36/bastion.tf''']
<<<OUTPUT STARTS>>>
[{"detector":"aws_instance_default_standard_volume","type":"WARNING","message":"\"volume_type\" is not specified. Default standard volume type is not recommended. You can use \"gp2\
", \"io1\", etc instead.","line":27,"file":"/Users/benny/.vimtmp/vHyo9Sb/36/bastion.tf","link":"https://github.com/wata727/tflint/blob/master/docs/aws_instance_default_standard_v
olume.md"}]
```

I have absolutely no experience with Vader testing either so I'm still figuring out how to test this. Any help in that regard is appreciated. I've also updated the docs, but again, first time.
