### PR TITLE
Fix PHP linter to support PHP 7.2 lint output

### DIFF
--- a/ale_linters/php/php.vim
+++ b/ale_linters/php/php.vim
@@ -4,12 +4,14 @@
 function! ale_linters#php#php#Handle(buffer, lines) abort
     " Matches patterns like the following:
     "
-    " Parse error:  syntax error, unexpected ';', expecting ']' in - on line 15
-    let l:pattern = '\v^%(Fatal|Parse) error:\s+(.+unexpected ''(.+)%(expecting.+)@<!''.*|.+) in - on line (\d+)'
+    " PHP 7.1<= - Parse error:  syntax error, unexpected ';', expecting ']' in - on line 15
+    " PHP 7.2>= - Parse error:  syntax error, unexpected ';', expecting ']' in Standard input code on line 15
+    let l:pattern = '\v^%(Fatal|Parse) error:\s+(.+unexpected ''(.+)%(expecting.+)@<!''.*|.+) in %(-|Standard input code) on line (\d+)'
     let l:output = []
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)
         let l:col = empty(l:match[2]) ? 0 : stridx(getline(l:match[3]), l:match[2]) + 1
+
         let l:obj = {
         \   'lnum': l:match[3] + 0,
         \   'col': l:col,

--- a/test/handler/test_php_handler.vader
+++ b/test/handler/test_php_handler.vader
@@ -54,6 +54,18 @@ Execute (The php handler should ignore lines starting with 'PHP Parse error'):
   \   "PHP Parse error:  syntax error, This line should be ignored completely in - on line 1",
   \ ])
 
+Execute (The php handler should handle lines containing 'Standard input code'):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 47,
+  \     'col': 0,
+  \     'text': "Invalid numeric literal",
+  \   },
+  \ ],
+  \ ale_linters#php#php#Handle(347, [
+  \   "Parse error: Invalid numeric literal in Standard input code on line 47",
+  \ ])
 Execute (The php handler should parse lines without column indication):
   AssertEqual
   \ [


### PR DESCRIPTION
Vadar test added.

PHP 7.2 outputs slighty different for lint command compared to PHP 7.1 and older.

E.g.

PHP 7.2
```
Parse error: syntax error, unexpected '"£$%"' (T_CONSTANT_ENCAPSED_STRING) in Standard input code on line 11

Errors parsing Standard input code
```


PHP 7.1
```
Parse error: syntax error, unexpected '"£$%"' (T_CONSTANT_ENCAPSED_STRING) in - on line 11

Errors parsing -
```