### PR TITLE
Added NASM assembly linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ formatting.
 | Markdown | [alex](https://github.com/wooorm/alex) !!, [markdownlint](https://github.com/DavidAnson/markdownlint) !!, [mdl](https://github.com/mivok/markdownlint), [prettier](https://github.com/prettier/prettier), [proselint](http://proselint.com/), [redpen](http://redpen.cc/), [remark-lint](https://github.com/wooorm/remark-lint) !!, [textlint](https://textlint.github.io/), [vale](https://github.com/ValeLint/vale), [write-good](https://github.com/btford/write-good) |
 | MATLAB | [mlint](https://www.mathworks.com/help/matlab/ref/mlint.html) |
 | Mercury | [mmc](http://mercurylang.org) !! |
+| NASM | [nasm](https://www.nasm.us/) !! |
 | Nim | [nim check](https://nim-lang.org/docs/nimc.html) !! |
 | nix | [nix-instantiate](http://nixos.org/nix/manual/#sec-nix-instantiate) |
 | nroff | [alex](https://github.com/wooorm/alex) !!, [proselint](http://proselint.com/), [write-good](https://github.com/btford/write-good)|

--- a/ale_linters/nasm/nasm.vim
+++ b/ale_linters/nasm/nasm.vim
@@ -1,0 +1,50 @@
+" Author: Oyvind Ingvaldsen <oyvind.ingvaldsen@gmail.com>
+" Description: NASM linter for asmsyntax nasm.
+
+call ale#Set('nasm_nasm_executable', 'nasm')
+call ale#Set('nasm_nasm_options', '')
+
+function! ale_linters#nasm#nasm#GetExecutable(buffer) abort
+    return ale#Var(a:buffer, 'nasm_nasm_executable')
+endfunction
+
+function! ale_linters#nasm#nasm#GetOptions(buffer) abort
+    return ale#Var(a:buffer, 'nasm_nasm_options')
+endfunction
+
+function! ale_linters#nasm#nasm#GetCommand(buffer) abort
+    " Note that NASM require a trailing slash to the -I option.
+    let l:executable = ale#Escape(ale_linters#nasm#nasm#GetExecutable(a:buffer))
+    let l:separator = has('win32') ? '\' : '/'
+    let l:path = ale#Escape(fnamemodify(bufname(a:buffer), ':p:h') . l:separator)
+    let l:options = ale_linters#nasm#nasm#GetOptions(a:buffer)
+
+    return l:executable
+    \   . ' -X gnu'
+    \   . ' -I ' . l:path
+    \   . ' ' . l:options
+    \   . ' %s'
+endfunction
+
+function! ale_linters#nasm#nasm#Handle(buffer, lines) abort
+    " Note that we treat 'fatal' as errors.
+    let l:pattern = '^.\+:\(\d\+\): \([^:]\+\): \(.\+\)$'
+    let l:output = []
+    for l:match in ale#util#GetMatches(a:lines, l:pattern)
+        call add(l:output, {
+        \ 'lnum': l:match[1] + 0,
+        \ 'type': l:match[2] =~? 'error\|fatal' ? 'E' : 'W',
+        \ 'text': l:match[3],
+        \})
+    endfor
+    return l:output
+endfunction
+
+call ale#linter#Define('nasm', {
+\   'name': 'nasm',
+\   'executable': 'nasm',
+\   'output_stream': 'stderr',
+\   'lint_file': 1,
+\   'command_callback': 'ale_linters#nasm#nasm#GetCommand',
+\   'callback': 'ale_linters#nasm#nasm#Handle',
+\})

--- a/doc/ale-nasm.txt
+++ b/doc/ale-nasm.txt
@@ -1,0 +1,26 @@
+===============================================================================
+ALE NASM Integration                                         *ale-nasm-options*
+
+
+===============================================================================
+nasm                                                            *ale-nasm-nasm*
+
+g:ale_nasm_nasm_executable                         *g:ale_nasm_nasm_executable*
+                                                   *b:ale_nasm_nasm_executable*
+
+  Type: |String|
+  Default `'nasm'`
+
+  This variable can be changed to use different executable for NASM.
+
+
+g:ale_nasm_nasm_options                               *g:ale_nasm_nasm_options*
+                                                      *b:ale_nasm_nasm_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be set to pass additional options to NASM.
+
+
+===============================================================================
+  vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -145,6 +145,8 @@ CONTENTS                                                         *ale-contents*
       write-good..........................|ale-markdown-write-good|
     mercury...............................|ale-mercury-options|
       mmc.................................|ale-mercury-mmc|
+    nasm..................................|ale-nasm-options|
+      nasm................................|ale-nasm-nasm|
     nroff.................................|ale-nroff-options|
       write-good..........................|ale-nroff-write-good|
     objc..................................|ale-objc-options|
@@ -360,6 +362,7 @@ Notes:
 * Markdown: `alex`!!, `markdownlint`!!, `mdl`, `prettier`, `proselint`, `redpen`, `remark-lint`, `textlint`, `vale`, `write-good`
 * MATLAB: `mlint`
 * Mercury: `mmc`!!
+* NASM: `nasm`!!
 * Nim: `nim check`!!
 * nix: `nix-instantiate`
 * nroff: `alex`!!, `proselint`, `write-good`

--- a/test/command_callback/test_nasm_nasm_command_callbacks.vader
+++ b/test/command_callback/test_nasm_nasm_command_callbacks.vader
@@ -10,9 +10,9 @@ Before:
   runtime ale_linters/nasm/nasm.vim
 
   let b:command_tail =
-  \ ' -X gnu -I ' . ale#Escape(getcwd() . '/') . '  %s'
+  \ ' -X gnu -I ' . ale#Escape(getcwd() . (has('win32') ? '\' : '/')) . '  %s'
   let b:command_tail_opt =
-  \ ' -X gnu -I ' . ale#Escape(getcwd() . '/') . ' -w+orphan-labels %s'
+  \ ' -X gnu -I ' . ale#Escape(getcwd() . (has('win32') ? '\' : '/')) . ' -w+orphan-labels %s'
 
 After:
   Restore

--- a/test/command_callback/test_nasm_nasm_command_callbacks.vader
+++ b/test/command_callback/test_nasm_nasm_command_callbacks.vader
@@ -1,0 +1,52 @@
+Before:
+  Save g:ale_nasm_nasm_executable
+  Save g:ale_nasm_nasm_options
+
+  unlet! g:ale_nasm_nasm_executable
+  unlet! b:ale_nasm_nasm_executable
+  unlet! g:ale_nasm_nasm_options
+  unlet! b:ale_nasm_nasm_options
+
+  runtime ale_linters/nasm/nasm.vim
+
+  let b:command_tail =
+  \ ' -X gnu -I ' . ale#Escape(getcwd() . '/') . '  %s'
+  let b:command_tail_opt =
+  \ ' -X gnu -I ' . ale#Escape(getcwd() . '/') . ' -w+orphan-labels %s'
+
+After:
+  Restore
+  unlet! b:command_tail
+  unlet! b:command_tail_opt
+  unlet! b:ale_nasm_nasm_executable
+  unlet! b:ale_nasm_nasm_options
+  call ale#linter#Reset()
+
+Execute(The executable should be configurable):
+  AssertEqual 'nasm', ale_linters#nasm#nasm#GetExecutable(bufnr(''))
+
+  let b:ale_nasm_nasm_executable = '/opt/nasm/nasm'
+
+  AssertEqual '/opt/nasm/nasm', ale_linters#nasm#nasm#GetExecutable(bufnr(''))
+
+Execute(The executable should be used in the command):
+  AssertEqual
+  \ ale#Escape('nasm') . b:command_tail,
+  \ ale_linters#nasm#nasm#GetCommand(bufnr(''))
+
+  let b:ale_nasm_nasm_executable = '~/nasm'
+
+  AssertEqual
+  \ ale#Escape('~/nasm') . b:command_tail,
+  \ ale_linters#nasm#nasm#GetCommand(bufnr(''))
+
+Execute(The options should be configurable):
+  AssertEqual '', ale_linters#nasm#nasm#GetOptions(bufnr(''))
+  let b:ale_nasm_nasm_options = '-w-macro-params'
+  AssertEqual '-w-macro-params', ale_linters#nasm#nasm#GetOptions(bufnr(''))
+
+Execute(The options should be used in command):
+    let b:ale_nasm_nasm_options = '-w+orphan-labels'
+    AssertEqual
+    \ ale#Escape('nasm') . b:command_tail_opt,
+    \ ale_linters#nasm#nasm#GetCommand(bufnr(''))

--- a/test/handler/test_nasm_handler.vader
+++ b/test/handler/test_nasm_handler.vader
@@ -1,0 +1,30 @@
+Before:
+  runtime ale_linters/nasm/nasm.vim
+
+After:
+  call ale#linter#Reset()
+
+Execute(The nasm handler should parse GCC style output from nasm correctly):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 2,
+  \     'text': "label alone on a line without a colon might be in error",
+  \     'type': 'W',
+  \   },
+  \   {
+  \     'lnum': 4,
+  \     'text': "invalid combination of opcode and operands",
+  \     'type': 'E',
+  \   },
+  \   {
+  \     'lnum': 7,
+  \     'text': "unable to open include file `bar.asm'",
+  \     'type': 'E',
+  \   },
+  \ ],
+  \ ale_linters#nasm#nasm#Handle(357, [
+  \   "tmp.asm:2: warning: label alone on a line without a colon might be in error",
+  \   "tmp.asm:4: error: invalid combination of opcode and operands",
+  \   "tmp.asm:7: fatal: unable to open include file `bar.asm'"
+  \ ])

--- a/test/handler/test_nasm_handler.vader
+++ b/test/handler/test_nasm_handler.vader
@@ -23,7 +23,7 @@ Execute(The nasm handler should parse GCC style output from nasm correctly):
   \     'type': 'E',
   \   },
   \ ],
-  \ ale_linters#nasm#nasm#Handle(357, [
+  \ ale_linters#nasm#nasm#Handle(bufnr(''), [
   \   "tmp.asm:2: warning: label alone on a line without a colon might be in error",
   \   "tmp.asm:4: error: invalid combination of opcode and operands",
   \   "tmp.asm:7: fatal: unable to open include file `bar.asm'"


### PR DESCRIPTION
Added linter for filetype/asmsyntax `nasm` (a file linter as NASM doesn't support input from stdin).

Was uncertain if this should have been added as a NASM linter for `asm`, but considering `asm` and `nasm` being different filetypes I guess this is the correct organization. 

Tested with NASM 2.12.01 (latest in Debian stable) and NASM 2.13.03 (latest).