### PR TITLE
Integration of qmlfmt linting tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ formatting.
 | Pug | [pug-lint](https://github.com/pugjs/pug-lint) |
 | Puppet | [puppet](https://puppet.com), [puppet-lint](https://puppet-lint.com) |
 | Python | [autopep8](https://github.com/hhatto/autopep8), [flake8](http://flake8.pycqa.org/en/latest/), [isort](https://github.com/timothycrosley/isort), [mypy](http://mypy-lang.org/), [prospector](http://github.com/landscapeio/prospector), [pycodestyle](https://github.com/PyCQA/pycodestyle), [pyls](https://github.com/palantir/python-language-server), [pylint](https://www.pylint.org/) !!, [yapf](https://github.com/google/yapf) |
-| QML | [qmllint](https://github.com/qt/qtdeclarative/tree/5.11/tools/qmllint) |
+| QML | [qmlfmt](https://github.com/jesperhh/qmlfmt), [qmllint](https://github.com/qt/qtdeclarative/tree/5.11/tools/qmllint) |
 | R | [lintr](https://github.com/jimhester/lintr) |
 | ReasonML | [merlin](https://github.com/the-lambda-church/merlin) see `:help ale-reasonml-ols` for configuration instructions, [ols](https://github.com/freebroccolo/ocaml-language-server), [refmt](https://github.com/reasonml/reason-cli) |
 | reStructuredText | [alex](https://github.com/wooorm/alex) !!, [proselint](http://proselint.com/), [redpen](http://redpen.cc/), [rstcheck](https://github.com/myint/rstcheck), [vale](https://github.com/ValeLint/vale), [write-good](https://github.com/btford/write-good) |

--- a/ale_linters/qml/qmlfmt.vim
+++ b/ale_linters/qml/qmlfmt.vim
@@ -1,0 +1,35 @@
+" Author: pylipp (www.github.com/pylipp)
+" Description: qmlfmt for QML files
+
+let g:ale_qml_qmlfmt_executable = get(g:, 'ale_qml_qmlfmt_executable', 'qmlfmt')
+
+function! ale_linters#qml#qmlfmt#GetExecutable(buffer) abort
+    return ale#Var(a:buffer, 'qml_qmlfmt_executable')
+endfunction
+
+" Find lines like
+" Error:11:1: Expected token `}'
+function! ale_linters#qml#qmlfmt#Handle(buffer, lines) abort
+    let l:pattern = '\v^(Error|Warning):(\d+):(\d+): (.\+)$'
+    let l:output = []
+
+    for l:match in ale#util#GetMatches(a:lines, l:pattern)
+        let l:item = {
+        \   'lnum': l:match[2] + 0,
+        \   'col': l:match[3],
+        \   'text': l:match[4],
+        \   'type': l:match[1] is# 'Warning' ? 'W' : 'E',
+        \}
+        call add(l:output, l:item)
+    endfor
+
+    return l:output
+endfunction
+
+call ale#linter#Define('qml', {
+\   'name': 'qmlfmt',
+\   'output_stream': 'stderr',
+\   'executable_callback': 'ale_linters#qml#qmlfmt#GetExecutable',
+\   'command': g:ale_linters#qml#qmlfmt#GetExecutable . ' -e %t',
+\   'callback': 'ale_linters#qml#qmlfmt#Handle',
+\})

--- a/ale_linters/qml/qmlfmt.vim
+++ b/ale_linters/qml/qmlfmt.vim
@@ -15,13 +15,13 @@ endfunction
 " Find lines like
 " Error:11:1: Expected token `}'
 function! ale_linters#qml#qmlfmt#Handle(buffer, lines) abort
-    let l:pattern = '\v^(Error|Warning):(\d+):(\d+): (.\+)$'
+    let l:pattern = '\v^(Error|Warning):(\d+):(\d+): (.+)$'
     let l:output = []
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)
         let l:item = {
         \   'lnum': l:match[2] + 0,
-        \   'col': l:match[3],
+        \   'col': l:match[3] + 0,
         \   'text': l:match[4],
         \   'type': l:match[1] is# 'Warning' ? 'W' : 'E',
         \}

--- a/ale_linters/qml/qmlfmt.vim
+++ b/ale_linters/qml/qmlfmt.vim
@@ -7,6 +7,11 @@ function! ale_linters#qml#qmlfmt#GetExecutable(buffer) abort
     return ale#Var(a:buffer, 'qml_qmlfmt_executable')
 endfunction
 
+function! ale_linters#qml#qmlfmt#GetCommand(buffer) abort
+    return ale#Escape(ale_linters#qml#qmlfmt#GetExecutable(a:buffer))
+    \   . ' -e'
+endfunction
+
 " Find lines like
 " Error:11:1: Expected token `}'
 function! ale_linters#qml#qmlfmt#Handle(buffer, lines) abort
@@ -30,6 +35,6 @@ call ale#linter#Define('qml', {
 \   'name': 'qmlfmt',
 \   'output_stream': 'stderr',
 \   'executable_callback': 'ale_linters#qml#qmlfmt#GetExecutable',
-\   'command': g:ale_linters#qml#qmlfmt#GetExecutable . ' -e %t',
+\   'command_callback': 'ale_linters#qml#qmlfmt#GetCommand',
 \   'callback': 'ale_linters#qml#qmlfmt#Handle',
 \})

--- a/doc/ale-qml.txt
+++ b/doc/ale-qml.txt
@@ -1,0 +1,18 @@
+===============================================================================
+ALE QML Integration                                           *ale-qml-options*
+
+
+===============================================================================
+qmlfmt                                                         *ale-qml-qmlfmt*
+
+g:ale_qml_qmlfmt_executable                       *g:ale_qml_qmlfmt_executable*
+                                                  *b:ale_qml_qmlfmt_executable*
+  Type: |String|
+  Default: `'qmlfmt'`
+
+  This variable can be set to change the path to qmlfmt.
+
+
+===============================================================================
+  vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:
+

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -185,6 +185,8 @@ CONTENTS                                                         *ale-contents*
       pylint..............................|ale-python-pylint|
       pyls................................|ale-python-pyls|
       yapf................................|ale-python-yapf|
+    qml...................................|ale-qml-options|
+      qmlfmt..............................|ale-qml-qmlfmt|
     r.....................................|ale-r-options|
       lintr...............................|ale-r-lintr|
     reasonml..............................|ale-reasonml-options|
@@ -365,7 +367,7 @@ Notes:
 * Pug: `pug-lint`
 * Puppet: `puppet`, `puppet-lint`
 * Python: `autopep8`, `flake8`, `isort`, `mypy`, `prospector`, `pycodestyle`, `pyls`, `pylint`!!, `yapf`
-* QML: `qmllint`
+* QML: `qmlfmt`, `qmllint`
 * R: `lintr`
 * ReasonML: `merlin`, `ols`, `refmt`
 * reStructuredText: `alex`!!, `proselint`, `redpen`, `rstcheck`, `vale`, `write-good`

--- a/test/command_callback/test_qmlfmt_command_callback.vader
+++ b/test/command_callback/test_qmlfmt_command_callback.vader
@@ -1,0 +1,18 @@
+Before:
+  runtime ale_linters/qml/qmlfmt.vim
+
+After:
+  let g:ale_qml_qmlfmt_executable = 'qmlfmt'
+
+  call ale#linter#Reset()
+
+Execute(The qml qmlfmt command callback should return the correct default string):
+  AssertEqual ale#Escape('qmlfmt') . ' -e',
+  \ join(split(ale_linters#qml#qmlfmt#GetCommand(1)))
+
+Execute(The qmlfmt executable should be configurable):
+  let g:ale_qml_qmlfmt_executable = '~/.local/bin/qmlfmt'
+
+  AssertEqual '~/.local/bin/qmlfmt', ale_linters#qml#qmlfmt#GetExecutable(1)
+  AssertEqual ale#Escape('~/.local/bin/qmlfmt') . ' -e',
+  \ join(split(ale_linters#qml#qmlfmt#GetCommand(1)))

--- a/test/handler/test_qmlfmt_handler.vader
+++ b/test/handler/test_qmlfmt_handler.vader
@@ -1,0 +1,19 @@
+Before:
+  runtime ale_linters/qml/qmlfmt.vim
+
+After:
+  call ale#linter#Reset()
+
+Execute(The qmlfmt handler should parse error messages correctly):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 22,
+  \     'col': 1,
+  \     'type': 'E',
+  \     'text': 'Expected token ''}''.'
+  \   }
+  \ ],
+  \ ale_linters#qml#qmlfmt#Handle(1, [
+  \   'Error:22:1: Expected token ''}''.'
+  \ ])


### PR DESCRIPTION
qmlfmt has several advantages over qmllint as a QML linting tool. It
gives information about error types and the precise position of the
error. It can also be used to format QML code (which might be a separate
PR).

The commits, new files and new documentation should speak for themselves
;)