### PR TITLE
Added option for `gometalinter` to lint package

### DIFF
--- a/ale_linters/go/gometalinter.vim
+++ b/ale_linters/go/gometalinter.vim
@@ -20,15 +20,13 @@ function! ale_linters#go#gometalinter#GetCommand(buffer) abort
     if l:lint_package
         return ale#path#BufferCdString(a:buffer)
         \   . ale#Escape(l:executable)
-        \   . (!empty(l:options) ? ' ' . l:options : '')
-        \   . ' .' 
+        \   . (!empty(l:options) ? ' ' . l:options : '') . ' .'
     endif
 
     return ale#path#BufferCdString(a:buffer)
     \   . ale#Escape(l:executable)
     \   . ' --include=' . ale#Escape(ale#util#EscapePCRE(l:filename))
-    \   . (!empty(l:options) ? ' ' . l:options : '')
-    \   . ' .' 
+    \   . (!empty(l:options) ? ' ' . l:options : '') . ' .'
 endfunction
 
 function! ale_linters#go#gometalinter#GetMatches(lines) abort

--- a/ale_linters/go/gometalinter.vim
+++ b/ale_linters/go/gometalinter.vim
@@ -34,9 +34,12 @@ function! ale_linters#go#gometalinter#GetMatches(lines) abort
 endfunction
 
 function! ale_linters#go#gometalinter#Handler(buffer, lines) abort
-    let l:dir = expand('#' . a:buffer . ':p:h')
+    let l:dir = getcwd()
     let l:output = []
 
+    " gometalinter always gives the output in filenames with a path that is relative to
+    " the current directory, so passing `l:dir` and the match name to `GetAbsPath` should
+    " compute the correct absolute filepath
     for l:match in ale_linters#go#gometalinter#GetMatches(a:lines)
         call add(l:output, {
         \   'filename': ale#path#GetAbsPath(l:dir, l:match[1]),

--- a/ale_linters/go/gometalinter.vim
+++ b/ale_linters/go/gometalinter.vim
@@ -11,7 +11,7 @@ endfunction
 
 function! ale_linters#go#gometalinter#GetCommand(buffer) abort
     let l:executable = ale_linters#go#gometalinter#GetExecutable(a:buffer)
-    let l:filename = expand('#' . a:buffer)
+    let l:filename = expand('#' . a:buffer . ':t')
     let l:options = ale#Var(a:buffer, 'go_gometalinter_options')
     let l:lint_package = ale#Var(a:buffer, 'go_gometalinter_lint_package')
 

--- a/ale_linters/go/gometalinter.vim
+++ b/ale_linters/go/gometalinter.vim
@@ -15,14 +15,18 @@ function! ale_linters#go#gometalinter#GetCommand(buffer) abort
     let l:options = ale#Var(a:buffer, 'go_gometalinter_options')
     let l:lint_package = ale#Var(a:buffer, 'go_gometalinter_lint_package')
 
+    " standard format string given by gometalinter, but with absolute path to file
+    let l:fmt = '{{.Path.Abs}}:{{.Line}}:{{if .Col}}{{.Col}}{{end}}:{{.Severity}}: {{.Message}} ({{.Linter}}'
     if l:lint_package
         return ale#Escape(l:executable)
+        \   . ' --format=' . ale#Escape(l:fmt)
         \   . (!empty(l:options) ? ' ' . l:options : '')
         \   . ' ' . ale#Escape(fnamemodify(l:filename, ':h'))
     endif
 
     return ale#Escape(l:executable)
-    \   . ' --include=' . ale#Escape('^' . ale#util#EscapePCRE(l:filename))
+    \   . ' --format=' . ale#Escape(l:fmt)
+    \   . ' --include=' . ale#Escape(ale#util#EscapePCRE(l:filename))
     \   . (!empty(l:options) ? ' ' . l:options : '')
     \   . ' ' . ale#Escape(fnamemodify(l:filename, ':h'))
 endfunction
@@ -34,15 +38,12 @@ function! ale_linters#go#gometalinter#GetMatches(lines) abort
 endfunction
 
 function! ale_linters#go#gometalinter#Handler(buffer, lines) abort
-    let l:dir = getcwd()
     let l:output = []
 
-    " gometalinter always gives the output in filenames with a path that is relative to
-    " the current directory, so passing `l:dir` and the match name to `GetAbsPath` should
-    " compute the correct absolute filepath
     for l:match in ale_linters#go#gometalinter#GetMatches(a:lines)
+        " l:match[1] will already be an absolute path, output from gometalinter
         call add(l:output, {
-        \   'filename': ale#path#GetAbsPath(l:dir, l:match[1]),
+        \   'filename': l:match[1],
         \   'lnum': l:match[2] + 0,
         \   'col': l:match[3] + 0,
         \   'type': tolower(l:match[4]) is# 'warning' ? 'W' : 'E',

--- a/test/command_callback/test_gometalinter_command_callback.vader
+++ b/test/command_callback/test_gometalinter_command_callback.vader
@@ -25,7 +25,7 @@ Execute(The gometalinter callback should return the right defaults):
   AssertEqual
   \ 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
   \   . ale#Escape('gometalinter')
-  \   . ' --include=' . ale#Escape(ale#util#EscapePCRE(expand('%')))
+  \   . ' --include=' . ale#Escape(ale#util#EscapePCRE(expand('%' . ':t')))
   \   . ' .',
   \ ale_linters#go#gometalinter#GetCommand(bufnr(''))
 
@@ -38,7 +38,7 @@ Execute(The gometalinter callback should use a configured executable):
   AssertEqual
   \ 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
   \   . ale#Escape('something else')
-  \   . ' --include=' . ale#Escape(ale#util#EscapePCRE(expand('%')))
+  \   . ' --include=' . ale#Escape(ale#util#EscapePCRE(expand('%' . ':t')))
   \   . ' .', 
   \ ale_linters#go#gometalinter#GetCommand(bufnr(''))
 
@@ -48,7 +48,7 @@ Execute(The gometalinter callback should use configured options):
   AssertEqual
   \ 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
   \   . ale#Escape('gometalinter')
-  \   . ' --include=' . ale#Escape(ale#util#EscapePCRE(expand('%')))
+  \   . ' --include=' . ale#Escape(ale#util#EscapePCRE(expand('%' . ':t')))
   \   . ' --foobar' . ' .',
   \ ale_linters#go#gometalinter#GetCommand(bufnr(''))
 

--- a/test/command_callback/test_gometalinter_command_callback.vader
+++ b/test/command_callback/test_gometalinter_command_callback.vader
@@ -7,7 +7,6 @@ Before:
   let b:ale_go_gometalinter_options = ''
   let b:ale_go_gometalinter_lint_package = 0
 
-  let fmt = '{{.Path.Abs}}:{{.Line}}:{{if .Col}}{{.Col}}{{end}}:{{.Severity}}: {{.Message}} ({{.Linter}}'
   runtime ale_linters/go/gometalinter.vim
 
   call ale#test#SetDirectory('/testplugin/test/command_callback')
@@ -24,10 +23,10 @@ Execute(The gometalinter callback should return the right defaults):
   \ 'gometalinter',
   \ ale_linters#go#gometalinter#GetExecutable(bufnr(''))
   AssertEqual
-  \ ale#Escape('gometalinter')
-  \   . ' --format=' . ale#Escape(fmt)
+  \ 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \   . ale#Escape('gometalinter')
   \   . ' --include=' . ale#Escape(ale#util#EscapePCRE(expand('%')))
-  \   . ' ' . ale#Escape(getcwd()),
+  \   . ' .',
   \ ale_linters#go#gometalinter#GetCommand(bufnr(''))
 
 Execute(The gometalinter callback should use a configured executable):
@@ -37,28 +36,26 @@ Execute(The gometalinter callback should use a configured executable):
   \ 'something else',
   \ ale_linters#go#gometalinter#GetExecutable(bufnr(''))
   AssertEqual
-  \ ale#Escape('something else')
-  \   . ' --format=' . ale#Escape(fmt)
+  \ 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \   . ale#Escape('something else')
   \   . ' --include=' . ale#Escape(ale#util#EscapePCRE(expand('%')))
-  \   . ' ' . ale#Escape(getcwd()),
+  \   . ' .', 
   \ ale_linters#go#gometalinter#GetCommand(bufnr(''))
 
 Execute(The gometalinter callback should use configured options):
   let b:ale_go_gometalinter_options = '--foobar'
 
   AssertEqual
-  \ ale#Escape('gometalinter')
-  \   . ' --format=' . ale#Escape(fmt)
+  \ 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \   . ale#Escape('gometalinter')
   \   . ' --include=' . ale#Escape(ale#util#EscapePCRE(expand('%')))
-  \   . ' --foobar'
-  \   . ' ' . ale#Escape(getcwd()),
+  \   . ' --foobar' . ' .',
   \ ale_linters#go#gometalinter#GetCommand(bufnr(''))
 
 Execute(The gometalinter `lint_package` option should use the correct command):
   let b:ale_go_gometalinter_lint_package = 1
 
   AssertEqual
-  \ ale#Escape('gometalinter')
-  \   . ' --format=' . ale#Escape(fmt)
-  \   . ' ' . ale#Escape(getcwd()),
+  \ 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \   . ale#Escape('gometalinter') . ' .',
   \ ale_linters#go#gometalinter#GetCommand(bufnr(''))

--- a/test/command_callback/test_gometalinter_command_callback.vader
+++ b/test/command_callback/test_gometalinter_command_callback.vader
@@ -7,6 +7,7 @@ Before:
   let b:ale_go_gometalinter_options = ''
   let b:ale_go_gometalinter_lint_package = 0
 
+  let fmt = '{{.Path.Abs}}:{{.Line}}:{{if .Col}}{{.Col}}{{end}}:{{.Severity}}: {{.Message}} ({{.Linter}}'
   runtime ale_linters/go/gometalinter.vim
 
   call ale#test#SetDirectory('/testplugin/test/command_callback')
@@ -24,7 +25,8 @@ Execute(The gometalinter callback should return the right defaults):
   \ ale_linters#go#gometalinter#GetExecutable(bufnr(''))
   AssertEqual
   \ ale#Escape('gometalinter')
-  \   . ' --include=' . ale#Escape('^' . ale#util#EscapePCRE(expand('%')))
+  \   . ' --format=' . ale#Escape(fmt)
+  \   . ' --include=' . ale#Escape(ale#util#EscapePCRE(expand('%')))
   \   . ' ' . ale#Escape(getcwd()),
   \ ale_linters#go#gometalinter#GetCommand(bufnr(''))
 
@@ -36,7 +38,8 @@ Execute(The gometalinter callback should use a configured executable):
   \ ale_linters#go#gometalinter#GetExecutable(bufnr(''))
   AssertEqual
   \ ale#Escape('something else')
-  \   . ' --include=' . ale#Escape('^' . ale#util#EscapePCRE(expand('%')))
+  \   . ' --format=' . ale#Escape(fmt)
+  \   . ' --include=' . ale#Escape(ale#util#EscapePCRE(expand('%')))
   \   . ' ' . ale#Escape(getcwd()),
   \ ale_linters#go#gometalinter#GetCommand(bufnr(''))
 
@@ -45,7 +48,8 @@ Execute(The gometalinter callback should use configured options):
 
   AssertEqual
   \ ale#Escape('gometalinter')
-  \   . ' --include=' . ale#Escape('^' . ale#util#EscapePCRE(expand('%')))
+  \   . ' --format=' . ale#Escape(fmt)
+  \   . ' --include=' . ale#Escape(ale#util#EscapePCRE(expand('%')))
   \   . ' --foobar'
   \   . ' ' . ale#Escape(getcwd()),
   \ ale_linters#go#gometalinter#GetCommand(bufnr(''))
@@ -55,5 +59,6 @@ Execute(The gometalinter `lint_package` option should use the correct command):
 
   AssertEqual
   \ ale#Escape('gometalinter')
+  \   . ' --format=' . ale#Escape(fmt)
   \   . ' ' . ale#Escape(getcwd()),
   \ ale_linters#go#gometalinter#GetCommand(bufnr(''))

--- a/test/command_callback/test_gometalinter_command_callback.vader
+++ b/test/command_callback/test_gometalinter_command_callback.vader
@@ -1,9 +1,11 @@
 Before:
   Save b:ale_go_gometalinter_executable
   Save b:ale_go_gometalinter_options
+  Save b:ale_go_gometalinter_lint_package
 
   let b:ale_go_gometalinter_executable = 'gometalinter'
   let b:ale_go_gometalinter_options = ''
+  let b:ale_go_gometalinter_lint_package = 0
 
   runtime ale_linters/go/gometalinter.vim
 
@@ -45,5 +47,13 @@ Execute(The gometalinter callback should use configured options):
   \ ale#Escape('gometalinter')
   \   . ' --include=' . ale#Escape('^' . ale#util#EscapePCRE(expand('%')))
   \   . ' --foobar'
+  \   . ' ' . ale#Escape(getcwd()),
+  \ ale_linters#go#gometalinter#GetCommand(bufnr(''))
+
+Execute(The gometalinter `lint_package` option should use the correct command):
+  let b:ale_go_gometalinter_lint_package = 1
+
+  AssertEqual
+  \ ale#Escape('gometalinter')
   \   . ' ' . ale#Escape(getcwd()),
   \ ale_linters#go#gometalinter#GetCommand(bufnr(''))

--- a/test/handler/test_gometalinter_handler.vader
+++ b/test/handler/test_gometalinter_handler.vader
@@ -30,7 +30,7 @@ Execute (The gometalinter handler should handle names with spaces):
   \ ]), 'v:val[1:5]')
 
 Execute (The gometalinter handler should handle relative paths correctly):
-  silent file /foo/bar/baz.go
+  call ale#test#SetFilename('app/test.go')
 
   AssertEqual
   \ [
@@ -39,15 +39,17 @@ Execute (The gometalinter handler should handle relative paths correctly):
   \     'col': 3,
   \     'text': 'expected ''package'', found ''IDENT'' gibberish (staticcheck)',
   \     'type': 'W',
+  \     'filename': ale#path#Winify(expand('%:p:h') . '/test.go'),
   \   },
   \   {
   \     'lnum': 37,
   \     'col': 5,
   \     'text': 'expected ''package'', found ''IDENT'' gibberish (golint)',
   \     'type': 'E',
+  \     'filename': ale#path#Winify(expand('%:p:h') . '/test.go'),
   \   },
   \ ],
   \ ale_linters#go#gometalinter#Handler(bufnr(''), [
-  \   'baz.go:12:3:warning: expected ''package'', found ''IDENT'' gibberish (staticcheck)',
-  \   'baz.go:37:5:error: expected ''package'', found ''IDENT'' gibberish (golint)',
+  \   'test.go:12:3:warning: expected ''package'', found ''IDENT'' gibberish (staticcheck)',
+  \   'test.go:37:5:error: expected ''package'', found ''IDENT'' gibberish (golint)',
   \ ])

--- a/test/handler/test_gometalinter_handler.vader
+++ b/test/handler/test_gometalinter_handler.vader
@@ -50,6 +50,6 @@ Execute (The gometalinter handler should handle relative paths correctly):
   \   },
   \ ],
   \ ale_linters#go#gometalinter#Handler(bufnr(''), [
-  \   'test.go:12:3:warning: expected ''package'', found ''IDENT'' gibberish (staticcheck)',
-  \   'test.go:37:5:error: expected ''package'', found ''IDENT'' gibberish (golint)',
+  \   'app/test.go:12:3:warning: expected ''package'', found ''IDENT'' gibberish (staticcheck)',
+  \   'app/test.go:37:5:error: expected ''package'', found ''IDENT'' gibberish (golint)',
   \ ])

--- a/test/handler/test_gometalinter_handler.vader
+++ b/test/handler/test_gometalinter_handler.vader
@@ -29,7 +29,7 @@ Execute (The gometalinter handler should handle names with spaces):
   \   'C:\something\file with spaces.go:37:5:error: expected ''package'', found ''IDENT'' gibberish (golint)',
   \ ]), 'v:val[1:5]')
 
-Execute (The gometalinter handler should handle relative paths correctly):
+Execute (The gometalinter handler should handle paths correctly):
   call ale#test#SetFilename('app/test.go')
 
   AssertEqual
@@ -50,6 +50,6 @@ Execute (The gometalinter handler should handle relative paths correctly):
   \   },
   \ ],
   \ ale_linters#go#gometalinter#Handler(bufnr(''), [
-  \   'app/test.go:12:3:warning: expected ''package'', found ''IDENT'' gibberish (staticcheck)',
-  \   'app/test.go:37:5:error: expected ''package'', found ''IDENT'' gibberish (golint)',
+  \   '/testplugin/test/handler/app/test.go:12:3:warning: expected ''package'', found ''IDENT'' gibberish (staticcheck)',
+  \   '/testplugin/test/handler/app/test.go:37:5:error: expected ''package'', found ''IDENT'' gibberish (golint)',
   \ ])

--- a/test/handler/test_gometalinter_handler.vader
+++ b/test/handler/test_gometalinter_handler.vader
@@ -32,6 +32,8 @@ Execute (The gometalinter handler should handle names with spaces):
 Execute (The gometalinter handler should handle paths correctly):
   call ale#test#SetFilename('app/test.go')
 
+  let file = ale#path#GetAbsPath(expand('%:p:h'), 'test.go')
+
   AssertEqual
   \ [
   \   {
@@ -50,6 +52,6 @@ Execute (The gometalinter handler should handle paths correctly):
   \   },
   \ ],
   \ ale_linters#go#gometalinter#Handler(bufnr(''), [
-  \   '/testplugin/test/handler/app/test.go:12:3:warning: expected ''package'', found ''IDENT'' gibberish (staticcheck)',
-  \   '/testplugin/test/handler/app/test.go:37:5:error: expected ''package'', found ''IDENT'' gibberish (golint)',
+  \   file . ':12:3:warning: expected ''package'', found ''IDENT'' gibberish (staticcheck)',
+  \   file . ':37:5:error: expected ''package'', found ''IDENT'' gibberish (golint)',
   \ ])


### PR DESCRIPTION
- added tests for the `gometalinter` command

@notjrbauer @svanharmelen this is a WIP to get `gometalinter` to lint the current package
<!--
READ THIS: Before creating a pull request, please consider the following first.

* The most important thing you can do is write tests. Code without tests
  probably doesn't work, and will almost certainly stop working later on. Pull
  requests without tests probably won't be accepted, although there are some
  exceptions.
* Read the Contributing guide linked above first.
* If you are adding a new linter, remember to update the README.md file and
  doc/ale.txt first.
* If you add or modify a function for converting error lines into loclist items
  that ALE can work with, please add Vader tests for them. Look at existing
  tests in the test/handler directory, etc.
* If you add or modify a function for computing a command line string for
  running a command, please add Vader tests for that.
* Generally try and cover anything with Vader tests, although some things just
  can't be tested with Vader, or at least they can be hard to test. Consider
  breaking up your code so that some parts can be tested, and generally open up
  a discussion about it.
* Have fun!
-->
