### PR TITLE
Implemented fix from @ifyouseewendy

### DIFF
--- a/autoload/ale/fixers/brittany.vim
+++ b/autoload/ale/fixers/brittany.vim
@@ -1,4 +1,4 @@
-" Author: eborden <evan@evan-borden.com>
+" Author: eborden <evan@evan-borden.com>, ifyouseewendy <ifyouseewendy@gmail.com>, aspidiets <emarshall85@gmail.com>
 " Description: Integration of brittany with ALE.
 
 call ale#Set('haskell_brittany_executable', 'brittany')

--- a/autoload/ale/fixers/brittany.vim
+++ b/autoload/ale/fixers/brittany.vim
@@ -2,16 +2,13 @@
 " Description: Integration of brittany with ALE.
 
 call ale#Set('haskell_brittany_executable', 'brittany')
-call ale#Set('haskell_brittany_options', '--write-mode inplace')
 
 function! ale#fixers#brittany#Fix(buffer) abort
     let l:executable = ale#Var(a:buffer, 'haskell_brittany_executable')
-    let l:options = ale#Var(a:buffer, 'haskell_brittany_options')
-
 
     return {
     \   'command': ale#Escape(l:executable)
-    \       . (!empty(l:options) ? ' ' . l:options : '--write-mode inplace')
+    \       . ' --write-mode inplace'
     \       . ' %t',
     \   'read_temporary_file': 1,
     \}

--- a/autoload/ale/fixers/brittany.vim
+++ b/autoload/ale/fixers/brittany.vim
@@ -2,12 +2,16 @@
 " Description: Integration of brittany with ALE.
 
 call ale#Set('haskell_brittany_executable', 'brittany')
+call ale#Set('haskell_brittany_options', '--write-mode inplace')
 
 function! ale#fixers#brittany#Fix(buffer) abort
     let l:executable = ale#Var(a:buffer, 'haskell_brittany_executable')
+    let l:options = ale#Var(a:buffer, 'haskell_brittany_options')
+
 
     return {
     \   'command': ale#Escape(l:executable)
+    \       . (!empty(l:options) ? ' ' . l:options : '--write-mode inplace')
     \       . ' %t',
     \   'read_temporary_file': 1,
     \}


### PR DESCRIPTION
# Description
This basically implements the fix from #1424. The only deviation from the proposed fix is to imply the '--write-mode inplace' option as I cannot imagine a case where you don't want that, and I don't think it's idiomatic for a user to have to specify that in there config before the fixer even works. 

I have to admit that I've never written VimL, so don't know how to use vader. Looking in `test/fixers`, though, it appears that we are only testing that the command is called correctly, not that a particular fixer executes as expected, so I think I'm OK? I've also never used vint, but after installing `vint -s brittany.vim` doesn't produce output, so I assume I'm OK here as well. 

Happy to take feedback in either case, so long as you realize that responses will be a bit slow, as I only really have weekends to play around with this.
