### PR TITLE
Allow passing options to mix_format

### DIFF
--- a/autoload/ale/fixers/mix_format.vim
+++ b/autoload/ale/fixers/mix_format.vim
@@ -1,16 +1,23 @@
-" Author: carakan <carakan@gmail.com>
+" Author: carakan <carakan@gmail.com>, Fernando Mendes <fernando@mendes.codes>
 " Description: Fixing files with elixir formatter 'mix format'.
 
 call ale#Set('elixir_mix_executable', 'mix')
+call ale#Set('elixir_mix_format_options', '')
 
 function! ale#fixers#mix_format#GetExecutable(buffer) abort
     return ale#Var(a:buffer, 'elixir_mix_executable')
 endfunction
 
+function! ale#fixers#mix_format#GetCommand(buffer) abort
+    let l:executable = ale#Escape(ale#fixers#mix_format#GetExecutable(a:buffer))
+    let l:options = ale#Var(a:buffer, 'elixir_mix_format_options')
+
+    return l:executable . ' format ' . l:options . ' %t'
+endfunction
+
 function! ale#fixers#mix_format#Fix(buffer) abort
     return {
-    \   'command': ale#Escape(ale#fixers#mix_format#GetExecutable(a:buffer))
-    \       . ' format %t',
+    \   'command': ale#fixers#mix_format#GetCommand(a:buffer),
     \   'read_temporary_file': 1,
     \}
 endfunction

--- a/doc/ale-elixir.txt
+++ b/doc/ale-elixir.txt
@@ -14,6 +14,18 @@ g:ale_elixir_mix_options                             *g:ale_elixir_mix_options*
   This variable can be changed to specify the mix executable.
 
 ===============================================================================
+mix_format                                              *ale-elixir-mix-format*
+
+g:ale_elixir_mix_format_options               *g:ale_elixir_mix_format_options*
+                                              *b:ale_elixir_mix_format_options*
+  Type: |String|
+  Default: `''`
+
+
+  This variable can be changed to specify the mix options passed to the
+  mix_format fixer
+
+===============================================================================
 dialyxir                                                  *ale-elixir-dialyxir*
 
 Dialyzer, a DIscrepancy AnaLYZer for ERlang programs.

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -59,6 +59,7 @@ CONTENTS                                                         *ale-contents*
       hadolint............................|ale-dockerfile-hadolint|
     elixir................................|ale-elixir-options|
       mix.................................|ale-elixir-mix|
+      mix_format..........................|ale-elixir-mix-format|
       dialyxir............................|ale-elixir-dialyxir|
     elm...................................|ale-elm-options|
       elm-format..........................|ale-elm-elm-format|

--- a/test/fixers/test_mix_format_fixer_callback.vader
+++ b/test/fixers/test_mix_format_fixer_callback.vader
@@ -1,6 +1,7 @@
 Before:
   call ale#test#SetDirectory('/testplugin/test/fixers')
   Save g:ale_elixir_mix_executable
+  Save g:ale_elixir_mix_format_options
 
   let g:ale_elixir_mix_executable = 'xxxinvalid'
 
@@ -14,7 +15,18 @@ Execute(The mix_format callback should return the correct default values):
   \ {
   \   'read_temporary_file': 1,
   \   'command': ale#Escape('xxxinvalid')
-  \     . ' format %t',
+  \     . ' format  %t',
   \ },
   \ ale#fixers#mix_format#Fix(bufnr(''))
 
+Execute(The mix_format callback should include the correct format options):
+  let g:ale_elixir_mix_format_options = 'invalid_options'
+  call ale#test#SetFilename('../elixir-test-files/testfile.ex')
+
+  AssertEqual
+  \ {
+  \   'read_temporary_file': 1,
+  \   'command': ale#Escape('xxxinvalid')
+  \     . ' format invalid_options %t',
+  \ },
+  \ ale#fixers#mix_format#Fix(bufnr(''))


### PR DESCRIPTION
Allow setting `g:ale_elixir_mix_format_options` and `b:ale_elixir_mix_format_options` to pass options down to the `mix format` invocation.

This is particularly useful for umbrella apps, since you can specify the root project `.formatter.exs` by doing something like:

```vim
if filereadable("../../.formatter.exs")
  let g:ale_fixers['elixir'] = ['mix_format']
  let g:ale_elixir_mix_format_options = "--dot-formatter ../../.formatter.exs"
endif
```