### PR TITLE
Add support for Mercury language using mmc as a linter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ formatting.
 | Make | [checkmake](https://github.com/mrtazz/checkmake) |
 | Markdown | [alex](https://github.com/wooorm/alex) !!, [mdl](https://github.com/mivok/markdownlint), [prettier](https://github.com/prettier/prettier), [proselint](http://proselint.com/), [redpen](http://redpen.cc/), [remark-lint](https://github.com/wooorm/remark-lint) !!, [vale](https://github.com/ValeLint/vale), [write-good](https://github.com/btford/write-good) |
 | MATLAB | [mlint](https://www.mathworks.com/help/matlab/ref/mlint.html) |
+| Mercury | [mmc](http://mercurylang.org) !! |
 | Nim | [nim check](https://nim-lang.org/docs/nimc.html) !! |
 | nix | [nix-instantiate](http://nixos.org/nix/manual/#sec-nix-instantiate) |
 | nroff | [alex](https://github.com/wooorm/alex) !!, [proselint](http://proselint.com/), [write-good](https://github.com/btford/write-good)|

--- a/ale_linters/mercury/mmc.vim
+++ b/ale_linters/mercury/mmc.vim
@@ -1,0 +1,45 @@
+" Author: stewy33 <slocumstewy@gmail.com>
+" Description: Lints mercury files using mmc
+
+call ale#Set('mercury_mmc_executable', 'mmc')
+call ale#Set('mercury_mmc_options', '--make --output-compile-error-lines 100')
+
+function! ale_linters#mercury#mmc#GetExecutable(buffer) abort
+    return ale#Var(a:buffer, 'mercury_mmc_executable')
+endfunction
+
+function! ale_linters#mercury#mmc#GetCommand(buffer) abort
+    let l:module_name = expand('#' . a:buffer . ':t:r')
+
+    return ale#path#BufferCdString(a:buffer)
+    \ . ale_linters#mercury#mmc#GetExecutable(a:buffer)
+    \ . ' --errorcheck-only '
+    \ . ale#Var(a:buffer, 'mercury_mmc_options')
+    \ . ' ' . l:module_name
+endfunction
+
+function! ale_linters#mercury#mmc#Handle(buffer, lines) abort
+    " output format
+    " <filename>:<line>:   <issue type>: <message>
+    let l:pattern = '\v^\w+\.m:(\d+):\s+([W|w]arning|.*[E|e]rror.*): (.*)'
+    let l:output = []
+
+    for l:match in ale#util#GetMatches(a:lines, l:pattern)
+        call add(l:output, {
+        \   'lnum': substitute(l:match[1], '\v^0*', '', '') + 0,
+        \   'type': l:match[2][0] =~? 'W' ? 'W' : 'E',
+        \   'text': l:match[2] . ': ' . l:match[3]
+        \})
+    endfor
+
+    return l:output
+endfunction
+
+call ale#linter#Define('mercury', {
+\   'name': 'mmc',
+\   'output_stream': 'stderr',
+\   'executable_callback': 'ale_linters#mercury#mmc#GetExecutable',
+\   'command_callback': 'ale_linters#mercury#mmc#GetCommand',
+\   'callback': 'ale_linters#mercury#mmc#Handle',
+\   'lint_file': 1,
+\})

--- a/doc/ale-mercury.txt
+++ b/doc/ale-mercury.txt
@@ -1,0 +1,26 @@
+===============================================================================
+ALE Mercury Integration                                   *ale-mercury-options*
+
+
+===============================================================================
+mmc                                                           *ale-mercury-mmc*
+
+
+g:ale_mercury_mmc_executable                     *g:ale_mercury_mmc_executable*
+                                                 *b:ale_mercury_mmc_executable*
+  Type: |String|
+  Default: `'mmc'`
+
+  This variable can be changed to use a different executable for mmc.
+
+
+g:ale_mercury_mmc_options                           *g:ale_mercury_mmc_options*
+                                                    *b:ale_mercury_mmc_options*
+  Type: |String|
+  Default: `'--make --output-compile-error-lines 100'`
+
+  This variable can be set to pass additional options to mmc.
+
+
+===============================================================================
+  vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -139,6 +139,8 @@ CONTENTS                                                         *ale-contents*
       mdl.................................|ale-markdown-mdl|
       prettier............................|ale-markdown-prettier|
       write-good..........................|ale-markdown-write-good|
+    mercury...............................|ale-mercury-options|
+      mmc.................................|ale-mercury-mmc|
     nroff.................................|ale-nroff-options|
       write-good..........................|ale-nroff-write-good|
     objc..................................|ale-objc-options|
@@ -346,6 +348,7 @@ Notes:
 * Make: `checkmake`
 * Markdown: `alex`!!, `mdl`, `prettier`, `proselint`, `redpen`, `remark-lint`, `vale`, `write-good`
 * MATLAB: `mlint`
+* Mercury: `mmc`!!
 * Nim: `nim check`!!
 * nix: `nix-instantiate`
 * nroff: `alex`!!, `proselint`, `write-good`

--- a/test/command_callback/test_mercury_mmc_command_callback.vader
+++ b/test/command_callback/test_mercury_mmc_command_callback.vader
@@ -1,0 +1,42 @@
+Before:
+  Save g:ale_mercury_mmc_executable
+  Save g:ale_mercury_mmc_options
+
+  unlet! g:ale_mercury_mmc_executable
+  unlet! b:ale_mercury_mmc_executable
+  unlet! g:ale_mercury_mmc_options
+  unlet! b:ale_mercury_mmc_options
+
+  runtime ale_linters/mercury/mmc.vim
+  call ale#test#SetDirectory('/testplugin/test/command_callback')
+
+After:
+  unlet! b:ale_mercury_mmc_executable
+  unlet! b:ale_mercury_mmc_options
+
+  Restore
+  call ale#test#RestoreDirectory()
+  call ale#linter#Reset()
+
+Execute(The default command should be correct):
+  AssertEqual
+  \ ale#path#BufferCdString(bufnr(''))
+  \ . 'mmc --errorcheck-only --make --output-compile-error-lines 100 dummy',
+  \
+  \ ale_linters#mercury#mmc#GetCommand(bufnr(''))
+
+Execute(The executable should be configurable):
+  let b:ale_mercury_mmc_executable = 'foo'
+  AssertEqual
+  \ ale#path#BufferCdString(bufnr(''))
+  \ . 'foo --errorcheck-only --make --output-compile-error-lines 100 dummy',
+  \
+  \ ale_linters#mercury#mmc#GetCommand(bufnr(''))
+
+Execute(The options should be configurable):
+  let b:ale_mercury_mmc_options = '--bar'
+  AssertEqual
+  \ ale#path#BufferCdString(bufnr(''))
+  \ . 'mmc --errorcheck-only --bar dummy',
+  \
+  \ ale_linters#mercury#mmc#GetCommand(bufnr(''))

--- a/test/handler/test_mercury_mmc_handler.vader
+++ b/test/handler/test_mercury_mmc_handler.vader
@@ -1,0 +1,58 @@
+Before:
+  runtime ale_linters/mercury/mmc.vim
+
+After:
+  call ale#linter#Reset()
+
+Execute(The mmc handler should handle syntax errors):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 3,
+  \     'type': 'E',
+  \     'text': "Syntax error at token ',': operator precedence error."
+  \   }
+  \ ],
+  \ ale_linters#mercury#mmc#Handle(1, [
+  \    "file_name.m:003: Syntax error at token ',': operator precedence error."
+  \ ])
+
+Execute(The mmc handler should handle warnings):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 10,
+  \     'type': 'W',
+  \     'text': 'Warning: reference to uninitialized state variable !.X.'
+  \   },
+  \   {
+  \     'lnum': 12,
+  \     'type': 'W',
+  \     'text': 'warning: determinism declaration could be tighter.'
+  \   }
+  \ ],
+  \ ale_linters#mercury#mmc#Handle(1, [
+  \   'file_name.m:010: Warning: reference to uninitialized state variable !.X.',
+  \   "file_name.m:012: In `some_predicate':",
+  \   'file_name.m:012:    warning: determinism declaration could be tighter.'
+  \ ])
+
+Execute(The mmc handler should handle semantic errors):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 7,
+  \     'type': 'E',
+  \     'text': "error: undefined type `bar'/0."
+  \   },
+  \   {
+  \     'lnum': 15,
+  \     'type': 'E',
+  \     'text': "Error: circular equivalence type `file_name.foo'/0."
+  \   }
+  \ ],
+  \ ale_linters#mercury#mmc#Handle(1, [
+  \    "file_name.m:007: In clause for predicate `foldit'/4:",
+  \    "file_name.m:007:   error: undefined type `bar'/0.",
+  \    "file_name.m:015: Error: circular equivalence type `file_name.foo'/0."
+  \ ])


### PR DESCRIPTION
Straightforward linting support for logic/functional programming language Mercury. Uses mmc, the Melbourne Mercury Compiler to provide errors and warnings. There is almost no code, but if you want I can write tests, I am just a little unclear on how to do so based on tests in the test directory. Let me know if you want anything else done.