### PR TITLE
Parse compile_commands.json to get flags for the clang linters

### DIFF
--- a/ale_linters/c/clang.vim
+++ b/ale_linters/c/clang.vim
@@ -12,7 +12,7 @@ endfunction
 function! ale_linters#c#clang#GetCommand(buffer, output) abort
     let l:compile_command = ale#c#GetCompileCommand(a:buffer)
     if l:compile_command isnot 0
-        return l:compile_command
+        return l:compile_command . ' ' . ale#Var(a:buffer, 'c_clang_options')
     endif
 
     let l:cflags = ale#c#GetCFlags(a:buffer, a:output)

--- a/ale_linters/c/clang.vim
+++ b/ale_linters/c/clang.vim
@@ -1,4 +1,5 @@
 " Author: Masahiro H https://github.com/mshr-h
+" Author: tbodt <https://github.com/tbodt>
 " Description: clang linter for c files
 
 call ale#Set('c_clang_executable', 'clang')
@@ -9,6 +10,11 @@ function! ale_linters#c#clang#GetExecutable(buffer) abort
 endfunction
 
 function! ale_linters#c#clang#GetCommand(buffer, output) abort
+    let l:compile_command = ale#c#GetCompileCommand(a:buffer)
+    if l:compile_command isnot 0
+        return l:compile_command
+    endif
+
     let l:cflags = ale#c#GetCFlags(a:buffer, a:output)
 
     " -iquote with the directory the file is in makes #include work for

--- a/ale_linters/cpp/clang.vim
+++ b/ale_linters/cpp/clang.vim
@@ -12,7 +12,7 @@ endfunction
 function! ale_linters#cpp#clang#GetCommand(buffer, output) abort
     let l:compile_command = ale#c#GetCompileCommand(a:buffer)
     if l:compile_command isnot 0
-        return l:compile_command
+        return l:compile_command . ' ' . ale#Var(a:buffer, 'cpp_clang_options')
     endif
 
     let l:cflags = ale#c#GetCFlags(a:buffer, a:output)

--- a/ale_linters/cpp/clang.vim
+++ b/ale_linters/cpp/clang.vim
@@ -1,4 +1,5 @@
 " Author: Tomota Nakamura <https://github.com/tomotanakamura>
+" Author: tbodt <https://github.com/tbodt>
 " Description: clang linter for cpp files
 
 call ale#Set('cpp_clang_executable', 'clang++')
@@ -9,6 +10,11 @@ function! ale_linters#cpp#clang#GetExecutable(buffer) abort
 endfunction
 
 function! ale_linters#cpp#clang#GetCommand(buffer, output) abort
+    let l:compile_command = ale#c#GetCompileCommand(a:buffer)
+    if l:compile_command isnot 0
+        return l:compile_command
+    endif
+
     let l:cflags = ale#c#GetCFlags(a:buffer, a:output)
 
     " -iquote with the directory the file is in makes #include work for

--- a/autoload/ale/c.vim
+++ b/autoload/ale/c.vim
@@ -1,4 +1,6 @@
-" Author: gagbo <gagbobada@gmail.com>, w0rp <devw0rp@gmail.com>, roel0 <postelmansroel@gmail.com>
+" Author: gagbo <gagbobada@gmail.com>, w0rp <devw0rp@gmail.com>
+" Author: roel0 <postelmansroel@gmail.com>
+" Author: tbodt <https://github.com/tbodt>
 " Description: Functions for integrating with C-family linters.
 
 call ale#Set('c_parse_makefile', 0)
@@ -173,4 +175,28 @@ function! ale#c#FindCompileCommands(buffer) abort
     endfor
 
     return ''
+endfunction
+
+" Given a buffer number, return the relevant command from
+" compile_commands.json. Return 0 if none could be found.
+function! ale#c#GetCompileCommand(buffer) abort
+    let l:build_dir = ale#c#FindCompileCommands(a:buffer)
+    if empty(l:build_dir)
+        return 0
+    endif
+    let l:commands = json_decode(readfile(l:build_dir . '/compile_commands.json'))
+    let l:file = fnamemodify(bufname(a:buffer), ':p')
+    " save current directory, so we can restore it before returning
+    let l:cwd = getcwd()
+    for l:command in l:commands
+        " temporarily change dir to run fnamemodify
+        execute 'cd' l:command.directory
+        let l:command.file = fnamemodify(l:command.file, ':p')
+        if l:file ==# l:command.file
+            execute 'cd' l:cwd
+            return 'cd ' . ale#Escape(l:command.directory) . ';' . l:command.command
+        endif
+    endfor
+    execute 'cd' l:cwd
+    return 0
 endfunction

--- a/test/test_c_compile_commands.vader
+++ b/test/test_c_compile_commands.vader
@@ -1,0 +1,12 @@
+Before:
+  call ale#test#SetDirectory('/testplugin/test')
+
+After:
+  call ale#test#RestoreDirectory()
+  call ale#linter#Reset()
+
+Execute(Should find compile_commands.json):
+  call ale#test#SetFilename('test_c_projects/json_project/test.c')
+  echom ale#c#GetCompileCommand(bufnr(''))
+  AssertEqual ale#c#GetCompileCommand(bufnr('')),
+  \ "cd '/testplugin/test/test_c_projects/json_project/build';clang -I../include test.c"

--- a/test/test_c_projects/json_project/build/compile_commands.json
+++ b/test/test_c_projects/json_project/build/compile_commands.json
@@ -1,0 +1,7 @@
+[
+    {
+        "directory": "/testplugin/test/test_c_projects/json_project/build",
+        "command": "clang -I../include test.c",
+        "file": "../test.c"
+    }
+]

--- a/test/test_c_projects/json_project/test.c
+++ b/test/test_c_projects/json_project/test.c
@@ -1,0 +1,3 @@
+int main() {
+    return 0;
+}


### PR DESCRIPTION
Spiritual successor to #1242. A few things have been fixed and improved, and there are now tests.