### PR TITLE
cppcheck should not use compilation database, it's a wrong behavior

### DIFF
--- a/ale_linters/c/cppcheck.vim
+++ b/ale_linters/c/cppcheck.vim
@@ -9,23 +9,9 @@ function! ale_linters#c#cppcheck#GetExecutable(buffer) abort
 endfunction
 
 function! ale_linters#c#cppcheck#GetCommand(buffer) abort
-    " Search upwards from the file for compile_commands.json.
-    "
-    " If we find it, we'll `cd` to where the compile_commands.json file is,
-    " then use the file to set up import paths, etc.
-    let l:compile_commmands_path = ale#path#FindNearestFile(a:buffer, 'compile_commands.json')
-
-    let l:cd_command = !empty(l:compile_commmands_path)
-    \   ? ale#path#CdString(fnamemodify(l:compile_commmands_path, ':h'))
-    \   : ''
-    let l:compile_commands_option = !empty(l:compile_commmands_path)
-    \   ? '--project=compile_commands.json '
-    \   : ''
-
     return l:cd_command
     \   . ale#Escape(ale_linters#c#cppcheck#GetExecutable(a:buffer))
     \   . ' -q --language=c '
-    \   . l:compile_commands_option
     \   . ale#Var(a:buffer, 'c_cppcheck_options')
     \   . ' %t'
 endfunction

--- a/ale_linters/cpp/cppcheck.vim
+++ b/ale_linters/cpp/cppcheck.vim
@@ -9,23 +9,8 @@ function! ale_linters#cpp#cppcheck#GetExecutable(buffer) abort
 endfunction
 
 function! ale_linters#cpp#cppcheck#GetCommand(buffer) abort
-    " Search upwards from the file for compile_commands.json.
-    "
-    " If we find it, we'll `cd` to where the compile_commands.json file is,
-    " then use the file to set up import paths, etc.
-    let l:compile_commmands_path = ale#path#FindNearestFile(a:buffer, 'compile_commands.json')
-
-    let l:cd_command = !empty(l:compile_commmands_path)
-    \   ? ale#path#CdString(fnamemodify(l:compile_commmands_path, ':h'))
-    \   : ''
-    let l:compile_commands_option = !empty(l:compile_commmands_path)
-    \   ? '--project=compile_commands.json '
-    \   : ''
-
-    return l:cd_command
-    \   . ale#Escape(ale_linters#cpp#cppcheck#GetExecutable(a:buffer))
+    return ale#Escape(ale_linters#cpp#cppcheck#GetExecutable(a:buffer))
     \   . ' -q --language=c++ '
-    \   . l:compile_commands_option
     \   . ale#Var(a:buffer, 'cpp_cppcheck_options')
     \   . ' %t'
 endfunction


### PR DESCRIPTION
ALE is a awsome vim plugin, however there is a small bug in cppcheck integration. 
ALE should check current buffer, but if it invokes cppcheck with --project=compile_commands, cppcheck will check the whole project, and it's extremely slow and make no sense
<!--
READ THIS: Before creating a pull request, please consider the following first.

* The most important thing you can do is write tests. Code without tests
  probably doesn't work, and will almost certainly stop working later on. Pull
  requests without tests probably won't be accepted, although there are some
  exceptions.
* Read the Contributing guide linked above first.
* If you are adding a new linter, remember to update the README.md file and
  doc/ale.txt first.
* If you add or modify a function for converting error lines into loclist items
  that ALE can work with, please add Vader tests for them. Look at existing
  tests in the test/handler directory, etc.
* If you add or modify a function for computing a command line string for
  running a command, please add Vader tests for that.
* Generally try and cover anything with Vader tests, although some things just
  can't be tested with Vader, or at least they can be hard to test. Consider
  breaking up your code so that some parts can be tested, and generally open up
  a discussion about it.
* Have fun!
-->
