### PR TITLE
Puppet: allow for when parser doesn't supply column for errors

### DIFF
--- a/ale_linters/puppet/puppet.vim
+++ b/ale_linters/puppet/puppet.vim
@@ -5,7 +5,7 @@ function! ale_linters#puppet#puppet#Handle(buffer, lines) abort
     " Error: Could not parse for environment production: Syntax error at ':' at /root/puppetcode/modules/nginx/manifests/init.pp:43:12
     " Error: Could not parse for environment production: Syntax error at '='; expected '}' at /root/puppetcode/modules/pancakes/manifests/init.pp:5"
 
-    let l:pattern = '^Error: .*: \(.\+\) at \/.\+\.pp:\(\d\+\):\=\(\d*\)'
+    let l:pattern = '^Error: .*: \(.\+\) at .\+\.pp:\(\d\+\):\=\(\d*\)'
     let l:output = []
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)

--- a/ale_linters/puppet/puppet.vim
+++ b/ale_linters/puppet/puppet.vim
@@ -3,8 +3,9 @@
 function! ale_linters#puppet#puppet#Handle(buffer, lines) abort
     " Matches patterns like the following:
     " Error: Could not parse for environment production: Syntax error at ':' at /root/puppetcode/modules/nginx/manifests/init.pp:43:12
+    " Error: Could not parse for environment production: Syntax error at '='; expected '}' at /root/puppetcode/modules/pancakes/manifests/init.pp:5"
 
-    let l:pattern = '^Error: .*: \(.\+\) at .\+:\(\d\+\):\(\d\+\)$'
+    let l:pattern = '^Error: .*: \(.\+\) at \/.\+\.pp:\(\d\+\):\=\(\d*\)'
     let l:output = []
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)

--- a/test/handler/test_puppet_handler.vader
+++ b/test/handler/test_puppet_handler.vader
@@ -12,10 +12,16 @@ Execute(The puppet handler should parse lines correctly when no column is suppli
   \     'lnum': 5,
   \     'col': 0,
   \     'text': "Syntax error at '='; expected '}'"
-  \   }
+  \   },
+  \   {
+  \     'lnum': 3,
+  \     'col': 0,
+  \     'text': "Syntax error at '='; expected '}'"
+  \   },
   \ ],
   \ ale_linters#puppet#puppet#Handle(255, [
-  \   "Error: Could not parse for environment production: Syntax error at '='; expected '}' at /root/puppetcode/modules/pancakes/manifests/init.pp:5"
+  \   "Error: Could not parse for environment production: Syntax error at '='; expected '}' at /root/puppetcode/modules/pancakes/manifests/init.pp:5",
+  \   "Error: Could not parse for environment production: Syntax error at '='; expected '}' at C:/puppet/modules/pancakes/manifests/init.pp:3",
   \ ])
 
 Execute(The puppet handler should parse lines and column correctly):
@@ -26,8 +32,14 @@ Execute(The puppet handler should parse lines and column correctly):
   \     'lnum': 43,
   \     'col': 12,
   \     'text': "Syntax error at ':'"
+  \   },
+  \   {
+  \     'lnum': 54,
+  \     'col': 9,
+  \     'text': "Syntax error at ':'"
   \   }
   \ ],
   \ ale_linters#puppet#puppet#Handle(255, [
-  \   "Error: Could not parse for environment production: Syntax error at ':' at /root/puppetcode/modules/nginx/manifests/init.pp:43:12"
+  \   "Error: Could not parse for environment production: Syntax error at ':' at /root/puppetcode/modules/nginx/manifests/init.pp:43:12",
+  \   "Error: Could not parse for environment production: Syntax error at ':' at C:/puppet/modules/nginx/manifests/init.pp:54:9",
   \ ])

--- a/test/handler/test_puppet_handler.vader
+++ b/test/handler/test_puppet_handler.vader
@@ -1,0 +1,19 @@
+Before:
+  runtime ale_linters/puppet/puppet.vim
+
+After:
+  call ale#linter#Reset()
+
+Execute(The puppet handler should parse lines and column correctly):
+  " Line Error
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 43 ,
+  \     'col': 12,
+  \     'text': "Syntax error at ':'"
+  \   }
+  \ ],
+  \ ale_linters#puppet#puppet#Handle(255, [
+  \   "Error: Could not parse for environment production: Syntax error at ':' at /root/puppetcode/modules/nginx/manifests/init.pp:43:12"
+  \ ])

--- a/test/handler/test_puppet_handler.vader
+++ b/test/handler/test_puppet_handler.vader
@@ -4,12 +4,26 @@ Before:
 After:
   call ale#linter#Reset()
 
+Execute(The puppet handler should parse lines correctly when no column is supplied):
+  " Line Error
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 5,
+  \     'col': 0,
+  \     'text': "Syntax error at '='; expected '}'"
+  \   }
+  \ ],
+  \ ale_linters#puppet#puppet#Handle(255, [
+  \   "Error: Could not parse for environment production: Syntax error at '='; expected '}' at /root/puppetcode/modules/pancakes/manifests/init.pp:5"
+  \ ])
+
 Execute(The puppet handler should parse lines and column correctly):
   " Line Error
   AssertEqual
   \ [
   \   {
-  \     'lnum': 43 ,
+  \     'lnum': 43,
   \     'col': 12,
   \     'text': "Syntax error at ':'"
   \   }


### PR DESCRIPTION
Sometimes (mostly with older versions) puppet doesn't supply the column for where an error is, eg:
```
Error: Could not parse for environment production: Syntax error at '='; expected '}' at /root/puppetcode/modules/statsd/manifests/init.pp:5
```

Updated `l:pattern` to make the column optional.