### PR TITLE
Delete to black hole register in fixer

### DIFF
--- a/autoload/ale/fix.vim
+++ b/autoload/ale/fix.vim
@@ -35,7 +35,7 @@ function! ale#fix#ApplyQueuedFixes() abort
 
         if l:end_line >= l:start_line
             let l:save = winsaveview()
-            silent execute l:start_line . ',' . l:end_line . 'd'
+            silent execute l:start_line . ',' . l:end_line . 'd_'
             call winrestview(l:save)
         endif
 


### PR DESCRIPTION
Otherwise it'll be in `""` and `"0`, which is an unexpected side-effect
IMHO.

Should probably add a test to ensure that the registers are untouched, but I spent a long time struggling with this Vader thing for this 30-second patch 😭. I can look again later.