### PR TITLE
Fix typos in "lint package" options in docs/ale-go

### DIFF
--- a/doc/ale-go.txt
+++ b/doc/ale-go.txt
@@ -73,8 +73,8 @@ g:ale_go_gometalinter_options                   *g:ale_go_gometalinter_options*
   number of linters known to be slow or consume a lot of resources.
 
 
-g:ale_go_gometalinter_package                   *g:ale_go_gometalinter_package*
-                                                *b:ale_go_gometalinter_package*
+g:ale_go_gometalinter_lint_package         *g:ale_go_gometalinter_lint_package*
+                                           *b:ale_go_gometalinter_lint_package*
   Type: |Number|
   Default: `0`
 
@@ -94,8 +94,8 @@ g:ale_go_staticcheck_options                     *g:ale_go_staticcheck_options*
   linter.
 
 
-g:ale_go_staticcheck_package                     *g:ale_go_staticcheck_package*
-                                                 *b:ale_go_staticcheck_package*
+g:ale_go_staticcheck_lint_package           *g:ale_go_staticcheck_lint_package*
+                                            *b:ale_go_staticcheck_lint_package*
   Type: |Number|
   Default: `0`
 


### PR DESCRIPTION
https://github.com/w0rp/ale/blob/d8d09c2048a72a6205bcf1c5069f7016a3a6261e/ale_linters/go/gometalinter.vim#L16

https://github.com/w0rp/ale/blob/d8d09c2048a72a6205bcf1c5069f7016a3a6261e/ale_linters/go/staticcheck.vim#L10