### PR TITLE
Add prototool

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ formatting.
 | PO | [alex](https://github.com/wooorm/alex) !!, [msgfmt](https://www.gnu.org/software/gettext/manual/html_node/msgfmt-Invocation.html), [proselint](http://proselint.com/), [write-good](https://github.com/btford/write-good) |
 | Pod | [alex](https://github.com/wooorm/alex) !!, [proselint](http://proselint.com/), [write-good](https://github.com/btford/write-good) |
 | Pony | [ponyc](https://github.com/ponylang/ponyc) |
-| proto | [protoc-gen-lint](https://github.com/ckaznocha/protoc-gen-lint) |
+| proto | [protoc-gen-lint](https://github.com/ckaznocha/protoc-gen-lint) , [prototool](https://github.com/uber/prototool) !! |
 | Pug | [pug-lint](https://github.com/pugjs/pug-lint) |
 | Puppet | [puppet](https://puppet.com), [puppet-lint](https://puppet-lint.com) |
 | Python | [autopep8](https://github.com/hhatto/autopep8), [flake8](http://flake8.pycqa.org/en/latest/), [isort](https://github.com/timothycrosley/isort), [mypy](http://mypy-lang.org/), [prospector](http://github.com/landscapeio/prospector), [pycodestyle](https://github.com/PyCQA/pycodestyle), [pyls](https://github.com/palantir/python-language-server), [pylint](https://www.pylint.org/) !!, [yapf](https://github.com/google/yapf) |

--- a/ale_linters/proto/prototool.vim
+++ b/ale_linters/proto/prototool.vim
@@ -5,13 +5,13 @@ call ale#Set('proto_prototool_command', 'all')
 
 function! ale_linters#proto#prototool#GetCommand(buffer) abort
     let l:command = ale#Var(a:buffer, 'proto_prototool_command')
-    if l:command ==? 'all'
+    if l:command is? 'all'
       " Compile the file, then do generation, then lint
       return 'prototool all --disable-format --dir-mode %s'
-    elseif l:command ==? 'compile'
+    elseif l:command is? 'compile'
       " Compile the file only, doing no generation
       return 'prototool compile --dir-mode %s'
-    elseif l:command ==? 'lint'
+    elseif l:command is? 'lint'
       " Compile the file and then lint, doing no generation
       return 'prototool lint --dir-mode %s'
     else

--- a/ale_linters/proto/prototool.vim
+++ b/ale_linters/proto/prototool.vim
@@ -5,13 +5,13 @@ call ale#Set('proto_prototool_command', 'all')
 
 function! ale_linters#proto#prototool#GetCommand(buffer) abort
     let l:command = ale#Var(a:buffer, 'proto_prototool_command')
-    if l:command == 'all'
+    if l:command ==? 'all'
       " Compile the file, then do generation, then lint
       return 'prototool all --disable-format --dir-mode %s'
-    elseif l:command == 'compile'
+    elseif l:command ==? 'compile'
       " Compile the file only, doing no generation
       return 'prototool compile --dir-mode %s'
-    elseif l:command == 'lint'
+    elseif l:command ==? 'lint'
       " Compile the file and then lint, doing no generation
       return 'prototool lint --dir-mode %s'
     else
@@ -22,39 +22,39 @@ function! ale_linters#proto#prototool#GetCommand(buffer) abort
 endfunction
 
 call ale#linter#Define('proto', {
-			\   'name': 'prototool',
-			\   'lint_file': 1,
-			\   'output_stream': 'stdout',
-			\   'executable': 'prototool',
-      \   'command_callback': 'ale_linters#proto#prototool#GetCommand',
-			\   'callback': 'ale#handlers#unix#HandleAsError',
-			\})
+    \   'name': 'prototool',
+    \   'lint_file': 1,
+    \   'output_stream': 'stdout',
+    \   'executable': 'prototool',
+    \   'command_callback': 'ale_linters#proto#prototool#GetCommand',
+    \   'callback': 'ale#handlers#unix#HandleAsError',
+    \})
 
 " TODO: not sure how to integrate the below properly, see PR description
 
-function! PrototoolEnable()
-  silent! let g:prototool_format_enable = 1
+function! PrototoolEnable() abort
+    silent! let g:prototool_format_enable = 1
 endfunction
 
-function! PrototoolDisable()
-  silent! unlet g:prototool_format_enable
+function! PrototoolDisable() abort
+    silent! unlet g:prototool_format_enable
 endfunction
 
-function! PrototoolFormatToggle()
-  if exists("g:prototool_format_enable")
-    call PrototoolDisable()
-    echo "prototool format DISABLED"
-  else
-    call PrototoolEnable()
-    echo "prototool format ENABLED"
-  endif
+function! PrototoolFormatToggle() abort
+    if exists('g:prototool_format_enable')
+        call PrototoolDisable()
+        execute 'echo "prototool format DISABLED"'
+    else
+        call PrototoolEnable()
+        execute 'echo "prototool format ENABLED"'
+    endif
 endfunction
 
-function! PrototoolFormat()
-  if exists("g:prototool_format_enable")
-    silent! execute "!prototool format -w %"
-    silent! edit
-  endif
+function! PrototoolFormat() abort
+    if exists('g:prototool_format_enable')
+        silent! execute '!prototool format -w %'
+        silent! edit
+    endif
 endfunction
 
 autocmd BufEnter,BufWritePost *.proto :call PrototoolFormat()

--- a/ale_linters/proto/prototool.vim
+++ b/ale_linters/proto/prototool.vim
@@ -32,20 +32,20 @@ call ale#linter#Define('proto', {
 
 " TODO: not sure how to integrate the below properly, see PR description
 
-function! PrototoolEnable() abort
+function! PrototoolFormatEnable() abort
     silent! let g:prototool_format_enable = 1
 endfunction
 
-function! PrototoolDisable() abort
+function! PrototoolFormatDisable() abort
     silent! unlet g:prototool_format_enable
 endfunction
 
 function! PrototoolFormatToggle() abort
     if exists('g:prototool_format_enable')
-        call PrototoolDisable()
+        call PrototoolFormatDisable()
         execute 'echo "prototool format DISABLED"'
     else
-        call PrototoolEnable()
+        call PrototoolFormatEnable()
         execute 'echo "prototool format ENABLED"'
     endif
 endfunction

--- a/ale_linters/proto/prototool.vim
+++ b/ale_linters/proto/prototool.vim
@@ -1,0 +1,62 @@
+" Author: Peter Edge <pedge@uber.com>
+" Description: run the prototool linter
+
+call ale#Set('proto_prototool_command', 'all')
+
+function! ale_linters#proto#prototool#GetCommand(buffer) abort
+    let l:command = ale#Var(a:buffer, 'proto_prototool_command')
+    if l:command == 'all'
+      " Compile the file, then do generation, then lint
+      return 'prototool all --disable-format --dir-mode %s'
+    elseif l:command == 'compile'
+      " Compile the file only, doing no generation
+      return 'prototool compile --dir-mode %s'
+    elseif l:command == 'lint'
+      " Compile the file and then lint, doing no generation
+      return 'prototool lint --dir-mode %s'
+    else
+      " Sensible default, would be better if we could return error
+      " Is there a way to return error?
+      return 'prototool all --disable-format --dir-mode %s'
+    endif
+endfunction
+
+call ale#linter#Define('proto', {
+			\   'name': 'prototool',
+			\   'lint_file': 1,
+			\   'output_stream': 'stdout',
+			\   'executable': 'prototool',
+      \   'command_callback': 'ale_linters#proto#prototool#GetCommand',
+			\   'callback': 'ale#handlers#unix#HandleAsError',
+			\})
+
+" TODO: not sure how to integrate the below properly, see PR description
+
+function! PrototoolEnable()
+  silent! let g:prototool_format_enable = 1
+endfunction
+
+function! PrototoolDisable()
+  silent! unlet g:prototool_format_enable
+endfunction
+
+function! PrototoolFormatToggle()
+  if exists("g:prototool_format_enable")
+    call PrototoolDisable()
+    echo "prototool format DISABLED"
+  else
+    call PrototoolEnable()
+    echo "prototool format ENABLED"
+  endif
+endfunction
+
+function! PrototoolFormat()
+  if exists("g:prototool_format_enable")
+    silent! execute "!prototool format -w %"
+    silent! edit
+  endif
+endfunction
+
+autocmd BufEnter,BufWritePost *.proto :call PrototoolFormat()
+
+"nnoremap <silent> <leader>f :call PrototoolFormatToggle()<CR>

--- a/doc/ale-proto.txt
+++ b/doc/ale-proto.txt
@@ -46,7 +46,7 @@ prototool                                                  *ale-proto-prototool*
 
   See https://github.com/uber/prototool for more details.
 
-g:ale_proto_prototool_command                  *g:ale_proto_prototool_command*
+g:ale_proto_prototool_command                   *g:ale_proto_prototool_command*
 
   Type: |String|
   Default: `'all'`

--- a/doc/ale-proto.txt
+++ b/doc/ale-proto.txt
@@ -34,7 +34,7 @@ g:ale_proto_protoc_gen_lint_options       *g:ale_proto_protoc_gen_lint_options*
   before any user-supplied options.
 
 ===============================================================================
-prototool                                      *ale-proto-prototool*
+prototool                                                  *ale-proto-prototool*
 
   Prototool provides a full toolbelt for working with `.proto` files. The
   compile, generate, and lint commands are integrated into ale.
@@ -46,7 +46,7 @@ prototool                                      *ale-proto-prototool*
 
   See https://github.com/uber/prototool for more details.
 
-g:ale_proto_prototool_command       *g:ale_proto_prototool_command*
+g:ale_proto_prototool_command                  *g:ale_proto_prototool_command*
 
   Type: |String|
   Default: `'all'`

--- a/doc/ale-proto.txt
+++ b/doc/ale-proto.txt
@@ -5,19 +5,23 @@ ALE Proto Integration                                         *ale-proto-options
 ===============================================================================
 Integration Information
 
-Linting of `.proto` files requires that the `protoc` binary is installed in the
-system path and that the `protoc-gen-lint` plugin for the `protoc` binary is also
-installed.
+Two linters are available for .proto files: protoc-gen-lint and prototool.
 
 To enable `.proto` file linting, update |g:ale_linters| as appropriate:
 >
-  " Enable linter for .proto files
+  " Enable the protoc-gen-lint linter for .proto files
   let g:ale_linters = {'proto': ['protoc-gen-lint']}
+  " Enable the protoool linter for .proto files
+  let g:ale_linters = {'proto': ['prototool']}
 <
 ===============================================================================
 protoc-gen-lint                                      *ale-proto-protoc-gen-lint*
 
-  The linter is a plugin for the `protoc` binary. As long as the binary resides
+  The linter is a plugin for the `protoc` binary.
+
+  Linting of `.proto` files with protoc-gen-lint requires that the `protoc` binary
+  is installed in the system path and that the `protoc-gen-lint` plugin for the
+  `protoc` binary is also installed. As long as the binary resides
   in the system path, `protoc` will find it.
 
 g:ale_proto_protoc_gen_lint_options       *g:ale_proto_protoc_gen_lint_options*
@@ -28,6 +32,34 @@ g:ale_proto_protoc_gen_lint_options       *g:ale_proto_protoc_gen_lint_options*
   This variable can be changed to modify flags given to protoc. Note that the
   directory of the linted file is always passed as an include path with '-I'
   before any user-supplied options.
+
+===============================================================================
+prototool                                      *ale-proto-prototool*
+
+  Prototool provides a full toolbelt for working with `.proto` files. The
+  compile, generate, and lint commands are integrated into ale.
+
+  Prototool takes care of downloading and caching `protoc` for you, so only
+  the `prototool` command must be on your path.
+
+  Prototool is in early alpha, expect breaking changes.
+
+  See https://github.com/uber/prototool for more details.
+
+g:ale_proto_prototool_command       *g:ale_proto_prototool_command*
+
+  Type: |String|
+  Default: `'all'`
+
+  This variable controls the sub command that is used with `prototool`.
+  There are three valid options:
+
+  - `'compile'`: Compile your files with `protoc`. This does no generation.
+  - `'lint'`: Compile and then lint. This does no generation.
+  - `'all'`: Compile, then generate according to your `prototool.yaml`
+    configuration file, then lint. Any plugins referenced must be on
+    your path. If no plugins are referenced in your `prototool.yaml` file,
+    this will only compile and lint, and is equivalent to `'lint'`.
 
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -167,6 +167,7 @@ CONTENTS                                                         *ale-contents*
       ponyc...............................|ale-pony-ponyc|
     proto.................................|ale-proto-options|
       protoc-gen-lint.....................|ale-proto-protoc-gen-lint|
+      prototool...........................|ale-proto-prototool|
     pug...................................|ale-pug-options|
       puglint.............................|ale-pug-puglint|
     puppet................................|ale-puppet-options|
@@ -355,7 +356,7 @@ Notes:
 * PO: `alex`!!, `msgfmt`, `proselint`, `write-good`
 * Pod: `alex`!!, `proselint`, `write-good`
 * Pony: `ponyc`
-* proto: `protoc-gen-lint`
+* proto: `protoc-gen-lint`, `prototool`!!
 * Pug: `pug-lint`
 * Puppet: `puppet`, `puppet-lint`
 * Python: `autopep8`, `flake8`, `isort`, `mypy`, `prospector`, `pycodestyle`, `pyls`, `pylint`!!, `yapf`

--- a/test/command_callback/test_prototool_command_callback.vader
+++ b/test/command_callback/test_prototool_command_callback.vader
@@ -10,19 +10,19 @@ After:
 
 Execute(The default command should be correct):
   AssertEqual
-  \ 'prototool all --disable-format --dirmode ' . '%s',
+  \ 'prototool all --disable-format --dir-mode %s',
   \ ale_linters#proto#prototool#GetCommand(bufnr(''))
 
 Execute(The compile command should be correct):
   let b:ale_proto_prototool_command = 'compile'
 
   AssertEqual
-  \ 'prototool compile --dirmode ' . '%s',
+  \ 'prototool compile --dir-mode %s',
   \ ale_linters#proto#prototool#GetCommand(bufnr(''))
 
 Execute(The lint command should be correct):
   let b:ale_proto_prototool_command = 'lint'
 
   AssertEqual
-  \ 'prototool lint --dirmode ' . '%s',
+  \ 'prototool lint --dir-mode %s',
   \ ale_linters#proto#prototool#GetCommand(bufnr(''))

--- a/test/command_callback/test_prototool_command_callback.vader
+++ b/test/command_callback/test_prototool_command_callback.vader
@@ -1,0 +1,28 @@
+Before:
+  call ale#test#SetFilename('test.proto')
+
+After:
+  Restore
+
+  unlet! b:ale_proto_prototool_command
+
+  call ale#linter#Reset()
+
+Execute(The default command should be correct):
+  AssertEqual
+  \ 'prototool all --disable-format --dirmode ' . '%s',
+  \ ale_linters#proto#prototool#GetCommand(bufnr(''))
+
+Execute(The compile command should be correct):
+  let b:ale_proto_prototool_command = 'compile'
+
+  AssertEqual
+  \ 'prototool compile --dirmode ' . '%s',
+  \ ale_linters#proto#prototool#GetCommand(bufnr(''))
+
+Execute(The lint command should be correct):
+  let b:ale_proto_prototool_command = 'lint'
+
+  AssertEqual
+  \ 'prototool lint --dirmode ' . '%s',
+  \ ale_linters#proto#prototool#GetCommand(bufnr(''))


### PR DESCRIPTION
This adds prototool as an available `.proto` linter.

https://github.com/uber/prototool

Protoc-gen-lint is a fine linter, and I don't want to disturb the work going on there, prototool has a bunch of extra functionality.

Prototool is a toolbelt for working with Protocol Buffers - it takes care of downloading and caching protoc from https://github.com/google/protobuf/releases for you so you don't have to worry about where or whether it is installed, or what version of `protoc` you have, and prototool can compile, lint, and format your files on the fly. A standard `prototool.yaml` config file describes your build, however for most `.proto` files this won't be needed. It's also extremely fast - I'm able to compile and lint around 200 files in about half a second.

Here is a list of the currently available linters:

```
$ prototool list-all-linters
COMMENTS_NO_C_STYLE                                   Verifies that there are no /* c-style */ comments.
ENUMS_HAVE_COMMENTS                                   Verifies that all enums have a comment of the form "// EnumName ...".
ENUM_FIELD_NAMES_UPPERCASE                            Verifies that all enum field names are UPPERCASE.
ENUM_FIELD_NAMES_UPPER_SNAKE_CASE                     Verifies that all enum field names are UPPER_SNAKE_CASE.
ENUM_FIELD_PREFIXES                                   Verifies that all enum fields are prefixed with [NESTED_MESSAGE_NAME_]ENUM_NAME_.
ENUM_NAMES_CAMEL_CASE                                 Verifies that all enum names are CamelCase.
ENUM_NAMES_CAPITALIZED                                Verifies that all enum names are Capitalized.
ENUM_ZERO_VALUES_INVALID                              Verifies that all enum zero value names are [NESTED_MESSAGE_NAME_]ENUM_NAME_INVALID.
FILE_OPTIONS_EQUAL_GO_PACKAGE_PB_SUFFIX               Verifies that the file option "go_package" is equal to $(basename PACKAGE)pb.
FILE_OPTIONS_EQUAL_JAVA_MULTIPLE_FILES_TRUE           Verifies that the file option "java_multiple_files" is equal to true.
FILE_OPTIONS_EQUAL_JAVA_PACKAGE_COM_PB                Verifies that the file option "java_package" is equal to com.PACKAGE.pb.
FILE_OPTIONS_REQUIRE_GO_PACKAGE                       Verifies that the file option "go_package" is set.
FILE_OPTIONS_REQUIRE_JAVA_MULTIPLE_FILES              Verifies that the file option "java_multiple_files" is set.
FILE_OPTIONS_REQUIRE_JAVA_PACKAGE                     Verifies that the file option "java_package" is set.
MESSAGES_HAVE_COMMENTS                                Verifies that all non-extended messages have a comment of the form "// MessageName ...".
MESSAGES_HAVE_COMMENTS_EXCEPT_REQUEST_RESPONSE_TYPES  Verifies that all non-extended messages except for request and response types have a comment of the form "// MessageName ...".
MESSAGE_FIELDS_NOT_FLOATS                             Verifies that all message fields are not floats or doubles.
MESSAGE_FIELD_NAMES_LOWERCASE                         Verifies that all message field names are lowercase.
MESSAGE_FIELD_NAMES_LOWER_SNAKE_CASE                  Verifies that all message field names are lower_snake_case.
MESSAGE_NAMES_CAMEL_CASE                              Verifies that all non-extended message names are CamelCase.
MESSAGE_NAMES_CAPITALIZED                             Verifies that all non-extended message names are Capitalized.
ONEOF_NAMES_LOWER_SNAKE_CASE                          Verifies that all oneof names are lower_snake_case.
PACKAGE_LOWER_SNAKE_CASE                              Verifies that the package is lower_snake.case.
REQUEST_RESPONSE_NAMES_MATCH_RPC                      Verifies that all request names are RpcNameRequest and all response names are RpcNameResponse.
REQUEST_RESPONSE_TYPES_IN_SAME_FILE                   Verifies that all request and response types are in the same file as their corresponding service and are not nested messages.
REQUEST_RESPONSE_TYPES_UNIQUE                         Verifies that all request and response types are unique to each rpc.
RPCS_HAVE_COMMENTS                                    Verifies that all rpcs have a comment of the form "// RPCName ...".
RPC_NAMES_CAMEL_CASE                                  Verifies that all RPC names are CamelCase.
RPC_NAMES_CAPITALIZED                                 Verifies that all RPC names are Capitalized.
SERVICES_HAVE_COMMENTS                                Verifies that all services have a comment of the form "// ServiceName ...".
SERVICE_NAMES_CAMEL_CASE                              Verifies that all service names are CamelCase.
SERVICE_NAMES_CAPITALIZED                             Verifies that all service names are Capitalized.
SYNTAX_PROTO3                                         Verifies that the syntax is proto3.
WKT_DIRECTLY_IMPORTED                                 Verifies that the Well-Known Types are directly imported using "google/protobuf/" as the base of the import.
```

I've been effectively using this plugin for a while now https://github.com/uber/prototool#vim-integration but would love to get it on mainline!

Prototool is in extreme alpha, but I've abstracted the options away so that future changes can be easily made without breaking e.g. `ale_proto_prototool_command`. However any early adopters will understand this and I'll be sure to push any updates.

The formatting I'm not sure how to integrate, and would love any pointers. The general issue is that the formatter needs to be able to read the file from disk, and then write back to disk, which I'm not sure if this fits into the ALE fixer paradigm. I've included the functions I use here, but they surely can't be merged as-is.

Let me know if you have any pointers or other questions, I love your plugin and want others to be able to take advantage of what we're doing.