### PR TITLE
[WIP] TUI / GUI tooltip with content from ALEHover

### DIFF
--- a/autoload/ale/balloon.vim
+++ b/autoload/ale/balloon.vim
@@ -20,9 +20,33 @@ function! ale#balloon#Expr() abort
 endfunction
 
 function! ale#balloon#Disable() abort
-    set noballooneval balloonexpr=
+    if !has('balloon_eval') && !has('balloon_eval_term')
+        finish
+    endif
+
+    if has('balloon_eval')
+        set noballooneval
+    endif
+
+    if has('balloon_eval_term')
+        set noballoonevalterm
+    endif
+
+    set balloonexpr=
 endfunction
 
 function! ale#balloon#Enable() abort
-    set ballooneval balloonexpr=ale#balloon#Expr()
+    if !has('balloon_eval') && !has('balloon_eval_term')
+        finish
+    endif
+
+    if has('balloon_eval')
+        set ballooneval
+    endif
+
+    if has('balloon_eval_term')
+        set balloonevalterm
+    endif
+
+    set balloonexpr=ale#balloon#Expr()
 endfunction

--- a/autoload/ale/balloon.vim
+++ b/autoload/ale/balloon.vim
@@ -19,6 +19,13 @@ function! ale#balloon#Expr() abort
     return ale#balloon#MessageForPos(v:beval_bufnr, v:beval_lnum, v:beval_col)
 endfunction
 
+function! ale#balloon#HoverExpr() abort
+    " TODO : Find a way with ale#hover API to just extract the message, given
+    " beval_bufnr, beval_lnum, beval_col.
+    " Note : Termdebug uses beval_text
+    return 'Test'
+endfunction
+
 function! ale#balloon#Disable() abort
     if !has('balloon_eval') && !has('balloon_eval_term')
         finish


### PR DESCRIPTION
This is a RFC / small fix maybe.

I would like to have `:ALEHover` content displayed in a tooltip like `termdebug` plugin so beautifully do in [vim](https://asciinema.org/a/BQiwffN0QVS9K54XLydo49s3e)

I found out that ale already uses the balloon feature that termdebug uses under the hood, therefore I would like to find the correct way to access the string that `ale#hover#Show()` ultimately shows in the message bar. I discovered that it's not that easy. What do you think the best way is ?

Should I reimplement all functions that autoload/hover.vim uses ?
- Should I make more functions public so we can have easier access (ShowDetails ?) ?
- Should I change the signatures of some functions so they actually return strings (namely the callback handlers ?) ?

Ultimately, the goal is to allow users to choose a source for the `balloonexpr`, from loclist like it's currently done, or from `:ALEHover` content (typically a setting that would be buffer dependent, so it's possible to activate the Hover source only for filetypes where LSP linters are plugged in)

Also, since I was there, I added some guards around the `set ballooneval`, so neovim or old vim versions won't complain, and also added `balloonevalterm` because in vim the GUI and TUI tooltips are separated options (but I assumed that we would want them in all possible cases if the user activated the feature).
