### PR TITLE
Fix elm-format fixer name

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -23,6 +23,12 @@ let s:default_registry = {
 \       'description': 'Apply prettier-standard to a file.',
 \       'aliases': ['prettier-standard'],
 \   },
+\   'elm-format': {
+\       'function': 'ale#fixers#elm_format#Fix',
+\       'suggested_filetypes': ['elm'],
+\       'description': 'Apply elm-format to a file.',
+\       'aliases': ['format'],
+\   },
 \   'eslint': {
 \       'function': 'ale#fixers#eslint#Fix',
 \       'suggested_filetypes': ['javascript', 'typescript'],
@@ -32,11 +38,6 @@ let s:default_registry = {
 \       'function': 'ale#fixers#mix_format#Fix',
 \       'suggested_filetypes': ['elixir'],
 \       'description': 'Apply mix format to a file.',
-\   },
-\   'format': {
-\       'function': 'ale#fixers#format#Fix',
-\       'suggested_filetypes': ['elm'],
-\       'description': 'Apply elm-format to a file.',
 \   },
 \   'isort': {
 \       'function': 'ale#fixers#isort#Fix',

--- a/autoload/ale/fixers/elm_format.vim
+++ b/autoload/ale/fixers/elm_format.vim
@@ -5,17 +5,17 @@ call ale#Set('elm_format_executable', 'elm-format')
 call ale#Set('elm_format_use_global', 0)
 call ale#Set('elm_format_options', '--yes')
 
-function! ale#fixers#format#GetExecutable(buffer) abort
+function! ale#fixers#elm_format#GetExecutable(buffer) abort
     return ale#node#FindExecutable(a:buffer, 'elm_format', [
     \   'node_modules/.bin/elm-format',
     \])
 endfunction
 
-function! ale#fixers#format#Fix(buffer) abort
+function! ale#fixers#elm_format#Fix(buffer) abort
     let l:options = ale#Var(a:buffer, 'elm_format_options')
 
     return {
-    \   'command': ale#Escape(ale#fixers#format#GetExecutable(a:buffer))
+    \   'command': ale#Escape(ale#fixers#elm_format#GetExecutable(a:buffer))
     \       . ' %t'
     \       . (empty(l:options) ? '' : ' ' . l:options),
     \   'read_temporary_file': 1,

--- a/test/fixers/test_elm_format_fixer_callback.vader
+++ b/test/fixers/test_elm_format_fixer_callback.vader
@@ -18,7 +18,7 @@ Execute(The elm-format command should have default params):
   \     ale#Escape(ale#path#Simplify(g:dir . '/../elm-test-files/node_modules/.bin/elm-format'))
   \     . ' %t --yes',
   \ },
-  \ ale#fixers#format#Fix(bufnr(''))
+  \ ale#fixers#elm_format#Fix(bufnr(''))
 
 Execute(The elm-format command should manage use_global = 1 param):
   call ale#test#SetFilename('../elm-test-files/src/subdir/testfile.elm')
@@ -31,7 +31,7 @@ Execute(The elm-format command should manage use_global = 1 param):
   \     ale#Escape('elm-format')
   \     . ' %t --yes',
   \ },
-  \ ale#fixers#format#Fix(bufnr(''))
+  \ ale#fixers#elm_format#Fix(bufnr(''))
 
 Execute(The elm-format command should manage executable param):
   call ale#test#SetFilename('../elm-test-files/src/subdir/testfile.elm')
@@ -45,7 +45,7 @@ Execute(The elm-format command should manage executable param):
   \     ale#Escape('elmformat')
   \     . ' %t --yes',
   \ },
-  \ ale#fixers#format#Fix(bufnr(''))
+  \ ale#fixers#elm_format#Fix(bufnr(''))
 
 Execute(The elm-format command should manage empty options):
   call ale#test#SetFilename('../elm-test-files/src/subdir/testfile.elm')
@@ -58,7 +58,7 @@ Execute(The elm-format command should manage empty options):
   \     ale#Escape(ale#path#Simplify(g:dir . '/../elm-test-files/node_modules/.bin/elm-format'))
   \     . ' %t',
   \ },
-  \ ale#fixers#format#Fix(bufnr(''))
+  \ ale#fixers#elm_format#Fix(bufnr(''))
 
 Execute(The elm-format command should manage custom options):
   call ale#test#SetFilename('../elm-test-files/src/subdir/testfile.elm')
@@ -71,4 +71,4 @@ Execute(The elm-format command should manage custom options):
   \     ale#Escape(ale#path#Simplify(g:dir . '/../elm-test-files/node_modules/.bin/elm-format'))
   \     . ' %t --param1 --param2',
   \ },
-  \ ale#fixers#format#Fix(bufnr(''))
+  \ ale#fixers#elm_format#Fix(bufnr(''))


### PR DESCRIPTION
Support for elm-format as a fixer has existed since Sept 2017, but it's not
easy to discover because the fixer was named `format`. This breaks the
convention of the other fixers that use the full name in the registry.

I've gone ahead and fixed this discrepancy, but I left the existing registry
entry in place. We should move people towards using `elm-format` as the fixer
name, but I'd hate to break existing setups.