### PR TITLE
Improve g:ale_set_balloons default value

### DIFF
--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -1350,7 +1350,8 @@ g:ale_set_balloons                                         *g:ale_set_balloons*
                                                            *b:ale_set_balloons*
 
   Type: |Number|
-  Default: `has('balloon_eval')`
+  Default: `has('balloon_eval') && has('gui_running') ||`
+           `has('balloon_eval_term') && !has('gui_running')`
 
   When this option is set to `1`, balloon messages will be displayed for
   problems. Problems nearest to the cursor on the line the cursor is over will

--- a/plugin/ale.vim
+++ b/plugin/ale.vim
@@ -174,7 +174,10 @@ let g:ale_echo_cursor = get(g:, 'ale_echo_cursor', 1)
 let g:ale_echo_delay = get(g:, 'ale_echo_delay', 10)
 
 " This flag can be set to 0 to disable balloon support.
-call ale#Set('set_balloons', has('balloon_eval'))
+call ale#Set('set_balloons',
+\   has('balloon_eval') && has('gui_running') ||
+\   has('balloon_eval_term') && !has('gui_running')
+\)
 
 " A deprecated setting for ale#statusline#Status()
 " See :help ale#statusline#Count() for getting status reports.

--- a/test/test_ale_toggle.vader
+++ b/test/test_ale_toggle.vader
@@ -12,7 +12,9 @@ Before:
   let g:ale_run_synchronously = 1
   let g:ale_pattern_options = {}
   let g:ale_pattern_options_enabled = 1
-  let g:ale_set_balloons = has('balloon_eval')
+  let g:ale_set_balloons =
+  \   has('balloon_eval') && has('gui_running') ||
+  \   has('balloon_eval_term') && !has('gui_running')
 
   unlet! b:ale_enabled
 
@@ -349,7 +351,8 @@ Execute(ALEResetBuffer should reset everything for a buffer):
 
 Execute(Disabling ALE should disable balloons):
   " These tests won't run in the console, but we can run them manually in GVim.
-  if has('balloon_eval')
+  if has('balloon_eval') && has('gui_running') ||
+  \  has('balloon_eval_term') && !has('gui_running')
     call ale#linter#Reset()
 
     " Enable balloons, so we can check the expr value.
@@ -367,7 +370,8 @@ Execute(Disabling ALE should disable balloons):
   endif
 
 Execute(Enabling ALE should enable balloons if the setting is on):
-  if has('balloon_eval')
+  if has('balloon_eval') && has('gui_running') ||
+  \  has('balloon_eval_term') && !has('gui_running')
     call ale#linter#Reset()
     call ale#balloon#Disable()
     ALEDisable


### PR DESCRIPTION
<!--
READ THIS: Before creating a pull request, please consider the following first.

* The most important thing you can do is write tests. Code without tests
  probably doesn't work, and will almost certainly stop working later on. Pull
  requests without tests probably won't be accepted, although there are some
  exceptions.
* Read the Contributing guide linked above first.
* If you are adding a new linter, remember to update the README.md file and
  doc/ale.txt first.
* If you add or modify a function for converting error lines into loclist items
  that ALE can work with, please add Vader tests for them. Look at existing
  tests in the test/handler directory, etc.
* If you add or modify a function for computing a command line string for
  running a command, please add Vader tests for that.
* Generally try and cover anything with Vader tests, although some things just
  can't be tested with Vader, or at least they can be hard to test. Consider
  breaking up your code so that some parts can be tested, and generally open up
  a discussion about it.
* Have fun!
-->

Vim help says:

```
m  *+balloon_eval*	|balloon-eval| support in the GUI. Included when
			compiling with supported GUI (Motif, GTK, GUI) and
			either Netbeans/Sun Workshop integration or |+eval|
			feature.
H  *+balloon_eval_term*	|balloon-eval| support in the terminal,
			'balloonevalterm'
```

It means `balloon_eval` is for GUI, and `balloon_eval_term` should be referred on CUI instead. I changed the default value of `g:ale_set_balloons` considering that.
