### PR TITLE
doc/cpp: fix duplicate ale_cpp_flawfinder_executable help tag

### DIFF
--- a/doc/ale-cpp.txt
+++ b/doc/ale-cpp.txt
@@ -157,7 +157,7 @@ g:ale_cpp_cpplint_options                           *g:ale_cpp_cpplint_options*
 flawfinder                                                 *ale-cpp-flawfinder*
 
 g:ale_cpp_flawfinder_executable               *g:ale_cpp_flawfinder_executable*
-                                              *g:ale_cpp_flawfinder_executable*
+                                              *b:ale_cpp_flawfinder_executable*
   Type: |String|
   Default: `'flawfinder'`
 


### PR DESCRIPTION
Fix duplicate `ale_cpp_flawfinder_executable` help tag which both of `g:` prefix (again).