### PR TITLE
use compile_commands.json for clang linter

### DIFF
--- a/ale_linters/cpp/clang.vim
+++ b/ale_linters/cpp/clang.vim
@@ -26,7 +26,11 @@ function! ale_linters#cpp#clang#GetCommand(buffer) abort
         let l:b = fnamemodify(bufname(a:buffer), ':p')
         for l:d in l:l
             if l:d["file"] == l:b
-                return l:d["command"] . ' -fsyntax-only'
+                " Key 'command' contains -o with path relative to key 'directory'
+                " Make it absolute path. This way this linter generates valid
+                " .o which makes subsequent build of whole project faster...
+                let l:s = substitute(l:d["command"], "-o ", "-o ".l:d["directory"]."/","")
+                return l:s
             endif
         endfor
         echom "ALE: Please refresh your compile_commands.json!"

--- a/ale_linters/cpp/clang.vim
+++ b/ale_linters/cpp/clang.vim
@@ -1,4 +1,5 @@
 " Author: Tomota Nakamura <https://github.com/tomotanakamura>
+" Author: Milan Svoboda <https://github.com/tex>
 " Description: clang linter for cpp files
 
 call ale#Set('cpp_clang_executable', 'clang++')
@@ -9,15 +10,27 @@ function! ale_linters#cpp#clang#GetExecutable(buffer) abort
 endfunction
 
 function! ale_linters#cpp#clang#GetCommand(buffer) abort
-    let l:paths = ale#c#FindLocalHeaderPaths(a:buffer)
-
-    " -iquote with the directory the file is in makes #include work for
-    "  headers in the same directory.
-    return ale#Escape(ale_linters#cpp#clang#GetExecutable(a:buffer))
-    \   . ' -S -x c++ -fsyntax-only '
-    \   . '-iquote ' . ale#Escape(fnamemodify(bufname(a:buffer), ':p:h')) . ' '
-    \   . ale#c#IncludeOptions(l:paths)
-    \   . ale#Var(a:buffer, 'cpp_clang_options') . ' -'
+    let l:build_dir = ale#c#FindCompileCommands(a:buffer)
+    if empty(l:build_dir)
+        let l:paths = ale#c#FindLocalHeaderPaths(a:buffer)
+        " -iquote with the directory the file is in makes #include work for
+        "  headers in the same directory.
+        return ale#Escape(ale_linters#cpp#clang#GetExecutable(a:buffer))
+        \   . ' -S -x c++ -fsyntax-only '
+        \   . '-iquote ' . ale#Escape(fnamemodify(bufname(a:buffer), ':p:h')) . ' '
+        \   . ale#c#IncludeOptions(l:paths)
+        \   . ale#Var(a:buffer, 'cpp_clang_options') . ' -'
+    else
+        let l:c = readfile(l:build_dir . '/compile_commands.json')
+        let l:l = json_decode(l:c)
+        let l:b = fnamemodify(bufname(a:buffer), ':p')
+        for l:d in l:l
+            if l:d["file"] == l:b
+                return l:d["command"] . ' -fsyntax-only'
+            endif
+        endfor
+        echom "ALE: Please refresh your compile_commands.json!"
+    endif
 endfunction
 
 call ale#linter#Define('cpp', {


### PR DESCRIPTION
This parses compile_commands.json and uses specific compile command for clang. Works fine for me.
