### PR TITLE
Add Unity project path to Unity example in docs

### DIFF
--- a/doc/ale-cs.txt
+++ b/doc/ale-cs.txt
@@ -94,6 +94,7 @@ g:ale_cs_mcsc_assemblies                             *g:ale_cs_mcsc_assemblies*
     " Compile C# programs with the Unity engine DLL file on Mac.
     let g:ale_cs_mcsc_assemblies = [
     \ '/Applications/Unity/Unity.app/Contents/Frameworks/Managed/UnityEngine.dll',
+    \ 'path-to-unityproject/obj/Debug',
     \]
 <
 


### PR DESCRIPTION
For Ale to recognize the symbols in your project, you need to point it
at where Unity builds your assemblies. Add this path to the example.

On Windows, the dll path is this (by default):

    " or on Windows:
    let g:ale_cs_mcsc_assemblies = [
    \ expand('$ProgramFiles/Unity/Editor/Data/Managed/UnityEngine.dll'), 
    \ 'path-to-unityproject/obj/Debug',
    \]

I didn't add since it doesn't contribute much (just need to figure out the right prefix).

(I found #1226 before I found the help docs so I'll mention it so any others can find their way here.)

<!--
READ THIS: Before creating a pull request, please consider the following first.

* The most important thing you can do is write tests. Code without tests
  probably doesn't work, and will almost certainly stop working later on. Pull
  requests without tests probably won't be accepted, although there are some
  exceptions.
* Read the Contributing guide linked above first.
* If you are adding a new linter, remember to update the README.md file and
  doc/ale.txt first.
* If you add or modify a function for converting error lines into loclist items
  that ALE can work with, please add Vader tests for them. Look at existing
  tests in the test/handler directory, etc.
* If you add or modify a function for computing a command line string for
  running a command, please add Vader tests for that.
* Generally try and cover anything with Vader tests, although some things just
  can't be tested with Vader, or at least they can be hard to test. Consider
  breaking up your code so that some parts can be tested, and generally open up
  a discussion about it.
* Have fun!
-->
