### PR TITLE
add textlint support

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ formatting.
 | Lua | [luac](https://www.lua.org/manual/5.1/luac.html), [luacheck](https://github.com/mpeterv/luacheck) |
 | Mail | [alex](https://github.com/wooorm/alex) !!, [proselint](http://proselint.com/), [vale](https://github.com/ValeLint/vale) |
 | Make | [checkmake](https://github.com/mrtazz/checkmake) |
-| Markdown | [alex](https://github.com/wooorm/alex) !!, [mdl](https://github.com/mivok/markdownlint), [prettier](https://github.com/prettier/prettier), [proselint](http://proselint.com/), [redpen](http://redpen.cc/), [remark-lint](https://github.com/wooorm/remark-lint) !!, [vale](https://github.com/ValeLint/vale), [write-good](https://github.com/btford/write-good) |
+| Markdown | [alex](https://github.com/wooorm/alex) !!, [mdl](https://github.com/mivok/markdownlint), [prettier](https://github.com/prettier/prettier), [proselint](http://proselint.com/), [redpen](http://redpen.cc/), [remark-lint](https://github.com/wooorm/remark-lint) !!, [vale](https://github.com/ValeLint/vale), [write-good](https://github.com/btford/write-good) , [textlint](https://textlint.github.io/)|
 | MATLAB | [mlint](https://www.mathworks.com/help/matlab/ref/mlint.html) |
 | Nim | [nim check](https://nim-lang.org/docs/nimc.html) !! |
 | nix | [nix-instantiate](http://nixos.org/nix/manual/#sec-nix-instantiate) |

--- a/ale_linters/markdown/textlint.vim
+++ b/ale_linters/markdown/textlint.vim
@@ -1,0 +1,9 @@
+" Author: tokida https://rouger.info
+" Description: textlint, a proofreading tool (https://textlint.github.io/)
+
+call ale#linter#Define('markdown', {
+\   'name': 'textlint',
+\   'executable': 'textlint',
+\   'command': 'if [ -f .textlintrc ]; then textlint -f json %t ; else echo "[{\"filePath\":\"%t\",\"messages\":[]}]"; fi',
+\   'callback': 'ale#handlers#textlint#HandleTextlintOutput',
+\})

--- a/ale_linters/markdown/textlint.vim
+++ b/ale_linters/markdown/textlint.vim
@@ -1,9 +1,23 @@
 " Author: tokida https://rouger.info
 " Description: textlint, a proofreading tool (https://textlint.github.io/)
 
+function! ale_linters#markdown#textlint#GetCommand(buffer) abort
+	let l:cmd_path = ale#path#FindNearestFile(a:buffer, '.textlintrc')
+	if !empty(l:cmd_path)
+		return 'textlint'
+		\	. ' -c '
+		\	. l:cmd_path
+		\ 	. ' -f json %t'
+	else
+		return "[{\'filePath\':\'%t\',\'messages\':[]}]"
+	endif
+endfunction
+
+
 call ale#linter#Define('markdown', {
 \   'name': 'textlint',
 \   'executable': 'textlint',
-\   'command': 'if [ -f .textlintrc ]; then textlint -f json %t ; else echo "[{\"filePath\":\"%t\",\"messages\":[]}]"; fi',
+\   'command_callback': 'ale_linters#markdown#textlint#GetCommand',
 \   'callback': 'ale#handlers#textlint#HandleTextlintOutput',
 \})
+

--- a/ale_linters/markdown/textlint.vim
+++ b/ale_linters/markdown/textlint.vim
@@ -2,15 +2,15 @@
 " Description: textlint, a proofreading tool (https://textlint.github.io/)
 
 function! ale_linters#markdown#textlint#GetCommand(buffer) abort
-	let l:cmd_path = ale#path#FindNearestFile(a:buffer, '.textlintrc')
-	if !empty(l:cmd_path)
-		return 'textlint'
-		\	. ' -c '
-		\	. l:cmd_path
-		\ 	. ' -f json %t'
-	else
-		return "[{\'filePath\':\'%t\',\'messages\':[]}]"
-	endif
+    let l:cmd_path = ale#path#FindNearestFile(a:buffer, '.textlintrc')
+    if !empty(l:cmd_path)
+        return 'textlint'
+        \    . ' -c '
+        \    . l:cmd_path
+        \     . ' -f json %t'
+    else
+        return "[{\'filePath\':\'%t\',\'messages\':[]}]"
+    endif
 endfunction
 
 

--- a/ale_linters/markdown/textlint.vim
+++ b/ale_linters/markdown/textlint.vim
@@ -20,4 +20,3 @@ call ale#linter#Define('markdown', {
 \   'command_callback': 'ale_linters#markdown#textlint#GetCommand',
 \   'callback': 'ale#handlers#textlint#HandleTextlintOutput',
 \})
-

--- a/ale_linters/markdown/textlint.vim
+++ b/ale_linters/markdown/textlint.vim
@@ -3,14 +3,15 @@
 
 function! ale_linters#markdown#textlint#GetCommand(buffer) abort
     let l:cmd_path = ale#path#FindNearestFile(a:buffer, '.textlintrc')
+
     if !empty(l:cmd_path)
         return 'textlint'
         \    . ' -c '
         \    . l:cmd_path
         \     . ' -f json %t'
-    else
-        return "[{\'filePath\':\'%t\',\'messages\':[]}]"
     endif
+
+    return ''
 endfunction
 
 

--- a/autoload/ale/handlers/textlint.vim
+++ b/autoload/ale/handlers/textlint.vim
@@ -2,7 +2,7 @@
 " Description: Redpen, a proofreading tool (http://redpen.cc)
 
 function! ale#handlers#textlint#HandleTextlintOutput(buffer, lines) abort
-    let l:res = json_decode(join(a:lines))[0]
+    let l:res = get(ale#util#FuzzyJSONDecode(a:lines, []), 0, {'messages': []})
     let l:output = []
     for l:err in l:res.messages
         let l:item = {
@@ -14,5 +14,6 @@ function! ale#handlers#textlint#HandleTextlintOutput(buffer, lines) abort
         let l:item.col = l:err.column
         call add(l:output, l:item)
     endfor
+
     return l:output
 endfunction

--- a/autoload/ale/handlers/textlint.vim
+++ b/autoload/ale/handlers/textlint.vim
@@ -4,6 +4,7 @@
 function! ale#handlers#textlint#HandleTextlintOutput(buffer, lines) abort
     let l:res = get(ale#util#FuzzyJSONDecode(a:lines, []), 0, {'messages': []})
     let l:output = []
+
     for l:err in l:res.messages
         call add(l:output, {
         \   'text': l:err.message,

--- a/autoload/ale/handlers/textlint.vim
+++ b/autoload/ale/handlers/textlint.vim
@@ -5,14 +5,13 @@ function! ale#handlers#textlint#HandleTextlintOutput(buffer, lines) abort
     let l:res = get(ale#util#FuzzyJSONDecode(a:lines, []), 0, {'messages': []})
     let l:output = []
     for l:err in l:res.messages
-        let l:item = {
+        call add(l:output, {
         \   'text': l:err.message,
         \   'type': 'W',
         \   'code': l:err.ruleId,
-        \}
-        let l:item.lnum = l:err.line
-        let l:item.col = l:err.column
-        call add(l:output, l:item)
+		\   'lnum': l:err.line,
+		\   'col' : l:err.column
+		\})
     endfor
 
     return l:output

--- a/autoload/ale/handlers/textlint.vim
+++ b/autoload/ale/handlers/textlint.vim
@@ -1,0 +1,18 @@
+" Author: tokida https://rouger.info
+" Description: Redpen, a proofreading tool (http://redpen.cc)
+
+function! ale#handlers#textlint#HandleTextlintOutput(buffer, lines) abort
+    let l:res = json_decode(join(a:lines))[0]
+    let l:output = []
+    for l:err in l:res.messages
+        let l:item = {
+        \   'text': l:err.message,
+        \   'type': 'W',
+        \   'code': l:err.ruleId,
+        \}
+        let l:item.lnum = l:err.line
+        let l:item.col = l:err.column
+        call add(l:output, l:item)
+    endfor
+    return l:output
+endfunction

--- a/autoload/ale/handlers/textlint.vim
+++ b/autoload/ale/handlers/textlint.vim
@@ -9,9 +9,9 @@ function! ale#handlers#textlint#HandleTextlintOutput(buffer, lines) abort
         \   'text': l:err.message,
         \   'type': 'W',
         \   'code': l:err.ruleId,
-		\   'lnum': l:err.line,
-		\   'col' : l:err.column
-		\})
+        \   'lnum': l:err.line,
+        \   'col' : l:err.column
+        \})
     endfor
 
     return l:output

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -342,7 +342,7 @@ Notes:
 * Lua: `luac`, `luacheck`
 * Mail: `alex`!!, `proselint`, `vale`
 * Make: `checkmake`
-* Markdown: `alex`!!, `mdl`, `prettier`, `proselint`, `redpen`, `remark-lint`, `vale`, `write-good`
+* Markdown: `alex`!!, `mdl`, `prettier`, `proselint`, `redpen`, `remark-lint`, `vale`, `write-good`, `textlint`
 * MATLAB: `mlint`
 * Nim: `nim check`!!
 * nix: `nix-instantiate`

--- a/test/handler/test_textlint_handler.vader
+++ b/test/handler/test_textlint_handler.vader
@@ -38,10 +38,4 @@ Execute(textlint handler should no error output):
   AssertEqual
   \ [],
   \ ale#handlers#textlint#HandleTextlintOutput(bufnr(''), [
-  \   '[',
-  \   '  {',
-  \   '    "filePath": "test.md",',
-  \   '    "messages": []',
-  \   '  }',
-  \   ']',
   \ ])

--- a/test/handler/test_textlint_handler.vader
+++ b/test/handler/test_textlint_handler.vader
@@ -1,0 +1,47 @@
+Before:
+  runtime! ale_linters/markdown/textlint.vim
+
+After:
+  call ale#linter#Reset()
+
+Execute(textlint handler should handle errors output):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 16,
+  \     'col': 50,
+  \     'text': 'Found possibly misspelled word "NeoVim".',
+  \     'type': 'W',
+  \     'code': 'preset-japanese/no-doubled-joshi',
+  \   },
+  \ ],
+  \ ale#handlers#textlint#HandleTextlintOutput(bufnr(''), [
+  \   '[',
+  \   '  {',
+  \   '    "filePath": "test.md",',
+  \   '    "messages": [',
+  \   '      {',
+  \   '        "type": "lint",',
+  \   '        "ruleId": "preset-japanese/no-doubled-joshi",',
+  \   '        "index": 1332,',
+  \   '        "line": 16,',
+  \   '        "column": 50,',
+  \   '        "severity": 2,',
+  \   '        "message": "Found possibly misspelled word \"NeoVim\"."',
+  \   '      }',
+  \   '    ]',
+  \   '  }',
+  \   ']',
+  \ ])
+
+Execute(textlint handler should no error output):
+  AssertEqual
+  \ [],
+  \ ale#handlers#textlint#HandleTextlintOutput(bufnr(''), [
+  \   '[',
+  \   '  {',
+  \   '    "filePath": "test.md",',
+  \   '    "messages": []',
+  \   '  }',
+  \   ']',
+  \ ])


### PR DESCRIPTION
I added support for [textlint](https://textlint.github.io/), a proofreading tool for writers and programmers. It supports document formats markdown. I usually use textlint for markdown so I added it as a markdown linter at first.