### PR TITLE
Add XO fixer

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -190,6 +190,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['perl'],
 \       'description': 'Fix Perl files with perltidy.',
 \   },
+\   'xo': {
+\       'function': 'ale#fixers#xo#Fix',
+\       'suggested_filetypes': ['javascript'],
+\       'description': 'Fix JavaScript files using xo --fix.',
+\   },
 \}
 
 " Reset the function registry to the default entries.

--- a/autoload/ale/fixers/xo.vim
+++ b/autoload/ale/fixers/xo.vim
@@ -1,0 +1,23 @@
+" Author: Albert Marquez - https://github.com/a-marquez
+" Description: Fixing files with XO.
+
+call ale#Set('javascript_xo_executable', 'xo')
+call ale#Set('javascript_xo_use_global', get(g:, 'ale_use_global_executables', 0))
+call ale#Set('javascript_xo_options', '')
+
+function! ale#fixers#xo#GetExecutable(buffer) abort
+    return ale#node#FindExecutable(a:buffer, 'javascript_xo', [
+    \   'node_modules/xo/cli.js',
+    \   'node_modules/.bin/xo',
+    \])
+endfunction
+
+function! ale#fixers#xo#Fix(buffer) abort
+    let l:executable = ale#fixers#xo#GetExecutable(a:buffer)
+
+    return {
+    \   'command': ale#node#Executable(a:buffer, l:executable)
+    \       . ' --fix %t',
+    \   'read_temporary_file': 1,
+    \}
+endfunction


### PR DESCRIPTION
Small patches to add XO fixer definitions, the XO linter has been previously defined  and XO uses eslint under the hood.