### PR TITLE
Fixed Command String for phpcbf Fixer

### DIFF
--- a/autoload/ale/fixers/phpcbf.vim
+++ b/autoload/ale/fixers/phpcbf.vim
@@ -19,6 +19,6 @@ function! ale#fixers#phpcbf#Fix(buffer) abort
     \   ? '--standard=' . l:standard
     \   : ''
     return {
-    \   'command': ale#Escape(l:executable) . ' --stdin-path=%s ' . l:standard_option
+    \   'command': ale#Escape(l:executable) . ' --stdin-path=%s ' . l:standard_option . ' -'
     \}
 endfunction

--- a/test/fixers/test_phpcbf_fixer_callback.vader
+++ b/test/fixers/test_phpcbf_fixer_callback.vader
@@ -43,7 +43,7 @@ Execute(The phpcbf callback should return the correct default values):
   call ale#test#SetFilename('php_paths/project-with-phpcbf/foo/test.php')
 
   AssertEqual
-  \ {'command': ale#Escape(ale#path#Winify(g:dir . '/php_paths/project-with-phpcbf/vendor/bin/phpcbf')) . ' --stdin-path=%s ' },
+  \ {'command': ale#Escape(ale#path#Winify(g:dir . '/php_paths/project-with-phpcbf/vendor/bin/phpcbf')) . ' --stdin-path=%s  -' },
   \ ale#fixers#phpcbf#Fix(bufnr(''))
 
 Execute(The phpcbf callback should include the phpcbf_standard option):
@@ -51,7 +51,7 @@ Execute(The phpcbf callback should include the phpcbf_standard option):
   call ale#test#SetFilename('php_paths/project-with-phpcbf/foo/test.php')
 
   AssertEqual
-  \ {'command': ale#Escape(ale#path#Winify(g:dir . '/php_paths/project-with-phpcbf/vendor/bin/phpcbf')) . ' --stdin-path=%s ' . '--standard=phpcbf_ruleset.xml'},
+  \ {'command': ale#Escape(ale#path#Winify(g:dir . '/php_paths/project-with-phpcbf/vendor/bin/phpcbf')) . ' --stdin-path=%s ' . '--standard=phpcbf_ruleset.xml' . ' -'},
   \ ale#fixers#phpcbf#Fix(bufnr(''))
 
 Before:
@@ -99,7 +99,7 @@ Execute(The phpcbf callback should return the correct default values):
   call ale#test#SetFilename('php_paths/project-with-phpcbf/foo/test.php')
 
   AssertEqual
-  \ {'command': ale#Escape(ale#path#Winify(g:dir . '/php_paths/project-with-phpcbf/vendor/bin/phpcbf')) . ' --stdin-path=%s ' },
+  \ {'command': ale#Escape(ale#path#Winify(g:dir . '/php_paths/project-with-phpcbf/vendor/bin/phpcbf')) . ' --stdin-path=%s  -' },
   \ ale#fixers#phpcbf#Fix(bufnr(''))
 
 Execute(The phpcbf callback should include the phpcbf_standard option):
@@ -107,6 +107,6 @@ Execute(The phpcbf callback should include the phpcbf_standard option):
   call ale#test#SetFilename('php_paths/project-with-phpcbf/foo/test.php')
 
   AssertEqual
-  \ {'command': ale#Escape(ale#path#Winify(g:dir . '/php_paths/project-with-phpcbf/vendor/bin/phpcbf')) . ' --stdin-path=%s ' . '--standard=phpcbf_ruleset.xml'},
+  \ {'command': ale#Escape(ale#path#Winify(g:dir . '/php_paths/project-with-phpcbf/vendor/bin/phpcbf')) . ' --stdin-path=%s ' . '--standard=phpcbf_ruleset.xml' . ' -'},
   \ ale#fixers#phpcbf#Fix(bufnr(''))
 


### PR DESCRIPTION
In order to fix STDIN instead of local files and directories for the phpcbf fixer, the command must include a single hyphen (-) as a parameter. Otherwise, phpcbf reports the error "You must supply at least one file or directory to process."