### PR TITLE
fix issue with go1.10 govet

### DIFF
--- a/ale_linters/go/govet.vim
+++ b/ale_linters/go/govet.vim
@@ -1,10 +1,42 @@
 " Author: neersighted <bjorn@neersighted.com>
 " Description: go vet for Go files
+"
+" Author: John Eikenberry <jae@zhar.net>
+" Description: updated to work with go1.10
+
+" set 'b:ale_go_govet_lint_package = 1' to enable
+call ale#Set('go_govet_lint_package', 0)
+
+function! ale_linters#go#govet#GetCommand(buffer) abort
+    let l:lint_package = ale#Var(a:buffer, 'go_govet_lint_package')
+    if l:lint_package
+        return ale#path#BufferCdString(a:buffer) . ' go vet .'
+    endif
+    return 'go tool vet %t'
+endfunction
+
+function! ale_linters#go#govet#Handler(buffer, lines) abort
+    let l:pattern = '\v^([a-zA-Z]?:?[^:]+):(\d+):?(\d+)?:? ?(.+)$'
+    let l:output = []
+    let l:dir = expand('#' . a:buffer . ':p:h')
+
+    for l:match in ale#util#GetMatches(a:lines, l:pattern)
+        call add(l:output, {
+        \   'filename': ale#path#GetAbsPath(l:dir, l:match[1]),
+        \   'lnum': l:match[2] + 0,
+        \   'col': l:match[3] + 0,
+        \   'text': l:match[4],
+        \   'type': 'E',
+        \})
+    endfor
+    return l:output
+endfunction
 
 call ale#linter#Define('go', {
 \   'name': 'go vet',
 \   'output_stream': 'stderr',
 \   'executable': 'go',
-\   'command': 'go vet %t',
-\   'callback': 'ale#handlers#unix#HandleAsError',
+\   'command_callback': 'ale_linters#go#govet#GetCommand',
+\   'callback': 'ale_linters#go#govet#Handler',
+\   'lint_file': 1,
 \})


### PR DESCRIPTION
In go1.10 they have extended 'go vet' with access to more information.
As a side effect it seems you can no longer run 'go vet' against a
single file. You now need to specify all the files or the package.

Similar to w0rp/ale#936, without this it fails to find anything
(types, functions, etc) the other files in the package and reports a
bunch of spurious errors.

This change runs 'go vet' over the package containing the file loaded in
the current buffer.