### PR TITLE
[WIP] Finding tsserver inside cygwin

### DIFF
--- a/autoload/ale/path.vim
+++ b/autoload/ale/path.vim
@@ -31,6 +31,7 @@ endfunction
 " through the paths relative to the given buffer.
 function! ale#path#FindNearestFile(buffer, filename) abort
     let l:buffer_filename = fnamemodify(bufname(a:buffer), ':p')
+    let l:buffer_filename = fnameescape(l:buffer_filename)
 
     let l:relative_path = findfile(a:filename, l:buffer_filename . ';')
 


### PR DESCRIPTION
Targetting issue #1180 

1. `fnameescape` added after the resolving current bufname.
2. Now the correct tsserver executable is found

```
(started) ['/bin/bash', '-c', '/home/Galke Lukas/git/locdb-frend/node_modules/.bin/tsserver']
```

3. Still, the problem is not completely solved: no errors from tsserver are reported at all

The following vim error is reported **sometimes** when opening a typescript file:

```
"src/app/appwrapper/appwrapper.component.ts" 83L, 2235C
Fehler beim Ausführen von "function ale#Queue[9]..ale#CallWithCooldown[9]..<SNR>47_ALEQueueImpl[41]..ale#Lint[12]..ale#CallWithCooldown[9]..<SNR>47_ALELintImpl[16]..ale#engine#RunLinters[12
]..<SNR>109_RunLinter[2]..<SNR>109_CheckWithLSP[2]..ale#linter#StartLSP[54]..ale#lsp#Send[33]..<SNR>113_SendMessageData[2]..ale#job#SendRaw":
Zeile    4:
E631: ch_sendraw(): Schreiben fehlgeschlagen.
```

which translates to `Error on execution of`,..., `ch_sendraw(): Write failed`.

Do you have an idea of what is causing this?