### PR TITLE
Support textlint for plaintext

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ formatting.
 | Lua | [luac](https://www.lua.org/manual/5.1/luac.html), [luacheck](https://github.com/mpeterv/luacheck) |
 | Mail | [alex](https://github.com/wooorm/alex) !!, [proselint](http://proselint.com/), [vale](https://github.com/ValeLint/vale) |
 | Make | [checkmake](https://github.com/mrtazz/checkmake) |
-| Markdown | [alex](https://github.com/wooorm/alex) !!, [markdownlint](https://github.com/DavidAnson/markdownlint) !!, [mdl](https://github.com/mivok/markdownlint), [prettier](https://github.com/prettier/prettier), [proselint](http://proselint.com/), [redpen](http://redpen.cc/), [remark-lint](https://github.com/wooorm/remark-lint) !!, [vale](https://github.com/ValeLint/vale), [write-good](https://github.com/btford/write-good) , [textlint](https://textlint.github.io/)|
+| Markdown | [alex](https://github.com/wooorm/alex) !!, [markdownlint](https://github.com/DavidAnson/markdownlint) !!, [mdl](https://github.com/mivok/markdownlint), [prettier](https://github.com/prettier/prettier), [proselint](http://proselint.com/), [redpen](http://redpen.cc/), [remark-lint](https://github.com/wooorm/remark-lint) !!, [textlint](https://textlint.github.io/), [vale](https://github.com/ValeLint/vale), [write-good](https://github.com/btford/write-good) |
 | MATLAB | [mlint](https://www.mathworks.com/help/matlab/ref/mlint.html) |
 | Nim | [nim check](https://nim-lang.org/docs/nimc.html) !! |
 | nix | [nix-instantiate](http://nixos.org/nix/manual/#sec-nix-instantiate) |
@@ -158,7 +158,7 @@ formatting.
 | Tcl | [nagelfar](http://nagelfar.sourceforge.net) !! |
 | Terraform | [tflint](https://github.com/wata727/tflint) |
 | Texinfo | [alex](https://github.com/wooorm/alex) !!, [proselint](http://proselint.com/), [write-good](https://github.com/btford/write-good)|
-| Text^ | [alex](https://github.com/wooorm/alex) !!, [proselint](http://proselint.com/), [vale](https://github.com/ValeLint/vale), [write-good](https://github.com/btford/write-good), [redpen](http://redpen.cc/) |
+| Text^ | [alex](https://github.com/wooorm/alex) !!, [proselint](http://proselint.com/), [redpen](http://redpen.cc/), [textlint](https://textlint.github.io/), [vale](https://github.com/ValeLint/vale), [write-good](https://github.com/btford/write-good) |
 | Thrift | [thrift](http://thrift.apache.org/) |
 | TypeScript | [eslint](http://eslint.org/), [prettier](https://github.com/prettier/prettier), [tslint](https://github.com/palantir/tslint), tsserver, typecheck |
 | Verilog | [iverilog](https://github.com/steveicarus/iverilog), [verilator](http://www.veripool.org/projects/verilator/wiki/Intro) |

--- a/ale_linters/text/textlint.vim
+++ b/ale_linters/text/textlint.vim
@@ -1,7 +1,7 @@
-" Author: tokida https://rouger.info, Yasuhiro Kiyota <yasuhiroki.duck@gmail.com>
+" Author: Yasuhiro Kiyota <yasuhiroki.duck@gmail.com>
 " Description: textlint, a proofreading tool (https://textlint.github.io/)
 
-call ale#linter#Define('markdown', {
+call ale#linter#Define('text', {
 \   'name': 'textlint',
 \   'executable_callback': 'ale#handlers#textlint#GetExecutable',
 \   'command_callback': 'ale#handlers#textlint#GetCommand',

--- a/autoload/ale/handlers/textlint.vim
+++ b/autoload/ale/handlers/textlint.vim
@@ -1,5 +1,34 @@
-" Author: tokida https://rouger.info
-" Description: Redpen, a proofreading tool (http://redpen.cc)
+" Author: tokida https://rouger.info, Yasuhiro Kiyota <yasuhiroki.duck@gmail.com>
+" Description: textlint, a proofreading tool (https://textlint.github.io/)
+
+call ale#Set('textlint_executable', 'textlint')
+call ale#Set('textlint_use_global', 0)
+call ale#Set('textlint_options', '')
+
+function! ale#handlers#textlint#GetExecutable(buffer) abort
+    return ale#node#FindExecutable(a:buffer, 'textlint', [
+    \   'node_modules/.bin/textlint',
+    \   'node_modules/textlint/bin/textlint.js',
+    \])
+endfunction
+
+function! ale#handlers#textlint#GetCommand(buffer) abort
+    let l:cmd_path = ale#path#FindNearestFile(a:buffer, '.textlintrc')
+    let l:options = ale#Var(a:buffer, 'textlint_options')
+
+    if !empty(l:cmd_path)
+        return 'textlint'
+        \    . ' -c '
+        \    . l:cmd_path
+        \    . (!empty(l:options) ? ' ' . l:options : '')
+        \    . ' -f json %t'
+    endif
+
+    return 'textlint'
+    \    . (!empty(l:options) ? ' ' . l:options : '')
+    \    . ' -f json %t'
+endfunction
+
 
 function! ale#handlers#textlint#HandleTextlintOutput(buffer, lines) abort
     let l:res = get(ale#util#FuzzyJSONDecode(a:lines, []), 0, {'messages': []})

--- a/doc/ale-markdown.txt
+++ b/doc/ale-markdown.txt
@@ -28,6 +28,12 @@ See |ale-javascript-prettier| for information about the available options.
 
 
 ===============================================================================
+textlint                                                *ale-markdown-textlint*
+
+See |ale-text-textlint|
+
+
+===============================================================================
 write-good                                            *ale-markdown-write-good*
 
 See |ale-write-good-options|

--- a/doc/ale-text.txt
+++ b/doc/ale-text.txt
@@ -3,6 +3,36 @@ ALE Text Integration                                         *ale-text-options*
 
 
 ===============================================================================
+textlint                                                    *ale-text-textlint*
+
+The options for the textlint linter are global because it does not make
+sense to have them specified on a per-language basis.
+
+g:ale_textlint_executable                           *g:ale_textlint_executable*
+                                                    *b:ale_textlint_executable*
+  Type: |String|
+  Default: `'textlint'`
+
+  See |ale-integrations-local-executables|
+
+
+g:ale_textlint_options                                 *g:ale_textlint_options*
+                                                       *b:ale_textlint_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be set to pass additional options to textlint.
+
+
+g:ale_textlint_use_global                           *g:ale_textlint_use_global*
+                                                    *b:ale_textlint_use_global*
+  Type: |Number|
+  Default: `0`
+
+  See |ale-integrations-local-executables|
+
+
+===============================================================================
 write-good                                                *ale-text-write-good*
 
 See |ale-write-good-options|

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -139,6 +139,7 @@ CONTENTS                                                         *ale-contents*
     markdown..............................|ale-markdown-options|
       mdl.................................|ale-markdown-mdl|
       prettier............................|ale-markdown-prettier|
+      textlint............................|ale-markdown-textlint|
       write-good..........................|ale-markdown-write-good|
     nroff.................................|ale-nroff-options|
       write-good..........................|ale-nroff-write-good|
@@ -234,6 +235,7 @@ CONTENTS                                                         *ale-contents*
     texinfo...............................|ale-texinfo-options|
       write-good..........................|ale-texinfo-write-good|
     text..................................|ale-text-options|
+      textlint............................|ale-text-textlint|
       write-good..........................|ale-text-write-good|
     thrift................................|ale-thrift-options|
       thrift..............................|ale-thrift-thrift|
@@ -346,7 +348,7 @@ Notes:
 * Lua: `luac`, `luacheck`
 * Mail: `alex`!!, `proselint`, `vale`
 * Make: `checkmake`
-* Markdown: `alex`!!, `markdownlint`!!, `mdl`, `prettier`, `proselint`, `redpen`, `remark-lint`, `vale`, `write-good`, `textlint`
+* Markdown: `alex`!!, `markdownlint`!!, `mdl`, `prettier`, `proselint`, `redpen`, `remark-lint`, `textlint`, `vale`, `write-good`
 * MATLAB: `mlint`
 * Nim: `nim check`!!
 * nix: `nix-instantiate`
@@ -382,7 +384,7 @@ Notes:
 * Tcl: `nagelfar`!!
 * Terraform: `tflint`
 * Texinfo: `alex`!!, `proselint`, `write-good`
-* Text^: `alex`!!, `proselint`, `vale`, `write-good`, `redpen`
+* Text^: `alex`!!, `proselint`, `redpen`, `textlint`, `vale`, `write-good`
 * Thrift: `thrift`
 * TypeScript: `eslint`, `prettier`, `tslint`, `tsserver`, `typecheck`
 * Verilog: `iverilog`, `verilator`


### PR DESCRIPTION
- Support `textlint` for plaintext
- Enable to use textlint without `.textlintrc` file by `let g:ale_textlint_options = '--preset preset-ja-technical-writing'`
- Update documentation
  - Fix test failure of ToC sorting 
- I referenced to write-good ale handler implementation