### PR TITLE
Run sass-lint from the target's directory

### DIFF
--- a/ale_linters/sass/sasslint.vim
+++ b/ale_linters/sass/sasslint.vim
@@ -1,8 +1,18 @@
-" Author: KabbAmine - https://github.com/KabbAmine
+" Author: KabbAmine - https://github.com/KabbAmine, Ben Falconer
+" <ben@falconers.me.uk>
+
+function! ale_linters#sass#sasslint#GetCommand(buffer) abort
+    return ale#path#BufferCdString(a:buffer)
+    \   . ale#Escape('sass-lint')
+    \   . ' -v'
+    \   . ' -q'
+    \   . ' -f compact'
+    \   . ' %t'
+endfunction
 
 call ale#linter#Define('sass', {
 \   'name': 'sasslint',
 \   'executable': 'sass-lint',
-\   'command': 'sass-lint -v -q -f compact %t',
+\   'command_callback': 'ale_linters#sass#sasslint#GetCommand',
 \   'callback': 'ale#handlers#css#HandleCSSLintFormat',
 \})

--- a/ale_linters/scss/sasslint.vim
+++ b/ale_linters/scss/sasslint.vim
@@ -1,8 +1,18 @@
-" Author: KabbAmine - https://github.com/KabbAmine
+" Author: KabbAmine - https://github.com/KabbAmine, Ben Falconer
+" <ben@falconers.me.uk>
+
+function! ale_linters#scss#sasslint#GetCommand(buffer) abort
+    return ale#path#BufferCdString(a:buffer)
+    \   . ale#Escape('sass-lint')
+    \   . ' -v'
+    \   . ' -q'
+    \   . ' -f compact'
+    \   . ' %t'
+endfunction
 
 call ale#linter#Define('scss', {
 \   'name': 'sasslint',
 \   'executable': 'sass-lint',
-\   'command': 'sass-lint -v -q -f compact %t',
+\   'command_callback': 'ale_linters#scss#sasslint#GetCommand',
 \   'callback': 'ale#handlers#css#HandleCSSLintFormat',
 \})

--- a/test/command_callback/test_sasslint_command_callback.vader
+++ b/test/command_callback/test_sasslint_command_callback.vader
@@ -1,0 +1,17 @@
+Before:
+  runtime ale_linters/sass/sasslint.vim
+
+  call ale#test#SetDirectory('/testplugin/test/command_callback')
+  call ale#test#SetFilename('test.sass')
+
+After:
+  Restore
+
+  call ale#test#RestoreDirectory()
+  call ale#linter#Reset()
+
+Execute(The default sasslint command should be correct):
+  AssertEqual
+  \ 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \   . ale#Escape('sass-lint') . ' -v -q -f compact %t',
+  \ ale_linters#sass#sasslint#GetCommand(bufnr(''))


### PR DESCRIPTION
Running sass-lint from the directory of the target file causes the local linter config to be used (if it exists) rather than the global config.

> * If you add or modify a function for computing a command line string for
>   running a command, please add Vader tests for that.

Can someone point me in the direction of a Vader test that does this already?  I'm not familiar with vimscript so I'll have a very hard time without something to follow.