### PR TITLE
Fix rust rls linter argument

### DIFF
--- a/ale_linters/rust/rls.vim
+++ b/ale_linters/rust/rls.vim
@@ -12,8 +12,11 @@ function! ale_linters#rust#rls#GetCommand(buffer) abort
     let l:executable = ale_linters#rust#rls#GetExecutable(a:buffer)
     let l:toolchain = ale#Var(a:buffer, 'rust_rls_toolchain')
 
-    return ale#Escape(l:executable)
-    \   . ' +' . ale#Escape(l:toolchain)
+    if empty(l:toolchain)
+      return ale#Escape(l:executable)
+    else
+      return ale#Escape(l:executable) . ' +' . ale#Escape(l:toolchain)
+    endif
 endfunction
 
 function! ale_linters#rust#rls#GetLanguage(buffer) abort

--- a/test/command_callback/test_rust_rls_callbacks.vader
+++ b/test/command_callback/test_rust_rls_callbacks.vader
@@ -28,6 +28,13 @@ Execute(The toolchain should be configurable):
   \ ale#Escape('rls') . ' +' . ale#Escape('stable'),
   \ ale_linters#rust#rls#GetCommand(bufnr(''))
 
+Execute(The toolchain should be ommitted if not given):
+  let g:ale_rust_rls_toolchain = ''
+
+  AssertEqual
+  \ ale#Escape('rls'),
+  \ ale_linters#rust#rls#GetCommand(bufnr(''))
+
 Execute(The language string should be correct):
   AssertEqual 'rust', ale_linters#rust#rls#GetLanguage(bufnr(''))
 


### PR DESCRIPTION
As far as I can tell [1] there is no +nighly (or similar) option leading to
the termination of the server.

Not sure how to test this ...

[1] https://github.com/rust-lang-nursery/rls/blob/master/src/main.rs#L87


