### PR TITLE
doc/c: fix duplicate ale_c_flawfinder_executable help tag

### DIFF
--- a/doc/ale-c.txt
+++ b/doc/ale-c.txt
@@ -147,7 +147,7 @@ g:ale_c_cppcheck_options                             *g:ale_c_cppcheck_options*
 flawfinder                                                   *ale-c-flawfinder*
 
 g:ale_c_flawfinder_executable                   *g:ale_c_flawfinder_executable*
-                                                *g:ale_c_flawfinder_executable*
+                                                *b:ale_c_flawfinder_executable*
   Type: |String|
   Default: `'flawfinder'`
 


### PR DESCRIPTION
Fix duplicate `ale_c_flawfinder_executable` help tag which both of `g:` prefix.