### PR TITLE
Call lintr library before linting

### DIFF
--- a/ale_linters/r/lintr.vim
+++ b/ale_linters/r/lintr.vim
@@ -1,14 +1,17 @@
 " Author: Michel Lang <michellang@gmail.com>, w0rp <devw0rp@gmail.com>
 " Description: This file adds support for checking R code with lintr.
 
-let g:ale_r_lintr_options =
-\   get(g:, 'ale_r_lintr_options', 'lintr::with_defaults()')
+let g:ale_r_lintr_options = get(g:, 'ale_r_lintr_options', 'with_defaults()')
 " A reasonable alternative default:
-" \   get(g:, 'ale_r_lintr_options', 'lintr::with_defaults(object_usage_linter = NULL)')
+"   get(g:, 'ale_r_lintr_options', 'with_defaults(object_usage_linter = NULL)')
 
 function! ale_linters#r#lintr#GetCommand(buffer) abort
+    let l:cmd_string = 'suppressPackageStartupMessages(library(lintr));'
+          \ . 'lint(cache = FALSE, commandArgs(TRUE),'
+          \ . ale#Var(a:buffer, 'r_lintr_options') . ')'
     return ale#path#BufferCdString(a:buffer)
-    \   . 'Rscript -e ' . ale#Escape('lintr::lint(commandArgs(TRUE)[1], eval(parse(text = commandArgs(TRUE)[2])))') . ' %t' . ' ' . ale#Escape(ale#Var(a:buffer, 'r_lintr_options'))
+    \   . 'Rscript -e '
+    \   . ale#Escape(l:cmd_string) . ' %t'
 endfunction
 
 call ale#linter#Define('r', {
@@ -18,3 +21,4 @@ call ale#linter#Define('r', {
 \   'callback': 'ale#handlers#gcc#HandleGCCFormat',
 \   'output_stream': 'both',
 \})
+

--- a/ale_linters/r/lintr.vim
+++ b/ale_linters/r/lintr.vim
@@ -7,8 +7,9 @@ let g:ale_r_lintr_options = get(g:, 'ale_r_lintr_options', 'with_defaults()')
 
 function! ale_linters#r#lintr#GetCommand(buffer) abort
     let l:cmd_string = 'suppressPackageStartupMessages(library(lintr));'
-          \ . 'lint(cache = FALSE, commandArgs(TRUE),'
-          \ . ale#Var(a:buffer, 'r_lintr_options') . ')'
+    \   . 'lint(cache = FALSE, commandArgs(TRUE),'
+    \   . ale#Var(a:buffer, 'r_lintr_options') . ')'
+
     return ale#path#BufferCdString(a:buffer)
     \   . 'Rscript -e '
     \   . ale#Escape(l:cmd_string) . ' %t'
@@ -21,4 +22,3 @@ call ale#linter#Define('r', {
 \   'callback': 'ale#handlers#gcc#HandleGCCFormat',
 \   'output_stream': 'both',
 \})
-

--- a/test/command_callback/test_lintr_command_callback.vader
+++ b/test/command_callback/test_lintr_command_callback.vader
@@ -17,18 +17,20 @@ Execute(The default lintr command should be correct):
   AssertEqual
   \   'cd ' . ale#Escape(getcwd()) . ' && '
   \   . 'Rscript -e '
-  \   . ale#Escape('lintr::lint(commandArgs(TRUE)[1], eval(parse(text = commandArgs(TRUE)[2])))')
-  \   . ' %t '
-  \   . ale#Escape('lintr::with_defaults()'),
+  \   . ale#Escape('suppressPackageStartupMessages(library(lintr));'
+      \   .            'lint(cache = FALSE, commandArgs(TRUE),'
+      \   .            'with_defaults())')
+  \   . ' %t',
   \ ale_linters#r#lintr#GetCommand(bufnr(''))
 
 Execute(The lintr options should be configurable):
-  let b:ale_r_lintr_options = 'lintr::with_defaults(object_usage_linter = NULL)'
+  let b:ale_r_lintr_options = 'with_defaults(object_usage_linter = NULL)'
 
   AssertEqual
   \   'cd ' . ale#Escape(getcwd()) . ' && '
   \   . 'Rscript -e '
-  \   . ale#Escape('lintr::lint(commandArgs(TRUE)[1], eval(parse(text = commandArgs(TRUE)[2])))')
-  \   . ' %t '
-  \   . ale#Escape('lintr::with_defaults(object_usage_linter = NULL)'),
+  \   . ale#Escape('suppressPackageStartupMessages(library(lintr));'
+      \   .            'lint(cache = FALSE, commandArgs(TRUE),'
+      \   .            'with_defaults(object_usage_linter = NULL))')
+  \   . ' %t',
   \ ale_linters#r#lintr#GetCommand(bufnr(''))


### PR DESCRIPTION
This solves namespace issues related to the objects used to set linting options.

<!--
READ THIS: Before creating a pull request, please consider the following first.

* The most important thing you can do is write tests. Code without tests
  probably doesn't work, and will almost certainly stop working later on. Pull
  requests without tests probably won't be accepted, although there are some
  exceptions.
* Read the Contributing guide linked above first.
* If you are adding a new linter, remember to update the README.md file and
  doc/ale.txt first.
* If you add or modify a function for converting error lines into loclist items
  that ALE can work with, please add Vader tests for them. Look at existing
  tests in the test/handler directory, etc.
* If you add or modify a function for computing a command line string for
  running a command, please add Vader tests for that.
* Generally try and cover anything with Vader tests, although some things just
  can't be tested with Vader, or at least they can be hard to test. Consider
  breaking up your code so that some parts can be tested, and generally open up
  a discussion about it.
* Have fun!
-->
