### PR TITLE
Add support phan_client for php

### DIFF
--- a/ale_linters/php/phan.vim
+++ b/ale_linters/php/phan.vim
@@ -45,7 +45,7 @@ function! ale_linters#php#phan#Handle(buffer, lines) abort
     let l:output = []
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)
-        if ale#Var('php_phan_use_client') == 1
+        if ale#Var(a:buffer, 'php_phan_use_client') == 1
             let l:dict = {
             \   'lnum': l:match[4] + 0,
             \   'text': l:match[2],

--- a/ale_linters/php/phan.vim
+++ b/ale_linters/php/phan.vim
@@ -9,7 +9,7 @@ let g:ale_php_phan_use_client = get(g:, 'ale_php_phan_use_client', 0)
 
 function! ale_linters#php#phan#GetExecutable(buffer) abort
     let l:executable = ale#Var(a:buffer, 'php_phan_executable')
-    if g:ale_php_phan_use_client == 1 && l:executable == 'phan'
+    if g:ale_php_phan_use_client == 1 && l:executable ==# 'phan'
         let l:executable = 'phan_client'
     endif
 

--- a/ale_linters/php/phan.vim
+++ b/ale_linters/php/phan.vim
@@ -9,7 +9,7 @@ let g:ale_php_phan_use_client = get(g:, 'ale_php_phan_use_client', 0)
 
 function! ale_linters#php#phan#GetExecutable(buffer) abort
     let l:executable = ale#Var(a:buffer, 'php_phan_executable')
-    if g:ale_php_phan_use_client == 1 && l:executable ==# 'phan'
+    if g:ale_php_phan_use_client == 1 && l:executable is# 'phan'
         let l:executable = 'phan_client'
     endif
 

--- a/ale_linters/php/phan.vim
+++ b/ale_linters/php/phan.vim
@@ -9,7 +9,8 @@ let g:ale_php_phan_use_client = get(g:, 'ale_php_phan_use_client', 0)
 
 function! ale_linters#php#phan#GetExecutable(buffer) abort
     let l:executable = ale#Var(a:buffer, 'php_phan_executable')
-    if g:ale_php_phan_use_client == 1 && l:executable is# 'phan'
+
+    if ale#Var(a:buffer, 'php_phan_use_client') == 1 && l:executable is# 'phan'
         let l:executable = 'phan_client'
     endif
 
@@ -17,7 +18,7 @@ function! ale_linters#php#phan#GetExecutable(buffer) abort
 endfunction
 
 function! ale_linters#php#phan#GetCommand(buffer) abort
-    if g:ale_php_phan_use_client == 1
+    if ale#Var(a:buffer, 'php_phan_use_client') == 1
         let l:args = '-l '
         \   . ' %s'
     else
@@ -33,7 +34,7 @@ endfunction
 
 function! ale_linters#php#phan#Handle(buffer, lines) abort
     " Matches against lines like the following:
-    if g:ale_php_phan_use_client == 1
+    if ale#Var(a:buffer, 'php_phan_use_client') == 1
         " Phan error: ERRORTYPE: message in /path/to/some-filename.php on line nnn
         let l:pattern = '^Phan error: \(\w\+\): \(.\+\) in \(.\+\) on line \(\d\+\)$'
     else
@@ -42,8 +43,9 @@ function! ale_linters#php#phan#Handle(buffer, lines) abort
     endif
 
     let l:output = []
+
     for l:match in ale#util#GetMatches(a:lines, l:pattern)
-        if g:ale_php_phan_use_client == 1
+        if ale#Var('php_phan_use_client') == 1
             let l:dict = {
             \   'lnum': l:match[4] + 0,
             \   'text': l:match[2],

--- a/ale_linters/php/phan.vim
+++ b/ale_linters/php/phan.vim
@@ -1,4 +1,4 @@
-" Author: diegoholiveira <https://github.com/diegoholiveira>, haginaga
+" Author: diegoholiveira <https://github.com/diegoholiveira>, haginaga <https://github.com/haginaga>
 " Description: static analyzer for PHP
 
 " Define the minimum severity
@@ -8,12 +8,16 @@ let g:ale_php_phan_executable = get(g:, 'ale_php_phan_executable', 'phan')
 let g:ale_php_phan_use_client = get(g:, 'ale_php_phan_use_client', 0)
 
 function! ale_linters#php#phan#GetExecutable(buffer) abort
-    return ale#Var(a:buffer, 'php_phan_executable')
+    let l:executable = ale#Var(a:buffer, 'php_phan_executable')
+    if g:ale_php_phan_use_client == 1 && l:executable == 'phan'
+        let l:executable = 'phan_client'
+    endif
+
+    return l:executable
 endfunction
 
 function! ale_linters#php#phan#GetCommand(buffer) abort
-    let l:use_client = ale#Var(a:buffer, 'php_phan_use_client')
-    if l:use_client == 1
+    if g:ale_php_phan_use_client == 1
         let l:args = '-l '
         \   . ' %s'
     else
@@ -28,10 +32,8 @@ function! ale_linters#php#phan#GetCommand(buffer) abort
 endfunction
 
 function! ale_linters#php#phan#Handle(buffer, lines) abort
-    let l:use_client = ale#Var(a:buffer, 'php_phan_use_client')
-
     " Matches against lines like the following:
-    if l:use_client == 1
+    if g:ale_php_phan_use_client == 1
         " Phan error: ERRORTYPE: message in /path/to/some-filename.php on line nnn
         let l:pattern = '^Phan error: \(\w\+\): \(.\+\) in \(.\+\) on line \(\d\+\)$'
     else
@@ -41,7 +43,7 @@ function! ale_linters#php#phan#Handle(buffer, lines) abort
 
     let l:output = []
     for l:match in ale#util#GetMatches(a:lines, l:pattern)
-        if l:use_client == 1
+        if g:ale_php_phan_use_client == 1
             let l:dict = {
             \   'lnum': l:match[4] + 0,
             \   'text': l:match[2],

--- a/ale_linters/php/phan.vim
+++ b/ale_linters/php/phan.vim
@@ -1,28 +1,61 @@
-" Author: diegoholiveira <https://github.com/diegoholiveira>
+" Author: diegoholiveira <https://github.com/diegoholiveira>, haginaga
 " Description: static analyzer for PHP
 
 " Define the minimum severity
 let g:ale_php_phan_minimum_severity = get(g:, 'ale_php_phan_minimum_severity', 0)
 
+let g:ale_php_phan_executable = get(g:, 'ale_php_phan_executable', 'phan')
+let g:ale_php_phan_use_client = get(g:, 'ale_php_phan_use_client', 0)
+
+function! ale_linters#php#phan#GetExecutable(buffer) abort
+    return ale#Var(a:buffer, 'php_phan_executable')
+endfunction
+
 function! ale_linters#php#phan#GetCommand(buffer) abort
-    return 'phan -y '
-    \   . ale#Var(a:buffer, 'php_phan_minimum_severity')
-    \   . ' %s'
+    let l:use_client = ale#Var(a:buffer, 'php_phan_use_client')
+    if l:use_client == 1
+        let l:args = '-l '
+        \   . ' %s'
+    else
+        let l:args = '-y '
+        \   . ale#Var(a:buffer, 'php_phan_minimum_severity')
+        \   . ' %s'
+    endif
+
+    let l:executable = ale_linters#php#phan#GetExecutable(a:buffer)
+
+    return ale#Escape(l:executable) . ' ' . l:args
 endfunction
 
 function! ale_linters#php#phan#Handle(buffer, lines) abort
-    " Matches against lines like the following:
-    "
-    " /path/to/some-filename.php:18 ERRORTYPE message
-    let l:pattern = '^.*:\(\d\+\)\s\(\w\+\)\s\(.\+\)$'
-    let l:output = []
+    let l:use_client = ale#Var(a:buffer, 'php_phan_use_client')
 
+    " Matches against lines like the following:
+    if l:use_client == 1
+        " Phan error: ERRORTYPE: message in /path/to/some-filename.php on line nnn
+        let l:pattern = '^Phan error: \(\w\+\): \(.\+\) in \(.\+\) on line \(\d\+\)$'
+    else
+        " /path/to/some-filename.php:18 ERRORTYPE message
+        let l:pattern = '^.*:\(\d\+\)\s\(\w\+\)\s\(.\+\)$'
+    endif
+
+    let l:output = []
     for l:match in ale#util#GetMatches(a:lines, l:pattern)
-        call add(l:output, {
-        \   'lnum': l:match[1] + 0,
-        \   'text': l:match[3],
-        \   'type': 'W',
-        \})
+        if l:use_client == 1
+            let l:dict = {
+            \   'lnum': l:match[4] + 0,
+            \   'text': l:match[2],
+            \   'type': 'W',
+            \}
+        else
+            let l:dict = {
+            \   'lnum': l:match[1] + 0,
+            \   'text': l:match[3],
+            \   'type': 'W',
+            \}
+        endif
+
+        call add(l:output, l:dict)
     endfor
 
     return l:output
@@ -30,7 +63,7 @@ endfunction
 
 call ale#linter#Define('php', {
 \   'name': 'phan',
-\   'executable': 'phan',
+\   'executable_callback': 'ale_linters#php#phan#GetExecutable',
 \   'command_callback': 'ale_linters#php#phan#GetCommand',
 \   'callback': 'ale_linters#php#phan#Handle',
 \})

--- a/doc/ale-php.txt
+++ b/doc/ale-php.txt
@@ -48,7 +48,7 @@ g:ale_php_langserver_use_global               *g:ale_php_langserver_use_global*
 ===============================================================================
 phan                                                             *ale-php-phan*
 
-WARNING: please do not use this linter if you have an configuration file
+WARNING: please use the phan_client linter if you have an configuration file
 for your project because the phan will look into your entirely project and
 ale will display in the current buffer warnings that may belong to other file.
 
@@ -57,8 +57,22 @@ g:ale_php_phan_minimum_severity               *g:ale_php_phan_minimum_severity*
   Type: |Number|
   Default: `0`
 
-  This variable defines the minimum severity level
+  This variable defines the minimum severity level.
 
+g:ale_php_phan_executable                           *g:ale_php_phan_executable*
+                                                    *b:ale_php_phan_executable*
+  Type: |String|
+  Default: `'phan'`
+
+  This variable sets executable used for phan or phan_client.
+
+g:ale_php_phan_use_client                           *g:ale_php_phan_use_client*
+                                                    *b:ale_php_phan_use_client*
+  Type: |Number|
+  Default: `get(g:, 'ale_php_phan_use_client', 0)`
+
+  This variable can be set to 1 to use the phan_client with phan daemon mode
+  instead of the phan standalone.
 
 ===============================================================================
 phpcbf                                                         *ale-php-phpcbf*


### PR DESCRIPTION
I've added support phan_client for php. (#1561)

In .vimrc  file to enable to use the phan_client, 
```
let g:ale_php_phan_use_client = 1
let g:ale_php_phan_executable = 'phan_client'
```