### PR TITLE
Added the word 'find' as it was missing in docs/ale-cs.txt

### DIFF
--- a/doc/ale-cs.txt
+++ b/doc/ale-cs.txt
@@ -38,7 +38,7 @@ mcsc                                                              *ale-cs-mcsc*
   The paths to search for additional assembly files can be specified using the
   |g:ale_cs_mcsc_assembly_path| or |b:ale_cs_mcsc_assembly_path| variables.
 
-  NOTE: ALE will not any errors in files apart from syntax errors if any one
+  NOTE: ALE will not find any errors in files apart from syntax errors if any one
   of the source files contains a syntax error. Syntax errors must be fixed
   first before other errors will be shown.
 


### PR DESCRIPTION
I haven't changed anything else but the wording inside ale-cs.txt file, so no tests should fail