### PR TITLE
Send didSave message to LSP-based linters

### DIFF
--- a/autoload/ale/engine.vim
+++ b/autoload/ale/engine.vim
@@ -703,6 +703,13 @@ function! s:CheckWithLSP(buffer, linter) abort
     \   : ale#lsp#message#DidChange(a:buffer)
     let l:request_id = ale#lsp#Send(l:id, l:change_message, l:root)
 
+    " If this was a file save event, also notify the server of that.
+    let l:is_save = getbufvar(a:buffer, 'ale_save_event_fired', 0)
+    if l:is_save != 0
+      let l:save_message = ale#lsp#message#DidSave(a:buffer)
+      let l:request_id = ale#lsp#Send(l:id, l:save_message, l:root)
+    endif
+
     if l:request_id != 0
         if index(l:info.active_linter_list, a:linter.name) < 0
             call add(l:info.active_linter_list, a:linter.name)

--- a/test/lsp/test_lsp_communication.vader
+++ b/test/lsp/test_lsp_communication.vader
@@ -1,0 +1,97 @@
+Before:
+  Save g:ale_lint_on_save
+  Save g:ale_enabled
+  Save g:ale_linters
+  Save g:ale_run_synchronously
+
+  call ale#test#SetDirectory('/testplugin/test/completion')
+  call ale#test#SetFilename('dummy.txt')
+
+  runtime autoload/ale/lsp.vim
+
+  let g:ale_lint_on_save = 1
+  let b:ale_enabled = 1
+  let g:ale_lsp_next_message_id = 1
+  let g:ale_run_synchronously = 1
+  let g:message_list = []
+  let g:Callback = ''
+
+  call ale#linter#Define('foobar', {
+  \ 'name': 'dummy_linter',
+  \ 'lsp': 'stdio',
+  \ 'command': 'cat - > /dev/null',
+  \ 'executable': has('win32') ? 'cmd' : 'echo',
+  \ 'language_callback': {buffer -> 'foobar'},
+  \ 'project_root_callback': {buffer -> expand('.')},
+  \ })
+  let g:ale_linters = {'foobar': ['dummy_linter']}
+
+  function! ale#linter#StartLSP(buffer, linter, callback) abort
+    let g:Callback = a:callback
+
+    return {
+    \ 'connection_id': 347,
+    \ 'project_root': '/foo/bar',
+    \}
+  endfunction
+
+  " Replace the Send function for LSP, so we can monitor calls to it.
+  function! ale#lsp#Send(conn_id, message, ...) abort
+    call add(g:message_list, a:message)
+  endfunction
+
+After:
+  Restore
+
+  unlet! b:ale_enabled
+  unlet! b:ale_linters
+  unlet! g:Callback
+  unlet! g:message_list
+
+  call ale#test#RestoreDirectory()
+  call ale#linter#Reset()
+
+  " Stop any timers we left behind.
+  " This stops the tests from failing randomly.
+  call ale#completion#StopTimer()
+
+  runtime autoload/ale/completion.vim
+  runtime autoload/ale/lsp.vim
+
+Given foobar (Some imaginary filetype):
+  <contents>
+
+Execute(Server should be notified on save):
+  call ale#events#SaveEvent(bufnr(''))
+
+  AssertEqual
+  \ [
+  \   [1, 'textDocument/didChange', {
+  \     'textDocument': {
+  \       'uri': ale#path#ToURI(expand('%:p')),
+  \       'version': g:ale_lsp_next_version_id - 1,
+  \     },
+  \     'contentChanges': [{'text': join(getline(1, '$'), "\n") . "\n"}],
+  \   }],
+  \   [1, 'textDocument/didSave', {
+  \     'textDocument': {
+  \       'uri': ale#path#ToURI(expand('%:p')),
+  \     },
+  \   }],
+  \ ],
+  \ g:message_list
+
+Execute(Server should be notified on change):
+  call ale#events#FileChangedEvent(bufnr(''))
+
+  AssertEqual
+  \ [
+  \   [1, 'textDocument/didChange', {
+  \     'textDocument': {
+  \       'uri': ale#path#ToURI(expand('%:p')),
+  \       'version': g:ale_lsp_next_version_id - 1,
+  \     },
+  \     'contentChanges': [{'text': join(getline(1, '$'), "\n") . "\n"}],
+  \   }],
+  \ ],
+  \ g:message_list


### PR DESCRIPTION
#1288: We should also notify the LSP server of saves.

One situation where this might be important is if an LSP would handle saves differently, e.g. starting more expensive checks. Currently, the server is only notified on changes, and all that `:ALELint` does is to send a new `didChange` event.

With this patch, if the file has just been saved we'll send both a `didChange` and a `didSave` event (the `didChange` being at most redundant and probably harmless). 

Tests were heavily based on test/completion/test_lsp_completion_messages.vader, which is the only test I found that mocked communication with the server, although I don't think this test would fit in that file since it's not about completion.