### PR TITLE
Add g:ale_php_cs_fixer_options variable

### DIFF
--- a/autoload/ale/fixers/php_cs_fixer.vim
+++ b/autoload/ale/fixers/php_cs_fixer.vim
@@ -3,6 +3,7 @@
 
 call ale#Set('php_cs_fixer_executable', 'php-cs-fixer')
 call ale#Set('php_cs_fixer_use_global', 0)
+call ale#Set('php_cs_fixer_options', '')
 
 function! ale#fixers#php_cs_fixer#GetExecutable(buffer) abort
     return ale#node#FindExecutable(a:buffer, 'php_cs_fixer', [
@@ -14,10 +15,9 @@ endfunction
 function! ale#fixers#php_cs_fixer#Fix(buffer) abort
     let l:executable = ale#fixers#php_cs_fixer#GetExecutable(a:buffer)
     return {
-    \   'command': ale#Escape(l:executable) . ' fix %t',
+    \   'command': ale#Escape(l:executable)
+    \       . ' ' . ale#Var(a:buffer, 'php_cs_fixer_options')
+    \       . ' fix %t',
     \   'read_temporary_file': 1,
     \}
 endfunction
-
-
-

--- a/doc/ale-php.txt
+++ b/doc/ale-php.txt
@@ -183,5 +183,12 @@ g:ale_php_cs_fixer_use_global                    *g:ale_php_cs_fixer_use_global*
 
   This variable force globally installed fixer.
 
+g:ale_php_cs_fixer_options                          *g:ale_php_cs_fixer_options*
+                                                    *b:ale_php_cs_fixer_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be set to pass additional options to php-cs-fixer.
+
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/test/fixers/test_php_cs_fixer.vader
+++ b/test/fixers/test_php_cs_fixer.vader
@@ -2,6 +2,7 @@ Before:
   Save g:ale_php_cs_fixer_executable
   Save g:ale_php_cs_fixer_options
   let g:ale_php_cs_fixer_executable = 'php-cs-fixer'
+  let g:ale_php_cs_fixer_options = ''
 
   call ale#test#SetDirectory('/testplugin/test/fixers')
   silent cd ..
@@ -43,7 +44,12 @@ Execute(The php-cs-fixer callback should return the correct default values):
   call ale#test#SetFilename('php_paths/project-without-php-cs-fixer/foo/test.php')
 
   AssertEqual
-  \ {'read_temporary_file': 1, 'command': ale#Escape('php-cs-fixer') . ' fix %t' },
+  \ {
+  \   'read_temporary_file': 1,
+  \   'command': ale#Escape('php-cs-fixer')
+  \      . ' ' . g:ale_php_cs_fixer_options
+  \      . ' fix %t'
+  \ },
   \ ale#fixers#php_cs_fixer#Fix(bufnr(''))
 
 Execute(The php-cs-fixer callback should include custom php-cs-fixer options):

--- a/test/fixers/test_php_cs_fixer.vader
+++ b/test/fixers/test_php_cs_fixer.vader
@@ -1,5 +1,6 @@
 Before:
   Save g:ale_php_cs_fixer_executable
+  Save g:ale_php_cs_fixer_options
   let g:ale_php_cs_fixer_executable = 'php-cs-fixer'
 
   call ale#test#SetDirectory('/testplugin/test/fixers')
@@ -43,4 +44,16 @@ Execute(The php-cs-fixer callback should return the correct default values):
 
   AssertEqual
   \ {'read_temporary_file': 1, 'command': ale#Escape('php-cs-fixer') . ' fix %t' },
+  \ ale#fixers#php_cs_fixer#Fix(bufnr(''))
+
+Execute(The php-cs-fixer callback should include custom php-cs-fixer options):
+  let g:ale_php_cs_fixer_options = '--config="$HOME/.php_cs"'
+  call ale#test#SetFilename('php_paths/project-without-php-cs-fixer/test.php')
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape(g:ale_php_cs_fixer_executable)
+  \     . ' --config="$HOME/.php_cs" fix %t',
+  \   'read_temporary_file': 1,
+  \ },
   \ ale#fixers#php_cs_fixer#Fix(bufnr(''))


### PR DESCRIPTION
This allows me to fall back to a global config file:

```vim
if !filereadable('.php_cs') && !filereadable('.php_cs.dist')
  let g:ale_php_cs_fixer_options = '--config="$HOME/.php_cs"'
endif
```