### PR TITLE
tslint windows 10 neovim file path mistake fix

### DIFF
--- a/ale_linters/typescript/tslint.vim
+++ b/ale_linters/typescript/tslint.vim
@@ -74,7 +74,7 @@ function! ale_linters#typescript#tslint#GetCommand(buffer) abort
     \   . ' --format json'
     \   . l:tslint_config_option
     \   . l:tslint_rules_option
-    \   . ' %t'
+    \   . ' %s'
 endfunction
 
 call ale#linter#Define('typescript', {

--- a/test/command_callback/test_tslint_command_callback.vader
+++ b/test/command_callback/test_tslint_command_callback.vader
@@ -28,7 +28,7 @@ After:
 Execute(The default tslint command should be correct):
   AssertEqual
   \ 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
-  \   . ale#Escape('tslint') . ' --format json %t',
+  \   . ale#Escape('tslint') . ' --format json %s',
   \ ale_linters#typescript#tslint#GetCommand(bufnr(''))
 
 Execute(The rules directory option should be included if set):
@@ -38,7 +38,7 @@ Execute(The rules directory option should be included if set):
   \ 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
   \   . ale#Escape('tslint') . ' --format json'
   \   . ' -r ' . ale#Escape('/foo/bar')
-  \   . ' %t',
+  \   . ' %s',
   \ ale_linters#typescript#tslint#GetCommand(bufnr(''))
 
 Execute(The executable should be configurable and escaped):
@@ -47,5 +47,5 @@ Execute(The executable should be configurable and escaped):
   AssertEqual 'foo bar', ale_linters#typescript#tslint#GetExecutable(bufnr(''))
   AssertEqual
   \ 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
-  \   . ale#Escape('foo bar') . ' --format json %t',
+  \   . ale#Escape('foo bar') . ' --format json %s',
   \ ale_linters#typescript#tslint#GetCommand(bufnr(''))


### PR DESCRIPTION
# Environment
NVIM v0.2.2

# ALEInfo
 Current Filetype: typescript
Available Linters: ['eslint', 'tslint', 'tsserver', 'typecheck']
  Enabled Linters: ['eslint', 'tslint', 'tsserver', 'typecheck']
 Linter Variables:

let g:ale_typescript_tslint_config_path = ''
let g:ale_typescript_tslint_executable = 'tslint'
let g:ale_typescript_tslint_ignore_empty_files = 0
let g:ale_typescript_tslint_rules_dir = ''
let g:ale_typescript_tslint_use_global = 0
let g:ale_typescript_tsserver_config_path = ''
let g:ale_typescript_tsserver_executable = 'tsserver'
let g:ale_typescript_tsserver_use_global = 0
 Global Variables:

let g:ale_cache_executable_check_failures = 0
let g:ale_change_sign_column_color = 0
let g:ale_command_wrapper = ''
let g:ale_completion_delay = 100
let g:ale_completion_enabled = 0
let g:ale_completion_max_suggestions = 50
let g:ale_echo_cursor = 1
let g:ale_echo_msg_error_str = 'Error'
let g:ale_echo_msg_format = '%code: %%s'
let g:ale_echo_msg_info_str = 'Info'
let g:ale_echo_msg_warning_str = 'Warning'
let g:ale_enabled = 1
let g:ale_fix_on_save = 0
let g:ale_fixers = {'typescript': ['tslint']}
let g:ale_history_enabled = 1
let g:ale_history_log_output = 1
let g:ale_keep_list_window_open = 0
let g:ale_lint_delay = 200
let g:ale_lint_on_enter = 0
let g:ale_lint_on_filetype_changed = 0
let g:ale_lint_on_save = 1
let g:ale_lint_on_text_changed = 'never'
let g:ale_lint_on_insert_leave = 0
let g:ale_linter_aliases = {}
let g:ale_linters = {}
let g:ale_linters_explicit = 0
let g:ale_list_window_size = 10
let g:ale_list_vertical = 0
let g:ale_loclist_msg_format = '%code: %%s'
let g:ale_max_buffer_history_size = 20
let g:ale_max_signs = -1
let g:ale_maximum_file_size = 0
let g:ale_open_list = 0
let g:ale_pattern_options = {}
let g:ale_pattern_options_enabled = 0
let g:ale_set_balloons = 0
let g:ale_set_highlights = 1
let g:ale_set_loclist = 0
let g:ale_set_quickfix = 1
let g:ale_set_signs = 0
let g:ale_sign_column_always = 0
let g:ale_sign_error = '>>'
let g:ale_sign_info = '--'
let g:ale_sign_offset = 1000000
let g:ale_sign_style_error = '>>'
let g:ale_sign_style_warning = '--'
let g:ale_sign_warning = '--'
let g:ale_statusline_format = ['%d error(s)', '%d warning(s)', 'OK']
let g:ale_type_map = {}
let g:ale_use_global_executables = v:null
let g:ale_warn_about_trailing_blank_lines = 1
let g:ale_warn_about_trailing_whitespace = 1
  Command History:

(executable check - failure) eslint
(executable check - success) d:\Work\learning-typescript\node_modules\.bin\tslint
(finished - exit code 2) 'cmd /s/c "cd d:\Work\learning-typescript\source\app && d:\Work\learning-typescript\node_modules\.bin\tslint --format json -c d:\Work\learning-typescript\tslint.json C:\Users\zhaoxu\AppData\Local\Temp\nvimgTWi9K\2\main.ts"'

<<<OUTPUT STARTS>>>
[{"endPosition":{"character":50,"line":9,"position":418},"failure":"Missing trailing comma","fix":{"innerStart":418,"innerLength":0,"innerText":","},"name":"C:/Users/zhaoxu/AppData/Local/Temp/nvimgTWi9K/2/main.ts","ruleName":"trailing-comma","ruleSeverity":"ERROR","startPosition":{"character":50,"line":9,"position":418}}]
<<<OUTPUT ENDS>>>

(started) 'cmd /s/c "d:\Work\learning-typescript\node_modules\.bin\tsserver"'
(executable check - failure) typecheck

# Quickfix
d:\Work\learning-typescript\source\app\C:Users\zhaoxu\AppData\Local\Temp\nvimgTWi9K\2\main.ts|10 col 51 error| trailing-comma: Missing trailing comma

# Fixed
source\app\main.ts|10 col 51 error| trailing-comma: Missing trailing comma

(executable check - success) d:\Work\learning-typescript\node_modules\.bin\tslint
(finished - exit code 2) 'cmd /s/c "cd d:\Work\learning-typescript\source\app && d:\Work\learning-typescript\node_modules\.bin\tslint --format json -c d:\Work\learning-typescript\tslint.json d:\Work\learning-typescript\source\app\main.ts < C:\Users\zhaoxu\AppData\Local\Temp\nvimx3AuBD\2\main.ts"'

<<<OUTPUT STARTS>>>
[{"endPosition":{"character":50,"line":9,"position":418},"failure":"Missing trailing comma","fix":{"innerStart":418,"innerLength":0,"innerText":","},"name":"main.ts","ruleName":"trailing-comma","ruleSeverity":"ERROR","startPosition":{"character":50,"line":9,"position":418}}]
<<<OUTPUT ENDS>>>