### PR TITLE
fixed: pylint doesn't work on windows:

### DIFF
--- a/ale_linters/python/pylint.vim
+++ b/ale_linters/python/pylint.vim
@@ -17,7 +17,7 @@ function! ale_linters#python#pylint#GetCommand(buffer) abort
     return ale#path#BufferCdString(a:buffer)
     \   . ale#Escape(ale_linters#python#pylint#GetExecutable(a:buffer))
     \   . ' ' . ale#Var(a:buffer, 'python_pylint_options')
-    \   . ' --output-format text --msg-template="{path}:{line}:{column}: {msg_id} ({symbol}) {msg}" --reports n'
+    \   . ' --output-format text --msg-template="{module}:{line}:{column}: {msg_id} ({symbol}) {msg}" --reports n'
     \   . ' %s'
 endfunction
 


### PR DESCRIPTION
This patch solved: https://github.com/w0rp/ale/issues/1492

On windows, pylint will output file's full path name which contains colon and backslash in it. and it will break the regexp in pylint.vim.
So, all the pylint output will be discarded by pylint.vim.

Since filename is ignored in pylint.vim, so I change the pylint's output template {path} to {module}, and it will never contain any colon and backslash again.

This patch works great on windos and linux.


