### PR TITLE
Make it possible to inject flags of protoc invocation.

### DIFF
--- a/ale_linters/proto/protoc_gen_lint.vim
+++ b/ale_linters/proto/protoc_gen_lint.vim
@@ -1,12 +1,20 @@
 " Author: Jeff Willette <jrwillette88@gmail.com>
 " Description: run the protoc-gen-lint plugin for the protoc binary
 
+call ale#Set('proto_protoc_gen_lint_options', '')
+
 function! ale_linters#proto#protoc_gen_lint#GetCommand(buffer) abort
     let l:dirname = expand('#' . a:buffer . ':p:h')
 
-    return 'protoc'
-    \   . ' -I ' . ale#Escape(l:dirname)
-    \   . ' --lint_out=. ' . '%s'
+    let l:options = ['-I ' . ale#Escape(l:dirname)]
+
+    if !empty(ale#Var(a:buffer, 'proto_protoc_gen_lint_options'))
+        let l:options += [ale#Var(a:buffer, 'proto_protoc_gen_lint_options')]
+    endif
+
+    let l:options += ['--lint_out=. ' . '%s']
+
+    return 'protoc' . ' ' . join(l:options)
 endfunction
 
 call ale#linter#Define('proto', {

--- a/doc/ale-proto.txt
+++ b/doc/ale-proto.txt
@@ -20,5 +20,14 @@ protoc-gen-lint                                      *ale-proto-protoc-gen-lint*
   The linter is a plugin for the `protoc` binary. As long as the binary resides
   in the system path, `protoc` will find it.
 
+g:ale_proto_protoc_gen_lint_options       *g:ale_proto_protoc_gen_lint_options*
+
+  Type: |String|
+  Default: `''`
+
+  This variable can be changed to modify flags given to protoc. Note that the
+  directory of the linted file is always passed as an include path with '-I'
+  before any user-supplied options.
+
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/test/command_callback/test_proto_command_callback.vader
+++ b/test/command_callback/test_proto_command_callback.vader
@@ -4,9 +4,18 @@ Before:
 After:
   Restore
 
+  unlet! b:ale_proto_protoc_gen_lint_options
+
   call ale#linter#Reset()
 
 Execute(The default command should be correct):
   AssertEqual
   \ 'protoc' . ' -I ' . ale#Escape(getcwd()) . ' --lint_out=. ' . '%s',
+  \ ale_linters#proto#protoc_gen_lint#GetCommand(bufnr(''))
+
+Execute(The callback should include any additional options):
+  let b:ale_proto_protoc_gen_lint_options = '--some-option'
+
+  AssertEqual
+  \ 'protoc' . ' -I ' . ale#Escape(getcwd()) . ' --some-option --lint_out=. ' . '%s',
   \ ale_linters#proto#protoc_gen_lint#GetCommand(bufnr(''))

--- a/test/command_callback/test_proto_command_callback.vader
+++ b/test/command_callback/test_proto_command_callback.vader
@@ -1,11 +1,9 @@
 Before:
-  call ale#test#SetDirectory('/testplugin/test/command_callback')
   call ale#test#SetFilename('test.proto')
 
 After:
   Restore
 
-  call ale#test#RestoreDirectory()
   call ale#linter#Reset()
 
 Execute(The default command should be correct):


### PR DESCRIPTION
Typically proto files depend on and make use of proto definitions in
other files. When invoking protoc user can supply paths to inspect for
dependencies.

This patch makes it possible to configure flags passed to protoc. This
makes it e.g., possible to change include paths of the linter's protoc
invocation.

<!--
READ THIS: Before creating a pull request, please consider the following first.

* The most important thing you can do is write tests. Code without tests
  probably doesn't work, and will almost certainly stop working later on. Pull
  requests without tests probably won't be accepted, although there are some
  exceptions.
* Read the Contributing guide linked above first.
* If you are adding a new linter, remember to update the README.md file and
  doc/ale.txt first.
* If you add or modify a function for converting error lines into loclist items
  that ALE can work with, please add Vader tests for them. Look at existing
  tests in the test/handler directory, etc.
* If you add or modify a function for computing a command line string for
  running a command, please add Vader tests for that.
* Generally try and cover anything with Vader tests, although some things just
  can't be tested with Vader, or at least they can be hard to test. Consider
  breaking up your code so that some parts can be tested, and generally open up
  a discussion about it.
* Have fun!
-->
