### PR TITLE
Add options for markdown_mdl linter

### DIFF
--- a/ale_linters/markdown/mdl.vim
+++ b/ale_linters/markdown/mdl.vim
@@ -1,5 +1,8 @@
-" Author: Steve Dignam <steve@dignam.xyz>
-" Description: Support for mdl, a markdown linter
+" Author: Steve Dignam <steve@dignam.xyz>, Josh Leeb-du Toit <joshleeb.com>
+" Description: Support for mdl, a markdown linter.
+
+call ale#Set('markdown_mdl_executable', 'mdl')
+call ale#Set('markdown_mdl_options', '')
 
 function! ale_linters#markdown#mdl#Handle(buffer, lines) abort
     " matches: '(stdin):173: MD004 Unordered list style'
@@ -17,9 +20,17 @@ function! ale_linters#markdown#mdl#Handle(buffer, lines) abort
     return l:output
 endfunction
 
+function! ale_linters#markdown#mdl#GetCommand(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'markdown_mdl_executable')
+    let l:options = ale#Var(a:buffer, 'markdown_mdl_options')
+
+    return l:executable . (!empty(l:options) ? ' ' . l:options : '')
+endfunction
+
+
 call ale#linter#Define('markdown', {
 \   'name': 'mdl',
 \   'executable': 'mdl',
-\   'command': 'mdl',
+\   'command_callback': 'ale_linters#markdown#mdl#GetCommand',
 \   'callback': 'ale_linters#markdown#mdl#Handle'
 \})

--- a/doc/ale-markdown.txt
+++ b/doc/ale-markdown.txt
@@ -3,6 +3,25 @@ ALE Markdown Integration                                 *ale-markdown-options*
 
 
 ===============================================================================
+mdl                                                          *ale-markdown-mdl*
+
+g:ale_markdown_mdl_executable                   *g:ale_markdown_mdl_executable*
+                                                *b:ale_markdown_mdl_executable*
+  Type: |String|
+  Default: `'mdl'`
+
+  See |ale-integrations-local-executables|
+
+
+g:ale_markdown_mdl_options                         *g:ale_markdown_mdl_options*
+                                                   *b:ale_markdown_mdl_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be set to pass additional options to mdl.
+
+
+===============================================================================
 prettier                                                *ale-markdown-prettier*
 
 See |ale-javascript-prettier| for information about the available options.

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -136,6 +136,7 @@ CONTENTS                                                         *ale-contents*
       luac................................|ale-lua-luac|
       luacheck............................|ale-lua-luacheck|
     markdown..............................|ale-markdown-options|
+      mdl.................................|ale-markdown-mdl|
       prettier............................|ale-markdown-prettier|
       write-good..........................|ale-markdown-write-good|
     nroff.................................|ale-nroff-options|


### PR DESCRIPTION
Add options to specify the executable and the command options for the Markdown `mdl` linter.