### PR TITLE
[eruby] Add erubi linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ formatting.
 | Dockerfile | [hadolint](https://github.com/lukasmartinelli/hadolint) |
 | Elixir | [credo](https://github.com/rrrene/credo), [dogma](https://github.com/lpil/dogma) !! |
 | Elm | [elm-format](https://github.com/avh4/elm-format), [elm-make](https://github.com/elm-lang/elm-make) |
-| Erb | [erb](https://github.com/jeremyevans/erubi), [erubis](https://github.com/kwatch/erubis) |
+| Erb | [erb](https://apidock.com/ruby/ERB), [erubi](https://github.com/jeremyevans/erubi), [erubis](https://github.com/kwatch/erubis) |
 | Erlang | [erlc](http://erlang.org/doc/man/erlc.html), [SyntaxErl](https://github.com/ten0s/syntaxerl) |
 | Fortran | [gcc](https://gcc.gnu.org/) |
 | FusionScript | [fusion-lint](https://github.com/RyanSquared/fusionscript) |

--- a/ale_linters/eruby/erubi.vim
+++ b/ale_linters/eruby/erubi.vim
@@ -1,0 +1,35 @@
+" Author: Eddie Lebow https://github.com/elebow
+" Description: eruby checker using `erubi`
+
+function! ale_linters#eruby#erubi#CheckErubi(buffer) abort
+    return 'ruby -r erubi/capture_end -e ' . ale#Escape('""')
+endfunction
+
+function! ale_linters#eruby#erubi#GetCommand(buffer, check_erubi_output) abort
+    let l:rails_root = ale#ruby#FindRailsRoot(a:buffer)
+
+    if (!empty(a:check_erubi_output))
+        " The empty command in CheckErubi returns nothing if erubi runs and
+        " emits an error if erubi is not present
+        return ''
+    endif
+
+    if empty(l:rails_root)
+        return 'ruby -r erubi/capture_end -e ' . ale#Escape('puts Erubi::CaptureEndEngine.new($stdin.read).src') . '< %t | ruby -c'
+    endif
+
+    " Rails-flavored eRuby does not comply with the standard as understood by
+    " Erubi, so we'll have to do some substitution. This does not reduce the
+    " effectiveness of the linter---the translated code is still evaluated.
+    return 'ruby -r erubi/capture_end -e ' . ale#Escape('puts Erubi::CaptureEndEngine.new($stdin.read.gsub(%{<%=},%{<%}), nil, %{-}).src') . '< %t | ruby -c'
+endfunction
+
+call ale#linter#Define('eruby', {
+\   'name': 'erubi',
+\   'executable': 'ruby',
+\   'command_chain': [
+\     {'callback': 'ale_linters#eruby#erubi#CheckErubi'},
+\     {'callback': 'ale_linters#eruby#erubi#GetCommand', 'output_stream': 'stderr'},
+\   ],
+\   'callback': 'ale#handlers#ruby#HandleSyntaxErrors',
+\})

--- a/doc/ale-eruby.txt
+++ b/doc/ale-eruby.txt
@@ -1,17 +1,15 @@
 ===============================================================================
 ALE Eruby Integration                                       *ale-eruby-options*
 
-There are two linters for `eruby` files:
+There are three linters for `eruby` files:
 
 - `erb`
 - `erubis`
+- `erubi`
 
-If you don't know which one your project uses, it's probably `erb`.
-To selectively enable one or the other, see |g:ale_linters|.
-
-(Note that ALE already disables linters if the executable for that linter is
-not found; thus, there's probably no need to disable one of these if you're
-using the other one.)
+`erb` is in the Ruby standard library and is mostly universal. `erubis` is the
+default parser in Rails between 3.0 and 5.1. `erubi` is the default in Rails
+5.1 and later. To selectively enable a subset, see |g:ale_linters|.
 
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -286,7 +286,7 @@ Notes:
 * Dockerfile: `hadolint`
 * Elixir: `credo`, `dogma`!!
 * Elm: `elm-format, elm-make`
-* Erb: `erb`, `erubis`
+* Erb: `erb`, `erubi`, `erubis`
 * Erlang: `erlc`, `SyntaxErl`
 * Fortran: `gcc`
 * FusionScript: `fusion-lint`

--- a/test/command_callback/test_erubi_command_callback.vader
+++ b/test/command_callback/test_erubi_command_callback.vader
@@ -1,0 +1,31 @@
+Before:
+  runtime ale_linters/eruby/erubi.vim
+  call ale#test#SetDirectory('/testplugin/test/command_callback')
+
+After:
+  call ale#linter#Reset()
+  call ale#test#RestoreDirectory()
+
+Execute(Executable should not contain any filter code by default):
+  call ale#test#SetFilename('../ruby_fixtures/not_a_rails_app/file.rb')
+
+  AssertEqual
+  \ 'ruby -r erubi/capture_end -e ' . ale#Escape('puts Erubi::CaptureEndEngine.new($stdin.read).src') . '< %t | ruby -c',
+  \ ale_linters#eruby#erubi#GetCommand(bufnr(''), [])
+
+Execute(Executable should filter invalid eRuby when inside a Rails project):
+  call ale#test#SetFilename('../ruby_fixtures/valid_rails_app/app/views/my_great_view.html.erb')
+
+  AssertEqual
+  \ 'ruby -r erubi/capture_end -e ' . ale#Escape('puts Erubi::CaptureEndEngine.new($stdin.read.gsub(%{<%=},%{<%}), nil, %{-}).src') . '< %t | ruby -c',
+  \ ale_linters#eruby#erubi#GetCommand(bufnr(''), [])
+
+Execute(Command should be blank if the first command in the chain return output):
+  let output_lines = [
+  \    "/usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require': cannot load such file -- erubi/capture_end (LoadError)",
+  \    "        from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'",
+  \]
+
+  AssertEqual
+  \ '',
+  \ ale_linters#eruby#erubi#GetCommand(bufnr(''), output_lines)


### PR DESCRIPTION
Erubi is yet another parser for eRuby. This is the default parser in
Rails as of version 5.1. It supports some additional syntax with similar
behavior to Rails' extensions to the language, though incompatible.
Rails currently still recommends their own syntax, so GetCommand still
has to do the translation introduced in
https://github.com/w0rp/ale/pull/1114 .

Erubi does not supply an executable—It is intended to be invoked only
from within a Ruby program. Consequently, GetExecutable has to do some
trickery to inform ALE when the linter is available.