### PR TITLE
Use the command line to filter ALEFix's command line completion.

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -327,7 +327,7 @@ endfunction
 
 " Function that returns autocomplete candidates for ALEFix command
 function! ale#fix#registry#CompleteFixers(ArgLead, CmdLine, CursorPos) abort
-    return ale#fix#registry#GetApplicableFixers(&filetype)
+    return filter(ale#fix#registry#GetApplicableFixers(&filetype), 'v:val =~? a:ArgLead')
 endfunction
 
 " Suggest functions to use from the registry.

--- a/test/fix/test_ale_fix_completion_filter.vader
+++ b/test/fix/test_ale_fix_completion_filter.vader
@@ -1,0 +1,14 @@
+Before:
+  call ale#fix#registry#Clear()
+  call ale#test#SetFilename('test.js')
+  call ale#fix#registry#Add('prettier', '', ['javascript'], 'prettier')
+  call ale#fix#registry#Add('eslint', '', ['javascript'], 'eslint')
+  setfiletype javascript
+
+Execute(completeFixers returns all of the applicable fixers without an arglead):
+  AssertEqual ['eslint', 'prettier'],
+  \ ale#fix#registry#CompleteFixers('', 'ALEFix ', 7)
+
+Execute(completeFixers returns all of the applicable fixers without an arglead):
+  AssertEqual ['prettier'],
+  \ ale#fix#registry#CompleteFixers('pre', 'ALEFix ', 10)


### PR DESCRIPTION
Currently when calling `:ALEFix pret<TAB>`, instead of completing to `prettier`, the `<TAB>` complete to the first fixer applicable for the filetype:

![ale-fixer-before](https://user-images.githubusercontent.com/980367/39756651-ad0705da-52ca-11e8-8f87-d05f968d1960.gif)

This PR fixes this by filtering the suggested fixers using what is already written:

![ale-fixer-after](https://user-images.githubusercontent.com/980367/39756666-b67ba80a-52ca-11e8-8cc1-4370aa14c65b.gif)