### PR TITLE
Add psalm linter for PHP

### DIFF
--- a/ale_linters/php/psalm.vim
+++ b/ale_linters/php/psalm.vim
@@ -1,0 +1,38 @@
+" Author: richard marmorstein <https://github.com/twitchard>
+" Description: plugin for Psalm, static analyzer for PHP
+
+let g:ale_php_phpstan_executable = get(g:, 'ale_php_psalm_executable', 'psalm')
+
+function! ale_linters#php#psalm#GetExecutable(buffer) abort
+    return ale#Var(a:buffer, 'php_psalm_executable')
+endfunction
+
+function! ale_linters#php#psalm#GetCommand(buffer) abort
+    return ale#Escape(ale_linters#php#psalm#GetExecutable(a:buffer)) . ' --diff --output-format=emacs %s'
+endfunction
+
+function! ale_linters#php#psalm#Handle(buffer, lines) abort
+    " Matches patterns like the following:
+
+    let l:pattern = '^.*:\(\d\+\):\(\d\+\):\(\w\+\) - \(.*\)$'
+    let l:output = []
+
+
+    for l:match in ale#util#GetMatches(a:lines, l:pattern)
+        call add(l:output, {
+        \   'lnum': l:match[1] + 0,
+        \   'text': l:match[4],
+        \   'type': l:match[3][:0] is# 'e' ? 'E' : 'W',
+        \})
+    endfor
+
+    return l:output
+endfunction
+
+call ale#linter#Define('php', {
+\   'name': 'psalm',
+\   'executable': 'echo',
+\   'command_callback': 'ale_linters#php#psalm#GetCommand',
+\   'callback': 'ale_linters#php#psalm#Handle',
+\   'lint_file': 1,
+\})

--- a/ale_linters/php/psalm.vim
+++ b/ale_linters/php/psalm.vim
@@ -1,7 +1,7 @@
 " Author: richard marmorstein <https://github.com/twitchard>
 " Description: plugin for Psalm, static analyzer for PHP
 
-let g:ale_php_phpstan_executable = get(g:, 'ale_php_psalm_executable', 'psalm')
+let g:ale_php_psalm_executable = get(g:, 'ale_php_psalm_executable', 'psalm')
 
 function! ale_linters#php#psalm#GetExecutable(buffer) abort
     return ale#Var(a:buffer, 'php_psalm_executable')

--- a/test/handler/test_php_psalm_handler.vader
+++ b/test/handler/test_php_psalm_handler.vader
@@ -1,0 +1,24 @@
+Before:
+  runtime ale_linters/php/psalm.vim
+
+After:
+  call ale#linter#Reset()
+
+Execute(The php static analyzer handler should parse errors from psalm):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 1,
+  \     'type': 'W',
+  \     'text': 'somewarning',
+  \   },
+  \   {
+  \     'lnum': 11,
+  \     'type': 'E',
+  \     'text': 'someerror',
+  \   },
+  \ ],
+  \ ale_linters#php#psalm#Handle(347, [
+  \ "/file:1:3:warning - somewarning",
+  \ "/file:11:33:error - someerror",
+  \ ])


### PR DESCRIPTION
This adds the PHP linter psalm. Probably I should customize it to add specification of additional variables, but at least it's a start and would help anybody who uses this linter.
<!--
READ THIS: Before creating a pull request, please consider the following first.

* The most important thing you can do is write tests. Code without tests
  probably doesn't work, and will almost certainly stop working later on. Pull
  requests without tests probably won't be accepted, although there are some
  exceptions.
* Read the Contributing guide linked above first.
* If you are adding a new linter, remember to update the README.md file and
  doc/ale.txt first.
* If you add or modify a function for converting error lines into loclist items
  that ALE can work with, please add Vader tests for them. Look at existing
  tests in the test/handler directory, etc.
* If you add or modify a function for computing a command line string for
  running a command, please add Vader tests for that. Look at existing
  tests in the test/command_callback directory, etc.
* Generally try and cover anything with Vader tests, although some things just
  can't be tested with Vader, or at least they can be hard to test. Consider
  breaking up your code so that some parts can be tested, and generally open up
  a discussion about it.
* Have fun!
-->
