### PR TITLE
Teach ALE about cargo features and add some configuration options

### DIFF
--- a/ale_linters/rust/cargo.vim
+++ b/ale_linters/rust/cargo.vim
@@ -1,8 +1,11 @@
-" Author: Daniel Schemala <istjanichtzufassen@gmail.com>
+" Author: Daniel Schemala <istjanichtzufassen@gmail.com>,
+" Ivan Petkov <ivanppetkov@gmail.com>
 " Description: rustc invoked by cargo for rust files
 
 call ale#Set('rust_cargo_use_check', 1)
 call ale#Set('rust_cargo_check_all_targets', 0)
+call ale#Set('rust_cargo_default_feature_behavior', 'default')
+call ale#Set('rust_cargo_include_features', '')
 
 function! ale_linters#rust#cargo#GetCargoExecutable(bufnr) abort
     if ale#path#FindNearestFile(a:bufnr, 'Cargo.toml') isnot# ''
@@ -29,10 +32,27 @@ function! ale_linters#rust#cargo#GetCommand(buffer, version_output) abort
     \   && ale#Var(a:buffer, 'rust_cargo_check_all_targets')
     \   && ale#semver#GTE(l:version, [0, 22, 0])
 
+    let l:include_features = ale#Var(a:buffer, 'rust_cargo_include_features')
+    if !empty(l:include_features)
+        let l:include_features = ' --features ' . ale#Escape(l:include_features)
+    endif
+
+    let l:default_feature_behavior = ale#Var(a:buffer, 'rust_cargo_default_feature_behavior')
+    if l:default_feature_behavior is# 'all'
+        let l:include_features = ''
+        let l:default_feature = ' --all-features'
+    elseif l:default_feature_behavior is# 'none'
+        let l:default_feature = ' --no-default-features'
+    else
+        let l:default_feature = ''
+    endif
+
     return 'cargo '
     \   . (l:use_check ? 'check' : 'build')
     \   . (l:use_all_targets ? ' --all-targets' : '')
     \   . ' --frozen --message-format=json -q'
+    \   . l:default_feature
+    \   . l:include_features
 endfunction
 
 call ale#linter#Define('rust', {

--- a/doc/ale-rust.txt
+++ b/doc/ale-rust.txt
@@ -59,6 +59,36 @@ g:ale_rust_cargo_check_all_targets         *g:ale_rust_cargo_check_all_targets*
   is used. See |g:ale_rust_cargo_use_check|,
 
 
+g:ale_rust_cargo_default_feature_behavior
+                                    *g:ale_rust_cargo_default_feature_behavior*
+                                    *b:ale_rust_cargo_default_feature_behavior*
+  Type: |String|
+  Default: `default`
+
+  When set to `none`, ALE will set the `--no-default-features` option when
+  invoking `cargo`. Only the features specified in
+  |g:ale_rust_cargo_include_features| will be included when performing the
+  lint check.
+
+  When set to `default`, ALE will instruct `cargo` to build all default
+  features specified in the project's `Cargo.toml` file, in addition to
+  including any additional features defined in
+  |g:ale_rust_cargo_include_features|.
+
+  When set to `all`, ALE will set the `--all-features` option when
+  invoking `cargo`, which will include all features defined in the project's
+  `Cargo.toml` file when performing the lint check.
+
+
+g:ale_rust_cargo_include_features           *g:ale_rust_cargo_include_features*
+                                            *b:ale_rust_cargo_include_features*
+  Type: |String|
+  Default: `''`
+
+  When defined, ALE will set the `--features` option when invoking `cargo` to
+  perform the lint check. See |g:ale_rust_cargo_default_feature_behavior|.
+
+
 ===============================================================================
 rls                                                              *ale-rust-rls*
 

--- a/test/command_callback/test_cargo_command_callbacks.vader
+++ b/test/command_callback/test_cargo_command_callbacks.vader
@@ -1,9 +1,13 @@
 Before:
   Save g:ale_rust_cargo_use_check
   Save g:ale_rust_cargo_check_all_targets
+  Save g:ale_rust_cargo_default_feature_behavior
+  Save g:ale_rust_cargo_include_features
 
   unlet! g:ale_rust_cargo_use_check
   unlet! g:ale_cargo_check_all_targets
+  unlet! g:ale_rust_cargo_default_feature_behavior
+  unlet! g:ale_rust_cargo_include_features
 
   runtime ale_linters/rust/cargo.vim
   call ale#test#SetDirectory('/testplugin/test/command_callback')
@@ -114,3 +118,47 @@ Execute(--all-targets should be used when g:ale_rust_cargo_check_all_targets is 
   \ ale_linters#rust#cargo#GetCommand(bufnr(''), [])
 
   AssertEqual '', ale_linters#rust#cargo#VersionCheck(bufnr(''))
+
+Execute(--no-default-features should be used when g:ale_rust_cargo_default_feature_behavior is none):
+  let g:ale_rust_cargo_default_feature_behavior = 'none'
+
+  AssertEqual
+  \ 'cargo check' . g:suffix . ' --no-default-features',
+  \ ale_linters#rust#cargo#GetCommand(bufnr(''), [
+  \   'cargo 0.22.0 (3423351a5 2017-10-06)',
+  \ ])
+
+Execute(g:ale_rust_cargo_include_features added when g:ale_rust_cargo_default_feature_behavior is none):
+  let g:ale_rust_cargo_default_feature_behavior = 'none'
+  let g:ale_rust_cargo_include_features = 'foo bar'
+
+  AssertEqual
+  \ 'cargo check' . g:suffix . ' --no-default-features --features ' .
+  \ (fnamemodify(&shell, ':t') is? 'cmd.exe' ? '"foo bar"' : "'foo bar'"),
+  \ ale_linters#rust#cargo#GetCommand(bufnr(''), [
+  \   'cargo 0.22.0 (3423351a5 2017-10-06)',
+  \ ])
+
+Execute(g:ale_rust_cargo_include_features added and escaped):
+  let g:ale_rust_cargo_default_feature_behavior = 'default'
+  let g:ale_rust_cargo_include_features = "foo bar baz"
+
+  AssertEqual
+  \ 'cargo check' . g:suffix . ' --features ' .
+  \ (fnamemodify(&shell, ':t') is? 'cmd.exe' ? '"foo bar baz"' : "'foo bar baz'"),
+  \ ale_linters#rust#cargo#GetCommand(bufnr(''), [
+  \   'cargo 0.22.0 (3423351a5 2017-10-06)',
+  \ ])
+
+Execute(--all-features should be used when g:ale_rust_cargo_default_feature_behavior is all):
+  let g:ale_rust_cargo_default_feature_behavior = 'all'
+
+  " When all features are enabled we should ignore extra features to add
+  " since it won't do anything
+  let g:ale_rust_cargo_include_features = 'foo bar'
+
+  AssertEqual
+  \ 'cargo check' . g:suffix . ' --all-features',
+  \ ale_linters#rust#cargo#GetCommand(bufnr(''), [
+  \   'cargo 0.22.0 (3423351a5 2017-10-06)',
+  \ ])


### PR DESCRIPTION
* When working on rust/cargo projects of varying sizes, it may be useful
to either build all possible features (i.e. lint all possible
conditionally compiled code), or even turn off other features for a
quicker edit-lint cycle (e.g. for large projects with large build times)
* Added a `g:ale_rust_cargo_default_feature_behavior` flag for instructing
cargo to not build any features at all (via `--no-default-features`),
building default features (via no extra flags), or building all possible
features (via `--all-features`)
* Also added a `g:ale_rust_cargo_include_features` flag for including
arbitrary features to be checked by cargo. When coupled with
`g:ale_rust_cargo_default_feature_behavior` this allows for full
customization of what features are checked and which ones are ignored

Note: for some reason running `help g:ale_rust_cargo_default_feature_behavior` or `help g:ale_rust_cargo_include_features` fails to look up the documentation. I believe the doc page is formatted correctly, I'm pretty new to Vim plugin development, so I'm not exactly sure what's wrong there or how to debug it