### PR TITLE
Add support for go_gobuild_options

### DIFF
--- a/ale_linters/go/gobuild.vim
+++ b/ale_linters/go/gobuild.vim
@@ -4,6 +4,8 @@
 
 " inspired by work from dzhou121 <dzhou121@gmail.com>
 
+call ale#Set('go_gobuild_options', '')
+
 function! ale_linters#go#gobuild#GoEnv(buffer) abort
     if exists('s:go_env')
         return ''
@@ -13,6 +15,8 @@ function! ale_linters#go#gobuild#GoEnv(buffer) abort
 endfunction
 
 function! ale_linters#go#gobuild#GetCommand(buffer, goenv_output) abort
+    let l:options = ale#Var(a:buffer, 'go_gobuild_options')
+
     if !exists('s:go_env')
         let s:go_env = {
         \   'GOPATH': a:goenv_output[0],
@@ -23,7 +27,7 @@ function! ale_linters#go#gobuild#GetCommand(buffer, goenv_output) abort
     " Run go test in local directory with relative path
     return 'GOPATH=' . s:go_env.GOPATH
     \   . ' cd ' . fnamemodify(bufname(a:buffer), ':.:h')
-    \   . ' && go test -c -o /dev/null ./'
+    \   . ' && go test ' . l:options . ' -c -o /dev/null ./'
 endfunction
 
 function! ale_linters#go#gobuild#GetMatches(lines) abort

--- a/doc/ale-go.txt
+++ b/doc/ale-go.txt
@@ -21,6 +21,17 @@ while ensuring it doesn't run any linters known to be slow or resource
 intensive.
 
 ===============================================================================
+gobuild                                                        *ale-go-gobuild*
+
+g:ale_go_gobuild_options                             *g:ale_go_gobuild_options*
+                                                     *b:ale_go_gobuild_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be set to pass additional options to the gobuild linter.
+  They are injected directly after "go test".
+
+===============================================================================
 gofmt                                                            *ale-go-gofmt*
 
 g:ale_go_gofmt_options                                 *g:ale_go_gofmt_options*

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -72,6 +72,7 @@ CONTENTS                                                         *ale-contents*
       glslang.............................|ale-glsl-glslang|
       glslls..............................|ale-glsl-glslls|
     go....................................|ale-go-options|
+      gobuild.............................|ale-go-gobuild|
       gofmt...............................|ale-go-gofmt|
       gometalinter........................|ale-go-gometalinter|
     graphql...............................|ale-graphql-options|


### PR DESCRIPTION
Use case: `let g:ale_go_gobuild_options = "-gcflags='-e'"`