### PR TITLE
Explain in more detail why perl checks are disabled by default

### DIFF
--- a/doc/ale-perl.txt
+++ b/doc/ale-perl.txt
@@ -3,6 +3,9 @@ ALE Perl Integration                                         *ale-perl-options*
 
 ALE offers a few ways to check Perl code. Checking code with `perl` is
 disabled by default, as `perl` code cannot be checked without executing it.
+Specifically, we use the `-c` flag to see if `perl` code compiles. This does
+not execute all of the code in a file, but it does run `BEGIN` and `CHECK`
+blocks. See `perl --help` and https://stackoverflow.com/a/12908487/406224
 
 See |g:ale_linters|.
 


### PR DESCRIPTION
This is a purely a doc patch.  I thought it would be helpful to explain in a little more detail the new defaults around Perl linting.