### PR TITLE
Add bundle option to mdl

### DIFF
--- a/ale_linters/markdown/mdl.vim
+++ b/ale_linters/markdown/mdl.vim
@@ -10,9 +10,13 @@ endfunction
 
 function! ale_linters#markdown#mdl#GetCommand(buffer) abort
     let l:executable = ale_linters#markdown#mdl#GetExecutable(a:buffer)
+    let l:exec_args = l:executable =~? 'bundle$'
+    \   ? ' exec mdl'
+    \   : ''
+
     let l:options = ale#Var(a:buffer, 'markdown_mdl_options')
 
-    return ale#Escape(l:executable)
+    return ale#Escape(l:executable) . l:exec_args
     \   . (!empty(l:options) ? ' ' . l:options : '')
 endfunction
 

--- a/doc/ale-markdown.txt
+++ b/doc/ale-markdown.txt
@@ -10,7 +10,8 @@ g:ale_markdown_mdl_executable                   *g:ale_markdown_mdl_executable*
   Type: |String|
   Default: `'mdl'`
 
-  See |ale-integrations-local-executables|
+  Override the invoked mdl binary. This is useful for running mdl from
+  binstubs or a bundle.
 
 
 g:ale_markdown_mdl_options                         *g:ale_markdown_mdl_options*

--- a/test/command_callback/test_markdown_mdl_command_callback.vader
+++ b/test/command_callback/test_markdown_mdl_command_callback.vader
@@ -26,3 +26,10 @@ Execute(The executable and options should be configurable):
   AssertEqual
   \ ale_linters#markdown#mdl#GetCommand(bufnr('')),
   \ ale#Escape('foo bar') . ' --wat'
+
+Execute(Setting bundle appends 'exec mdl'):
+  let g:ale_markdown_mdl_executable = 'path to/bundle'
+
+  AssertEqual
+  \ ale#Escape('path to/bundle') . ' exec mdl',
+  \ ale_linters#markdown#mdl#GetCommand(bufnr(''))


### PR DESCRIPTION
<!--
READ THIS: Before creating a pull request, please consider the following first.

* The most important thing you can do is write tests. Code without tests
  probably doesn't work, and will almost certainly stop working later on. Pull
  requests without tests probably won't be accepted, although there are some
  exceptions.
* Read the Contributing guide linked above first.
* If you are adding a new linter, remember to update the README.md file and
  doc/ale.txt first.
* If you add or modify a function for converting error lines into loclist items
  that ALE can work with, please add Vader tests for them. Look at existing
  tests in the test/handler directory, etc.
* If you add or modify a function for computing a command line string for
  running a command, please add Vader tests for that.
* Generally try and cover anything with Vader tests, although some things just
  can't be tested with Vader, or at least they can be hard to test. Consider
  breaking up your code so that some parts can be tested, and generally open up
  a discussion about it.
* Have fun!
-->

Just like [rubocop](https://github.com/bbatsov/rubocop), [mdl](https://github.com/markdownlint/markdownlint) is distributed as a ruby gem. So like with `rubocop`, I think it makes sense to provide a `bundler` option, so that a well defined version of the library is used.

This PR is an adaptation of https://github.com/w0rp/ale/pull/561 to `mdl`.