### PR TITLE
set missing Credo column to 1

### DIFF
--- a/ale_linters/elixir/credo.vim
+++ b/ale_linters/elixir/credo.vim
@@ -20,7 +20,7 @@ function! ale_linters#elixir#credo#Handle(buffer, lines) abort
         " column can be missing:
         "
         " lib/filename.ex:19: F: Pipe chain should start with a raw value.
-        let l:col = l:match[2] || 1
+        let l:col = empty(l:match[2]) ? 1 : l:match[2]
 
         call add(l:output, {
         \   'bufnr': a:buffer,

--- a/ale_linters/elixir/credo.vim
+++ b/ale_linters/elixir/credo.vim
@@ -17,10 +17,15 @@ function! ale_linters#elixir#credo#Handle(buffer, lines) abort
             let l:type = 'W'
         endif
 
+        " column can be missing:
+        "
+        " lib/filename.ex:19: F: Pipe chain should start with a raw value.
+        let l:col = l:match[2] || 1
+
         call add(l:output, {
         \   'bufnr': a:buffer,
         \   'lnum': l:match[1] + 0,
-        \   'col': l:match[2] + 0,
+        \   'col': l:col + 0,
         \   'type': l:type,
         \   'text': l:text,
         \})

--- a/test/handler/test_credo_handler.vader
+++ b/test/handler/test_credo_handler.vader
@@ -17,7 +17,7 @@ Execute(The credo handler should parse lines correctly):
   \   {
   \     'bufnr': 347,
   \     'lnum': 26,
-  \     'col': 0,
+  \     'col': 1,
   \     'text': 'If/else blocks should not have a negated condition in `if`.',
   \     'type': 'W',
   \   },


### PR DESCRIPTION
Credo column might be missing in Credo output:

```
lib/filename.ex:19: F: Pipe chain should start with a raw value.
```

in this case it's set to 0 in _credo.vim_:

```vim
\   'col': l:match[2] + 0,
```

but 0 is invalid Vim column - it causes a bug when navigating to previous issue with `ALEPrevious` or `ALEPreviousWrap` commands.