### PR TITLE
Lint whole package for gosimple and gotype

### DIFF
--- a/ale_linters/go/gosimple.vim
+++ b/ale_linters/go/gosimple.vim
@@ -9,7 +9,7 @@ call ale#linter#Define('go', {
 \   'name': 'gosimple',
 \   'executable': 'gosimple',
 \   'command_callback': 'ale_linters#go#gosimple#GetCommand',
-\   'callback': 'ale#handlers#unix#HandleAsWarning',
+\   'callback': 'ale#handlers#go#Handler',
 \   'output_stream': 'both',
 \   'lint_file': 1,
 \})

--- a/ale_linters/go/gosimple.vim
+++ b/ale_linters/go/gosimple.vim
@@ -1,10 +1,14 @@
 " Author: Ben Reedy <https://github.com/breed808>
 " Description: gosimple for Go files
 
+function! ale_linters#go#gosimple#GetCommand(buffer) abort
+    return ale#path#BufferCdString(a:buffer) . ' gosimple .'
+endfunction
+
 call ale#linter#Define('go', {
 \   'name': 'gosimple',
 \   'executable': 'gosimple',
-\   'command': 'gosimple %s',
+\   'command_callback': 'ale_linters#go#gosimple#GetCommand',
 \   'callback': 'ale#handlers#unix#HandleAsWarning',
 \   'output_stream': 'both',
 \   'lint_file': 1,

--- a/ale_linters/go/gotype.vim
+++ b/ale_linters/go/gotype.vim
@@ -15,6 +15,6 @@ call ale#linter#Define('go', {
 \   'output_stream': 'stderr',
 \   'executable': 'gotype',
 \   'command_callback': 'ale_linters#go#gotype#GetCommand',
-\   'callback': 'ale#handlers#unix#HandleAsError',
+\   'callback': 'ale#handlers#go#Handler',
 \   'lint_file': 1,
 \})

--- a/ale_linters/go/gotype.vim
+++ b/ale_linters/go/gotype.vim
@@ -6,7 +6,8 @@ function! ale_linters#go#gotype#GetCommand(buffer) abort
         return
     endif
 
-    return 'gotype %s'
+
+    return ale#path#BufferCdString(a:buffer) . ' gotype .'
 endfunction
 
 call ale#linter#Define('go', {

--- a/ale_linters/go/govet.vim
+++ b/ale_linters/go/govet.vim
@@ -8,28 +8,11 @@ function! ale_linters#go#govet#GetCommand(buffer) abort
     return ale#path#BufferCdString(a:buffer) . ' go vet .'
 endfunction
 
-function! ale_linters#go#govet#Handler(buffer, lines) abort
-    let l:pattern = '\v^([a-zA-Z]?:?[^:]+):(\d+):?(\d+)?:? ?(.+)$'
-    let l:output = []
-    let l:dir = expand('#' . a:buffer . ':p:h')
-
-    for l:match in ale#util#GetMatches(a:lines, l:pattern)
-        call add(l:output, {
-        \   'filename': ale#path#GetAbsPath(l:dir, l:match[1]),
-        \   'lnum': l:match[2] + 0,
-        \   'col': l:match[3] + 0,
-        \   'text': l:match[4],
-        \   'type': 'E',
-        \})
-    endfor
-    return l:output
-endfunction
-
 call ale#linter#Define('go', {
 \   'name': 'go vet',
 \   'output_stream': 'stderr',
 \   'executable': 'go',
 \   'command_callback': 'ale_linters#go#govet#GetCommand',
-\   'callback': 'ale_linters#go#govet#Handler',
+\   'callback': 'ale#handlers#go#Handler',
 \   'lint_file': 1,
 \})

--- a/ale_linters/go/staticcheck.vim
+++ b/ale_linters/go/staticcheck.vim
@@ -27,7 +27,7 @@ call ale#linter#Define('go', {
 \   'name': 'staticcheck',
 \   'executable': 'staticcheck',
 \   'command_callback': 'ale_linters#go#staticcheck#GetCommand',
-\   'callback': 'ale#handlers#unix#HandleAsWarning',
+\   'callback': 'ale#handlers#go#Handler',
 \   'output_stream': 'both',
 \   'lint_file': 1,
 \})

--- a/autoload/ale/handlers/go.vim
+++ b/autoload/ale/handlers/go.vim
@@ -1,0 +1,25 @@
+" Author: neersighted <bjorn@neersighted.com>
+" Description: go vet for Go files
+"
+" Author: John Eikenberry <jae@zhar.net>
+" Description: updated to work with go1.10
+"
+" Author: Ben Paxton <ben@gn32.uk>
+" Description: moved to generic Golang file from govet
+
+function! ale#handlers#go#Handler(buffer, lines) abort
+    let l:pattern = '\v^([a-zA-Z]?:?[^:]+):(\d+):?(\d+)?:? ?(.+)$'
+    let l:output = []
+    let l:dir = expand('#' . a:buffer . ':p:h')
+
+    for l:match in ale#util#GetMatches(a:lines, l:pattern)
+        call add(l:output, {
+        \   'filename': ale#path#GetAbsPath(l:dir, l:match[1]),
+        \   'lnum': l:match[2] + 0,
+        \   'col': l:match[3] + 0,
+        \   'text': l:match[4],
+        \   'type': 'E',
+        \})
+    endfor
+    return l:output
+endfunction

--- a/test/command_callback/test_gosimple_command_callback.vader
+++ b/test/command_callback/test_gosimple_command_callback.vader
@@ -1,0 +1,12 @@
+Before:
+  runtime ale_linters/go/gosimple.vim
+  call ale#test#SetFilename('../go_files/testfile2.go')
+
+After:
+  call ale#linter#Reset()
+
+Execute(The default gosimple command should be correct):
+  AssertEqual 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \ . ' gosimple .',
+  \ ale_linters#go#gosimple#GetCommand(bufnr(''))
+

--- a/test/command_callback/test_gotype_command_callback.vader
+++ b/test/command_callback/test_gotype_command_callback.vader
@@ -6,7 +6,9 @@ After:
   call ale#linter#Reset()
 
 Execute(The default gotype command should be correct):
-  AssertEqual 'gotype %s', ale_linters#go#gotype#GetCommand(bufnr(''))
+  AssertEqual 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \ . ' gotype .',
+  \ ale_linters#go#gotype#GetCommand(bufnr(''))
 
 Execute(The gotype callback should ignore test files):
   call ale#test#SetFilename('bla_test.go')

--- a/test/handler/test_go_generic_handler.vader
+++ b/test/handler/test_go_generic_handler.vader
@@ -1,10 +1,4 @@
-Before:
-  runtime ale_linters/go/govet.vim
-
-After:
-  call ale#linter#Reset()
-
-Execute(The govet handler should return the correct filenames):
+Execute(The golang handler should return the correct filenames):
   AssertEqual
   \ [
   \   {
@@ -22,7 +16,7 @@ Execute(The govet handler should return the correct filenames):
   \     'filename': ale#path#Simplify(expand('%:p:h') . '/other.go'),
   \   },
   \ ],
-  \ ale_linters#go#govet#Handler(bufnr(''), [
+  \ ale#handlers#go#Handler(bufnr(''), [
   \   'test.go:27: some error',
   \   'other.go:27:5: some error with a column',
   \ ])


### PR DESCRIPTION
Fixes #936

Neither of these linters can handle single files of a package - both want either all files in the package, or a directory containing a package.