### PR TITLE
Update run-tests to make use of /usr/bin/env

### DIFF
--- a/run-tests
+++ b/run-tests
@@ -1,4 +1,7 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+
+set -e
+set -u
 
 # Author: w0rp <devw0rp@gmail.com>
 #


### PR DESCRIPTION
This fixes run-tests for Unix platforms that do not bundle bash.