### PR TITLE
Respect buffer-level ale_lint_on_* variables

### DIFF
--- a/autoload/ale/toggle.vim
+++ b/autoload/ale/toggle.vim
@@ -1,7 +1,4 @@
 function! ale#toggle#InitAuGroups() abort
-    " This value used to be a Boolean as a Number, and is now a String.
-    let l:text_changed = '' . g:ale_lint_on_text_changed
-
     augroup ALEPatternOptionsGroup
         autocmd!
         autocmd BufEnter,BufRead * call ale#pattern_options#SetOptions(str2nr(expand('<abuf>')))
@@ -10,13 +7,7 @@ function! ale#toggle#InitAuGroups() abort
     augroup ALERunOnTextChangedGroup
         autocmd!
         if g:ale_enabled
-            if l:text_changed is? 'always' || l:text_changed is# '1'
-                autocmd TextChanged,TextChangedI * call ale#Queue(g:ale_lint_delay)
-            elseif l:text_changed is? 'normal'
-                autocmd TextChanged * call ale#Queue(g:ale_lint_delay)
-            elseif l:text_changed is? 'insert'
-                autocmd TextChangedI * call ale#Queue(g:ale_lint_delay)
-            endif
+            autocmd TextChanged,TextChangedI * call ale#events#TextChangedEvent(str2nr(expand('<abuf>')))
         endif
     augroup END
 
@@ -35,7 +26,7 @@ function! ale#toggle#InitAuGroups() abort
 
     augroup ALERunOnFiletypeChangeGroup
         autocmd!
-        if g:ale_enabled && g:ale_lint_on_filetype_changed
+        if g:ale_enabled
             " Only start linting if the FileType actually changes after
             " opening a buffer. The FileType will fire when buffers are opened.
             autocmd FileType * call ale#events#FileTypeEvent(
@@ -52,8 +43,8 @@ function! ale#toggle#InitAuGroups() abort
 
     augroup ALERunOnInsertLeave
         autocmd!
-        if g:ale_enabled && g:ale_lint_on_insert_leave
-            autocmd InsertLeave * call ale#Queue(0)
+        if g:ale_enabled
+            autocmd InsertLeave * call ale#events#InsertLeaveEvent(str2nr(expand('<abuf>')))
         endif
     augroup END
 

--- a/test/test_buffer_lint_on_override.vader
+++ b/test/test_buffer_lint_on_override.vader
@@ -1,0 +1,47 @@
+Before:
+  let g:unchanged_success = 1
+  let g:ale_run_synchronously = 1
+
+  Save g:ale_pattern_options
+  Save g:ale_pattern_options_enabled
+  Save &filetype
+
+  let g:ale_pattern_options_enabled = 1
+  let g:ale_pattern_options = {}
+
+After:
+  Restore
+  let g:ale_run_synchronously = 0
+  augroup VaderTest
+      autocmd!
+  augroup end
+  augroup! VaderTest
+
+Execute (Setup pattern options to override global variables ale_lint_on_*, verify they are respected):
+  let g:ale_pattern_options = {
+  \ '.*\.js': {
+  \   'ale_enabled': 1,
+  \   'ale_lint_on_enter': 0,
+  \   'ale_lint_on_text_changed': 0,
+  \   'ale_lint_on_insert_leave': 0,
+  \   'ale_lint_on_save': 0,
+  \   'ale_lint_on_filetype_changed': 0,
+  \ },
+  \}
+
+  augroup VaderTest
+    autocmd!
+    autocmd User ALELintPost let g:unchanged_success = 0
+  augroup end
+
+  call ale#test#SetFilename('foobar.js')
+  call ale#pattern_options#SetOptions(bufnr(''))
+  set filetype=javascript
+
+  call ale#events#EnterEvent(bufnr(''))
+  call ale#events#TextChangedEvent(bufnr(''))
+  call ale#events#InsertLeaveEvent(bufnr(''))
+  call ale#events#SaveEvent(bufnr(''))
+  call ale#events#FileTypeEvent(bufnr(''), 'javascript')
+
+  AssertEqual 1, g:unchanged_success


### PR DESCRIPTION
This makes ale check for buffer-level (i.e. `b:..`) versions of the `ale_lint_on_*` variables before linting.

I implemented this because I wanted to be able to e.g. not lint on text change for very large files using `ale_pattern_options`, but still lint on save, etc. However I noticed it was written to only check `g:ale_lint_on_*` and not `b:ale_lint_on_*`.