### PR TITLE
Add a linter for alex

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ formatting.
 | ASM | [gcc](https://gcc.gnu.org) |
 | Ansible | [ansible-lint](https://github.com/willthames/ansible-lint) |
 | API Blueprint | [drafter](https://github.com/apiaryio/drafter) |
-| AsciiDoc | [proselint](http://proselint.com/), [write-good](https://github.com/btford/write-good), [redpen](http://redpen.cc/)|
+| AsciiDoc | [alex](https://github.com/wooorm/alex), [proselint](http://proselint.com/), [write-good](https://github.com/btford/write-good), [redpen](http://redpen.cc/)|
 | Awk | [gawk](https://www.gnu.org/software/gawk/)|
 | Bash | shell [-n flag](https://www.gnu.org/software/bash/manual/bash.html#index-set), [shellcheck](https://www.shellcheck.net/), [shfmt](https://github.com/mvdan/sh) |
 | Bourne Shell | shell [-n flag](http://linux.die.net/man/1/sh), [shellcheck](https://www.shellcheck.net/), [shfmt](https://github.com/mvdan/sh) |
@@ -106,36 +106,36 @@ formatting.
 | Haml | [haml-lint](https://github.com/brigade/haml-lint) |
 | Handlebars | [ember-template-lint](https://github.com/rwjblue/ember-template-lint) |
 | Haskell | [brittany](https://github.com/lspitzner/brittany), [ghc](https://www.haskell.org/ghc/), [stack-ghc](https://haskellstack.org/), [stack-build](https://haskellstack.org/) !!, [ghc-mod](https://github.com/DanielG/ghc-mod), [stack-ghc-mod](https://github.com/DanielG/ghc-mod), [hlint](https://hackage.haskell.org/package/hlint), [hdevtools](https://hackage.haskell.org/package/hdevtools), [hfmt](https://github.com/danstiner/hfmt) |
-| HTML | [HTMLHint](http://htmlhint.com/), [proselint](http://proselint.com/), [tidy](http://www.html-tidy.org/), [write-good](https://github.com/btford/write-good) |
+| HTML | [alex](https://github.com/wooorm/alex), [HTMLHint](http://htmlhint.com/), [proselint](http://proselint.com/), [tidy](http://www.html-tidy.org/), [write-good](https://github.com/btford/write-good) |
 | Idris | [idris](http://www.idris-lang.org/) |
 | Java | [checkstyle](http://checkstyle.sourceforge.net), [javac](http://www.oracle.com/technetwork/java/javase/downloads/index.html) |
 | JavaScript | [eslint](http://eslint.org/), [flow](https://flowtype.org/), [jscs](http://jscs.info/), [jshint](http://jshint.com/), [prettier](https://github.com/prettier/prettier), prettier-eslint >= 4.2.0, prettier-standard, [standard](http://standardjs.com/), [xo](https://github.com/sindresorhus/xo)
 | JSON | [jsonlint](http://zaa.ch/jsonlint/), [prettier](https://github.com/prettier/prettier) |
 | Kotlin | [kotlinc](https://kotlinlang.org) !!, [ktlint](https://ktlint.github.io) !! see `:help ale-integration-kotlin` for configuration instructions |
-| LaTeX | [chktex](http://www.nongnu.org/chktex/), [lacheck](https://www.ctan.org/pkg/lacheck), [proselint](http://proselint.com/), [write-good](https://github.com/btford/write-good), [redpen](http://redpen.cc/) |
+| LaTeX | [alex](https://github.com/wooorm/alex), [chktex](http://www.nongnu.org/chktex/), [lacheck](https://www.ctan.org/pkg/lacheck), [proselint](http://proselint.com/), [write-good](https://github.com/btford/write-good), [redpen](http://redpen.cc/) |
 | Less | [lessc](https://www.npmjs.com/package/less), [prettier](https://github.com/prettier/prettier), [stylelint](https://github.com/stylelint/stylelint) |
 | LLVM | [llc](https://llvm.org/docs/CommandGuide/llc.html) |
 | Lua | [luacheck](https://github.com/mpeterv/luacheck) |
-| Mail | [proselint](http://proselint.com/), [vale](https://github.com/ValeLint/vale) |
+| Mail | [alex](https://github.com/wooorm/alex), [proselint](http://proselint.com/), [vale](https://github.com/ValeLint/vale) |
 | Make | [checkmake](https://github.com/mrtazz/checkmake) |
-| Markdown | [mdl](https://github.com/mivok/markdownlint), [proselint](http://proselint.com/), [vale](https://github.com/ValeLint/vale), [remark-lint](https://github.com/wooorm/remark-lint) !!, [write-good](https://github.com/btford/write-good), [redpen](http://redpen.cc/) |
+| Markdown | [alex](https://github.com/wooorm/alex), [mdl](https://github.com/mivok/markdownlint), [proselint](http://proselint.com/), [vale](https://github.com/ValeLint/vale), [remark-lint](https://github.com/wooorm/remark-lint) !!, [write-good](https://github.com/btford/write-good), [redpen](http://redpen.cc/) |
 | MATLAB | [mlint](https://www.mathworks.com/help/matlab/ref/mlint.html) |
 | Nim | [nim check](https://nim-lang.org/docs/nimc.html) !! |
 | nix | [nix-instantiate](http://nixos.org/nix/manual/#sec-nix-instantiate) |
-| nroff | [proselint](http://proselint.com/), [write-good](https://github.com/btford/write-good)|
+| nroff | [alex](https://github.com/wooorm/alex), [proselint](http://proselint.com/), [write-good](https://github.com/btford/write-good)|
 | Objective-C | [clang](http://clang.llvm.org/) |
 | Objective-C++ | [clang](http://clang.llvm.org/) |
 | OCaml | [merlin](https://github.com/the-lambda-church/merlin) see `:help ale-ocaml-merlin` for configuration instructions, [ols](https://github.com/freebroccolo/ocaml-language-server) |
 | Perl | [perl -c](https://perl.org/), [perl-critic](https://metacpan.org/pod/Perl::Critic) |
 | PHP | [hack](http://hacklang.org/), [hackfmt](https://github.com/facebook/flow/tree/master/hack/hackfmt), [langserver](https://github.com/felixfbecker/php-language-server), [phan](https://github.com/phan/phan) see `:help ale-php-phan` to instructions, [php -l](https://secure.php.net/), [phpcs](https://github.com/squizlabs/PHP_CodeSniffer), [phpmd](https://phpmd.org), [phpstan](https://github.com/phpstan/phpstan), [phpcbf](https://github.com/squizlabs/PHP_CodeSniffer) |
-| Pod | [proselint](http://proselint.com/), [write-good](https://github.com/btford/write-good) |
+| Pod | [alex](https://github.com/wooorm/alex), [proselint](http://proselint.com/), [write-good](https://github.com/btford/write-good) |
 | proto | [protoc-gen-lint](https://github.com/ckaznocha/protoc-gen-lint) |
 | Pug | [pug-lint](https://github.com/pugjs/pug-lint) |
 | Puppet | [puppet](https://puppet.com), [puppet-lint](https://puppet-lint.com) |
 | Python | [autopep8](https://github.com/hhatto/autopep8), [flake8](http://flake8.pycqa.org/en/latest/), [isort](https://github.com/timothycrosley/isort), [mypy](http://mypy-lang.org/), [prospector](http://github.com/landscapeio/prospector), [pycodestyle](https://github.com/PyCQA/pycodestyle), [pyls](https://github.com/palantir/python-language-server), [pylint](https://www.pylint.org/) !!, [yapf](https://github.com/google/yapf) |
 | R | [lintr](https://github.com/jimhester/lintr) |
 | ReasonML | [merlin](https://github.com/the-lambda-church/merlin) see `:help ale-integration-reason-merlin` for configuration instructions, [ols](https://github.com/freebroccolo/ocaml-language-server), [refmt](https://github.com/reasonml/reason-cli) |
-| reStructuredText | [proselint](http://proselint.com/), [rstcheck](https://github.com/myint/rstcheck), [write-good](https://github.com/btford/write-good), [redpen](http://redpen.cc/) |
+| reStructuredText | [alex](https://github.com/wooorm/alex), [proselint](http://proselint.com/), [rstcheck](https://github.com/myint/rstcheck), [write-good](https://github.com/btford/write-good), [redpen](http://redpen.cc/) |
 | Re:VIEW | [redpen](http://redpen.cc/) |
 | RPM spec | [rpmlint](https://github.com/rpm-software-management/rpmlint) (disabled by default; see `:help ale-integration-spec`) |
 | Ruby | [brakeman](http://brakemanscanner.org/) !!, [rails_best_practices](https://github.com/flyerhzm/rails_best_practices) !!, [reek](https://github.com/troessner/reek), [rubocop](https://github.com/bbatsov/rubocop), [ruby](https://www.ruby-lang.org) |
@@ -151,14 +151,14 @@ formatting.
 | Swift | [swiftlint](https://github.com/realm/SwiftLint), [swiftformat](https://github.com/nicklockwood/SwiftFormat) |
 | Tcl | [nagelfar](http://nagelfar.sourceforge.net) !! |
 | Terraform | [tflint](https://github.com/wata727/tflint) |
-| Texinfo | [proselint](http://proselint.com/), [write-good](https://github.com/btford/write-good)|
-| Text^ | [proselint](http://proselint.com/), [vale](https://github.com/ValeLint/vale), [write-good](https://github.com/btford/write-good), [redpen](http://redpen.cc/) |
+| Texinfo | [alex](https://github.com/wooorm/alex), [proselint](http://proselint.com/), [write-good](https://github.com/btford/write-good)|
+| Text^ | [alex](https://github.com/wooorm/alex), [proselint](http://proselint.com/), [vale](https://github.com/ValeLint/vale), [write-good](https://github.com/btford/write-good), [redpen](http://redpen.cc/) |
 | Thrift | [thrift](http://thrift.apache.org/) |
 | TypeScript | [eslint](http://eslint.org/), [prettier](https://github.com/prettier/prettier), [tslint](https://github.com/palantir/tslint), tsserver, typecheck |
 | Verilog | [iverilog](https://github.com/steveicarus/iverilog), [verilator](http://www.veripool.org/projects/verilator/wiki/Intro) |
 | Vim | [vint](https://github.com/Kuniwak/vint) |
-| Vim help^ | [proselint](http://proselint.com/), [write-good](https://github.com/btford/write-good) |
-| XHTML | [proselint](http://proselint.com/), [write-good](https://github.com/btford/write-good) |
+| Vim help^ | [alex](https://github.com/wooorm/alex), [proselint](http://proselint.com/), [write-good](https://github.com/btford/write-good) |
+| XHTML | [alex](https://github.com/wooorm/alex), [proselint](http://proselint.com/), [write-good](https://github.com/btford/write-good) |
 | XML | [xmllint](http://xmlsoft.org/xmllint.html) |
 | YAML | [swaglint](https://github.com/byCedric/swaglint), [yamllint](https://yamllint.readthedocs.io/) |
 

--- a/ale_linters/asciidoc/alex.vim
+++ b/ale_linters/asciidoc/alex.vim
@@ -1,0 +1,10 @@
+" Author: Johannes Wienke <languitar@semipol.de>
+" Description: alex for asciidoc files
+
+call ale#linter#Define('asciidoc', {
+\   'name': 'alex',
+\   'executable': 'alex',
+\   'command': 'alex %t -t',
+\   'output_stream': 'stderr',
+\   'callback': 'ale#handlers#alex#Handle',
+\})

--- a/ale_linters/help/alex.vim
+++ b/ale_linters/help/alex.vim
@@ -1,0 +1,10 @@
+" Author: Johannes Wienke <languitar@semipol.de>
+" Description: alex for help files
+
+call ale#linter#Define('help', {
+\   'name': 'alex',
+\   'executable': 'alex',
+\   'command': 'alex %t -t',
+\   'output_stream': 'stderr',
+\   'callback': 'ale#handlers#alex#Handle',
+\})

--- a/ale_linters/html/alex.vim
+++ b/ale_linters/html/alex.vim
@@ -1,0 +1,10 @@
+" Author: Johannes Wienke <languitar@semipol.de>
+" Description: alex for HTML files
+
+call ale#linter#Define('html', {
+\   'name': 'alex',
+\   'executable': 'alex',
+\   'command': 'alex %t -t',
+\   'output_stream': 'stderr',
+\   'callback': 'ale#handlers#alex#Handle',
+\})

--- a/ale_linters/mail/alex.vim
+++ b/ale_linters/mail/alex.vim
@@ -1,0 +1,10 @@
+" Author: Johannes Wienke <languitar@semipol.de>
+" Description: alex for HTML files
+
+call ale#linter#Define('mail', {
+\   'name': 'alex',
+\   'executable': 'alex',
+\   'command': 'alex %t -t',
+\   'output_stream': 'stderr',
+\   'callback': 'ale#handlers#alex#Handle',
+\})

--- a/ale_linters/markdown/alex.vim
+++ b/ale_linters/markdown/alex.vim
@@ -1,0 +1,10 @@
+" Author: Johannes Wienke <languitar@semipol.de>
+" Description: alex for markdown files
+
+call ale#linter#Define('markdown', {
+\   'name': 'alex',
+\   'executable': 'alex',
+\   'command': 'alex %t -t',
+\   'output_stream': 'stderr',
+\   'callback': 'ale#handlers#alex#Handle',
+\})

--- a/ale_linters/nroff/alex.vim
+++ b/ale_linters/nroff/alex.vim
@@ -1,0 +1,10 @@
+" Author: Johannes Wienke <languitar@semipol.de>
+" Description: alex for nroff files
+
+call ale#linter#Define('nroff', {
+\   'name': 'alex',
+\   'executable': 'alex',
+\   'command': 'alex %t -t',
+\   'output_stream': 'stderr',
+\   'callback': 'ale#handlers#alex#Handle',
+\})

--- a/ale_linters/pod/alex.vim
+++ b/ale_linters/pod/alex.vim
@@ -1,0 +1,10 @@
+" Author: Johannes Wienke <languitar@semipol.de>
+" Description: alex for pod files
+
+call ale#linter#Define('pod', {
+\   'name': 'alex',
+\   'executable': 'alex',
+\   'command': 'alex %t -t',
+\   'output_stream': 'stderr',
+\   'callback': 'ale#handlers#alex#Handle',
+\})

--- a/ale_linters/rst/alex.vim
+++ b/ale_linters/rst/alex.vim
@@ -1,0 +1,10 @@
+" Author: Johannes Wienke <languitar@semipol.de>
+" Description: alex for rst files
+
+call ale#linter#Define('rst', {
+\   'name': 'alex',
+\   'executable': 'alex',
+\   'command': 'alex %t -t',
+\   'output_stream': 'stderr',
+\   'callback': 'ale#handlers#alex#Handle',
+\})

--- a/ale_linters/tex/alex.vim
+++ b/ale_linters/tex/alex.vim
@@ -1,0 +1,10 @@
+" Author: Johannes Wienke <languitar@semipol.de>
+" Description: alex for TeX files
+
+call ale#linter#Define('tex', {
+\   'name': 'alex',
+\   'executable': 'alex',
+\   'command': 'alex %t -t',
+\   'output_stream': 'stderr',
+\   'callback': 'ale#handlers#alex#Handle',
+\})

--- a/ale_linters/texinfo/alex.vim
+++ b/ale_linters/texinfo/alex.vim
@@ -1,0 +1,10 @@
+" Author: Johannes Wienke <languitar@semipol.de>
+" Description: alex for texinfo files
+
+call ale#linter#Define('texinfo', {
+\   'name': 'alex',
+\   'executable': 'alex',
+\   'command': 'alex %t -t',
+\   'output_stream': 'stderr',
+\   'callback': 'ale#handlers#alex#Handle',
+\})

--- a/ale_linters/text/alex.vim
+++ b/ale_linters/text/alex.vim
@@ -1,0 +1,10 @@
+" Author: Johannes Wienke <languitar@semipol.de>
+" Description: alex for text files
+
+call ale#linter#Define('text', {
+\   'name': 'alex',
+\   'executable': 'alex',
+\   'command': 'alex %t -t',
+\   'output_stream': 'stderr',
+\   'callback': 'ale#handlers#alex#Handle',
+\})

--- a/ale_linters/xhtml/alex.vim
+++ b/ale_linters/xhtml/alex.vim
@@ -1,0 +1,10 @@
+" Author: Johannes Wienke <languitar@semipol.de>
+" Description: alex for XHTML files
+
+call ale#linter#Define('xhtml', {
+\   'name': 'alex',
+\   'executable': 'alex',
+\   'command': 'alex %t -t',
+\   'output_stream': 'stderr',
+\   'callback': 'ale#handlers#alex#Handle',
+\})

--- a/autoload/ale/handlers/alex.vim
+++ b/autoload/ale/handlers/alex.vim
@@ -1,0 +1,22 @@
+" Author: Johannes Wienke <languitar@semipol.de>
+" Description: Error handling for errors in alex output format
+
+function! ale#handlers#alex#Handle(buffer, lines) abort
+    " Example output:
+    "       6:256-6:262  warning  Be careful with “killed”, it’s profane in some cases      killed           retext-profanities
+    let l:pattern = '^ *\(\d\+\):\(\d\+\)-\(\d\+\):\(\d\+\) \+warning \+\(.\{-\}\)  \+\(.\{-\}\)  \+\(.\{-\}\)$'
+    let l:output = []
+
+    for l:match in ale#util#GetMatches(a:lines, l:pattern)
+        call add(l:output, {
+        \   'lnum': l:match[1] + 0,
+        \   'col': l:match[2] + 0,
+        \   'end_lnum': l:match[3] + 0,
+        \   'end_col': l:match[4] - 1,
+        \   'text': l:match[5] . ' (' . (l:match[7]) . ')',
+        \   'type': 'W',
+        \})
+    endfor
+
+    return l:output
+endfunction

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -274,7 +274,7 @@ Notes:
 * ASM: `gcc`
 * Ansible: `ansible-lint`
 * API Blueprint: `drafter`
-* AsciiDoc: `proselint`, `write-good`, `redpen`
+* AsciiDoc: `alex`, `proselint`, `write-good`, `redpen`
 * Awk: `gawk`
 * Bash: `shell` (-n flag), `shellcheck`, `shfmt`
 * Bourne Shell: `shell` (-n flag), `shellcheck`, `shfmt`
@@ -305,36 +305,36 @@ Notes:
 * Haml: `haml-lint`
 * Handlebars: `ember-template-lint`
 * Haskell: `brittany`, `ghc`, `stack-ghc`, `stack-build`!!, `ghc-mod`, `stack-ghc-mod`, `hlint`, `hdevtools`, `hfmt`
-* HTML: `HTMLHint`, `proselint`, `tidy`, `write-good`
+* HTML: `alex`, `HTMLHint`, `proselint`, `tidy`, `write-good`
 * Idris: `idris`
 * Java: `checkstyle`, `javac`
 * JavaScript: `eslint`, `flow`, `jscs`, `jshint`, `prettier`, `prettier-eslint` >= 4.2.0, `prettier-standard`, `standard`, `xo`
 * JSON: `jsonlint`, `prettier`
 * Kotlin: `kotlinc`, `ktlint`
-* LaTeX (tex): `chktex`, `lacheck`, `proselint`, `write-good`, `redpen`
+* LaTeX (tex): `alex`, `chktex`, `lacheck`, `proselint`, `write-good`, `redpen`
 * Less: `lessc`, `prettier`, `stylelint`
 * LLVM: `llc`
 * Lua: `luacheck`
-* Mail: `proselint`, `vale`
+* Mail: `alex`, `proselint`, `vale`
 * Make: `checkmake`
-* Markdown: `mdl`, `proselint`, `vale`, `remark-lint`, `write-good`, `redpen`
+* Markdown: `alex`, `mdl`, `proselint`, `vale`, `remark-lint`, `write-good`, `redpen`
 * MATLAB: `mlint`
 * Nim: `nim check`!!
 * nix: `nix-instantiate`
-* nroff: `proselint`, `write-good`
+* nroff: `alex`, `proselint`, `write-good`
 * Objective-C: `clang`
 * Objective-C++: `clang`
 * OCaml: `merlin` (see |ale-ocaml-merlin|), `ols`
 * Perl: `perl -c`, `perl-critic`
 * PHP: `hack`, `hackfmt`, `langserver`, `phan`, `php -l`, `phpcs`, `phpmd`, `phpstan`, `phpcbf`
-* Pod: `proselint`, `write-good`
+* Pod: `alex`, `proselint`, `write-good`
 * proto: `protoc-gen-lint`
 * Pug: `pug-lint`
 * Puppet: `puppet`, `puppet-lint`
 * Python: `autopep8`, `flake8`, `isort`, `mypy`, `prospector`, `pycodestyle`, `pyls`, `pylint`!!, `yapf`
 * R: `lintr`
 * ReasonML: `merlin`, `ols`, `refmt`
-* reStructuredText: `proselint`, `rstcheck`, `write-good`, `redpen`
+* reStructuredText: `alex`, `proselint`, `rstcheck`, `write-good`, `redpen`
 * Re:VIEW: `redpen`
 * RPM spec: `rpmlint`
 * Ruby: `brakeman`, `rails_best_practices`!!, `reek`, `rubocop`, `ruby`
@@ -350,14 +350,14 @@ Notes:
 * Swift: `swiftlint`, `swiftformat`
 * Tcl: `nagelfar`!!
 * Terraform: `tflint`
-* Texinfo: `proselint`, `write-good`
-* Text^: `proselint`, `vale`, `write-good`, `redpen`
+* Texinfo: `alex`, `proselint`, `write-good`
+* Text^: `alex`, `proselint`, `vale`, `write-good`, `redpen`
 * Thrift: `thrift`
 * TypeScript: `eslint`, `prettier`, `tslint`, `tsserver`, `typecheck`
 * Verilog: `iverilog`, `verilator`
 * Vim: `vint`
-* Vim help^: `proselint`, `write-good`
-* XHTML: `proselint`, `write-good`
+* Vim help^: `alex`, `proselint`, `write-good`
+* XHTML: `alex`, `proselint`, `write-good`
 * XML: `xmllint`
 * YAML: `swaglint`, `yamllint`
 

--- a/test/handler/test_alex_handler.vader
+++ b/test/handler/test_alex_handler.vader
@@ -1,0 +1,54 @@
+Execute(The alex handler should handle the example from the alex README):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 1,
+  \     'col': 5,
+  \     'end_lnum': 1,
+  \     'end_col': 13,
+  \     'type': 'W',
+  \     'text': '`boogeyman` may be insensitive, use `boogey` instead (retext-equality)',
+  \   },
+  \   {
+  \     'lnum': 1,
+  \     'col': 42,
+  \     'end_lnum': 1,
+  \     'end_col': 47,
+  \     'type': 'W',
+  \     'text': '`master` / `slaves` may be insensitive, use `primary` / `replica` instead (retext-equality)',
+  \   },
+  \   {
+  \     'lnum': 1,
+  \     'col': 69,
+  \     'end_lnum': 1,
+  \     'end_col': 74,
+  \     'type': 'W',
+  \     'text': 'Don’t use “slaves”, it’s profane (retext-profanities)',
+  \   },
+  \   {
+  \     'lnum': 2,
+  \     'col': 52,
+  \     'end_lnum': 2,
+  \     'end_col': 53,
+  \     'type': 'W',
+  \     'text': '`he` may be insensitive, use `they`, `it` instead (retext-equality)',
+  \   },
+  \   {
+  \     'lnum': 2,
+  \     'col': 61,
+  \     'end_lnum': 2,
+  \     'end_col': 67,
+  \     'type': 'W',
+  \     'text': '`cripple` may be insensitive, use `person with a limp` instead (retext-equality)',
+  \   },
+  \ ],
+  \ ale#handlers#alex#Handle(bufnr(''), [
+  \ 'example.md',
+  \ '   1:5-1:14  warning  `boogeyman` may be insensitive, use `boogey` instead                       boogeyman-boogeywoman  retext-equality',
+  \ '  1:42-1:48  warning  `master` / `slaves` may be insensitive, use `primary` / `replica` instead  master-slave           retext-equality',
+  \ '  1:69-1:75  warning  Don’t use “slaves”, it’s profane                                           slaves                 retext-profanities',
+  \ '  2:52-2:54  warning  `he` may be insensitive, use `they`, `it` instead                          he-she                 retext-equality',
+  \ '  2:61-2:68  warning  `cripple` may be insensitive, use `person with a limp` instead             cripple                retext-equality',
+  \ '',
+  \ '⚠ 5 warnings',
+  \ ])


### PR DESCRIPTION
https://github.com/wooorm/alex

Enabled for text-like file formats and documented in README and doc.

Tests for the message handler exist.

Things have been constructed along the write-good example, apart from the variable command and option handling.