### PR TITLE
Fix rust error line when it happens on a macro

### DIFF
--- a/autoload/ale/handlers/rust.vim
+++ b/autoload/ale/handlers/rust.vim
@@ -8,7 +8,7 @@ if !exists('g:ale_rust_ignore_error_codes')
 endif
 
 function! s:FindSpan(buffer, span) abort
-    if ale#path#IsBufferPath(a:buffer, a:span.file_name) || a:span.file_name is# '<anon>'
+    if (ale#path#IsBufferPath(a:buffer, a:span.file_name) || a:span.file_name is# '<anon>') && a:span.file_name[:0] != '<'
         return a:span
     endif
 


### PR DESCRIPTION
Hi,

When using Rust with Cargo, when an error is on a macro you will have span(s), maybe with expansions, that contain `"file_name": "<something>"`.

That breaks when this string is given to the `ale#path#IsBufferPath` function, leading to a bad error line in the lint results.

Tell me if i should do the fix another way.