### PR TITLE
[new linter] Add mix linter for elixir

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ formatting.
 | Dafny | [dafny](https://rise4fun.com/Dafny) !! |
 | Dart | [dartanalyzer](https://github.com/dart-lang/sdk/tree/master/pkg/analyzer_cli) !!, [language_server](https://github.com/natebosch/dart_language_server) |
 | Dockerfile | [hadolint](https://github.com/hadolint/hadolint) |
-| Elixir | [credo](https://github.com/rrrene/credo), [dialyxir](https://github.com/jeremyjh/dialyxir), [dogma](https://github.com/lpil/dogma) !!|
+| Elixir | [credo](https://github.com/rrrene/credo), [dialyxir](https://github.com/jeremyjh/dialyxir), [dogma](https://github.com/lpil/dogma), [mix](https://hexdocs.pm/mix/Mix.html) !!|
 | Elm | [elm-format](https://github.com/avh4/elm-format), [elm-make](https://github.com/elm-lang/elm-make) |
 | Erb | [erb](https://apidock.com/ruby/ERB), [erubi](https://github.com/jeremyevans/erubi), [erubis](https://github.com/kwatch/erubis) |
 | Erlang | [erlc](http://erlang.org/doc/man/erlc.html), [SyntaxErl](https://github.com/ten0s/syntaxerl) |

--- a/ale_linters/elixir/mix.vim
+++ b/ale_linters/elixir/mix.vim
@@ -30,8 +30,16 @@ function! ale_linters#elixir#mix#Handle(buffer, lines) abort
     return l:output
 endfunction
 
+function! ale_linters#elixir#mix#FindProjectRoot(buffer) abort
+    let l:project_root = ale#path#FindNearestFile(a:buffer, 'mix.exs')
+    if !empty(l:project_root)
+      return fnamemodify(l:project_root, ':h')
+    endif
+    return ''
+endfunction
+
 function! ale_linters#elixir#mix#GetCommand(buffer) abort
-    let l:project_root = fnamemodify(ale#path#FindNearestFile(a:buffer, 'mix.exs'), ':h')
+    let l:project_root = ale_linters#elixir#mix#FindProjectRoot(a:buffer)
 
     let l:temp_dir = ale#engine#CreateDirectory(a:buffer)
 
@@ -49,4 +57,5 @@ call ale#linter#Define('elixir', {
 \   'executable': 'mix',
 \   'command_callback': 'ale_linters#elixir#mix#GetCommand',
 \   'callback': 'ale_linters#elixir#mix#Handle',
+\   'lint_file': 1,
 \})

--- a/ale_linters/elixir/mix.vim
+++ b/ale_linters/elixir/mix.vim
@@ -44,8 +44,8 @@ function! ale_linters#elixir#mix#GetCommand(buffer) abort
     let l:temp_dir = ale#engine#CreateDirectory(a:buffer)
 
     let l:mix_build_path = has('win32')
-    \   ? 'set MIX_BUILD_PATH=' . ale#Escape(l:temp_dir) . ' && '
-    \   : 'MIX_BUILD_PATH=' . ale#Escape(l:temp_dir) . ' '
+    \   ? 'set MIX_BUILD_PATH=' . ale#Escape(l:temp_dir) . ' &&'
+    \   : 'MIX_BUILD_PATH=' . ale#Escape(l:temp_dir)
 
     return ale#path#CdString(l:project_root)
           \ . l:mix_build_path

--- a/ale_linters/elixir/mix.vim
+++ b/ale_linters/elixir/mix.vim
@@ -31,7 +31,7 @@ endfunction
 
 function! ale_linters#elixir#mix#Command(buffer) abort
     let l:project_dir = fnamemodify(ale#path#FindNearestFile(a:buffer, 'mix.exs'), ':h')
-    return  'cd ' . l:project_dir . ' && mix compile %s'
+    return  'cd ' . l:project_dir . ' && MIX_BUILD_PATH=/tmp/mix mix compile %s'
 endfunction
 
 call ale#linter#Define('elixir', {

--- a/ale_linters/elixir/mix.vim
+++ b/ale_linters/elixir/mix.vim
@@ -1,0 +1,42 @@
+" Author: evnu - https://github.com/evnu
+" Author: colbydehart - https://github.com/colbydehart
+
+function! ale_linters#elixir#mix#Handle(buffer, lines) abort
+    " Matches patterns like the following:
+    "
+    " Error format
+    " ** (CompileError) apps/sim/lib/sim/server.ex:87: undefined function update_in/4
+    "
+    " TODO: Warning format
+    " warning: variable "foobar" does not exist and is being expanded to "foobar()", please use parentheses to remove the ambiguity or change the variable name
+
+    let l:pattern = '\v\(([^\)]+Error)\) ([^:]+):([^:]+): (.+)$'
+    let l:output = []
+
+    for l:match in ale#util#GetMatches(a:lines, l:pattern)
+        let l:type = 'E'
+        let l:text = l:match[4]
+
+        call add(l:output, {
+        \   'bufnr': a:buffer,
+        \   'lnum': l:match[3] + 0,
+        \   'col': 0,
+        \   'type': l:type,
+        \   'text': l:text,
+        \})
+    endfor
+
+    return l:output
+endfunction
+
+function! ale_linters#elixir#mix#Command(buffer) abort
+    let l:project_dir = fnamemodify(ale#path#FindNearestFile(a:buffer, 'mix.exs'), ':h')
+    return  'cd ' . l:project_dir . ' && mix compile %s'
+endfunction
+
+call ale#linter#Define('elixir', {
+\   'name': 'mix',
+\   'executable': 'mix',
+\   'command_callback': 'ale_linters#elixir#mix#Command',
+\   'callback': 'ale_linters#elixir#mix#Handle',
+\})

--- a/ale_linters/elixir/mix.vim
+++ b/ale_linters/elixir/mix.vim
@@ -31,11 +31,11 @@ function! ale_linters#elixir#mix#Handle(buffer, lines) abort
 endfunction
 
 function! ale_linters#elixir#mix#FindProjectRoot(buffer) abort
-    let l:project_root = ale#path#FindNearestFile(a:buffer, 'mix.exs')
-    if !empty(l:project_root)
-      return fnamemodify(l:project_root, ':h')
+    let l:mix_file = ale#path#FindNearestFile(a:buffer, 'mix.exs')
+    if !empty(l:mix_file)
+      return fnamemodify(l:mix_file, ':p:h')
     endif
-    return ''
+    return '.'
 endfunction
 
 function! ale_linters#elixir#mix#GetCommand(buffer) abort
@@ -47,7 +47,7 @@ function! ale_linters#elixir#mix#GetCommand(buffer) abort
     \   ? 'set MIX_BUILD_PATH=' . ale#Escape(l:temp_dir) . ' && '
     \   : 'MIX_BUILD_PATH=' . ale#Escape(l:temp_dir) . ' '
 
-    return  ale#path#CdString(l:project_root)
+    return ale#path#CdString(l:project_root)
           \ . l:mix_build_path
           \ . ' mix compile %s'
 endfunction

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -332,7 +332,7 @@ Notes:
 * Dafny: `dafny`!!
 * Dart: `dartanalyzer`!!, `language_server`
 * Dockerfile: `hadolint`
-* Elixir: `credo`, `dialyxir`, `dogma`!!
+* Elixir: `credo`, `dialyxir`, `dogma`, `mix`!!
 * Elm: `elm-format, elm-make`
 * Erb: `erb`, `erubi`, `erubis`
 * Erlang: `erlc`, `SyntaxErl`

--- a/test/command_callback/mix_paths/wrapped_project/mix.exs
+++ b/test/command_callback/mix_paths/wrapped_project/mix.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/test/command_callback/test_elixir_mix_command_callbacks.vader
+++ b/test/command_callback/test_elixir_mix_command_callbacks.vader
@@ -13,12 +13,8 @@ Before:
   function! GetCommand(buffer) abort
     let l:command = ale_linters#elixir#mix#GetCommand(a:buffer)
 
-    let l:split_command = split(l:command, 'MIX_BUILD_PATH=[^ ]*\s')
-
-    return l:split_command[0] . 'MIX_BUILD_PATH=TEMP' .  l:split_command[1]
+    return substitute(l:command, 'MIX_BUILD_PATH=[^ ]\+', 'MIX_BUILD_PATH=TEMP', '')
   endfunction
-
-
 
 After:
   Restore

--- a/test/command_callback/test_elixir_mix_command_callbacks.vader
+++ b/test/command_callback/test_elixir_mix_command_callbacks.vader
@@ -1,0 +1,36 @@
+Before:
+  runtime ale_linters/elixir/mix.vim
+
+  call ale#test#SetDirectory('/testplugin/test/command_callback')
+
+  let g:env_prefix = has('win32')
+  \ ? 'set MIX_BUILD_PATH=TEMP && '
+  \ : 'MIX_BUILD_PATH=TEMP '
+
+
+  function! GetCommand() abort
+    let l:command = ale_linters#elixir#mix#GetCommand(bufnr(''))
+
+    let l:split_command = split(l:command, 'MIX_BUILD_PATH=[^ ]*\s')
+
+    return l:split_command[0] . 'MIX_BUILD_PATH=TEMP' .  l:split_command[1]
+  endfunction
+
+
+
+After:
+  Restore
+
+  unlet! g:env_prefix
+
+  call ale#linter#Reset()
+  call ale#test#RestoreDirectory()
+
+  delfunction GetCommand
+
+Execute(The default mix command should be correct):
+  AssertEqual
+  \ GetCommand(),
+  \ 'cd '''' && '
+  \ . g:env_prefix
+  \ . 'mix compile %s'

--- a/test/command_callback/test_elixir_mix_command_callbacks.vader
+++ b/test/command_callback/test_elixir_mix_command_callbacks.vader
@@ -3,13 +3,15 @@ Before:
 
   call ale#test#SetDirectory('/testplugin/test/command_callback')
 
+  let g:project_root = ale#path#Simplify(g:dir . '/mix_paths/wrapped_project')
+
   let g:env_prefix = has('win32')
   \ ? 'set MIX_BUILD_PATH=TEMP && '
   \ : 'MIX_BUILD_PATH=TEMP '
 
 
-  function! GetCommand() abort
-    let l:command = ale_linters#elixir#mix#GetCommand(bufnr(''))
+  function! GetCommand(buffer) abort
+    let l:command = ale_linters#elixir#mix#GetCommand(a:buffer)
 
     let l:split_command = split(l:command, 'MIX_BUILD_PATH=[^ ]*\s')
 
@@ -22,6 +24,7 @@ After:
   Restore
 
   unlet! g:env_prefix
+  unlet! g:project_root
 
   call ale#linter#Reset()
   call ale#test#RestoreDirectory()
@@ -29,8 +32,10 @@ After:
   delfunction GetCommand
 
 Execute(The default mix command should be correct):
+  call ale#test#SetFilename('mix_paths/wrapped_project/lib/app.ex')
+
   AssertEqual
-  \ GetCommand(),
-  \ 'cd '''' && '
+  \ GetCommand(bufnr('')),
+  \ ale#path#CdString(g:project_root)
   \ . g:env_prefix
   \ . 'mix compile %s'

--- a/test/handler/test_mix_handler.vader
+++ b/test/handler/test_mix_handler.vader
@@ -1,0 +1,21 @@
+Before:
+  runtime ale_linters/elixir/mix.vim
+
+After:
+  call ale#linter#Reset()
+
+Execute(The mix handler should parse lines correctly):
+
+  AssertEqual
+  \ [
+  \   {
+  \     'bufnr': 347,
+  \     'lnum': 87,
+  \     'col': 0,
+  \     'text': 'undefined function update_in/4',
+  \     'type': 'E',
+  \   },
+  \ ],
+  \ ale_linters#elixir#mix#Handle(347, [
+  \   '** (CompileError) apps/sim/lib/sim/server.ex:87: undefined function update_in/4'
+  \ ])


### PR DESCRIPTION
This deals with #340 by adding a mix linter for elixir to get syntax errors. Used @evnu 's example in that issue, but using mix instead of elixirc so that dependencies won't crash the linter.