### PR TITLE
Support textlint for markdown and text files

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ formatting.
 | Lua | [luac](https://www.lua.org/manual/5.1/luac.html), [luacheck](https://github.com/mpeterv/luacheck) |
 | Mail | [alex](https://github.com/wooorm/alex) !!, [proselint](http://proselint.com/), [vale](https://github.com/ValeLint/vale) |
 | Make | [checkmake](https://github.com/mrtazz/checkmake) |
-| Markdown | [alex](https://github.com/wooorm/alex) !!, [mdl](https://github.com/mivok/markdownlint), [prettier](https://github.com/prettier/prettier), [proselint](http://proselint.com/), [redpen](http://redpen.cc/), [remark-lint](https://github.com/wooorm/remark-lint) !!, [vale](https://github.com/ValeLint/vale), [write-good](https://github.com/btford/write-good) |
+| Markdown | [alex](https://github.com/wooorm/alex) !!, [mdl](https://github.com/mivok/markdownlint), [prettier](https://github.com/prettier/prettier), [proselint](http://proselint.com/), [redpen](http://redpen.cc/), [remark-lint](https://github.com/wooorm/remark-lint) !!, [textlint](https://github.com/textlint/textlint), [vale](https://github.com/ValeLint/vale), [write-good](https://github.com/btford/write-good) |
 | MATLAB | [mlint](https://www.mathworks.com/help/matlab/ref/mlint.html) |
 | Nim | [nim check](https://nim-lang.org/docs/nimc.html) !! |
 | nix | [nix-instantiate](http://nixos.org/nix/manual/#sec-nix-instantiate) |
@@ -157,7 +157,7 @@ formatting.
 | Tcl | [nagelfar](http://nagelfar.sourceforge.net) !! |
 | Terraform | [tflint](https://github.com/wata727/tflint) |
 | Texinfo | [alex](https://github.com/wooorm/alex) !!, [proselint](http://proselint.com/), [write-good](https://github.com/btford/write-good)|
-| Text^ | [alex](https://github.com/wooorm/alex) !!, [proselint](http://proselint.com/), [vale](https://github.com/ValeLint/vale), [write-good](https://github.com/btford/write-good), [redpen](http://redpen.cc/) |
+| Text^ | [alex](https://github.com/wooorm/alex) !!, [proselint](http://proselint.com/), [textlint](https://github.com/textlint/textlint), [vale](https://github.com/ValeLint/vale), [write-good](https://github.com/btford/write-good), [redpen](http://redpen.cc/) |
 | Thrift | [thrift](http://thrift.apache.org/) |
 | TypeScript | [eslint](http://eslint.org/), [prettier](https://github.com/prettier/prettier), [tslint](https://github.com/palantir/tslint), tsserver, typecheck |
 | Verilog | [iverilog](https://github.com/steveicarus/iverilog), [verilator](http://www.veripool.org/projects/verilator/wiki/Intro) |

--- a/ale_linters/markdown/textlint.vim
+++ b/ale_linters/markdown/textlint.vim
@@ -1,0 +1,9 @@
+" Author: Yasuhiro Kiyota <yasuhiroki.duck@gmail.com>
+" Description: textlint for markdown files
+
+call ale#linter#Define('markdown', {
+\   'name': 'textlint',
+\   'executable_callback': 'ale#handlers#textlint#GetExecutable',
+\   'command_callback': 'ale#handlers#textlint#GetCommand',
+\   'callback': 'ale#handlers#unix#HandleAsWarning',
+\})

--- a/ale_linters/text/textlint.vim
+++ b/ale_linters/text/textlint.vim
@@ -1,0 +1,9 @@
+" Author: Yasuhiro Kiyota <yasuhiroki.duck@gmail.com>
+" Description: textlint for text files
+
+call ale#linter#Define('text', {
+\   'name': 'textlint',
+\   'executable_callback': 'ale#handlers#textlint#GetExecutable',
+\   'command_callback': 'ale#handlers#textlint#GetCommand',
+\   'callback': 'ale#handlers#unix#HandleAsWarning',
+\})

--- a/autoload/ale/handlers/textlint.vim
+++ b/autoload/ale/handlers/textlint.vim
@@ -1,0 +1,23 @@
+" Author: Yasuhiro Kiyota <yasuhiroki.duck@gmail.com>
+" Description: Integration of textlint with ALE.
+
+call ale#Set('textlint_executable', 'textlint')
+call ale#Set('textlint_use_global', 0)
+call ale#Set('textlint_options', '')
+
+function! ale#handlers#textlint#GetExecutable(buffer) abort
+    return ale#node#FindExecutable(a:buffer, 'textlint', [
+    \   'node_modules/.bin/textlint',
+    \   'node_modules/textlint/bin/textlint.js',
+    \])
+endfunction
+
+function! ale#handlers#textlint#GetCommand(buffer) abort
+    let l:executable = ale#handlers#textlint#GetExecutable(a:buffer)
+    let l:options = ale#Var(a:buffer, 'textlint_options')
+
+    return ale#node#Executable(a:buffer, l:executable)
+    \   . ' --format unix'
+    \   . (!empty(l:options) ? ' ' . l:options : '')
+    \   . ' %t'
+endfunction

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -344,7 +344,7 @@ Notes:
 * Lua: `luac`, `luacheck`
 * Mail: `alex`!!, `proselint`, `vale`
 * Make: `checkmake`
-* Markdown: `alex`!!, `mdl`, `prettier`, `proselint`, `redpen`, `remark-lint`, `vale`, `write-good`
+* Markdown: `alex`!!, `mdl`, `prettier`, `proselint`, `redpen`, `remark-lint`, `textlint`, `vale`, `write-good`
 * MATLAB: `mlint`
 * Nim: `nim check`!!
 * nix: `nix-instantiate`
@@ -380,7 +380,7 @@ Notes:
 * Tcl: `nagelfar`!!
 * Terraform: `tflint`
 * Texinfo: `alex`!!, `proselint`, `write-good`
-* Text^: `alex`!!, `proselint`, `vale`, `write-good`, `redpen`
+* Text^: `alex`!!, `proselint`, `textlint`, `vale`, `write-good`, `redpen`
 * Thrift: `thrift`
 * TypeScript: `eslint`, `prettier`, `tslint`, `tsserver`, `typecheck`
 * Verilog: `iverilog`, `verilator`


### PR DESCRIPTION
This plugin is a favorite tool for me. I really appreciate it! 

I add [textlint](https://github.com/textlint/textlint) linter for markdown and text files.
The `textlint` supports `unix` format and it can use existing handler.