### PR TITLE
Support Elm 0.19

### DIFF
--- a/ale_linters/elm/make.vim
+++ b/ale_linters/elm/make.vim
@@ -22,6 +22,10 @@ function! ale_linters#elm#make#Handle(buffer, lines) abort
                 " General problem
                 let l:details = ale_linters#elm#make#ParseMessage(l:report.message)
 
+                if empty(l:report.path)
+                    let l:report.path = 'Elm.Kernel'
+                endif
+
                 if ale_linters#elm#make#FileIsBuffer(l:report.path)
                     call add(l:output, {
                                 \    'lnum': 1,
@@ -36,7 +40,6 @@ function! ale_linters#elm#make#Handle(buffer, lines) abort
                                 \    'detail': l:report.path ." ----------\n\n". l:details,
                                 \})
                 endif
-
             else
                 " Compilation errors
                 for l:error in l:report.errors

--- a/ale_linters/elm/make.vim
+++ b/ale_linters/elm/make.vim
@@ -1,46 +1,66 @@
 " Author: buffalocoder - https://github.com/buffalocoder, soywod - https://github.com/soywod
 " Description: Elm linting in Ale. Closely follows the Syntastic checker in https://github.com/ElmCast/elm-vim.
 
-call ale#Set('elm_make_executable', 'elm-make')
-call ale#Set('elm_make_use_global', get(g:, 'ale_use_global_executables', 0))
+call ale#Set('elm_executable', 'elm')
+call ale#Set('elm_use_global', get(g:, 'ale_use_global_executables', 0))
 
 function! ale_linters#elm#make#GetExecutable(buffer) abort
-    return ale#node#FindExecutable(a:buffer, 'elm_make', [
-    \   'node_modules/.bin/elm-make',
+    return ale#node#FindExecutable(a:buffer, 'elm', [
+    \   'node_modules/.bin/elm',
     \])
 endfunction
 
 function! ale_linters#elm#make#Handle(buffer, lines) abort
     let l:output = []
-    let l:is_windows = has('win32')
-    let l:temp_dir = l:is_windows ? $TMP : $TMPDIR
     let l:unparsed_lines = []
+
     for l:line in a:lines
-        if l:line[0] is# '['
-            let l:errors = json_decode(l:line)
+        if l:line[0] is# '{'
+            let l:report = json_decode(l:line)
 
-            for l:error in l:errors
-                " Check if file is from the temp directory.
-                " Filters out any errors not related to the buffer.
-                if l:is_windows
-                    let l:file_is_buffer = l:error.file[0:len(l:temp_dir) - 1] is? l:temp_dir
-                else
-                    let l:file_is_buffer = l:error.file[0:len(l:temp_dir) - 1] is# l:temp_dir
-                endif
+            if l:report.type is? 'error'
+                " General problem
+                let l:details = map(copy(l:report.message), 'ale_linters#elm#make#ParseMessageItem(v:val)')
 
-                if l:file_is_buffer
-                    call add(l:output, {
-                    \    'lnum': l:error.region.start.line,
-                    \    'col': l:error.region.start.column,
-                    \    'end_lnum': l:error.region.end.line,
-                    \    'end_col': l:error.region.end.column,
-                    \    'type': (l:error.type is? 'error') ? 'E' : 'W',
-                    \    'text': l:error.overview,
-                    \    'detail': l:error.overview . "\n\n" . l:error.details
-                    \})
-                endif
-            endfor
-        elseif l:line isnot# 'Successfully generated /dev/null'
+                call add(l:output, {
+                            \    'lnum': 1,
+                            \    'type': 'E',
+                            \    'text': l:report.title,
+                            \    'detail': join(l:details, '')
+                            \})
+            else
+                " Compilation errors
+                for l:error in l:report.errors
+                    let l:file_is_buffer = ale_linters#elm#make#FileIsBuffer(l:error.path)
+
+                    for l:problem in l:error.problems
+                        let l:details = map(copy(l:problem.message), 'ale_linters#elm#make#ParseMessageItem(v:val)')
+
+                        if l:file_is_buffer
+                            " Buffer module has problems
+                            call add(l:output, {
+                                        \    'lnum': l:problem.region.start.line,
+                                        \    'col': l:problem.region.start.column,
+                                        \    'end_lnum': l:problem.region.end.line,
+                                        \    'end_col': l:problem.region.end.column,
+                                        \    'type': 'E',
+                                        \    'text': l:problem.title,
+                                        \    'detail': join(l:details, '')
+                                        \})
+                        else
+                            " Imported module has problems
+                            let l:location = l:error.path .':'. l:problem.region.start.line
+                            call add(l:output, {
+                                        \    'lnum': 1,
+                                        \    'type': 'E',
+                                        \    'text': l:location .' - '. l:problem.title,
+                                        \    'detail':  l:location ." -------\n\n" . join(l:details, '')
+                                        \})
+                        endif
+                    endfor
+                endfor
+            endif
+        else
             call add(l:unparsed_lines, l:line)
         endif
     endfor
@@ -57,23 +77,44 @@ function! ale_linters#elm#make#Handle(buffer, lines) abort
     return l:output
 endfunction
 
+function! ale_linters#elm#make#FileIsBuffer(path) abort
+    let l:is_windows = has('win32')
+    let l:temp_dir = l:is_windows ? $TMP : $TMPDIR
+
+    if has('win32')
+        return a:path[0:len(l:temp_dir) - 1] is? l:temp_dir
+    else
+        return a:path[0:len(l:temp_dir) - 1] is# l:temp_dir
+    endif
+endfunction
+
+function! ale_linters#elm#make#ParseMessageItem(item) abort
+    if type(a:item) == type('')
+        return a:item
+    else
+        return a:item.string
+    endif
+endfunction
+
 " Return the command to execute the linter in the projects directory.
 " If it doesn't, then this will fail when imports are needed.
 function! ale_linters#elm#make#GetCommand(buffer) abort
-    let l:elm_package = ale#path#FindNearestFile(a:buffer, 'elm-package.json')
+    let l:elm_json = ale#path#FindNearestFile(a:buffer, 'elm.json')
     let l:elm_exe = ale_linters#elm#make#GetExecutable(a:buffer)
-    if empty(l:elm_package)
+
+    if empty(l:elm_json)
         let l:dir_set_cmd = ''
     else
-        let l:root_dir = fnamemodify(l:elm_package, ':p:h')
+        let l:root_dir = fnamemodify(l:elm_json, ':p:h')
         let l:dir_set_cmd = 'cd ' . ale#Escape(l:root_dir) . ' && '
     endif
 
-    " The elm-make compiler, at the time of this writing, uses '/dev/null' as
+    " The elm compiler, at the time of this writing, uses '/dev/null' as
     " a sort of flag to tell the compiler not to generate an output file,
-    " which is why this is hard coded here. It does not use NUL on Windows.
-    " Source: https://github.com/elm-lang/elm-make/blob/master/src/Flags.hs
+    " which is why this is hard coded here.
+    " Source: https://github.com/elm-lang/elm-compiler/blob/19d5a769b30ec0b2fc4475985abb4cd94cd1d6c3/builder/src/Generate/Output.hs#L253
     let l:elm_cmd = ale#Escape(l:elm_exe)
+    \   . ' make'
     \   . ' --report=json'
     \   . ' --output=/dev/null'
 

--- a/ale_linters/elm/make.vim
+++ b/ale_linters/elm/make.vim
@@ -1,4 +1,4 @@
-" Author: buffalocoder - https://github.com/buffalocoder, soywod - https://github.com/soywod
+" Author: buffalocoder - https://github.com/buffalocoder, soywod - https://github.com/soywod, hecrj - https://github.com/hecrj
 " Description: Elm linting in Ale. Closely follows the Syntastic checker in https://github.com/ElmCast/elm-vim.
 
 call ale#Set('elm_make_executable', 'elm')

--- a/ale_linters/elm/make.vim
+++ b/ale_linters/elm/make.vim
@@ -1,11 +1,11 @@
 " Author: buffalocoder - https://github.com/buffalocoder, soywod - https://github.com/soywod
 " Description: Elm linting in Ale. Closely follows the Syntastic checker in https://github.com/ElmCast/elm-vim.
 
-call ale#Set('elm_executable', 'elm')
-call ale#Set('elm_use_global', get(g:, 'ale_use_global_executables', 0))
+call ale#Set('elm_make_executable', 'elm')
+call ale#Set('elm_make_use_global', get(g:, 'ale_use_global_executables', 0))
 
 function! ale_linters#elm#make#GetExecutable(buffer) abort
-    return ale#node#FindExecutable(a:buffer, 'elm', [
+    return ale#node#FindExecutable(a:buffer, 'elm_make', [
     \   'node_modules/.bin/elm',
     \])
 endfunction

--- a/ale_linters/elm/make.vim
+++ b/ale_linters/elm/make.vim
@@ -51,17 +51,17 @@ function! ale_linters#elm#make#HandleElm019Line(line, output) abort
 
         if ale_linters#elm#make#FileIsBuffer(l:report.path)
             call add(a:output, {
-                        \    'lnum': 1,
-                        \    'type': 'E',
-                        \    'text': l:details,
-                        \})
+            \    'lnum': 1,
+            \    'type': 'E',
+            \    'text': l:details,
+            \})
         else
             call add(a:output, {
-                        \    'lnum': 1,
-                        \    'type': 'E',
-                        \    'text': l:report.path .' - '. l:details,
-                        \    'detail': l:report.path ." ----------\n\n". l:details,
-                        \})
+            \    'lnum': 1,
+            \    'type': 'E',
+            \    'text': l:report.path .' - '. l:details,
+            \    'detail': l:report.path ." ----------\n\n". l:details,
+            \})
         endif
     else
         " Compilation errors
@@ -74,22 +74,22 @@ function! ale_linters#elm#make#HandleElm019Line(line, output) abort
                 if l:file_is_buffer
                     " Buffer module has problems
                     call add(a:output, {
-                                \    'lnum': l:problem.region.start.line,
-                                \    'col': l:problem.region.start.column,
-                                \    'end_lnum': l:problem.region.end.line,
-                                \    'end_col': l:problem.region.end.column,
-                                \    'type': 'E',
-                                \    'text': l:details,
-                                \})
+                    \    'lnum': l:problem.region.start.line,
+                    \    'col': l:problem.region.start.column,
+                    \    'end_lnum': l:problem.region.end.line,
+                    \    'end_col': l:problem.region.end.column,
+                    \    'type': 'E',
+                    \    'text': l:details,
+                    \})
                 else
                     " Imported module has problems
                     let l:location = l:error.path .':'. l:problem.region.start.line
                     call add(a:output, {
-                                \    'lnum': 1,
-                                \    'type': 'E',
-                                \    'text': l:location .' - '. l:details,
-                                \    'detail': l:location ." ----------\n\n". l:details,
-                                \})
+                    \    'lnum': 1,
+                    \    'type': 'E',
+                    \    'text': l:location .' - '. l:details,
+                    \    'detail': l:location ." ----------\n\n". l:details,
+                    \})
                 endif
             endfor
         endfor
@@ -105,24 +105,24 @@ function! ale_linters#elm#make#HandleElm018Line(line, output) abort
         if l:file_is_buffer
             " Current buffer has problems
             call add(a:output, {
-                        \    'lnum': l:error.region.start.line,
-                        \    'col': l:error.region.start.column,
-                        \    'end_lnum': l:error.region.end.line,
-                        \    'end_col': l:error.region.end.column,
-                        \    'type': (l:error.type is? 'error') ? 'E' : 'W',
-                        \    'text': l:error.overview,
-                        \    'detail': l:error.overview . "\n\n" . l:error.details
-                        \})
+            \    'lnum': l:error.region.start.line,
+            \    'col': l:error.region.start.column,
+            \    'end_lnum': l:error.region.end.line,
+            \    'end_col': l:error.region.end.column,
+            \    'type': (l:error.type is? 'error') ? 'E' : 'W',
+            \    'text': l:error.overview,
+            \    'detail': l:error.overview . "\n\n" . l:error.details
+            \})
         elseif l:error.type is? 'error'
             " Imported module has errors
             let l:location = l:error.file .':'. l:error.region.start.line
 
             call add(a:output, {
-                        \    'lnum': 1,
-                        \    'type': 'E',
-                        \    'text': l:location .' - '. l:error.overview,
-                        \    'detail': l:location ." ----------\n\n". l:error.overview . "\n\n" . l:error.details
-                        \})
+            \    'lnum': 1,
+            \    'type': 'E',
+            \    'text': l:location .' - '. l:error.overview,
+            \    'detail': l:location ." ----------\n\n". l:error.overview . "\n\n" . l:error.details
+            \})
         endif
     endfor
 endfunction

--- a/doc/ale-elm.txt
+++ b/doc/ale-elm.txt
@@ -34,7 +34,7 @@ elm-make                                                     *ale-elm-elm-make*
 g:ale_elm_make_executable                           *g:ale_elm_make_executable*
                                                     *b:ale_elm_make_executable*
   Type: |String|
-  Default: `'elm-make'`
+  Default: `'elm'`
 
   See |ale-integrations-local-executables|
 

--- a/test/handler/test_elmmake_handler.vader
+++ b/test/handler/test_elmmake_handler.vader
@@ -9,7 +9,10 @@ After:
 
   call ale#linter#Reset()
 
-Execute(The elm make handler should parse general problems correctly):
+
+" Elm 0.19
+
+Execute(The elm-make handler should parse Elm 0.19 general problems correctly):
   AssertEqual
   \ [
   \   {
@@ -27,7 +30,7 @@ Execute(The elm make handler should parse general problems correctly):
   \    }'
   \ ])
 
-Execute(The elm make handler should parse compilation errors correctly):
+Execute(The elm-make handler should parse Elm 0.19 compilation errors correctly):
   AssertEqual
   \ [
   \   {
@@ -83,7 +86,7 @@ Execute(The elm make handler should parse compilation errors correctly):
   \    }'
   \ ])
 
-Execute(The elm make handler should handle errors in imported modules):
+Execute(The elm-make handler should handle errors in Elm 0.19 imported modules):
   AssertEqual
   \ [
   \   {
@@ -95,8 +98,8 @@ Execute(The elm make handler should handle errors in imported modules):
   \   {
   \     'lnum': 1,
   \     'type': 'E',
-  \     'text': "Elm.Kernel - error details\n\nstyled details",
-  \     'detail': "Elm.Kernel ----------\n\nerror details\n\nstyled details"
+  \     'text': "Elm - error details\n\nstyled details",
+  \     'detail': "Elm ----------\n\nerror details\n\nstyled details"
   \   },
   \   {
   \     'lnum': 1,
@@ -135,7 +138,125 @@ Execute(The elm make handler should handle errors in imported modules):
   \    }'
   \ ])
 
-Execute(The elm make handler should put an error on the first line if a line cannot be parsed):
+
+" Elm 0.18
+
+Execute(The elm-make handler should parse Elm 0.18 compilation errors correctly):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 33,
+  \     'col': 1,
+  \     'end_lnum': 33,
+  \     'end_col': 19,
+  \     'type': 'W',
+  \     'text': 'warning overview',
+  \     'detail': "warning overview\n\nwarning details",
+  \   },
+  \   {
+  \     'lnum': 404,
+  \     'col': 1,
+  \     'end_lnum': 408,
+  \     'end_col': 18,
+  \     'type': 'E',
+  \     'text': 'error overview 1',
+  \     'detail': "error overview 1\n\nerror details 1",
+  \   },
+  \   {
+  \     'lnum': 406,
+  \     'col': 5,
+  \     'end_lnum': 407,
+  \     'end_col': 17,
+  \     'type': 'E',
+  \     'text': 'error overview 2',
+  \     'detail': "error overview 2\n\nerror details 2",
+  \   },
+  \   {
+  \     'lnum': 406,
+  \     'col': 5,
+  \     'end_lnum': 406,
+  \     'end_col': 93,
+  \     'type': 'E',
+  \     'text': 'error overview 3',
+  \     'detail': "error overview 3\n\nerror details 3",
+  \   },
+  \ ],
+  \ ale_linters#elm#make#Handle(347, [
+  \   '[
+  \      {
+  \         "tag": "unused import",
+  \         "overview": "warning overview",
+  \         "details": "warning details",
+  \         "region": {"start": { "line": 33, "column": 1 }, "end": { "line": 33, "column": 19 } },
+  \         "type": "warning",
+  \         "file": "' . b:tmp . '/Module.elm"
+  \      }
+  \    ]',
+  \   '[
+  \      {
+  \        "tag": "TYPE MISMATCH",
+  \        "overview": "error overview 1",
+  \        "subregion": { "start": { "line": 406, "column": 5 }, "end": { "line": 408, "column": 18 } },
+  \        "details": "error details 1",
+  \        "region": { "start": { "line": 404, "column": 1 }, "end": { "line": 408, "column": 18 } },
+  \        "type": "error",
+  \        "file":"' . b:tmp . '/Module.elm"
+  \      },
+  \      {
+  \        "tag": "TYPE MISMATCH",
+  \        "overview": "error overview 2",
+  \        "subregion": { "start": { "line": 407, "column": 12 }, "end": { "line": 407, "column": 17 } },
+  \        "details": "error details 2",
+  \        "region": { "start": { "line": 406, "column": 5}, "end": { "line": 407, "column": 17 } },
+  \        "type":"error",
+  \        "file":"' . b:tmp . '/Module.elm"
+  \      },
+  \      {
+  \        "tag": "TYPE MISMATCH",
+  \        "overview": "error overview 3",
+  \        "subregion": { "start": { "line": 406, "column": 88 }, "end": { "line": 406, "column": 93 } },
+  \        "details": "error details 3",
+  \        "region": { "start": { "line": 406, "column": 5 }, "end": { "line": 406, "column": 93 } },
+  \        "type":"error",
+  \        "file":"' . b:tmp . '/Module.elm"
+  \      }
+  \    ]'
+  \ ])
+
+Execute(The elm-make handler should handle errors in Elm 0.18 imported modules):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 1,
+  \     'type': 'E',
+  \     'text': "src/Module.elm:33 - error overview",
+  \     'detail': "src/Module.elm:33 ----------\n\nerror overview\n\nerror details"
+  \   }
+  \ ],
+  \ ale_linters#elm#make#Handle(347, [
+  \   '[
+  \      {
+  \         "tag": "unused import",
+  \         "overview": "warning overview",
+  \         "details": "warning details",
+  \         "region": {"start": { "line": 33, "column": 1 }, "end": { "line": 33, "column": 19 } },
+  \         "type": "warning",
+  \         "file": "src/Module.elm"
+  \      },
+  \      {
+  \         "tag": "type error",
+  \         "overview": "error overview",
+  \         "details": "error details",
+  \         "region": {"start": { "line": 33, "column": 1 }, "end": { "line": 33, "column": 19 } },
+  \         "type": "error",
+  \         "file": "src/Module.elm"
+  \      }
+  \    ]',
+  \ ])
+
+" Generic
+
+Execute(The elm-make handler should put an error on the first line if a line cannot be parsed):
   AssertEqual
   \ [
   \   {
@@ -171,4 +292,11 @@ Execute(The elm make handler should put an error on the first line if a line can
   \    }',
   \    'Not JSON',
   \    'Also not JSON',
+  \ ])
+
+Execute(The elm-make handler should ignore success lines):
+  AssertEqual
+  \ [],
+  \ ale_linters#elm#make#Handle(347, [
+  \    'Successfully generated /dev/null',
   \ ])

--- a/test/handler/test_elmmake_handler.vader
+++ b/test/handler/test_elmmake_handler.vader
@@ -9,7 +9,26 @@ After:
 
   call ale#linter#Reset()
 
-Execute(The elm-make handler should parse lines correctly):
+Execute(The elm make handler should parse general problems correctly):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 1,
+  \     'type': 'E',
+  \     'text': 'UNKNOWN IMPORT',
+  \     'detail': "error details 1\n\nstyled details"
+  \   }
+  \ ],
+  \ ale_linters#elm#make#Handle(347, [
+  \   '{
+  \      "type": "error",
+  \      "path": "' . b:tmp . '/Module.elm",
+  \      "title": "UNKNOWN IMPORT",
+  \      "message": ["error details 1\n\n", { "string": "styled details" }]
+  \    }'
+  \ ])
+
+Execute(The elm make handler should parse compilation errors correctly):
   AssertEqual
   \ [
   \   {
@@ -19,7 +38,7 @@ Execute(The elm-make handler should parse lines correctly):
   \     'end_col': 18,
   \     'type': 'E',
   \     'text': 'TYPE MISMATCH',
-  \     'detail': "error details 1 styled details"
+  \     'detail': "error details 1\n\nstyled details"
   \   },
   \   {
   \     'lnum': 406,
@@ -42,25 +61,25 @@ Execute(The elm-make handler should parse lines correctly):
   \ ],
   \ ale_linters#elm#make#Handle(347, [
   \   '{
-  \      "type":"compile-errors",
+  \      "type": "compile-errors",
   \      "errors": [
   \        {
-  \          "path": "' . b:tmp . 'Module.elm",
+  \          "path": "' . b:tmp . '/Module.elm",
   \          "problems": [
   \            {
   \              "title": "TYPE MISMATCH",
-  \              "message": ["error details 1 ", { "string": "styled details" }],
-  \              "region": { "start": { "line": 404, "column":1 }, "end": { "line":408, "column":18} }
+  \              "message": ["error details 1\n\n", { "string": "styled details" }],
+  \              "region": { "start": { "line": 404, "column": 1 }, "end": { "line": 408, "column": 18 } }
   \            },
   \            {
   \              "title": "TYPE MISMATCH",
   \              "message": ["error details 2"],
-  \              "region": { "start": {"line": 406, "column": 5}, "end": {"line": 407, "column": 17} }
+  \              "region": { "start": {"line": 406, "column": 5}, "end": {"line": 407, "column": 17 } }
   \            },
   \            {
   \              "title": "TYPE MISMATCH",
   \              "message": ["error details 3"],
-  \              "region": { "start": { "line": 406, "column": 5}, "end": {"line": 406, "column":93 } }
+  \              "region": { "start": { "line": 406, "column": 5}, "end": {"line": 406, "column": 93 } }
   \            }
   \          ]
   \        }
@@ -68,7 +87,35 @@ Execute(The elm-make handler should parse lines correctly):
   \    }'
   \ ])
 
-Execute(The elm-make handler should put an error on the first line if a line cannot be parsed):
+Execute(The elm make handler should put an error on the first line for compilation errors in imported modules):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 1,
+  \     'type': 'E',
+  \     'text': 'src/Module.elm:404 - TYPE MISMATCH',
+  \     'detail': "src/Module.elm:404 -------\n\nerror details\n\nstyled details"
+  \   },
+  \ ],
+  \ ale_linters#elm#make#Handle(347, [
+  \   '{
+  \      "type": "compile-errors",
+  \      "errors": [
+  \        {
+  \          "path": "src/Module.elm",
+  \          "problems": [
+  \            {
+  \              "title": "TYPE MISMATCH",
+  \              "message": ["error details\n\n", { "string": "styled details" }],
+  \              "region": { "start": { "line": 404, "column": 1 }, "end": { "line": 408, "column": 18 } }
+  \            }
+  \          ]
+  \        }
+  \      ]
+  \    }'
+  \ ])
+
+Execute(The elm make handler should put an error on the first line if a line cannot be parsed):
   AssertEqual
   \ [
   \   {
@@ -89,15 +136,15 @@ Execute(The elm-make handler should put an error on the first line if a line can
   \ ],
   \ ale_linters#elm#make#Handle(347, [
   \   '{
-  \      "type":"compile-errors",
+  \      "type": "compile-errors",
   \      "errors": [
   \        {
-  \          "path": "' . b:tmp . 'Module.elm",
+  \          "path": "' . b:tmp . '/Module.elm",
   \          "problems": [
   \            {
   \              "title": "TYPE MISMATCH",
   \              "message": ["error details 1 ", { "string": "styled details" }],
-  \              "region": { "start": { "line": 404, "column":1 }, "end": { "line":408, "column":18} }
+  \              "region": { "start": { "line": 404, "column": 1 }, "end": { "line": 408, "column": 18 } }
   \            }
   \          ]
   \        }

--- a/test/handler/test_elmmake_handler.vader
+++ b/test/handler/test_elmmake_handler.vader
@@ -15,8 +15,7 @@ Execute(The elm make handler should parse general problems correctly):
   \   {
   \     'lnum': 1,
   \     'type': 'E',
-  \     'text': 'UNKNOWN IMPORT',
-  \     'detail': "error details 1\n\nstyled details"
+  \     'text': "error details\n\nstyled details"
   \   }
   \ ],
   \ ale_linters#elm#make#Handle(347, [
@@ -24,7 +23,7 @@ Execute(The elm make handler should parse general problems correctly):
   \      "type": "error",
   \      "path": "' . b:tmp . '/Module.elm",
   \      "title": "UNKNOWN IMPORT",
-  \      "message": ["error details 1\n\n", { "string": "styled details" }]
+  \      "message": ["error details\n\n", { "string": "styled details" }]
   \    }'
   \ ])
 
@@ -37,8 +36,7 @@ Execute(The elm make handler should parse compilation errors correctly):
   \     'end_lnum': 408,
   \     'end_col': 18,
   \     'type': 'E',
-  \     'text': 'TYPE MISMATCH',
-  \     'detail': "error details 1\n\nstyled details"
+  \     'text': "error details 1\n\nstyled details"
   \   },
   \   {
   \     'lnum': 406,
@@ -46,8 +44,7 @@ Execute(The elm make handler should parse compilation errors correctly):
   \     'end_lnum': 407,
   \     'end_col': 17,
   \     'type': 'E',
-  \     'text': 'TYPE MISMATCH',
-  \     'detail': "error details 2",
+  \     'text': "error details 2",
   \   },
   \   {
   \     'lnum': 406,
@@ -55,8 +52,7 @@ Execute(The elm make handler should parse compilation errors correctly):
   \     'end_lnum': 406,
   \     'end_col': 93,
   \     'type': 'E',
-  \     'text': 'TYPE MISMATCH',
-  \     'detail': "error details 3",
+  \     'text': "error details 3",
   \   },
   \ ],
   \ ale_linters#elm#make#Handle(347, [
@@ -87,17 +83,29 @@ Execute(The elm make handler should parse compilation errors correctly):
   \    }'
   \ ])
 
-Execute(The elm make handler should put an error on the first line for compilation errors in imported modules):
+Execute(The elm make handler should handle errors in imported modules):
   AssertEqual
   \ [
   \   {
   \     'lnum': 1,
   \     'type': 'E',
-  \     'text': 'src/Module.elm:404 - TYPE MISMATCH',
-  \     'detail': "src/Module.elm:404 -------\n\nerror details\n\nstyled details"
+  \     'text': "src/Module.elm - error details\n\nstyled details",
+  \     'detail': "src/Module.elm ----------\n\nerror details\n\nstyled details"
+  \   },
+  \   {
+  \     'lnum': 1,
+  \     'type': 'E',
+  \     'text': "src/Module.elm:404 - error details\n\nstyled details",
+  \     'detail': "src/Module.elm:404 ----------\n\nerror details\n\nstyled details"
   \   },
   \ ],
   \ ale_linters#elm#make#Handle(347, [
+  \   '{
+  \      "type": "error",
+  \      "path": "src/Module.elm",
+  \      "title": "UNKNOWN IMPORT",
+  \      "message": ["error details\n\n", { "string": "styled details" }]
+  \    }',
   \   '{
   \      "type": "compile-errors",
   \      "errors": [
@@ -124,8 +132,7 @@ Execute(The elm make handler should put an error on the first line if a line can
   \     'end_lnum': 408,
   \     'end_col': 18,
   \     'type': 'E',
-  \     'text': 'TYPE MISMATCH',
-  \     'detail': "error details 1 styled details"
+  \     'text': "error details 1\n\nstyled details"
   \   },
   \   {
   \     'lnum': 1,
@@ -143,13 +150,13 @@ Execute(The elm make handler should put an error on the first line if a line can
   \          "problems": [
   \            {
   \              "title": "TYPE MISMATCH",
-  \              "message": ["error details 1 ", { "string": "styled details" }],
+  \              "message": ["error details 1\n\n", { "string": "styled details" }],
   \              "region": { "start": { "line": 404, "column": 1 }, "end": { "line": 408, "column": 18 } }
   \            }
   \          ]
   \        }
   \      ]
   \    }',
-  \    "Not JSON",
-  \    "Also not JSON",
+  \    'Not JSON',
+  \    'Also not JSON',
   \ ])

--- a/test/handler/test_elmmake_handler.vader
+++ b/test/handler/test_elmmake_handler.vader
@@ -95,6 +95,12 @@ Execute(The elm make handler should handle errors in imported modules):
   \   {
   \     'lnum': 1,
   \     'type': 'E',
+  \     'text': "Elm.Kernel - error details\n\nstyled details",
+  \     'detail': "Elm.Kernel ----------\n\nerror details\n\nstyled details"
+  \   },
+  \   {
+  \     'lnum': 1,
+  \     'type': 'E',
   \     'text': "src/Module.elm:404 - error details\n\nstyled details",
   \     'detail': "src/Module.elm:404 ----------\n\nerror details\n\nstyled details"
   \   },
@@ -103,6 +109,12 @@ Execute(The elm make handler should handle errors in imported modules):
   \   '{
   \      "type": "error",
   \      "path": "src/Module.elm",
+  \      "title": "UNKNOWN IMPORT",
+  \      "message": ["error details\n\n", { "string": "styled details" }]
+  \    }',
+  \   '{
+  \      "type": "error",
+  \      "path": null,
   \      "title": "UNKNOWN IMPORT",
   \      "message": ["error details\n\n", { "string": "styled details" }]
   \    }',

--- a/test/handler/test_elmmake_handler.vader
+++ b/test/handler/test_elmmake_handler.vader
@@ -13,22 +13,13 @@ Execute(The elm-make handler should parse lines correctly):
   AssertEqual
   \ [
   \   {
-  \     'lnum': 33,
-  \     'col': 1,
-  \     'end_lnum': 33,
-  \     'end_col': 19,
-  \     'type': 'W',
-  \     'text': 'warning overview',
-  \     'detail': "warning overview\n\nwarning details",
-  \   },
-  \   {
   \     'lnum': 404,
   \     'col': 1,
   \     'end_lnum': 408,
   \     'end_col': 18,
   \     'type': 'E',
-  \     'text': 'error overview 1',
-  \     'detail': "error overview 1\n\nerror details 1",
+  \     'text': 'TYPE MISMATCH',
+  \     'detail': "error details 1 styled details"
   \   },
   \   {
   \     'lnum': 406,
@@ -36,8 +27,8 @@ Execute(The elm-make handler should parse lines correctly):
   \     'end_lnum': 407,
   \     'end_col': 17,
   \     'type': 'E',
-  \     'text': 'error overview 2',
-  \     'detail': "error overview 2\n\nerror details 2",
+  \     'text': 'TYPE MISMATCH',
+  \     'detail': "error details 2",
   \   },
   \   {
   \     'lnum': 406,
@@ -45,26 +36,49 @@ Execute(The elm-make handler should parse lines correctly):
   \     'end_lnum': 406,
   \     'end_col': 93,
   \     'type': 'E',
-  \     'text': 'error overview 3',
-  \     'detail': "error overview 3\n\nerror details 3",
+  \     'text': 'TYPE MISMATCH',
+  \     'detail': "error details 3",
   \   },
   \ ],
   \ ale_linters#elm#make#Handle(347, [
-  \   '[{"tag":"unused import","overview":"warning overview","details":"warning details","region":{"start":{"line":33,"column":1},"end":{"line":33,"column":19}},"type":"warning","file":"' . b:tmp . 'Module.elm"}]',
-  \   '[{"tag":"TYPE MISMATCH","overview":"error overview 1","subregion":{"start":{"line":406,"column":5},"end":{"line":408,"column":18}},"details":"error details 1","region":{"start":{"line":404,"column":1},"end":{"line":408,"column":18}},"type":"error","file":"' . b:tmp . 'Module.elm"},{"tag":"TYPE MISMATCH","overview":"error overview 2","subregion":{"start":{"line":407,"column":12},"end":{"line":407,"column":17}},"details":"error details 2","region":{"start":{"line":406,"column":5},"end":{"line":407,"column":17}},"type":"error","file":"' . b:tmp . 'Module.elm"},{"tag":"TYPE MISMATCH","overview":"error overview 3","subregion":{"start":{"line":406,"column":88},"end":{"line":406,"column":93}},"details":"error details 3","region":{"start":{"line":406,"column":5},"end":{"line":406,"column":93}},"type":"error","file":"' . b:tmp . 'Module.elm"}]'
+  \   '{
+  \      "type":"compile-errors",
+  \      "errors": [
+  \        {
+  \          "path": "' . b:tmp . 'Module.elm",
+  \          "problems": [
+  \            {
+  \              "title": "TYPE MISMATCH",
+  \              "message": ["error details 1 ", { "string": "styled details" }],
+  \              "region": { "start": { "line": 404, "column":1 }, "end": { "line":408, "column":18} }
+  \            },
+  \            {
+  \              "title": "TYPE MISMATCH",
+  \              "message": ["error details 2"],
+  \              "region": { "start": {"line": 406, "column": 5}, "end": {"line": 407, "column": 17} }
+  \            },
+  \            {
+  \              "title": "TYPE MISMATCH",
+  \              "message": ["error details 3"],
+  \              "region": { "start": { "line": 406, "column": 5}, "end": {"line": 406, "column":93 } }
+  \            }
+  \          ]
+  \        }
+  \      ]
+  \    }'
   \ ])
 
 Execute(The elm-make handler should put an error on the first line if a line cannot be parsed):
   AssertEqual
   \ [
   \   {
-  \     'lnum': 33,
+  \     'lnum': 404,
   \     'col': 1,
-  \     'end_lnum': 33,
-  \     'end_col': 19,
-  \     'type': 'W',
-  \     'text': 'warning overview',
-  \     'detail': "warning overview\n\nwarning details",
+  \     'end_lnum': 408,
+  \     'end_col': 18,
+  \     'type': 'E',
+  \     'text': 'TYPE MISMATCH',
+  \     'detail': "error details 1 styled details"
   \   },
   \   {
   \     'lnum': 1,
@@ -74,7 +88,21 @@ Execute(The elm-make handler should put an error on the first line if a line can
   \   },
   \ ],
   \ ale_linters#elm#make#Handle(347, [
-  \   '[{"tag":"unused import","overview":"warning overview","details":"warning details","region":{"start":{"line":33,"column":1},"end":{"line":33,"column":19}},"type":"warning","file":"' . b:tmp . 'Module.elm"}]',
-  \   "Not JSON",
-  \   "Also not JSON",
+  \   '{
+  \      "type":"compile-errors",
+  \      "errors": [
+  \        {
+  \          "path": "' . b:tmp . 'Module.elm",
+  \          "problems": [
+  \            {
+  \              "title": "TYPE MISMATCH",
+  \              "message": ["error details 1 ", { "string": "styled details" }],
+  \              "region": { "start": { "line": 404, "column":1 }, "end": { "line":408, "column":18} }
+  \            }
+  \          ]
+  \        }
+  \      ]
+  \    }',
+  \    "Not JSON",
+  \    "Also not JSON",
   \ ])

--- a/test/test_elm_executable_detection.vader
+++ b/test/test_elm_executable_detection.vader
@@ -3,8 +3,8 @@ Before:
   runtime ale_linters/elm/make.vim
 
 After:
-  unlet! g:ale_elm_make_use_global
-  unlet! g:ale_elm_make_executable
+  unlet! g:ale_elm_use_global
+  unlet! g:ale_elm_executable
 
   call ale#test#RestoreDirectory()
 
@@ -12,25 +12,25 @@ Execute(should get valid executable with default params):
   call ale#test#SetFilename('elm-test-files/app/testfile.elm')
 
   AssertEqual
-  \ ale#path#Simplify(g:dir . '/elm-test-files/app/node_modules/.bin/elm-make'),
+  \ ale#path#Simplify(g:dir . '/elm-test-files/app/node_modules/.bin/elm'),
   \ ale_linters#elm#make#GetExecutable(bufnr(''))
 
 Execute(should get valid executable with 'use_global' params):
-  let g:ale_elm_make_use_global = 1
+  let g:ale_elm_use_global = 1
 
   call ale#test#SetFilename('elm-test-files/app/testfile.elm')
 
   AssertEqual
-  \ 'elm-make',
+  \ 'elm',
   \ ale_linters#elm#make#GetExecutable(bufnr(''))
 
 Execute(should get valid executable with 'use_global' and 'executable' params):
-  let g:ale_elm_make_executable = 'other-elm-make'
-  let g:ale_elm_make_use_global = 1
+  let g:ale_elm_executable = 'other-elm'
+  let g:ale_elm_use_global = 1
 
   call ale#test#SetFilename('elm-test-files/app/testfile.elm')
 
   AssertEqual
-  \ 'other-elm-make',
+  \ 'other-elm',
   \ ale_linters#elm#make#GetExecutable(bufnr(''))
 

--- a/test/test_elm_executable_detection.vader
+++ b/test/test_elm_executable_detection.vader
@@ -3,8 +3,8 @@ Before:
   runtime ale_linters/elm/make.vim
 
 After:
-  unlet! g:ale_elm_use_global
-  unlet! g:ale_elm_executable
+  unlet! g:ale_elm_make_use_global
+  unlet! g:ale_elm_make_executable
 
   call ale#test#RestoreDirectory()
 
@@ -16,7 +16,7 @@ Execute(should get valid executable with default params):
   \ ale_linters#elm#make#GetExecutable(bufnr(''))
 
 Execute(should get valid executable with 'use_global' params):
-  let g:ale_elm_use_global = 1
+  let g:ale_elm_make_use_global = 1
 
   call ale#test#SetFilename('elm-test-files/app/testfile.elm')
 
@@ -25,8 +25,8 @@ Execute(should get valid executable with 'use_global' params):
   \ ale_linters#elm#make#GetExecutable(bufnr(''))
 
 Execute(should get valid executable with 'use_global' and 'executable' params):
-  let g:ale_elm_executable = 'other-elm'
-  let g:ale_elm_use_global = 1
+  let g:ale_elm_make_executable = 'other-elm'
+  let g:ale_elm_make_use_global = 1
 
   call ale#test#SetFilename('elm-test-files/app/testfile.elm')
 


### PR DESCRIPTION
<!--
READ THIS: Before creating a pull request, please consider the following first.

* The most important thing you can do is write tests. Code without tests
  probably doesn't work, and will almost certainly stop working later on. Pull
  requests without tests probably won't be accepted, although there are some
  exceptions.
* Read the Contributing guide linked above first.
* If you are adding a new linter, remember to update the README.md file and
  doc/ale.txt first.
* If you add or modify a function for converting error lines into loclist items
  that ALE can work with, please add Vader tests for them. Look at existing
  tests in the test/handler directory, etc.
* If you add or modify a function for computing a command line string for
  running a command, please add Vader tests for that.
* Generally try and cover anything with Vader tests, although some things just
  can't be tested with Vader, or at least they can be hard to test. Consider
  breaking up your code so that some parts can be tested, and generally open up
  a discussion about it.
* Have fun!
-->
The Elm 0.19 alpha period started yesterday. Here are the main relevant changes:

  * The compiler is significantly faster.
  * There is now just one elm binary at the command line. `elm-make` is `elm make` now.
  * The output when using `--report=json` has changed. [Here](https://github.com/elm-lang/project-metadata-utils/blob/master/src/Elm/Error.elm) is a specification of the new format.

I have modified the current linter to support these changes, while also adding some tests. I hope this PR can help to get ALE ready for Elm 0.19 once the alpha period finishes :)

There is a main concern: these changes break support for Elm 0.18. How should we deal with that? Different linters? Configurable options? Use `elm version` to support both?

Finally, I want to thank you all for this amazing plugin.