### PR TITLE
goimports fixer doesn't work for vendored libraries

### DIFF
--- a/autoload/ale/fixers/goimports.vim
+++ b/autoload/ale/fixers/goimports.vim
@@ -14,7 +14,7 @@ function! ale#fixers#goimports#Fix(buffer) abort
 
     return {
     \   'command': ale#Escape(l:executable)
-    \       . ' -l -w'
+    \       . ' -l -w -srcdir %s'
     \       . (empty(l:options) ? '' : ' ' . l:options)
     \       . ' %t',
     \   'read_temporary_file': 1,

--- a/test/fixers/test_goimports_fixer_callback.vader
+++ b/test/fixers/test_goimports_fixer_callback.vader
@@ -25,7 +25,7 @@ Execute(The goimports callback should the command when the executable test passe
   AssertEqual
   \ {
   \   'read_temporary_file': 1,
-  \   'command': ale#Escape(g:ale_go_goimports_executable) . ' -l -w %t'
+  \   'command': ale#Escape(g:ale_go_goimports_executable) . ' -l -w -srcdir %s %t'
   \ },
   \ ale#fixers#goimports#Fix(bufnr(''))
 
@@ -36,6 +36,6 @@ Execute(The goimports callback should include extra options):
   AssertEqual
   \ {
   \   'read_temporary_file': 1,
-  \   'command': ale#Escape(g:ale_go_goimports_executable) . ' -l -w --xxx %t'
+  \   'command': ale#Escape(g:ale_go_goimports_executable) . ' -l -w -srcdir %s --xxx %t'
   \ },
   \ ale#fixers#goimports#Fix(bufnr(''))


### PR DESCRIPTION
In Go you can "vendor" packages by putting them in the `vendor/`
directory for a project. `goimports` picks up these packages, in
addition to what you have in GOPATH.

The `goimports` fixer works by copying the Go file to a temporary
directory (in e.g. `/tmp/`) and then running `goimports` on it. This
means that it won't see the vendored packages, since that is outside of
the project's directory.

To be useful, `goimports` should be run on the real file, and not a
temporary file.