### PR TITLE
Add python venv folder

### DIFF
--- a/autoload/ale/python.vim
+++ b/autoload/ale/python.vim
@@ -10,6 +10,7 @@ let g:ale_virtualenv_dir_names = get(g:, 'ale_virtualenv_dir_names', [
 \   've-py3',
 \   've',
 \   'virtualenv',
+\   'venv',
 \])
 
 function! ale#python#FindProjectRootIni(buffer) abort

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -1397,7 +1397,7 @@ g:ale_virtualenv_dir_names                         *g:ale_virtualenv_dir_names*
 b:ale_virtualenv_dir_names                         *b:ale_virtualenv_dir_names*
 
   Type: |List|
-  Default: `['.env', 'env', 've-py3', 've', 'virtualenv']`
+  Default: `['.env', 'env', 've-py3', 've', 'virtualenv', 'venv']`
 
   A list of directory names to be used when searching upwards from Python
   files to discover virtulenv directories with.


### PR DESCRIPTION
Add support for Python Virtual Environments called `vent`. As the following search shows, this ia quite a common practice: https://github.com/search?l=Python&q=venv&type=Code&utf8=✓