### PR TITLE
Fix erb linter for puppet style erb templates

### DIFF
--- a/ale_linters/eruby/erb.vim
+++ b/ale_linters/eruby/erb.vim
@@ -5,7 +5,7 @@ function! ale_linters#eruby#erb#GetCommand(buffer) abort
     let l:rails_root = ale#ruby#FindRailsRoot(a:buffer)
 
     if empty(l:rails_root)
-        return 'erb -P -x %t | ruby -c'
+        return 'erb -P -T - -x %t | ruby -c'
     endif
 
     " Rails-flavored eRuby does not comply with the standard as understood by

--- a/test/command_callback/test_erb_command_callback.vader
+++ b/test/command_callback/test_erb_command_callback.vader
@@ -10,7 +10,7 @@ Execute(Executable should not contain any filter code by default):
   call ale#test#SetFilename('../ruby_fixtures/not_a_rails_app/file.rb')
 
   AssertEqual
-  \ 'erb -P -x %t | ruby -c',
+  \ 'erb -P -T - -x %t | ruby -c',
   \ ale_linters#eruby#erb#GetCommand(bufnr(''))
 
 Execute(Executable should filter invalid eRuby when inside a Rails project):


### PR DESCRIPTION
This trims `-` characters from `<%-`, which makes `erb` work on puppet style erb templates. 