### PR TITLE
Don't use temporary file for rustfmt fixer

### DIFF
--- a/autoload/ale/fixers/rustfmt.vim
+++ b/autoload/ale/fixers/rustfmt.vim
@@ -10,8 +10,6 @@ function! ale#fixers#rustfmt#Fix(buffer) abort
 
     return {
     \   'command': ale#Escape(l:executable)
-    \       . (empty(l:options) ? '' : ' ' . l:options)
-    \       . ' %t',
-    \   'read_temporary_file': 1,
+    \       . (empty(l:options) ? '' : ' ' . l:options),
     \}
 endfunction

--- a/test/fixers/test_rustfmt_fixer_callback.vader
+++ b/test/fixers/test_rustfmt_fixer_callback.vader
@@ -18,9 +18,7 @@ Execute(The rustfmt callback should return the correct default values):
 
   AssertEqual
   \ {
-  \   'read_temporary_file': 1,
-  \   'command': ale#Escape('xxxinvalid')
-  \     . ' %t',
+  \   'command': ale#Escape('xxxinvalid'),
   \ },
   \ ale#fixers#rustfmt#Fix(bufnr(''))
 
@@ -30,9 +28,7 @@ Execute(The rustfmt callback should include custom rustfmt options):
 
   AssertEqual
   \ {
-  \   'read_temporary_file': 1,
   \   'command': ale#Escape('xxxinvalid')
-  \     . ' ' . g:ale_rust_rustfmt_options
-  \     . ' %t',
+  \     . ' ' . g:ale_rust_rustfmt_options,
   \ },
   \ ale#fixers#rustfmt#Fix(bufnr(''))


### PR DESCRIPTION
rustfmt normally acts on a file in place, and applies configuration from rustfmt.toml files according to the path of the file.

Using a temporary file in `/tmp/` for rustfmt breaks this functionality, so removing the '%t' from the rustfmt command.