### PR TITLE
New linter: Flawfinder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Asynchronous Lint Engine [![Travis CI Build Status](https://travis-ci.org/w0rp/ale.svg?branch=master)](https://travis-ci.org/w0rp/ale) [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/r0ef1xu8xjmik58d/branch/master?svg=true)](https://ci.appveyor.com/project/w0rp/ale)
+# Asynchronous Lint Engine [![Travis CI Build Status](https://travis-ci.org/w-1rp/ale.svg?branch=master)](https://travis-ci.org/w0rp/ale) [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/r0ef1xu8xjmik58d/branch/master?svg=true)](https://ci.appveyor.com/project/w0rp/ale)
 
 
 ![ALE Logo by Mark Grealish - https://www.bhalash.com/](img/logo.jpg?raw=true)
@@ -79,8 +79,8 @@ formatting.
 | Awk | [gawk](https://www.gnu.org/software/gawk/)|
 | Bash | shell [-n flag](https://www.gnu.org/software/bash/manual/bash.html#index-set), [shellcheck](https://www.shellcheck.net/), [shfmt](https://github.com/mvdan/sh) |
 | Bourne Shell | shell [-n flag](http://linux.die.net/man/1/sh), [shellcheck](https://www.shellcheck.net/), [shfmt](https://github.com/mvdan/sh) |
-| C | [cppcheck](http://cppcheck.sourceforge.net), [cpplint](https://github.com/google/styleguide/tree/gh-pages/cpplint), [gcc](https://gcc.gnu.org/), [clang](http://clang.llvm.org/), [clangtidy](http://clang.llvm.org/extra/clang-tidy/) !!, [clang-format](https://clang.llvm.org/docs/ClangFormat.html)|
-| C++ (filetype cpp) | [clang](http://clang.llvm.org/), [clangcheck](http://clang.llvm.org/docs/ClangCheck.html) !!, [clangtidy](http://clang.llvm.org/extra/clang-tidy/) !!, [clang-format](https://clang.llvm.org/docs/ClangFormat.html), [cppcheck](http://cppcheck.sourceforge.net), [cpplint](https://github.com/google/styleguide/tree/gh-pages/cpplint) !!, [gcc](https://gcc.gnu.org/) |
+| C | [cppcheck](http://cppcheck.sourceforge.net), [cpplint](https://github.com/google/styleguide/tree/gh-pages/cpplint), [clang](http://clang.llvm.org/), [clangtidy](http://clang.llvm.org/extra/clang-tidy/) !!, [clang-format](https://clang.llvm.org/docs/ClangFormat.html), [flawfinder](https://www.dwheeler.com/flawfinder/), [gcc](https://gcc.gnu.org/) |
+| C++ (filetype cpp) | [clang](http://clang.llvm.org/), [clangcheck](http://clang.llvm.org/docs/ClangCheck.html) !!, [clangtidy](http://clang.llvm.org/extra/clang-tidy/) !!, [clang-format](https://clang.llvm.org/docs/ClangFormat.html), [cppcheck](http://cppcheck.sourceforge.net), [cpplint](https://github.com/google/styleguide/tree/gh-pages/cpplint) !!, [flawfinder](https://www.dwheeler.com/flawfinder/), [gcc](https://gcc.gnu.org/) |
 | CUDA | [nvcc](http://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html) |
 | C# | [mcs](http://www.mono-project.com/docs/about-mono/languages/csharp/) see:`help ale-cs-mcs` for details, [mcsc](http://www.mono-project.com/docs/about-mono/languages/csharp/) !! see:`help ale-cs-mcsc` for details and configuration|
 | Chef | [foodcritic](http://www.foodcritic.io/) |

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Asynchronous Lint Engine [![Travis CI Build Status](https://travis-ci.org/w-1rp/ale.svg?branch=master)](https://travis-ci.org/w0rp/ale) [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/r0ef1xu8xjmik58d/branch/master?svg=true)](https://ci.appveyor.com/project/w0rp/ale)
+# Asynchronous Lint Engine [![Travis CI Build Status](https://travis-ci.org/w0rp/ale.svg?branch=master)](https://travis-ci.org/w0rp/ale) [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/r0ef1xu8xjmik58d/branch/master?svg=true)](https://ci.appveyor.com/project/w0rp/ale)
 
 
 ![ALE Logo by Mark Grealish - https://www.bhalash.com/](img/logo.jpg?raw=true)

--- a/ale_linters/c/flawfinder.vim
+++ b/ale_linters/c/flawfinder.vim
@@ -3,6 +3,7 @@
 
 call ale#Set('c_flawfinder_executable', 'flawfinder')
 call ale#Set('c_flawfinder_options', '')
+call ale#Set('c_flawfinder_minlevel', 1)
 
 function! ale_linters#c#flawfinder#GetExecutable(buffer) abort
    return ale#Var(a:buffer, 'c_flawfinder_executable')
@@ -11,15 +12,7 @@ endfunction
 function! ale_linters#c#flawfinder#GetCommand(buffer) abort
 
    " Set the minimum vulnerability level for flawfinder to bother with
-   " Default to level 1 as that is flawfinder's default level
-   let l:minlevel = ' --minlevel='
-   if exists('b:ale_c_flawfinder_minlevel')
-      let l:minlevel = l:minlevel . b:ale_c_flawfinder_minlevel
-   elseif exists('g:ale_c_flawfinder_minlevel')
-      let l:minlevel = l:minlevel . g:ale_c_flawfinder_minlevel
-   else
-      let l:minlevel = l:minlevel . '1'
-   endif
+   let l:minlevel = ' --minlevel=' . ale#Var(a:buffer, 'c_flawfinder_minlevel')
 
    return ale#Escape(ale_linters#c#flawfinder#GetExecutable(a:buffer))
    \  . ' -CDQS'

--- a/ale_linters/c/flawfinder.vim
+++ b/ale_linters/c/flawfinder.vim
@@ -1,0 +1,37 @@
+" Author: Christian Gibbons <cgibbons@gmu.edu>
+" Description: flawfinder linter for c files
+
+call ale#Set('c_flawfinder_executable', 'flawfinder')
+call ale#Set('c_flawfinder_options', '')
+
+function! ale_linters#c#flawfinder#GetExecutable(buffer) abort
+   return ale#Var(a:buffer, 'c_flawfinder_executable')
+endfunction
+
+function! ale_linters#c#flawfinder#GetCommand(buffer) abort
+
+   " Set the minimum vulnerability level for flawfinder to bother with
+   " Default to level 1 as that is flawfinder's default level
+   let l:minlevel = ' --minlevel='
+   if exists('b:ale_c_flawfinder_minlevel')
+      let l:minlevel = l:minlevel . b:ale_c_flawfinder_minlevel
+   elseif exists('g:ale_c_flawfinder_minlevel')
+      let l:minlevel = l:minlevel . g:ale_c_flawfinder_minlevel
+   else
+      let l:minlevel = l:minlevel . '1'
+   endif
+
+   return ale#Escape(ale_linters#c#flawfinder#GetExecutable(a:buffer))
+   \  . ' -CDQS'
+   \  . ale#Var(a:buffer, 'c_flawfinder_options')
+   \  . l:minlevel
+   \  . ' %t'
+endfunction
+      
+call ale#linter#Define('c', {
+\  'name': 'flawfinder',
+\  'output_stream': 'stdout',
+\  'executable_callback': 'ale_linters#c#flawfinder#GetExecutable',
+\  'command_callback': 'ale_linters#c#flawfinder#GetCommand',
+\  'callback': 'ale#handlers#gcc#HandleGCCFormat',
+\})

--- a/ale_linters/c/flawfinder.vim
+++ b/ale_linters/c/flawfinder.vim
@@ -27,7 +27,7 @@ function! ale_linters#c#flawfinder#GetCommand(buffer) abort
    \  . l:minlevel
    \  . ' %t'
 endfunction
-      
+
 call ale#linter#Define('c', {
 \  'name': 'flawfinder',
 \  'output_stream': 'stdout',

--- a/ale_linters/cpp/flawfinder.vim
+++ b/ale_linters/cpp/flawfinder.vim
@@ -1,0 +1,38 @@
+" Author: Christian Gibbons <cgibbons@gmu.edu>
+" Description: flawfinder linter for c++ files
+
+call ale#Set('cpp_flawfinder_executable', 'flawfinder')
+call ale#Set('cpp_flawfinder_options', '')
+
+function! ale_linters#cpp#flawfinder#GetExecutable(buffer) abort
+   return ale#Var(a:buffer, 'cpp_flawfinder_executable')
+endfunction
+
+function! ale_linters#cpp#flawfinder#GetCommand(buffer) abort
+
+   " Set the minimum vulnerability level for flawfinder to bother with
+   " Default to level 1 as that is flawfinder's default level
+   let l:minlevel = ' --minlevel='
+   if exists('b:ale_cpp_flawfinder_minlevel')
+      let l:minlevel = l:minlevel . b:ale_cpp_flawfinder_minlevel
+   elseif exists('g:ale_cpp_flawfinder_minlevel')
+      let l:minlevel = l:minlevel . g:ale_cpp_flawfinder_minlevel
+   else
+      let l:minlevel = l:minlevel . '1'
+   endif
+
+   return ale#Escape(ale_linters#cpp#flawfinder#GetExecutable(a:buffer))
+   \  . ' -CDQS'
+   \  . ale#Var(a:buffer, 'cpp_flawfinder_options')
+   \  . l:minlevel
+   \  . ' %t'
+endfunction
+      
+call ale#linter#Define('cpp', {
+\  'name': 'flawfinder',
+\  'output_stream': 'stdout',
+\  'executable_callback': 'ale_linters#cpp#flawfinder#GetExecutable',
+\  'command_callback': 'ale_linters#cpp#flawfinder#GetCommand',
+\  'callback': 'ale#handlers#gcc#HandleGCCFormat',
+\})
+

--- a/ale_linters/cpp/flawfinder.vim
+++ b/ale_linters/cpp/flawfinder.vim
@@ -27,7 +27,7 @@ function! ale_linters#cpp#flawfinder#GetCommand(buffer) abort
    \  . l:minlevel
    \  . ' %t'
 endfunction
-      
+
 call ale#linter#Define('cpp', {
 \  'name': 'flawfinder',
 \  'output_stream': 'stdout',

--- a/ale_linters/cpp/flawfinder.vim
+++ b/ale_linters/cpp/flawfinder.vim
@@ -3,6 +3,7 @@
 
 call ale#Set('cpp_flawfinder_executable', 'flawfinder')
 call ale#Set('cpp_flawfinder_options', '')
+call ale#Set('cpp_flawfinder_minlevel', 1)
 
 function! ale_linters#cpp#flawfinder#GetExecutable(buffer) abort
    return ale#Var(a:buffer, 'cpp_flawfinder_executable')
@@ -11,15 +12,7 @@ endfunction
 function! ale_linters#cpp#flawfinder#GetCommand(buffer) abort
 
    " Set the minimum vulnerability level for flawfinder to bother with
-   " Default to level 1 as that is flawfinder's default level
-   let l:minlevel = ' --minlevel='
-   if exists('b:ale_cpp_flawfinder_minlevel')
-      let l:minlevel = l:minlevel . b:ale_cpp_flawfinder_minlevel
-   elseif exists('g:ale_cpp_flawfinder_minlevel')
-      let l:minlevel = l:minlevel . g:ale_cpp_flawfinder_minlevel
-   else
-      let l:minlevel = l:minlevel . '1'
-   endif
+   let l:minlevel = ' --minlevel=' . ale#Var(a:buffer, 'cpp_flawfinder_minlevel')
 
    return ale#Escape(ale_linters#cpp#flawfinder#GetExecutable(a:buffer))
    \  . ' -CDQS'
@@ -35,4 +28,3 @@ call ale#linter#Define('cpp', {
 \  'command_callback': 'ale_linters#cpp#flawfinder#GetCommand',
 \  'callback': 'ale#handlers#gcc#HandleGCCFormat',
 \})
-

--- a/autoload/ale/handlers/gcc.vim
+++ b/autoload/ale/handlers/gcc.vim
@@ -24,7 +24,7 @@ function! ale#handlers#gcc#HandleGCCFormat(buffer, lines) abort
     " <stdin>:8:5: warning: conversion lacks type at end of format [-Wformat=]
     " <stdin>:10:27: error: invalid operands to binary - (have ‘int’ and ‘char *’)
     " -:189:7: note: $/${} is unnecessary on arithmetic variables. [SC2004]
-    let l:pattern = '\v^([a-zA-Z]?:?[^:]+):(\d+):(\d+)?:? ([^:]+): (.+)$'
+    let l:pattern = '\v^([a-zA-Z]?:?[^:]+):(\d+):(\d+)?:? ([^:]+): ?(.+)$'
     let l:output = []
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)

--- a/doc/ale-c.txt
+++ b/doc/ale-c.txt
@@ -146,12 +146,28 @@ g:ale_c_cppcheck_options                             *g:ale_c_cppcheck_options*
 ===============================================================================
 flawfinder                                                   *ale-c-flawfinder*
 
+g:ale_c_flawfinder_executable                   *g:ale_c_flawfinder_executable*
+                                                *g:ale_c_flawfinder_executable*
+  Type: |String|
+  Default: `'flawfinder'`
+
+  This variable can be changed to use a different executable for flawfinder.
+
+
 g:ale_c_flawfinder_minlevel                       *g:ale_c_flawfinder_minlevel*
                                                   *b:ale_c_flawfinder_minlevel*
   Type: |Number|
   Default: `1`
 
   This variable can be changed to ignore risks under the given risk threshold.
+
+
+g:ale_c_flawfinder_options                                 *g:ale-c-flawfinder*
+                                                           *b:ale-c-flawfinder*
+  Type: |String|
+  Default: `''`
+
+  This variable can be used to pass extra options into the flawfinder command.
 
 
 ===============================================================================

--- a/doc/ale-c.txt
+++ b/doc/ale-c.txt
@@ -148,7 +148,7 @@ flawfinder                                                   *ale-c-flawfinder*
 
 g:ale_c_flawfinder_minlevel                       *g:ale_c_flawfinder_minlevel*
                                                   *b:ale_c_flawfinder_minlevel*
-  Type: |Integer|
+  Type: |Number|
   Default: `1`
 
   This variable can be changed to ignore risks under the given risk threshold.

--- a/doc/ale-c.txt
+++ b/doc/ale-c.txt
@@ -144,6 +144,17 @@ g:ale_c_cppcheck_options                             *g:ale_c_cppcheck_options*
 
 
 ===============================================================================
+flawfinder                                                   *ale-c-flawfinder*
+
+g:ale_c_flawfinder_minlevel                       *g:ale_c_flawfinder_minlevel*
+                                                  *b:ale_c_flawfinder_minlevel*
+  Type: |Integer|
+  Default: `1`
+
+  This variable can be changed to ignore risks under the given risk threshold.
+
+
+===============================================================================
 gcc                                                                 *ale-c-gcc*
 
 g:ale_c_gcc_executable                                 *g:ale_c_gcc_executable*

--- a/doc/ale-cpp.txt
+++ b/doc/ale-cpp.txt
@@ -156,12 +156,28 @@ g:ale_cpp_cpplint_options                           *g:ale_cpp_cpplint_options*
 ===============================================================================
 flawfinder                                                 *ale-cpp-flawfinder*
 
+g:ale_cpp_flawfinder_executable               *g:ale_cpp_flawfinder_executable*
+                                              *g:ale_cpp_flawfinder_executable*
+  Type: |String|
+  Default: `'flawfinder'`
+
+  This variable can be changed to use a different executable for flawfinder.
+
+
 g:ale_cpp_flawfinder_minlevel                   *g:ale_cpp_flawfinder_minlevel*
                                                 *b:ale_cpp_flawfinder_minlevel*
   Type: |Number|
   Default: `1`
 
   This variable can be changed to ignore risks under the given risk threshold.
+
+
+g:ale_cpp_flawfinder_options                             *g:ale-cpp-flawfinder*
+                                                         *b:ale-cpp-flawfinder*
+  Type: |String|
+  Default: `''`
+
+  This variable can be used to pass extra options into the flawfinder command.
 
 
 ===============================================================================

--- a/doc/ale-cpp.txt
+++ b/doc/ale-cpp.txt
@@ -154,6 +154,17 @@ g:ale_cpp_cpplint_options                           *g:ale_cpp_cpplint_options*
 
 
 ===============================================================================
+flawfinder                                                 *ale-cpp-flawfinder*
+
+g:ale_cpp_flawfinder_minlevel                   *g:ale_cpp_flawfinder_minlevel*
+                                                *b:ale_cpp_flawfinder_minlevel*
+  Type: |Integer|
+  Default: `1`
+
+  This variable can be changed to ignore risks under the given risk threshold.
+
+
+===============================================================================
 gcc                                                               *ale-cpp-gcc*
 
 g:ale_cpp_gcc_executable                             *g:ale_cpp_gcc_executable*

--- a/doc/ale-cpp.txt
+++ b/doc/ale-cpp.txt
@@ -158,7 +158,7 @@ flawfinder                                                 *ale-cpp-flawfinder*
 
 g:ale_cpp_flawfinder_minlevel                   *g:ale_cpp_flawfinder_minlevel*
                                                 *b:ale_cpp_flawfinder_minlevel*
-  Type: |Integer|
+  Type: |Number|
   Default: `1`
 
   This variable can be changed to ignore risks under the given risk threshold.

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -297,8 +297,8 @@ Notes:
 * Awk: `gawk`
 * Bash: `shell` (-n flag), `shellcheck`, `shfmt`
 * Bourne Shell: `shell` (-n flag), `shellcheck`, `shfmt`
-* C: `cppcheck`, `cpplint`!!, `gcc`, `clang`, `clangtidy`!!, `clang-format`
-* C++ (filetype cpp): `clang`, `clangcheck`!!, `clangtidy`!!, `clang-format`, `cppcheck`, `cpplint`!!, `gcc`
+* C: `cppcheck`, `cpplint`!!, `clang`, `clangtidy`!!, `clang-format`, `flawfinder`, `gcc`
+* C++ (filetype cpp): `clang`, `clangcheck`!!, `clangtidy`!!, `clang-format`, `cppcheck`, `cpplint`!!, `flawfinder`, `gcc`
 * CUDA: `nvcc`!!
 * C#: `mcs`, `mcsc`!!
 * Chef: `foodcritic`

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -28,6 +28,7 @@ CONTENTS                                                         *ale-contents*
       clang-format........................|ale-c-clangformat|
       clangtidy...........................|ale-c-clangtidy|
       cppcheck............................|ale-c-cppcheck|
+      flawfinder..........................|ale-c-flawfinder|
       gcc.................................|ale-c-gcc|
     chef..................................|ale-chef-options|
       foodcritic..........................|ale-chef-foodcritic|
@@ -42,6 +43,7 @@ CONTENTS                                                         *ale-contents*
       clangtidy...........................|ale-cpp-clangtidy|
       cppcheck............................|ale-cpp-cppcheck|
       cpplint.............................|ale-cpp-cpplint|
+      flawfinder..........................|ale-cpp-flawfinder|
       gcc.................................|ale-cpp-gcc|
     c#....................................|ale-cs-options|
       mcs.................................|ale-cs-mcs|

--- a/test/command_callback/test_c_flawfinder_command_callbacks.vader
+++ b/test/command_callback/test_c_flawfinder_command_callbacks.vader
@@ -32,4 +32,20 @@ Execute(The minlevel of flawfinder should be configurable):
   AssertEqual
   \ ale#Escape('flawfinder')
   \   . ' -CDQS --minlevel=8 %t',
-  \ ale_linters#c#flawfinder#GetCommand(bufnr(''))  
+  \ ale_linters#c#flawfinder#GetCommand(bufnr(''))
+
+Execute(Additional flawfinder options should be configurable):
+  let b:ale_c_flawfinder_options = ' --foobar'
+
+  AssertEqual
+  \ ale#Escape('flawfinder')
+  \   . ' -CDQS --foobar --minlevel=1 %t',
+  \ ale_linters#c#flawfinder#GetCommand(bufnr(''))
+
+Execute(The flawfinder exectable should be configurable):
+  let b:ale_c_flawfinder_executable = 'foo/bar'
+
+  AssertEqual
+  \ ale#Escape('foo/bar')
+  \   . ' -CDQS --minlevel=1 %t',
+  \ ale_linters#c#flawfinder#GetCommand(bufnr(''))

--- a/test/command_callback/test_c_flawfinder_command_callbacks.vader
+++ b/test/command_callback/test_c_flawfinder_command_callbacks.vader
@@ -1,0 +1,35 @@
+Before:
+  Save g:ale_c_flawfinder_executable
+  Save g:ale_c_flawfinder_options
+  Save g:ale_c_flawfinder_minlevel
+
+  unlet! g:ale_c_flawfinder_executable
+  unlet! b:ale_c_flawfinder_executable
+  unlet! g:ale_c_flawfinder_options
+  unlet! b:ale_c_flawfinder_options
+  unlet! g:ale_c_flawfinder_minlevel
+  unlet! b:ale_c_flawfinder_minlevel
+
+  runtime ale_linters/c/flawfinder.vim
+
+After:
+  unlet! b:ale_c_flawfinder_executable
+  unlet! b:ale_c_flawfinder_options
+  unlet! b:ale_c_flawfinder_minlevel
+
+  Restore
+  call ale#linter#Reset()
+
+Execute(The flawfinder command should be correct):
+  AssertEqual
+  \ ale#Escape('flawfinder')
+  \   . ' -CDQS --minlevel=1 %t',
+  \ ale_linters#c#flawfinder#GetCommand(bufnr(''))
+
+Execute(The minlevel of flawfinder should be configurable):
+  let b:ale_c_flawfinder_minlevel = 8
+
+  AssertEqual
+  \ ale#Escape('flawfinder')
+  \   . ' -CDQS --minlevel=8 %t',
+  \ ale_linters#c#flawfinder#GetCommand(bufnr(''))  

--- a/test/command_callback/test_cpp_flawfinder_command_callbacks.vader
+++ b/test/command_callback/test_cpp_flawfinder_command_callbacks.vader
@@ -33,3 +33,19 @@ Execute(The minlevel of flawfinder should be configurable):
   \ ale#Escape('flawfinder')
   \   . ' -CDQS --minlevel=8 %t',
   \ ale_linters#cpp#flawfinder#GetCommand(bufnr(''))
+
+Execute(Additional flawfinder options should be configurable):
+  let b:ale_cpp_flawfinder_options = ' --foobar'
+
+  AssertEqual
+  \ ale#Escape('flawfinder')
+  \   . ' -CDQS --foobar --minlevel=1 %t',
+  \ ale_linters#cpp#flawfinder#GetCommand(bufnr(''))
+
+Execute(The flawfinder exectable should be configurable):
+  let b:ale_cpp_flawfinder_executable = 'foo/bar'
+
+  AssertEqual
+  \ ale#Escape('foo/bar')
+  \   . ' -CDQS --minlevel=1 %t',
+  \ ale_linters#cpp#flawfinder#GetCommand(bufnr(''))

--- a/test/command_callback/test_cpp_flawfinder_command_callbacks.vader
+++ b/test/command_callback/test_cpp_flawfinder_command_callbacks.vader
@@ -1,0 +1,35 @@
+Before:
+  Save g:ale_cpp_flawfinder_executable
+  Save g:ale_cpp_flawfinder_options
+  Save g:ale_cpp_flawfinder_minlevel
+
+  unlet! g:ale_cpp_flawfinder_executable
+  unlet! b:ale_cpp_flawfinder_executable
+  unlet! g:ale_cpp_flawfinder_options
+  unlet! b:ale_cpp_flawfinder_options
+  unlet! g:ale_cpp_flawfinder_minlevel
+  unlet! b:ale_cpp_flawfinder_minlevel
+
+  runtime ale_linters/cpp/flawfinder.vim
+
+After:
+  unlet! b:ale_cpp_flawfinder_executable
+  unlet! b:ale_cpp_flawfinder_options
+  unlet! b:ale_cpp_flawfinder_minlevel
+
+  Restore
+  call ale#linter#Reset()
+
+Execute(The flawfinder command should be correct):
+  AssertEqual
+  \ ale#Escape('flawfinder')
+  \   . ' -CDQS --minlevel=1 %t',
+  \ ale_linters#cpp#flawfinder#GetCommand(bufnr(''))
+
+Execute(The minlevel of flawfinder should be configurable):
+  let b:ale_cpp_flawfinder_minlevel = 8
+
+  AssertEqual
+  \ ale#Escape('flawfinder')
+  \   . ' -CDQS --minlevel=8 %t',
+  \ ale_linters#cpp#flawfinder#GetCommand(bufnr(''))


### PR DESCRIPTION
This pull request adds support for the Flawfinder linter for C and C++.   Resolves issue: #1161 
<!--
READ THIS: Before creating a pull request, please consider the following first.

* The most important thing you can do is write tests. Code without tests
  probably doesn't work, and will almost certainly stop working later on. Pull
  requests without tests probably won't be accepted, although there are some
  exceptions.
* Read the Contributing guide linked above first.
* If you are adding a new linter, remember to update the README.md file and
  doc/ale.txt first.
* If you add or modify a function for converting error lines into loclist items
  that ALE can work with, please add Vader tests for them. Look at existing
  tests in the test/handler directory, etc.
* If you add or modify a function for computing a command line string for
  running a command, please add Vader tests for that.
* Generally try and cover anything with Vader tests, although some things just
  can't be tested with Vader, or at least they can be hard to test. Consider
  breaking up your code so that some parts can be tested, and generally open up
  a discussion about it.
* Have fun!
-->
