### PR TITLE
Option to open lists vertically

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,6 +577,9 @@ let g:ale_open_list = 1
 let g:ale_keep_list_window_open = 1
 ```
 
+You can also set `let g:ale_list_vertical = 1` to open the windows vertically
+instead of the default horizontally.
+
 <a name="faq-jsx-stylelint-eslint"></a>
 
 ### 5.xii. How can I check JSX files with both stylelint and eslint?

--- a/autoload/ale/debugging.vim
+++ b/autoload/ale/debugging.vim
@@ -29,6 +29,7 @@ let s:global_variable_list = [
 \    'ale_linters',
 \    'ale_linters_explicit',
 \    'ale_list_window_size',
+\    'ale_list_vertical',
 \    'ale_loclist_msg_format',
 \    'ale_max_buffer_history_size',
 \    'ale_max_signs',

--- a/autoload/ale/list.vim
+++ b/autoload/ale/list.vim
@@ -97,12 +97,17 @@ function! s:SetListsImpl(timer_id, buffer, loclist) abort
         let l:reset_visual_selection = l:mode is? 'v' || l:mode is# "\<c-v>"
         let l:reset_character_selection = l:mode is? 's' || l:mode is# "\<c-s>"
 
+        " open windows vertically instead of default horizontally
+        let l:open_type = ''
+        if get(g:, 'ale_list_vertical') == 1
+            let l:open_type = 'vert '
+        endif
         if g:ale_set_quickfix
             if !ale#list#IsQuickfixOpen()
-                silent! execute 'copen ' . str2nr(ale#Var(a:buffer, 'list_window_size'))
+                silent! execute l:open_type . 'copen ' . str2nr(ale#Var(a:buffer, 'list_window_size'))
             endif
         elseif g:ale_set_loclist
-            silent! execute 'lopen ' . str2nr(ale#Var(a:buffer, 'list_window_size'))
+            silent! execute l:open_type . 'lopen ' . str2nr(ale#Var(a:buffer, 'list_window_size'))
         endif
 
         " If focus changed, restore it (jump to the last window).

--- a/autoload/ale/list.vim
+++ b/autoload/ale/list.vim
@@ -99,7 +99,7 @@ function! s:SetListsImpl(timer_id, buffer, loclist) abort
 
         " open windows vertically instead of default horizontally
         let l:open_type = ''
-        if get(g:, 'ale_list_vertical') == 1
+        if ale#Var(a:buffer, 'list_vertical') == 1
             let l:open_type = 'vert '
         endif
         if g:ale_set_quickfix

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -1222,6 +1222,8 @@ g:ale_open_list                                               *g:ale_open_list*
 
   The window size can be configured with |g:ale_list_window_size|.
 
+  Windows can be opened vertically with |g:ale_list_vertical|.
+
   If you want to close the loclist window automatically when the buffer is
   closed, you can set up the following |autocmd| command: >
 
@@ -1230,6 +1232,15 @@ g:ale_open_list                                               *g:ale_open_list*
     autocmd QuitPre * if empty(&buftype) | lclose | endif
   augroup END
 <
+
+g:ale_list_vertical                                       *g:ale_list_vertical*
+                                                          *g:ale_list_vertical*
+  Type: |Number|
+  Default: `0`
+
+  When set to `1`, this will cause ALE to open any windows (loclist or
+  quickfix) vertically instead of horizontally (|vert| |lopen|) or (|vert|
+  |copen|)
 
 g:ale_pattern_options                                   *g:ale_pattern_options*
 

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -1234,7 +1234,7 @@ g:ale_open_list                                               *g:ale_open_list*
 <
 
 g:ale_list_vertical                                       *g:ale_list_vertical*
-                                                          *g:ale_list_vertical*
+                                                          *b:ale_list_vertical*
   Type: |Number|
   Default: `0`
 

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -1151,6 +1151,16 @@ g:ale_linters_explicit                                 *g:ale_linters_explicit*
   as possible, unless otherwise specified.
 
 
+g:ale_list_vertical                                       *g:ale_list_vertical*
+                                                          *b:ale_list_vertical*
+  Type: |Number|
+  Default: `0`
+
+  When set to `1`, this will cause ALE to open any windows (loclist or
+  quickfix) vertically instead of horizontally (|vert| |lopen|) or (|vert|
+  |copen|)
+
+
 g:ale_loclist_msg_format                             *g:ale_loclist_msg_format*
 b:ale_loclist_msg_format                             *b:ale_loclist_msg_format*
 
@@ -1232,15 +1242,6 @@ g:ale_open_list                                               *g:ale_open_list*
     autocmd QuitPre * if empty(&buftype) | lclose | endif
   augroup END
 <
-
-g:ale_list_vertical                                       *g:ale_list_vertical*
-                                                          *b:ale_list_vertical*
-  Type: |Number|
-  Default: `0`
-
-  When set to `1`, this will cause ALE to open any windows (loclist or
-  quickfix) vertically instead of horizontally (|vert| |lopen|) or (|vert|
-  |copen|)
 
 g:ale_pattern_options                                   *g:ale_pattern_options*
 

--- a/plugin/ale.vim
+++ b/plugin/ale.vim
@@ -118,6 +118,9 @@ let g:ale_open_list = get(g:, 'ale_open_list', 0)
 " This flag dictates if ale keeps open loclist even if there is no error in loclist
 let g:ale_keep_list_window_open = get(g:, 'ale_keep_list_window_open', 0)
 
+" This flag dictates that quickfix windows should be opened vertically
+let g:ale_list_vertical = get(g:, 'ale_list_vertical', 0)
+
 " The window size to set for the quickfix and loclist windows
 call ale#Set('list_window_size', 10)
 

--- a/test/test_ale_info.vader
+++ b/test/test_ale_info.vader
@@ -66,6 +66,7 @@ Before:
   \  'let g:ale_linters = {}',
   \  'let g:ale_linters_explicit = 0',
   \  'let g:ale_list_window_size = 10',
+  \  'let g:ale_list_vertical = 0',
   \  'let g:ale_loclist_msg_format = ''%code: %%s''',
   \  'let g:ale_max_buffer_history_size = 20',
   \  'let g:ale_max_signs = -1',

--- a/test/test_list_opening.vader
+++ b/test/test_list_opening.vader
@@ -5,6 +5,7 @@ Before:
   Save g:ale_open_list
   Save g:ale_keep_list_window_open
   Save g:ale_list_window_size
+  Save g:ale_list_vertical
   Save g:ale_buffer_info
   Save g:ale_set_lists_synchronously
 
@@ -13,6 +14,7 @@ Before:
   let g:ale_open_list = 0
   let g:ale_keep_list_window_open = 0
   let g:ale_list_window_size = 10
+  let g:ale_list_vertical = 0
   let g:ale_set_lists_synchronously = 1
 
   let g:loclist = [
@@ -33,16 +35,29 @@ Before:
     return 0
   endfunction
 
+  " If the window is vertical, window size should match column size/width
+  function GetQuickfixIsVertical(cols) abort
+    for l:win in range(1, winnr('$'))
+        if getwinvar(l:win, '&buftype') ==# 'quickfix'
+            return winwidth(l:win) == a:cols
+        endif
+    endfor
+
+    return 0
+  endfunction
+
 After:
   Restore
 
   unlet! g:loclist
+  unlet! b:ale_list_vertical
   unlet! b:ale_list_window_size
   unlet! b:ale_open_list
   unlet! b:ale_keep_list_window_open
   unlet! b:ale_save_event_fired
 
   delfunction GetQuickfixHeight
+  delfunction GetQuickfixIsVertical
 
   " Close quickfix window after every execute block
   lcl
@@ -97,6 +112,24 @@ Execute(The quickfix window height should be correct for the loclist with buffer
   call ale#list#SetLists(bufnr('%'), g:loclist)
 
   AssertEqual 8, GetQuickfixHeight()
+
+Execute(The quickfix window should be vertical for the loclist with appropriate variables):
+  let g:ale_open_list = 1
+  let b:ale_list_window_size = 8
+  let b:ale_list_vertical = 1
+
+  call ale#list#SetLists(bufnr('%'), g:loclist)
+
+  AssertEqual 1, GetQuickfixIsVertical(b:ale_list_window_size)
+
+Execute(The quickfix window should be horizontal for the loclist with appropriate variables):
+  let g:ale_open_list = 1
+  let b:ale_list_window_size = 8
+  let b:ale_list_vertical = 0
+
+  call ale#list#SetLists(bufnr('%'), g:loclist)
+
+  AssertEqual 0, GetQuickfixIsVertical(b:ale_list_window_size)
 
 Execute(The quickfix window should stay open for just the loclist):
   let g:ale_open_list = 1
@@ -166,6 +199,24 @@ Execute(The quickfix window height should be correct for the quickfix list with 
   call ale#list#SetLists(bufnr('%'), g:loclist)
 
   AssertEqual 8, GetQuickfixHeight()
+
+Execute(The quickfix window should be vertical for the quickfix with appropriate variables):
+  let g:ale_open_list = 1
+  let b:ale_list_window_size = 8
+  let b:ale_list_vertical = 1
+
+  call ale#list#SetLists(bufnr('%'), g:loclist)
+
+  AssertEqual 1, GetQuickfixIsVertical(b:ale_list_window_size)
+
+Execute(The quickfix window should be horizontal for the quickfix with appropriate variables):
+  let g:ale_open_list = 1
+  let b:ale_list_window_size = 8
+  let b:ale_list_vertical = 0
+
+  call ale#list#SetLists(bufnr('%'), g:loclist)
+
+  AssertEqual 0, GetQuickfixIsVertical(b:ale_list_window_size)
 
 Execute(The buffer ale_open_list option should be respected):
   let b:ale_open_list = 1

--- a/test/test_list_opening.vader
+++ b/test/test_list_opening.vader
@@ -38,7 +38,7 @@ Before:
   " If the window is vertical, window size should match column size/width
   function GetQuickfixIsVertical(cols) abort
     for l:win in range(1, winnr('$'))
-        if getwinvar(l:win, '&buftype') ==# 'quickfix'
+        if getwinvar(l:win, '&buftype') is# 'quickfix'
             return winwidth(l:win) == a:cols
         endif
     endfor


### PR DESCRIPTION
Introduces a new option, `ale_list_vertical` that can be set globally or for a buffer to open the quickfix window vertically instead of the default horizontally.

Closes #1352