### PR TITLE
html: Avoid old tidy on macOS

### DIFF
--- a/ale_linters/html/tidy.vim
+++ b/ale_linters/html/tidy.vim
@@ -25,8 +25,16 @@ function! ale_linters#html#tidy#GetCommand(buffer) abort
     \   'utf-8':        '-utf8',
     \ }, &fileencoding, '-utf8')
 
+    " On macOS, old tidy (released on 31 Oct 2006) is installed. It does not
+    " consider HTML5 so we should avoid it.
+    let l:executable = ale#Var(a:buffer, 'html_tidy_executable')
+    if has('mac') && l:executable is# 'tidy' && exists('*exepath')
+    \  && exepath(l:executable) is# '/usr/bin/tidy'
+        return ''
+    endif
+
     return printf('%s %s %s -',
-    \   ale#Var(a:buffer, 'html_tidy_executable'),
+    \   l:executable,
     \   ale#Var(a:buffer, 'html_tidy_options'),
     \   l:file_encoding
     \)

--- a/doc/ale-html.txt
+++ b/doc/ale-html.txt
@@ -32,6 +32,21 @@ g:ale_html_htmlhint_use_global                 *g:ale_html_htmlhint_use_global*
 ===============================================================================
 tidy                                                            *ale-html-tidy*
 
+`tidy` is a console application which corrects and cleans up HTML and XML
+documents by fixing markup errors and upgrading legacy code to modern
+standards.
+
+Note:
+`/usr/bin/tidy` on macOS (installed by default) is too old. It was released
+on 31 Oct 2006. It does not consider modern HTML specs (HTML5) and shows
+outdated warnings. So |ale| ignores `/usr/bin/tidy` on macOS.
+
+To use `tidy` on macOS, please install the latest version with Homebrew:
+>
+  $ brew install tidy-html5
+<
+`/usr/local/bin/tidy` is installed.
+
 g:ale_html_tidy_executable                         *g:ale_html_tidy_executable*
                                                    *b:ale_html_tidy_executable*
   Type: |String|


### PR DESCRIPTION
## Problem

On macOS, Apple's command line toolchain installs very old `tidy` command (It was released on 31 Oct 2006) to `usr/bin`. It does not consider new specs such as HTML5 so we should avoid it.

## Solution

If `tidy` command is resolved to `/usr/bin/tidy`, let's say to ignore the executable to avoid above problem. I added `exists('*exepath')` check because `exepath()` was added to Vim recently.

<!--
READ THIS: Before creating a pull request, please consider the following first.

* The most important thing you can do is write tests. Code without tests
  probably doesn't work, and will almost certainly stop working later on. Pull
  requests without tests probably won't be accepted, although there are some
  exceptions.
* Read the Contributing guide linked above first.
* If you are adding a new linter, remember to update the README.md file and
  doc/ale.txt first.
* If you add or modify a function for converting error lines into loclist items
  that ALE can work with, please add Vader tests for them. Look at existing
  tests in the test/handler directory, etc.
* If you add or modify a function for computing a command line string for
  running a command, please add Vader tests for that.
* Generally try and cover anything with Vader tests, although some things just
  can't be tested with Vader, or at least they can be hard to test. Consider
  breaking up your code so that some parts can be tested, and generally open up
  a discussion about it.
* Have fun!
-->
