### PR TITLE
redpen: Use 'code' key to show validator

### DIFF
--- a/autoload/ale/handlers/redpen.vim
+++ b/autoload/ale/handlers/redpen.vim
@@ -8,8 +8,9 @@ function! ale#handlers#redpen#HandleRedpenOutput(buffer, lines) abort
     let l:output = []
     for l:err in l:res.errors
         let l:item = {
-        \   'text': l:err.message . ' (' . l:err.validator . ')',
+        \   'text': l:err.message,
         \   'type': 'W',
+        \   'code': l:err.validator,
         \}
         if has_key(l:err, 'startPosition')
             let l:item.lnum = l:err.startPosition.lineNum
@@ -19,6 +20,8 @@ function! ale#handlers#redpen#HandleRedpenOutput(buffer, lines) abort
                 let l:item.end_col = l:err.endPosition.offset
             endif
         else
+            " Fallback to a whole sentence region when a region is not
+            " specified by the error.
             let l:item.lnum = l:err.lineNum
             let l:item.col = l:err.sentenceStartColumnNum + 1
         endif

--- a/test/handler/test_redpen_handler.vader
+++ b/test/handler/test_redpen_handler.vader
@@ -12,14 +12,16 @@ Execute(redpen handler should handle errors output):
   \     'col': 10,
   \     'end_lnum': 1,
   \     'end_col': 15,
-  \     'text': 'Found possibly misspelled word "plugin". (Spelling)',
+  \     'text': 'Found possibly misspelled word "plugin".',
   \     'type': 'W',
+  \     'code': 'Spelling',
   \   },
   \   {
   \     'lnum': 1,
   \     'col': 1,
-  \     'text': 'Found possibly misspelled word "NeoVim". (Spelling)',
+  \     'text': 'Found possibly misspelled word "NeoVim".',
   \     'type': 'W',
+  \     'code': 'Spelling',
   \   },
   \ ],
   \ ale#handlers#redpen#HandleRedpenOutput(bufnr(''), [


### PR DESCRIPTION
<!--
READ THIS: Before creating a pull request, please consider the following first.

* The most important thing you can do is write tests. Code without tests
  probably doesn't work, and will almost certainly stop working later on. Pull
  requests without tests probably won't be accepted, although there are some
  exceptions.
* Read the Contributing guide linked above first.
* If you are adding a new linter, remember to update the README.md file and
  doc/ale.txt first.
* If you add or modify a function for converting error lines into loclist items
  that ALE can work with, please add Vader tests for them. Look at existing
  tests in the test/handler directory, etc.
* If you add or modify a function for computing a command line string for
  running a command, please add Vader tests for that.
* Generally try and cover anything with Vader tests, although some things just
  can't be tested with Vader, or at least they can be hard to test. Consider
  breaking up your code so that some parts can be tested, and generally open up
  a discussion about it.
* Have fun!
-->

I noticed that `.code` had been added as key of error object. So I used it for validator name of [redpen](http://redpen.cc/) checker.

Sample error output is:

```
Hyphenation: This phrase should be hyphenated (ie: "run-in").
```