### PR TITLE
correct cpp linter name from `g++` to `gcc`

### DIFF
--- a/ale_linters/cpp/gcc.vim
+++ b/ale_linters/cpp/gcc.vim
@@ -21,7 +21,7 @@ function! ale_linters#cpp#gcc#GetCommand(buffer, output) abort
 endfunction
 
 call ale#linter#Define('cpp', {
-\   'name': 'g++',
+\   'name': 'gcc',
 \   'output_stream': 'stderr',
 \   'executable_callback': 'ale_linters#cpp#gcc#GetExecutable',
 \   'command_chain': [


### PR DESCRIPTION
fixed: https://github.com/w0rp/ale/issues/1490
