### PR TITLE
add ale_matlab_mlint_options

### DIFF
--- a/ale_linters/matlab/mlint.vim
+++ b/ale_linters/matlab/mlint.vim
@@ -3,6 +3,8 @@
 
 let g:ale_matlab_mlint_executable =
 \   get(g:, 'ale_matlab_mlint_executable', 'mlint')
+let g:ale_matlab_mlint_options = get(g:, 'ale_matlab_mlint_options', '')
+let g:ale_matlab_mlint_use_global = get(g:, 'ale_matlab_mlint_use_global', 0)
 
 function! ale_linters#matlab#mlint#GetExecutable(buffer) abort
     return ale#Var(a:buffer, 'matlab_mlint_executable')
@@ -10,8 +12,11 @@ endfunction
 
 function! ale_linters#matlab#mlint#GetCommand(buffer) abort
     let l:executable = ale_linters#matlab#mlint#GetExecutable(a:buffer)
-
-    return l:executable . ' -id %t'
+    
+    if(ale#Var(a:buffer,'matlab_mlint_options') == '')
+        return l:executable.' -id %t'
+    else
+        return l:executable.' '.ale#Var(a:buffer, 'matlab_mlint_options').' %t'
 endfunction
 
 function! ale_linters#matlab#mlint#Handle(buffer, lines) abort

--- a/ale_linters/matlab/mlint.vim
+++ b/ale_linters/matlab/mlint.vim
@@ -13,10 +13,11 @@ endfunction
 function! ale_linters#matlab#mlint#GetCommand(buffer) abort
     let l:executable = ale_linters#matlab#mlint#GetExecutable(a:buffer)
     
-    if(ale#Var(a:buffer,'matlab_mlint_options') == '')
+    if ale#Var(a:buffer,'matlab_mlint_options') is# '' 
         return l:executable.' -id %t'
     else
         return l:executable.' '.ale#Var(a:buffer, 'matlab_mlint_options').' %t'
+    endif
 endfunction
 
 function! ale_linters#matlab#mlint#Handle(buffer, lines) abort

--- a/ale_linters/matlab/mlint.vim
+++ b/ale_linters/matlab/mlint.vim
@@ -12,8 +12,8 @@ endfunction
 
 function! ale_linters#matlab#mlint#GetCommand(buffer) abort
     let l:executable = ale_linters#matlab#mlint#GetExecutable(a:buffer)
-    
-    if ale#Var(a:buffer,'matlab_mlint_options') is# '' 
+
+    if ale#Var(a:buffer,'matlab_mlint_options') is# ''
         return l:executable.' -id %t'
     else
         return l:executable.' '.ale#Var(a:buffer, 'matlab_mlint_options').' %t'


### PR DESCRIPTION
I found that there is no ale-matlab.txt  in ale/doc, but I have no idea about to write a standard vimdoc help file. Sorry for that. 

This PR just add `ale_matlab_mlint_options`, because mlint can add args such as `-config=~/.vim/mlint.txt` to stop some error or warning type. 