### PR TITLE
Add brittany for Haskell formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ formatting.
 | GraphQL | [eslint](http://eslint.org/), [gqlint](https://github.com/happylinks/gqlint) |
 | Haml | [haml-lint](https://github.com/brigade/haml-lint) |
 | Handlebars | [ember-template-lint](https://github.com/rwjblue/ember-template-lint) |
-| Haskell | [ghc](https://www.haskell.org/ghc/), [stack-ghc](https://haskellstack.org/), [stack-build](https://haskellstack.org/) !!, [ghc-mod](https://github.com/DanielG/ghc-mod), [stack-ghc-mod](https://github.com/DanielG/ghc-mod), [hlint](https://hackage.haskell.org/package/hlint), [hdevtools](https://hackage.haskell.org/package/hdevtools), [hfmt](https://github.com/danstiner/hfmt) |
+| Haskell | [brittany](https://github.com/lspitzner/brittany), [ghc](https://www.haskell.org/ghc/), [stack-ghc](https://haskellstack.org/), [stack-build](https://haskellstack.org/) !!, [ghc-mod](https://github.com/DanielG/ghc-mod), [stack-ghc-mod](https://github.com/DanielG/ghc-mod), [hlint](https://hackage.haskell.org/package/hlint), [hdevtools](https://hackage.haskell.org/package/hdevtools), [hfmt](https://github.com/danstiner/hfmt) |
 | HTML | [HTMLHint](http://htmlhint.com/), [proselint](http://proselint.com/), [tidy](http://www.html-tidy.org/), [write-good](https://github.com/btford/write-good) |
 | Idris | [idris](http://www.idris-lang.org/) |
 | Java | [checkstyle](http://checkstyle.sourceforge.net), [javac](http://www.oracle.com/technetwork/java/javase/downloads/index.html) |

--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -134,6 +134,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['haskell'],
 \       'description': 'Fix Haskell files with hfmt.',
 \   },
+\   'brittany': {
+\       'function': 'ale#fixers#brittany#Fix',
+\       'suggested_filetypes': ['haskell'],
+\       'description': 'Fix Haskell files with brittany.',
+\   },
 \   'refmt': {
 \       'function': 'ale#fixers#refmt#Fix',
 \       'suggested_filetypes': ['reason'],

--- a/autoload/ale/fixers/brittany.vim
+++ b/autoload/ale/fixers/brittany.vim
@@ -1,0 +1,15 @@
+" Author: eborden <evan@evan-borden.com>
+" Description: Integration of brittany with ALE.
+
+call ale#Set('haskell_brittany_executable', 'brittany')
+
+function! ale#fixers#brittany#Fix(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'haskell_brittany_executable')
+
+    return {
+    \   'command': ale#Escape(l:executable)
+    \       . ' %t',
+    \   'read_temporary_file': 1,
+    \}
+endfunction
+

--- a/doc/ale-haskell.txt
+++ b/doc/ale-haskell.txt
@@ -3,6 +3,16 @@ ALE Haskell Integration                                   *ale-haskell-options*
 
 
 ===============================================================================
+brittany                                                 *ale-haskell-brittany*
+
+g:ale_haskell_brittany_executable           *g:ale_haskell_brittany_executable*
+                                            *b:ale_haskell_brittany_executable*
+  Type: |String|
+  Default: `'brittany'`
+
+  This variable can be changed to use a different executable for brittany.
+
+===============================================================================
 hdevtools                                               *ale-haskell-hdevtools*
 
 g:ale_haskell_hdevtools_executable         *g:ale_haskell_hdevtools_executable*

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -300,7 +300,7 @@ Notes:
 * GraphQL: `eslint`, `gqlint`
 * Haml: `haml-lint`
 * Handlebars: `ember-template-lint`
-* Haskell: `ghc`, `stack-ghc`, `stack-build`!!, `ghc-mod`, `stack-ghc-mod`, `hlint`, `hdevtools`, `hfmt`
+* Haskell: `ghc`, `stack-ghc`, `stack-build`!!, `ghc-mod`, `stack-ghc-mod`, `hlint`, `hdevtools`, `brittany`, `hfmt`
 * HTML: `HTMLHint`, `proselint`, `tidy`, `write-good`
 * Idris: `idris`
 * Java: `checkstyle`, `javac`

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -79,6 +79,7 @@ CONTENTS                                                         *ale-contents*
     handlebars............................|ale-handlebars-options|
       ember-template-lint.................|ale-handlebars-embertemplatelint|
     haskell...............................|ale-haskell-options|
+      brittany............................|ale-haskell-brittany|
       hdevtools...........................|ale-haskell-hdevtools|
       hfmt................................|ale-haskell-hfmt|
       stack-build.........................|ale-haskell-stack-build|

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -300,7 +300,7 @@ Notes:
 * GraphQL: `eslint`, `gqlint`
 * Haml: `haml-lint`
 * Handlebars: `ember-template-lint`
-* Haskell: `ghc`, `stack-ghc`, `stack-build`!!, `ghc-mod`, `stack-ghc-mod`, `hlint`, `hdevtools`, `brittany`, `hfmt`
+* Haskell: `brittany`, `ghc`, `stack-ghc`, `stack-build`!!, `ghc-mod`, `stack-ghc-mod`, `hlint`, `hdevtools`, `hfmt`
 * HTML: `HTMLHint`, `proselint`, `tidy`, `write-good`
 * Idris: `idris`
 * Java: `checkstyle`, `javac`

--- a/test/fixers/test_brittany_fixer_callback.vader
+++ b/test/fixers/test_brittany_fixer_callback.vader
@@ -1,0 +1,23 @@
+Before:
+  Save g:ale_haskell_brittany_executable
+
+  " Use an invalid global executable, so we don't match it.
+  let g:ale_haskell_brittany_executable = 'xxxinvalid'
+
+  call ale#test#SetDirectory('/testplugin/test/fixers')
+
+After:
+  Restore
+
+  call ale#test#RestoreDirectory()
+
+Execute(The brittany callback should return the correct default values):
+  call ale#test#SetFilename('../haskell_files/testfile.hs')
+
+  AssertEqual
+  \ {
+  \   'read_temporary_file': 1,
+  \   'command': ale#Escape('xxxinvalid')
+  \     . ' %t',
+  \ },
+  \ ale#fixers#brittany#Fix(bufnr(''))


### PR DESCRIPTION
`brittany` is one of the options for Haskell source formatting. This
adds the necessary fixer files and documentation to support `brittany`
in `ALE`.