### PR TITLE
added vimwiki as filetype using markdown linters

### DIFF
--- a/ale_linters/vimwiki/alex.vim
+++ b/ale_linters/vimwiki/alex.vim
@@ -1,0 +1,11 @@
+" Author: Johannes Wienke <languitar@semipol.de>
+" Description: alex for markdown files
+
+call ale#linter#Define('vimwiki', {
+\   'name': 'alex',
+\   'executable': 'alex',
+\   'command': 'alex %s -t',
+\   'output_stream': 'stderr',
+\   'callback': 'ale#handlers#alex#Handle',
+\   'lint_file': 1,
+\})

--- a/ale_linters/vimwiki/mdl.vim
+++ b/ale_linters/vimwiki/mdl.vim
@@ -1,0 +1,25 @@
+" Author: Steve Dignam <steve@dignam.xyz>
+" Description: Support for mdl, a markdown linter
+
+function! ale_linters#markdown#mdl#Handle(buffer, lines) abort
+    " matches: '(stdin):173: MD004 Unordered list style'
+    let l:pattern = ':\(\d*\): \(.*\)$'
+    let l:output = []
+
+    for l:match in ale#util#GetMatches(a:lines, l:pattern)
+        call add(l:output, {
+        \   'lnum': l:match[1] + 0,
+        \   'text': l:match[2],
+        \   'type': 'W',
+        \})
+    endfor
+
+    return l:output
+endfunction
+
+call ale#linter#Define('vimwiki', {
+\   'name': 'mdl',
+\   'executable': 'mdl',
+\   'command': 'mdl',
+\   'callback': 'ale_linters#markdown#mdl#Handle'
+\})

--- a/ale_linters/vimwiki/proselint.vim
+++ b/ale_linters/vimwiki/proselint.vim
@@ -1,0 +1,9 @@
+" Author: poohzrn https://github.com/poohzrn
+" Description: proselint for Markdown files
+
+call ale#linter#Define('vimwiki', {
+\   'name': 'proselint',
+\   'executable': 'proselint',
+\   'command': 'proselint %t',
+\   'callback': 'ale#handlers#unix#HandleAsWarning',
+\})

--- a/ale_linters/vimwiki/redpen.vim
+++ b/ale_linters/vimwiki/redpen.vim
@@ -1,0 +1,9 @@
+" Author: rhysd https://rhysd.github.io
+" Description: Redpen, a proofreading tool (http://redpen.cc)
+
+call ale#linter#Define('vimwiki', {
+\   'name': 'redpen',
+\   'executable': 'redpen',
+\   'command': 'redpen -f markdown -r json %t',
+\   'callback': 'ale#handlers#redpen#HandleRedpenOutput',
+\})

--- a/ale_linters/vimwiki/remark_lint.vim
+++ b/ale_linters/vimwiki/remark_lint.vim
@@ -1,0 +1,28 @@
+" Author rhysd https://rhysd.github.io/
+" Description: remark-lint for Markdown files
+
+function! ale_linters#markdown#remark_lint#Handle(buffer, lines) abort
+    " matches: '  1:4  warning  Incorrect list-item indent: add 1 space  list-item-indent  remark-lint'
+    let l:pattern = '^ \+\(\d\+\):\(\d\+\)  \(warning\|error\)  \(.\+\)$'
+    let l:output = []
+
+    for l:match in ale#util#GetMatches(a:lines, l:pattern)
+        call add(l:output, {
+        \   'lnum': l:match[1] + 0,
+        \   'col': l:match[2] + 0,
+        \   'type': l:match[3] is# 'error' ? 'E' : 'W',
+        \   'text': l:match[4],
+        \})
+    endfor
+
+    return l:output
+endfunction
+
+call ale#linter#Define('markdown', {
+\   'name': 'remark-lint',
+\   'executable': 'remark',
+\   'command': 'remark --no-stdout --no-color %s',
+\   'callback': 'ale_linters#markdown#remark_lint#Handle',
+\   'lint_file': 1,
+\   'output_stream': 'stderr',
+\})

--- a/ale_linters/vimwiki/vale.vim
+++ b/ale_linters/vimwiki/vale.vim
@@ -1,0 +1,9 @@
+" Author: chew-z https://github.com/chew-z
+" Description: vale for Markdown files
+
+call ale#linter#Define('vimwiki', {
+\   'name': 'vale',
+\   'executable': 'vale',
+\   'command': 'vale --output=JSON %t',
+\   'callback': 'ale#handlers#vale#Handle',
+\})

--- a/ale_linters/vimwiki/write-good.vim
+++ b/ale_linters/vimwiki/write-good.vim
@@ -1,0 +1,9 @@
+" Author: Sumner Evans <sumner.evans98@gmail.com>
+" Description: write-good for Markdown files
+
+call ale#linter#Define('vimwiki', {
+\   'name': 'write-good',
+\   'executable_callback': 'ale#handlers#writegood#GetExecutable',
+\   'command_callback': 'ale#handlers#writegood#GetCommand',
+\   'callback': 'ale#handlers#writegood#Handle',
+\})


### PR DESCRIPTION
I read the contribution.md and documentation for Ale. Saw the section how to add Linters, but couldn't figure out and easy way to add another filetype.

I copied the markdown linters and setup so it will support vimwiki file format. I kept the original linters author as I didn't really write anything.

If there is a better way to add another filetype to the markdown linters please let me know.

