### PR TITLE
Fish shell linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ formatting.
 | Elm | [elm-format](https://github.com/avh4/elm-format), [elm-make](https://github.com/elm-lang/elm-make) |
 | Erb | [erb](https://github.com/jeremyevans/erubi), [erubis](https://github.com/kwatch/erubis) |
 | Erlang | [erlc](http://erlang.org/doc/man/erlc.html), [SyntaxErl](https://github.com/ten0s/syntaxerl) |
+| Fish | fish [-n flag](https://linux.die.net/man/1/fish)
 | Fortran | [gcc](https://gcc.gnu.org/) |
 | FusionScript | [fusion-lint](https://github.com/RyanSquared/fusionscript) |
 | Git Commit Messages | [gitlint](https://github.com/jorisroovers/gitlint) |

--- a/ale_linters/fish/fish.vim
+++ b/ale_linters/fish/fish.vim
@@ -1,0 +1,36 @@
+" Author: Niraj Thapaliya - https://github.com/nthapaliya
+" Description: Lints fish files using fish -n
+
+function! ale_linters#fish#fish#Handle(buffer, lines) abort
+    " Matches patterns such as:
+    "
+    " home/.config/fish/functions/foo.fish (line 1): Missing end to balance this function definition
+    " function foo
+    " ^
+    " <W> fish: Error while reading file .config/fish/functions/foo.fish
+    let l:pattern = '^.* (line \(\d\+\)): \(.*\)$'
+    let l:output = []
+
+    let l:i = 0
+    while l:i < len(a:lines)
+      let l:match = matchlist(a:lines[l:i], l:pattern)
+      if len(l:match) && len(l:match[2])
+        call add(l:output, {
+              \  'col': len(a:lines[l:i + 2]),
+              \  'lnum': str2nr(l:match[1]),
+              \  'text': l:match[2],
+              \})
+      endif
+      let l:i += 1
+    endwhile
+
+    return l:output
+endfunction
+
+call ale#linter#Define('fish', {
+\   'name': 'fish',
+\   'output_stream': 'stderr',
+\   'executable': 'fish',
+\   'command': 'fish -n %t',
+\   'callback': 'ale_linters#fish#fish#Handle',
+\})

--- a/doc/ale-fish.txt
+++ b/doc/ale-fish.txt
@@ -1,0 +1,14 @@
+===============================================================================
+ALE Fish Integration                                         *ale-fish-options*
+
+Lints fish files using `fish -n`.
+
+Note that `fish -n` is not foolproof: it sometimes gives false positives or
+errors that are difficult to parse without more context. This integration skips
+displaying errors if an error message is not found.
+
+If ALE is not showing any errors but your file does not run as expected, run
+`fish -n <file.fish>` from the command line.
+
+===============================================================================
+  vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -64,6 +64,7 @@ CONTENTS                                                         *ale-contents*
       erlc................................|ale-erlang-erlc|
       syntaxerl...........................|ale-erlang-syntaxerl|
     eruby.................................|ale-eruby-options|
+    fish..................................|ale-fish-options|
     fortran...............................|ale-fortran-options|
       gcc.................................|ale-fortran-gcc|
     fusionscript..........................|ale-fuse-options|
@@ -300,6 +301,7 @@ Notes:
 * Elm: `elm-format, elm-make`
 * Erb: `erb`, `erubis`
 * Erlang: `erlc`, `SyntaxErl`
+* Fish: `fish` (-n flag)
 * Fortran: `gcc`
 * FusionScript: `fusion-lint`
 * Git Commit Messages: `gitlint`

--- a/test/handler/test_fish_handler.vader
+++ b/test/handler/test_fish_handler.vader
@@ -1,0 +1,39 @@
+Before:
+    runtime ale_linters/fish/fish.vim
+
+After:
+    call ale#linter#Reset()
+
+Execute(The fish handler should handle basic warnings and syntax errors):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 20,
+  \     'col': 23,
+  \     'text': "Unsupported use of '||'. In fish, please use 'COMMAND; or COMMAND'.",
+  \   },
+  \   {
+  \     'lnum': 26,
+  \     'col': 7,
+  \     'text': "Illegal command name '(prompt_pwd)'",
+  \   },
+  \   {
+  \     'lnum': 36,
+  \     'col': 1,
+  \     'text': "'end' outside of a block",
+  \   },
+  \ ],
+  \ ale_linters#fish#fish#Handle(1, [
+  \    "fish_prompt.fish (line 20): Unsupported use of '||'. In fish, please use 'COMMAND; or COMMAND'.",
+  \    'if set -q SSH_CLIENT || set -q SSH_TTY',
+  \    '                      ^',
+  \    "fish_prompt.fish (line 26): Illegal command name '(prompt_pwd)'",
+  \    '      (prompt_pwd) \',
+  \    '      ^',
+  \    "fish_prompt.fish (line 36): 'end' outside of a block",
+  \    'end',
+  \    '^',
+  \    'config.fish (line 45):',
+  \    "abbr --add p 'cd ~/Projects'",
+  \    '^',
+  \ ])


### PR DESCRIPTION
Simple linter for fish files, using output from `fish -n`

The output for `fish -n` is multiline, so required some hacky parsing.

Tests pass. Docs and readme updated.

I rarely write vim script, so if there are better and more readable ways to achieve what my code does, please let me know.
<!--
READ THIS: Before creating a pull request, please consider the following first.

* The most important thing you can do is write tests. Code without tests
  probably doesn't work, and will almost certainly stop working later on. Pull
  requests without tests probably won't be accepted, although there are some
  exceptions.
* Read the Contributing guide linked above first.
* If you are adding a new linter, remember to update the README.md file and
  doc/ale.txt first.
* If you add or modify a function for converting error lines into loclist items
  that ALE can work with, please add Vader tests for them. Look at existing
  tests in the test/handler directory, etc.
* If you add or modify a function for computing a command line string for
  running a command, please add Vader tests for that.
* Generally try and cover anything with Vader tests, although some things just
  can't be tested with Vader, or at least they can be hard to test. Consider
  breaking up your code so that some parts can be tested, and generally open up
  a discussion about it.
* Have fun!
-->
