### PR TITLE
Use JSON output with vale

### DIFF
--- a/ale_linters/mail/vale.vim
+++ b/ale_linters/mail/vale.vim
@@ -4,6 +4,6 @@
 call ale#linter#Define('mail', {
 \   'name': 'vale',
 \   'executable': 'vale',
-\   'command': 'vale --output=line %t',
-\   'callback': 'ale#handlers#unix#HandleAsWarning',
+\   'command': 'vale --output=JSON %t',
+\   'callback': 'ale#handlers#vale#Handle',
 \})

--- a/ale_linters/markdown/vale.vim
+++ b/ale_linters/markdown/vale.vim
@@ -4,6 +4,6 @@
 call ale#linter#Define('markdown', {
 \   'name': 'vale',
 \   'executable': 'vale',
-\   'command': 'vale --output=line %t',
-\   'callback': 'ale#handlers#unix#HandleAsWarning',
+\   'command': 'vale --output=JSON %t',
+\   'callback': 'ale#handlers#vale#Handle',
 \})

--- a/ale_linters/text/vale.vim
+++ b/ale_linters/text/vale.vim
@@ -4,6 +4,6 @@
 call ale#linter#Define('text', {
 \   'name': 'vale',
 \   'executable': 'vale',
-\   'command': 'vale --output=line %t',
-\   'callback': 'ale#handlers#unix#HandleAsWarning',
+\   'command': 'vale --output=JSON %t',
+\   'callback': 'ale#handlers#vale#Handle',
 \})

--- a/autoload/ale/handlers/vale.vim
+++ b/autoload/ale/handlers/vale.vim
@@ -1,0 +1,36 @@
+" Author: Johannes Wienke <languitar@semipol.de>
+" Description: output handler for the vale JSON format
+
+function! ale#handlers#vale#GetType(severity) abort
+    if a:severity is? 'warning'
+        return 'W'
+    endif
+
+    return 'E'
+endfunction
+
+function! ale#handlers#vale#Handle(buffer, lines) abort
+    try
+        let l:errors = json_decode(join(a:lines, ''))
+    catch
+        return []
+    endtry
+
+    if empty(l:errors)
+        return []
+    endif
+
+    let l:output = []
+    for l:error in l:errors[keys(l:errors)[0]]
+        call add(l:output, {
+        \   'lnum': l:error['Line'],
+        \   'col': l:error['Span'][0],
+        \   'end_col': l:error['Span'][1],
+        \   'code': l:error['Check'],
+        \   'text': l:error['Message'],
+        \   'type': ale#handlers#vale#GetType(l:error['Severity']),
+        \})
+    endfor
+
+    return l:output
+endfunction

--- a/test/handler/test_vale_handler.vader
+++ b/test/handler/test_vale_handler.vader
@@ -1,0 +1,67 @@
+Execute(The vale handler should handle broken JSON):
+  AssertEqual
+  \ [],
+  \ ale#handlers#vale#Handle(bufnr(''), ["{asdf"])
+
+Execute(The vale handler should handle am empty string response):
+  AssertEqual
+  \ [],
+  \ ale#handlers#vale#Handle(bufnr(''), [])
+
+Execute(The vale handler should handle an empty result):
+  AssertEqual
+  \ [],
+  \ ale#handlers#vale#Handle(bufnr(''), ["{}"])
+
+Execute(The vale handler should handle a normal example):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 5,
+  \     'col': 195,
+  \     'end_col': 201,
+  \     'type': 'W',
+  \     'text': "Consider removing 'usually'",
+  \     'code': 'vale.Hedging',
+  \   },
+  \   {
+  \     'lnum': 7,
+  \     'col': 1,
+  \     'end_col': 27,
+  \     'type': 'E',
+  \     'text': "'Documentation' is repeated!",
+  \     'code': 'vale.Repetition',
+  \   },
+  \ ],
+  \ ale#handlers#vale#Handle(bufnr(''), [
+  \   '{',
+  \   '  "/home/languitar/src/autosuspend/README.md": [',
+  \   '    {',
+  \   '      "Check": "vale.Hedging",',
+  \   '      "Description": "",',
+  \   '      "Line": 5,',
+  \   '      "Link": "",',
+  \   "      \"Message\": \"Consider removing 'usually'\",",
+  \   '      "Severity": "warning",',
+  \   '      "Span": [',
+  \   '        195,',
+  \   '        201',
+  \   '      ],',
+  \   '      "Hide": false',
+  \   '    },',
+  \   '    {',
+  \   '      "Check": "vale.Repetition",',
+  \   '      "Description": "",',
+  \   '      "Line": 7,',
+  \   '      "Link": "",',
+  \   "      \"Message\": \"'Documentation' is repeated!\",",
+  \   '      "Severity": "error",',
+  \   '      "Span": [',
+  \   '        1,',
+  \   '        27',
+  \   '      ],',
+  \   '      "Hide": false',
+  \   '    }',
+  \   '  ]',
+  \   '}',
+  \ ])


### PR DESCRIPTION
Switches all vale instances to JSON output and provides an appropriate handler for that. Without JSON, no end_col is provided and text highlighting only catches the first character of every result.

Tests are included.