### PR TITLE
Enable warnings of dmd command

### DIFF
--- a/ale_linters/d/dmd.vim
+++ b/ale_linters/d/dmd.vim
@@ -46,7 +46,7 @@ function! ale_linters#d#dmd#DMDCommand(buffer, dub_output) abort
         endif
     endfor
 
-    return 'dmd '. join(l:import_list) . ' -o- -vcolumns -c %t'
+    return 'dmd '. join(l:import_list) . ' -o- -wi -vcolumns -c %t'
 endfunction
 
 function! ale_linters#d#dmd#Handle(buffer, lines) abort


### PR DESCRIPTION
<!--
READ THIS: Before creating a pull request, please consider the following first.

* The most important thing you can do is write tests. Code without tests
  probably doesn't work, and will almost certainly stop working later on. Pull
  requests without tests probably won't be accepted, although there are some
  exceptions.
* Read the Contributing guide linked above first.
* If you are adding a new linter, remember to update the README.md file and
  doc/ale.txt first.
* If you add or modify a function for converting error lines into loclist items
  that ALE can work with, please add Vader tests for them. Look at existing
  tests in the test/handler directory, etc.
* If you add or modify a function for computing a command line string for
  running a command, please add Vader tests for that.
* Generally try and cover anything with Vader tests, although some things just
  can't be tested with Vader, or at least they can be hard to test. Consider
  breaking up your code so that some parts can be tested, and generally open up
  a discussion about it.
* Have fun!
-->

Currently, the arguments of dmd command, the linter of D-lang, lack the option to enable warning messages (`-wi`). I just added it.
