### PR TITLE
Show multiple lints in echo status and ALEDetail

### DIFF
--- a/test/test_cursor_warnings.vader
+++ b/test/test_cursor_warnings.vader
@@ -114,19 +114,21 @@ Execute(Messages should be shown for the correct lines):
   call cursor(1, 1)
   call ale#cursor#EchoCursorWarning()
 
-  AssertEqual 'semi: Missing semicolon.', GetLastMessage()
+  AssertEqual 'semi: Missing semicolon.; Some information', GetLastMessage()
 
 Execute(Messages should be shown for earlier columns):
   call cursor(2, 1)
   call ale#cursor#EchoCursorWarning()
 
-  AssertEqual 'space-infix-ops: Infix operators must be spaced.', GetLastMessage()
+  AssertEqual 'radix: Missing radix parameter; space-infix-ops: Infix
+    \ operators must be spaced.', GetLastMessage()
 
 Execute(Messages should be shown for later columns):
   call cursor(2, 16)
   call ale#cursor#EchoCursorWarning()
 
-  AssertEqual 'radix: Missing radix parameter', GetLastMessage()
+  AssertEqual 'radix: Missing radix parameter; space-infix-ops: Infix
+    \ operators must be spaced.', GetLastMessage()
 
 Execute(The message at the cursor should be shown when linting ends):
   call cursor(1, 1)
@@ -135,13 +137,14 @@ Execute(The message at the cursor should be shown when linting ends):
   \ g:ale_buffer_info[bufnr('%')].loclist,
   \)
 
-  AssertEqual 'semi: Missing semicolon.', GetLastMessage()
+  AssertEqual 'semi: Missing semicolon.; Some information', GetLastMessage()
 
 Execute(The message at the cursor should be shown on InsertLeave):
   call cursor(2, 9)
   doautocmd InsertLeave
 
-  AssertEqual 'space-infix-ops: Infix operators must be spaced.', GetLastMessage()
+  AssertEqual 'radix: Missing radix parameter; space-infix-ops: Infix
+    \ operators must be spaced.', GetLastMessage()
 
 Execute(ALEDetail should print 'detail' attributes):
   call cursor(1, 1)
@@ -149,7 +152,8 @@ Execute(ALEDetail should print 'detail' attributes):
   ALEDetail
 
   AssertEqual
-  \ ['Every statement should end with a semicolon', 'second line'],
+  \ ['Every statement should end with a semicolon', 'second line',
+  \ 'Some information'],
   \ getline(1, '$')
 
 Execute(ALEDetail should print regular 'text' attributes):
@@ -175,7 +179,7 @@ Execute(The linter name should be formatted into the message correctly):
   call ale#cursor#EchoCursorWarning()
 
   AssertEqual
-  \ 'eslint: Infix operators must be spaced.',
+  \ 'eslint: Missing radix parameter; eslint: Infix operators must be spaced.',
   \ GetLastMessage()
 
 Execute(The severity should be formatted into the message correctly):
@@ -185,7 +189,7 @@ Execute(The severity should be formatted into the message correctly):
   call ale#cursor#EchoCursorWarning()
 
   AssertEqual
-  \ 'Warning: Infix operators must be spaced.',
+  \ 'Error: Missing radix parameter; Warning: Infix operators must be spaced.',
   \ GetLastMessage()
 
   call cursor(1, 10)
@@ -205,7 +209,8 @@ Execute(The %code% and %ifcode% should show the code and some text):
   call ale#cursor#EchoCursorWarning()
 
   AssertEqual
-  \ '(space-infix-ops) Infix operators must be spaced.',
+  \ '(radix) Missing radix parameter; (space-infix-ops) Infix operators
+  \ must be spaced.',
   \ GetLastMessage()
 
 Execute(The %code% and %ifcode% should be removed when there's no code):

--- a/test/test_loclist_binary_search.vader
+++ b/test/test_loclist_binary_search.vader
@@ -13,6 +13,8 @@ Before:
   \ {'bufnr': 2, 'lnum': 9, 'col': 2},
   \ {'bufnr': 2, 'lnum': 10, 'col': 2},
   \ {'bufnr': 2, 'lnum': 11, 'col': 2},
+  \ {'bufnr': 2, 'lnum': 11, 'col': 5},
+  \ {'bufnr': 2, 'lnum': 11, 'col': 2},
   \]
 
 After:
@@ -45,5 +47,34 @@ Execute(Searches for buffers later in the list should work):
 
 Execute(Searches should work with just one item):
   let g:loclist = [{'bufnr': 1, 'lnum': 3, 'col': 10}]
-
   AssertEqual 0, ale#util#BinarySearch(g:loclist, 1, 3, 2)
+
+Execute(SearchToLine should find no match if none on the line):
+  AssertEqual -1, ale#util#BinarySearchToLine(g:loclist, 1, 0)
+
+Execute(SearchToLine should find the first on the line):
+  AssertEqual 0, ale#util#BinarySearchToLine(g:loclist, 1, 2)
+  AssertEqual 5, ale#util#BinarySearchToLine(g:loclist, 1, 5)
+
+Execute(SmartSearch should find nothing if no line):
+  AssertEqual [], ale#util#BinarySearchSmart(g:loclist, 1, 0, 1)
+
+Execute(SmartSearch should find all on the line if no column match):
+  AssertEqual [12, 13, 14], ale#util#BinarySearchSmart(g:loclist, 2, 11, 1)
+  AssertEqual [12, 13, 14], ale#util#BinarySearchSmart(g:loclist, 2, 11, 4)
+  AssertEqual [12, 13, 14], ale#util#BinarySearchSmart(g:loclist, 2, 11, 7)
+
+Execute(SmartSearch should find only indexes on line/column if exact match):
+  AssertEqual [12, 14], ale#util#BinarySearchSmart(g:loclist, 2, 11, 2)
+
+Execute(SmartSearch should sort indexes based on error priority and column):
+  let g:loclist = [
+  \{'bufnr': 1, 'lnum': 3, 'col': 10, 'type': 'W'},
+  \{'bufnr': 1, 'lnum': 3, 'col': 10, 'type': 'E'},
+  \{'bufnr': 1, 'lnum': 3, 'col': 10, 'type': 'W'},
+  \{'bufnr': 1, 'lnum': 3, 'col': 10, 'type': ''},
+  \{'bufnr': 1, 'lnum': 3, 'col': 10},
+  \{'bufnr': 1, 'lnum': 3, 'col': 10, 'type': 'I'},
+  \]
+  AssertEqual [1, 0, 2, 5, 3, 4],
+  \ale#util#BinarySearchSmart(g:loclist, 1, 3, 10)


### PR DESCRIPTION
I got annoyed that I'd need to dig through :llist to see the multiple
errors on a given line. I wanted ALE to show me all the problems, and
show the most critical errors first.

So that's what it now does!

By reimplementing FindItemAtCursor and refactoring the BinarySearch, we
now show all lints for a given line, or if the user has their cursor
exactly on the line/col of a highlighted lint we show all the lints for
that given line/col. We also sort the output based on decreasing error type
severity.

I left the old BinarySearch because that's what shows the popup
balloons, and I figure the old functionality suffices for the balloons.

Resolves #1426