### PR TITLE
Close loclist when associated buffer is closed

### DIFF
--- a/autoload/ale/events.vim
+++ b/autoload/ale/events.vim
@@ -3,7 +3,7 @@
 function! ale#events#QuitEvent(buffer) abort
     " Remember when ALE is quitting for BufWrite, etc.
     call setbufvar(a:buffer, 'ale_quitting', ale#util#ClockMilliseconds())
-    if empty(&bt) | lclose | endif
+    if empty(&buftype) | lclose | endif
 endfunction
 
 function! ale#events#QuitRecently(buffer) abort

--- a/autoload/ale/events.vim
+++ b/autoload/ale/events.vim
@@ -3,6 +3,7 @@
 function! ale#events#QuitEvent(buffer) abort
     " Remember when ALE is quitting for BufWrite, etc.
     call setbufvar(a:buffer, 'ale_quitting', ale#util#ClockMilliseconds())
+    if empty(&bt) | lclose | endif
 endfunction
 
 function! ale#events#QuitRecently(buffer) abort


### PR DESCRIPTION
This should automatically close the loclist when you quit the associated buffer.  Related to #1306 
<!--
READ THIS: Before creating a pull request, please consider the following first.

* The most important thing you can do is write tests. Code without tests
  probably doesn't work, and will almost certainly stop working later on. Pull
  requests without tests probably won't be accepted, although there are some
  exceptions.
* Read the Contributing guide linked above first.
* If you are adding a new linter, remember to update the README.md file and
  doc/ale.txt first.
* If you add or modify a function for converting error lines into loclist items
  that ALE can work with, please add Vader tests for them. Look at existing
  tests in the test/handler directory, etc.
* If you add or modify a function for computing a command line string for
  running a command, please add Vader tests for that.
* Generally try and cover anything with Vader tests, although some things just
  can't be tested with Vader, or at least they can be hard to test. Consider
  breaking up your code so that some parts can be tested, and generally open up
  a discussion about it.
* Have fun!
-->
