### PR TITLE
Add rufo fixer for Ruby files

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ formatting.
 | reStructuredText | [alex](https://github.com/wooorm/alex) !!, [proselint](http://proselint.com/), [redpen](http://redpen.cc/), [rstcheck](https://github.com/myint/rstcheck), [vale](https://github.com/ValeLint/vale), [write-good](https://github.com/btford/write-good) |
 | Re:VIEW | [redpen](http://redpen.cc/) |
 | RPM spec | [rpmlint](https://github.com/rpm-software-management/rpmlint) (disabled by default; see `:help ale-integration-spec`) |
-| Ruby | [brakeman](http://brakemanscanner.org/) !!, [rails_best_practices](https://github.com/flyerhzm/rails_best_practices) !!, [reek](https://github.com/troessner/reek), [rubocop](https://github.com/bbatsov/rubocop), [ruby](https://www.ruby-lang.org) |
+| Ruby | [brakeman](http://brakemanscanner.org/) !!, [rails_best_practices](https://github.com/flyerhzm/rails_best_practices) !!, [reek](https://github.com/troessner/reek), [rubocop](https://github.com/bbatsov/rubocop), [ruby](https://www.ruby-lang.org), [rufo](https://github.com/ruby-formatter/rufo) |
 | Rust |  cargo !! (see `:help ale-integration-rust` for configuration instructions), [rls](https://github.com/rust-lang-nursery/rls), [rustc](https://www.rust-lang.org/), [rustfmt](https://github.com/rust-lang-nursery/rustfmt) |
 | SASS | [sass-lint](https://www.npmjs.com/package/sass-lint), [stylelint](https://github.com/stylelint/stylelint) |
 | SCSS | [prettier](https://github.com/prettier/prettier), [sass-lint](https://www.npmjs.com/package/sass-lint), [scss-lint](https://github.com/brigade/scss-lint), [stylelint](https://github.com/stylelint/stylelint) |

--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -84,6 +84,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['ruby'],
 \       'description': 'Fix ruby files with rubocop --auto-correct.',
 \   },
+\   'rufo': {
+\       'function': 'ale#fixers#rufo#Fix',
+\       'suggested_filetypes': ['ruby'],
+\       'description': 'Fix ruby files with rufo',
+\   },
 \   'standard': {
 \       'function': 'ale#fixers#standard#Fix',
 \       'suggested_filetypes': ['javascript'],

--- a/autoload/ale/fixers/rufo.vim
+++ b/autoload/ale/fixers/rufo.vim
@@ -1,0 +1,20 @@
+" Author: Fohte (Hayato Kawai) https://github.com/fohte
+" Description: Integration of Rufo with ALE.
+
+call ale#Set('ruby_rufo_executable', 'rufo')
+
+function! ale#fixers#rufo#GetCommand(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'ruby_rufo_executable')
+    let l:exec_args = l:executable =~? 'bundle$'
+    \   ? ' exec rufo'
+    \   : ''
+
+    return ale#Escape(l:executable) . l:exec_args . ' %t'
+endfunction
+
+function! ale#fixers#rufo#Fix(buffer) abort
+    return {
+    \   'command': ale#fixers#rufo#GetCommand(a:buffer),
+    \   'read_temporary_file': 1,
+    \}
+endfunction

--- a/doc/ale-ruby.txt
+++ b/doc/ale-ruby.txt
@@ -87,4 +87,16 @@ g:ale_ruby_ruby_executable                         *g:ale_ruby_ruby_executable*
 
 
 ===============================================================================
+rufo                                                            *ale-ruby-rufo*
+
+g:ale_ruby_rufo_executable                         *g:ale_ruby_rufo_executable*
+                                                   *b:ale_ruby_rufo_executable*
+  Type: String
+  Default: `'rufo'`
+
+  Override the invoked rufo binary. This is useful for running rufo from
+  binstubs or a bundle.
+
+
+===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -197,6 +197,7 @@ CONTENTS                                                         *ale-contents*
       reek................................|ale-ruby-reek|
       rubocop.............................|ale-ruby-rubocop|
       ruby................................|ale-ruby-ruby|
+      rufo................................|ale-ruby-rufo|
     rust..................................|ale-rust-options|
       cargo...............................|ale-rust-cargo|
       rls.................................|ale-rust-rls|
@@ -366,7 +367,7 @@ Notes:
 * reStructuredText: `alex`!!, `proselint`, `redpen`, `rstcheck`, `vale`, `write-good`
 * Re:VIEW: `redpen`
 * RPM spec: `rpmlint`
-* Ruby: `brakeman`, `rails_best_practices`!!, `reek`, `rubocop`, `ruby`
+* Ruby: `brakeman`, `rails_best_practices`!!, `reek`, `rubocop`, `ruby`, `rufo`
 * Rust: `cargo`!!, `rls`, `rustc` (see |ale-integration-rust|), `rustfmt`
 * SASS: `sass-lint`, `stylelint`
 * SCSS: `prettier`, `sass-lint`, `scss-lint`, `stylelint`

--- a/test/fixers/test_rufo_fixer_callback.vader
+++ b/test/fixers/test_rufo_fixer_callback.vader
@@ -1,0 +1,33 @@
+Before:
+  Save g:ale_ruby_rufo_executable
+
+  " Use an invalid global executable, so we don't match it.
+  let g:ale_ruby_rufo_executable = 'xxxinvalid'
+
+  call ale#test#SetDirectory('/testplugin/test/fixers')
+  silent cd ..
+  silent cd command_callback
+  let g:dir = getcwd()
+
+After:
+  Restore
+
+  call ale#test#RestoreDirectory()
+
+Execute(The rufo command should contain `bundle exec` when executable is `bundle`):
+  let g:ale_ruby_rufo_executable = 'bundle'
+  call ale#test#SetFilename('ruby_paths/dummy.rb')
+
+  AssertEqual
+  \ ale#Escape('bundle') . ' exec rufo %t',
+  \ ale#fixers#rufo#GetCommand(bufnr(''))
+
+Execute(The rufo callback should return the correct default values):
+  call ale#test#SetFilename('ruby_paths/dummy.rb')
+
+  AssertEqual
+  \ {
+  \   'read_temporary_file': 1,
+  \   'command': ale#Escape('xxxinvalid') . ' %t'
+  \ },
+  \ ale#fixers#rufo#Fix(bufnr(''))


### PR DESCRIPTION
This PR adds [`rufo`](https://github.com/ruby-formatter/rufo) fixer for Ruby files. (closes #1339)