### PR TITLE
Use filename in unix matcher

### DIFF
--- a/autoload/ale/handlers/unix.vim
+++ b/autoload/ale/handlers/unix.vim
@@ -2,14 +2,15 @@
 " Description: Error handling for errors in a Unix format.
 
 function! s:HandleUnixFormat(buffer, lines, type) abort
-    let l:pattern = '\v^[a-zA-Z]?:?[^:]+:(\d+):?(\d+)?:? ?(.+)$'
+    let l:pattern = '\v^(([a-zA-Z]:)?[^:]+):(\d+):?(\d+)?:? ?(.+)$'
     let l:output = []
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)
         call add(l:output, {
-        \   'lnum': l:match[1] + 0,
-        \   'col': l:match[2] + 0,
-        \   'text': l:match[3],
+        \   'filename': l:match[1],
+        \   'lnum': l:match[3] + 0,
+        \   'col': l:match[4] + 0,
+        \   'text': l:match[5],
         \   'type': a:type,
         \})
     endfor

--- a/test/handler/test_common_handlers.vader
+++ b/test/handler/test_common_handlers.vader
@@ -79,18 +79,21 @@ Execute (HandleUnixFormatAsError should handle some example lines of output):
   AssertEqual
   \ [
   \   {
+  \     'filename': 'file.go',
   \     'lnum': 27,
   \     'col': 0,
   \     'type': 'E',
   \     'text': 'missing argument for Printf("%s"): format reads arg 2, have only 1 args',
   \   },
   \   {
+  \     'filename': 'file.go',
   \     'lnum': 53,
   \     'col': 10,
   \     'type': 'E',
   \     'text': 'if block ends with a return statement, so drop this else and outdent its block (move short variable declaration to its own line if necessary)',
   \   },
   \   {
+  \     'filename': 'test.pug',
   \     'lnum': 1,
   \     'col': 1,
   \     'type': 'E',
@@ -107,12 +110,14 @@ Execute (HandleUnixFormatAsError should handle lines with no space after the col
   AssertEqual
   \ [
   \   {
+  \     'filename': 'some_file.xyz',
   \     'lnum': 27,
   \     'col': 0,
   \     'type': 'E',
   \     'text': 'foo',
   \   },
   \   {
+  \     'filename': 'some_file.xyz',
   \     'lnum': 53,
   \     'col': 10,
   \     'type': 'E',
@@ -128,6 +133,7 @@ Execute (HandleUnixFormatAsError should handle names with spaces):
   AssertEqual
   \ [
   \   {
+  \     'filename': '/Users/rrj/Notes/Astro/Taurus December SM.txt',
   \     'lnum': 13,
   \     'col': 90,
   \     'type': 'E',
@@ -142,12 +148,14 @@ Execute (HandleUnixFormatAsWarning should handle some example lines of output):
   AssertEqual
   \ [
   \   {
+  \     'filename': 'file.go',
   \     'lnum': 27,
   \     'col': 0,
   \     'type': 'W',
   \     'text': 'missing argument for Printf("%s"): format reads arg 2, have only 1 args',
   \   },
   \   {
+  \     'filename': 'file.go',
   \     'lnum': 53,
   \     'col': 10,
   \     'type': 'W',
@@ -163,12 +171,14 @@ Execute (Unix format functions should handle Windows paths):
   AssertEqual
   \ [
   \   {
+  \     'filename': 'C:\Users\w0rp\AppData\Local\Temp\Xyz123.go',
   \     'lnum': 27,
   \     'col': 0,
   \     'type': 'E',
   \     'text': 'foo',
   \   },
   \   {
+  \     'filename': 'C:\Users\w0rp\AppData\Local\Temp\Xyz123.go',
   \     'lnum': 53,
   \     'col': 10,
   \     'type': 'E',


### PR DESCRIPTION
I ran into the issue that the `gotype` matcher matched all lines to the current file, even though some were for other files.
<!--
READ THIS: Before creating a pull request, please consider the following first.

* The most important thing you can do is write tests. Code without tests
  probably doesn't work, and will almost certainly stop working later on. Pull
  requests without tests probably won't be accepted, although there are some
  exceptions.
* Read the Contributing guide linked above first.
* If you are adding a new linter, remember to update the README.md file and
  doc/ale.txt first.
* If you add or modify a function for converting error lines into loclist items
  that ALE can work with, please add Vader tests for them. Look at existing
  tests in the test/handler directory, etc.
* If you add or modify a function for computing a command line string for
  running a command, please add Vader tests for that.
* Generally try and cover anything with Vader tests, although some things just
  can't be tested with Vader, or at least they can be hard to test. Consider
  breaking up your code so that some parts can be tested, and generally open up
  a discussion about it.
* Have fun!
-->