### PR TITLE
Add ALEFixPre and ALEFixPost events

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,15 +502,17 @@ Will give you:
 ### 5.viii. How can I execute some code when ALE starts or stops linting?
 
 ALE runs its own [autocmd](http://vimdoc.sourceforge.net/htmldoc/autocmd.html)
-events whenever has a linter is started and has been successfully executed and
-processed. These events can be used to call arbitrary functions before and after
-ALE stops linting.
+events when a lint or fix cycle are started and stopped. These events can be
+used to call arbitrary functions before and after ALE stops linting.
 
 ```vim
 augroup YourGroup
     autocmd!
     autocmd User ALELintPre  call YourFunction()
     autocmd User ALELintPost call YourFunction()
+
+    autocmd User ALEFixPre   call YourFunction()
+    autocmd User ALEFixPost  call YourFunction()
 augroup END
 ```
 

--- a/autoload/ale/fix.vim
+++ b/autoload/ale/fix.vim
@@ -54,6 +54,8 @@ function! ale#fix#ApplyQueuedFixes() abort
         let l:should_lint = l:data.changes_made
     endif
 
+    silent doautocmd <nomodeline> User ALEFixPost
+
     " If ALE linting is enabled, check for problems with the file again after
     " fixing problems.
     if g:ale_enabled
@@ -462,6 +464,8 @@ function! ale#fix#Fix(...) abort
     " Clean up any files we might have left behind from a previous run.
     call ale#fix#RemoveManagedFiles(l:buffer)
     call ale#fix#InitBufferData(l:buffer, l:fixing_flag)
+
+    silent doautocmd <nomodeline> User ALEFixPre
 
     call s:RunFixer({
     \   'buffer': l:buffer,

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2304,9 +2304,11 @@ b:ale_linted                                                     *b:ale_linted*
 
 ALELintPre                                                 *ALELintPre-autocmd*
 ALELintPost                                               *ALELintPost-autocmd*
+ALEFixPre                                                   *ALEFixPre-autocmd*
+ALEFixPost                                                 *ALEFixPost-autocmd*
 
-  These |User| autocommands are triggered before and after every lint cycle.
-  They can be used to update statuslines, send notifications, etc.
+  These |User| autocommands are triggered before and after every lint or fix
+  cycle. They can be used to update statuslines, send notifications, etc.
   The autocmd commands are run with |:silent|, so |:unsilent| is required for
   echoing messges.
 

--- a/test/fix/test_ale_fix.vader
+++ b/test/fix/test_ale_fix.vader
@@ -17,6 +17,14 @@ Before:
   \ 'testft': [],
   \}
 
+  let g:pre_success = 0
+  let g:post_success = 0
+  augroup VaderTest
+    autocmd!
+    autocmd User ALEFixPre let g:pre_success = 1
+    autocmd User ALEFixPost let g:post_success = 1
+  augroup end
+
   if !has('win32')
     let &shell = '/bin/bash'
   endif
@@ -171,6 +179,7 @@ After:
   unlet! g:ale_emulate_job_failure
   unlet! b:ale_fixers
   unlet! b:ale_fix_on_save
+  augroup! VaderTest
   delfunction AddCarets
   delfunction AddDollars
   delfunction DoNothing
@@ -664,3 +673,9 @@ Expect(The lines in the JSON should be used):
   x
   y
   z
+
+Execute(ALEFix should apply autocmds):
+  let g:ale_fixers.testft = ['AddCarets']
+  ALEFix
+  AssertEqual g:pre_success, 1
+  AssertEqual g:post_success, 1


### PR DESCRIPTION
To run autocmd before and after every fix cycle.

Fixes #623 (`ALELintPre` was added in #1203).