### PR TITLE
Set `--parser` option in Prettier's fixer

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -51,7 +51,7 @@ let s:default_registry = {
 \   },
 \   'prettier': {
 \       'function': 'ale#fixers#prettier#Fix',
-\       'suggested_filetypes': ['javascript', 'typescript', 'json', 'css', 'scss', 'less', 'markdown', 'graphql', 'vue'],
+\       'suggested_filetypes': ['javascript', 'typescript', 'css', 'less', 'scss', 'json', 'json5', 'graphql', 'markdown', 'vue'],
 \       'description': 'Apply prettier to a file.',
 \   },
 \   'prettier_eslint': {

--- a/autoload/ale/fixers/prettier.vim
+++ b/autoload/ale/fixers/prettier.vim
@@ -34,7 +34,7 @@ function! ale#fixers#prettier#ApplyFixForVersion(buffer, version_output) abort
 
     " Append the --parser flag depending on the current filetype (unless it's
     " already set in g:javascript_prettier_options).
-    if match(l:options, '--parser') == -1
+    if empty(expand('%:e')) && match(l:options, '--parser') == -1
       let l:prettier_parsers = ['typescript', 'css', 'less', 'scss', 'json', 'json5', 'graphql', 'markdown', 'vue']
 
       let l:parser = ''

--- a/autoload/ale/fixers/prettier.vim
+++ b/autoload/ale/fixers/prettier.vim
@@ -38,6 +38,7 @@ function! ale#fixers#prettier#ApplyFixForVersion(buffer, version_output) abort
     if empty(expand('#' . a:buffer . ':e')) && match(l:options, '--parser') == -1
       let l:prettier_parsers = ['typescript', 'css', 'less', 'scss', 'json', 'json5', 'graphql', 'markdown', 'vue']
 
+      let l:parser = 'babylon'
       for l:filetype in split(getbufvar(a:buffer, '&filetype'), '\.')
         if index(l:prettier_parsers, l:filetype) > -1
           let l:parser = l:filetype

--- a/autoload/ale/fixers/prettier.vim
+++ b/autoload/ale/fixers/prettier.vim
@@ -31,23 +31,24 @@ function! ale#fixers#prettier#ApplyFixForVersion(buffer, version_output) abort
     let l:executable = ale#fixers#prettier#GetExecutable(a:buffer)
     let l:options = ale#Var(a:buffer, 'javascript_prettier_options')
     let l:version = ale#semver#GetVersion(l:executable, a:version_output)
+    let l:parser = ''
 
     " Append the --parser flag depending on the current filetype (unless it's
     " already set in g:javascript_prettier_options).
-    let l:parser = ''
     if empty(expand('#' . a:buffer . ':e')) && match(l:options, '--parser') == -1
-      let l:prettier_parsers = ['typescript', 'css', 'less', 'scss', 'json', 'json5', 'graphql', 'markdown', 'vue']
+        let l:prettier_parsers = ['typescript', 'css', 'less', 'scss', 'json', 'json5', 'graphql', 'markdown', 'vue']
+        let l:parser = 'babylon'
 
-      let l:parser = 'babylon'
-      for l:filetype in split(getbufvar(a:buffer, '&filetype'), '\.')
-        if index(l:prettier_parsers, l:filetype) > -1
-          let l:parser = l:filetype
-          break
-        endif
-      endfor
+        for l:filetype in split(getbufvar(a:buffer, '&filetype'), '\.')
+            if index(l:prettier_parsers, l:filetype) > -1
+                let l:parser = l:filetype
+                break
+            endif
+        endfor
     endif
+
     if !empty(l:parser)
-      let l:options = (!empty(l:options) ? l:options . ' ' : '') . '--parser ' . l:parser
+        let l:options = (!empty(l:options) ? l:options . ' ' : '') . '--parser ' . l:parser
     endif
 
     " 1.4.0 is the first version with --stdin-filepath

--- a/autoload/ale/fixers/prettier.vim
+++ b/autoload/ale/fixers/prettier.vim
@@ -35,7 +35,7 @@ function! ale#fixers#prettier#ApplyFixForVersion(buffer, version_output) abort
     " Append the --parser flag depending on the current filetype (unless it's
     " already set in g:javascript_prettier_options).
     let l:parser = ''
-    if empty(expand('%:e')) && match(l:options, '--parser') == -1
+    if empty(expand('#' . a:buffer . ':e')) && match(l:options, '--parser') == -1
       let l:prettier_parsers = ['typescript', 'css', 'less', 'scss', 'json', 'json5', 'graphql', 'markdown', 'vue']
 
       for l:filetype in split(getbufvar(a:buffer, '&filetype'), '\.')

--- a/autoload/ale/fixers/prettier.vim
+++ b/autoload/ale/fixers/prettier.vim
@@ -30,8 +30,21 @@ endfunction
 function! ale#fixers#prettier#ApplyFixForVersion(buffer, version_output) abort
     let l:executable = ale#fixers#prettier#GetExecutable(a:buffer)
     let l:options = ale#Var(a:buffer, 'javascript_prettier_options')
-
+    let l:filetype = getbufvar(a:buffer, '&filetype')
     let l:version = ale#semver#GetVersion(l:executable, a:version_output)
+
+    " Append the --parser flag depending on the current filetype (unless it's
+    " already set in g:javascript_prettier_options).
+    if match(l:options, '--parser') == -1
+      let l:prettier_parsers = ['typescript', 'css', 'less', 'scss', 'json', 'json5', 'graphql', 'markdown', 'vue']
+
+      if index(l:prettier_parsers, l:filetype) > -1
+        let l:parser = l:filetype
+      else
+        let l:parser = 'babylon'
+      endif
+    endif
+    let l:options = (!empty(l:options) ? l:options . ' ' : '') . '--parser ' . l:parser
 
     " 1.4.0 is the first version with --stdin-filepath
     if ale#semver#GTE(l:version, [1, 4, 0])

--- a/autoload/ale/fixers/prettier.vim
+++ b/autoload/ale/fixers/prettier.vim
@@ -30,7 +30,6 @@ endfunction
 function! ale#fixers#prettier#ApplyFixForVersion(buffer, version_output) abort
     let l:executable = ale#fixers#prettier#GetExecutable(a:buffer)
     let l:options = ale#Var(a:buffer, 'javascript_prettier_options')
-    let l:filetype = getbufvar(a:buffer, '&filetype')
     let l:version = ale#semver#GetVersion(l:executable, a:version_output)
 
     " Append the --parser flag depending on the current filetype (unless it's
@@ -38,13 +37,17 @@ function! ale#fixers#prettier#ApplyFixForVersion(buffer, version_output) abort
     if match(l:options, '--parser') == -1
       let l:prettier_parsers = ['typescript', 'css', 'less', 'scss', 'json', 'json5', 'graphql', 'markdown', 'vue']
 
-      if index(l:prettier_parsers, l:filetype) > -1
-        let l:parser = l:filetype
-      else
-        let l:parser = 'babylon'
-      endif
+      let l:parser = ''
+      for l:filetype in split(getbufvar(a:buffer, '&filetype'), '\.')
+        if index(l:prettier_parsers, l:filetype) > -1
+          let l:parser = l:filetype
+          break
+        endif
+      endfor
     endif
-    let l:options = (!empty(l:options) ? l:options . ' ' : '') . '--parser ' . l:parser
+    if !empty(l:parser)
+      let l:options = (!empty(l:options) ? l:options . ' ' : '') . '--parser ' . l:parser
+    endif
 
     " 1.4.0 is the first version with --stdin-filepath
     if ale#semver#GTE(l:version, [1, 4, 0])

--- a/autoload/ale/fixers/prettier.vim
+++ b/autoload/ale/fixers/prettier.vim
@@ -34,10 +34,10 @@ function! ale#fixers#prettier#ApplyFixForVersion(buffer, version_output) abort
 
     " Append the --parser flag depending on the current filetype (unless it's
     " already set in g:javascript_prettier_options).
+    let l:parser = ''
     if empty(expand('%:e')) && match(l:options, '--parser') == -1
       let l:prettier_parsers = ['typescript', 'css', 'less', 'scss', 'json', 'json5', 'graphql', 'markdown', 'vue']
 
-      let l:parser = ''
       for l:filetype in split(getbufvar(a:buffer, '&filetype'), '\.')
         if index(l:prettier_parsers, l:filetype) > -1
           let l:parser = l:filetype

--- a/test/fixers/test_prettier_fixer_callback.vader
+++ b/test/fixers/test_prettier_fixer_callback.vader
@@ -95,3 +95,143 @@ Execute(The version number should be cached):
   \     . ' --stdin-filepath %s --stdin',
   \ },
   \ ale#fixers#prettier#ApplyFixForVersion(bufnr(''), [])
+
+Execute(Should set --parser based on filetype, TypeScript):
+  call ale#test#SetFilename('../prettier-test-files/testfile')
+
+  set filetype=typescript
+
+  AssertEqual
+  \ {
+  \   'command': 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \     . ale#Escape(g:ale_javascript_prettier_executable)
+  \     . ' --parser typescript'
+  \     . ' --stdin-filepath %s --stdin',
+  \ },
+  \ ale#fixers#prettier#ApplyFixForVersion(bufnr(''), ['1.6.0'])
+
+Execute(Should set --parser based on filetype, CSS):
+  call ale#test#SetFilename('../prettier-test-files/testfile')
+
+  set filetype=css
+
+  AssertEqual
+  \ {
+  \   'command': 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \     . ale#Escape(g:ale_javascript_prettier_executable)
+  \     . ' --parser css'
+  \     . ' --stdin-filepath %s --stdin',
+  \ },
+  \ ale#fixers#prettier#ApplyFixForVersion(bufnr(''), ['1.6.0'])
+
+Execute(Should set --parser based on filetype, LESS):
+  call ale#test#SetFilename('../prettier-test-files/testfile')
+
+  set filetype=less
+
+  AssertEqual
+  \ {
+  \   'command': 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \     . ale#Escape(g:ale_javascript_prettier_executable)
+  \     . ' --parser less'
+  \     . ' --stdin-filepath %s --stdin',
+  \ },
+  \ ale#fixers#prettier#ApplyFixForVersion(bufnr(''), ['1.6.0'])
+
+Execute(Should set --parser based on filetype, SCSS):
+  call ale#test#SetFilename('../prettier-test-files/testfile')
+
+  set filetype=scss
+
+  AssertEqual
+  \ {
+  \   'command': 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \     . ale#Escape(g:ale_javascript_prettier_executable)
+  \     . ' --parser scss'
+  \     . ' --stdin-filepath %s --stdin',
+  \ },
+  \ ale#fixers#prettier#ApplyFixForVersion(bufnr(''), ['1.6.0'])
+
+Execute(Should set --parser based on filetype, JSON):
+  call ale#test#SetFilename('../prettier-test-files/testfile')
+
+  set filetype=json
+
+  AssertEqual
+  \ {
+  \   'command': 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \     . ale#Escape(g:ale_javascript_prettier_executable)
+  \     . ' --parser json'
+  \     . ' --stdin-filepath %s --stdin',
+  \ },
+  \ ale#fixers#prettier#ApplyFixForVersion(bufnr(''), ['1.6.0'])
+
+Execute(Should set --parser based on filetype, JSON5):
+  call ale#test#SetFilename('../prettier-test-files/testfile')
+
+  set filetype=json5
+
+  AssertEqual
+  \ {
+  \   'command': 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \     . ale#Escape(g:ale_javascript_prettier_executable)
+  \     . ' --parser json5'
+  \     . ' --stdin-filepath %s --stdin',
+  \ },
+  \ ale#fixers#prettier#ApplyFixForVersion(bufnr(''), ['1.6.0'])
+
+Execute(Should set --parser based on filetype, GraphQL):
+  call ale#test#SetFilename('../prettier-test-files/testfile')
+
+  set filetype=graphql
+
+  AssertEqual
+  \ {
+  \   'command': 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \     . ale#Escape(g:ale_javascript_prettier_executable)
+  \     . ' --parser graphql'
+  \     . ' --stdin-filepath %s --stdin',
+  \ },
+  \ ale#fixers#prettier#ApplyFixForVersion(bufnr(''), ['1.6.0'])
+
+Execute(Should set --parser based on filetype, Markdown):
+  call ale#test#SetFilename('../prettier-test-files/testfile')
+
+  set filetype=markdown
+
+  AssertEqual
+  \ {
+  \   'command': 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \     . ale#Escape(g:ale_javascript_prettier_executable)
+  \     . ' --parser markdown'
+  \     . ' --stdin-filepath %s --stdin',
+  \ },
+  \ ale#fixers#prettier#ApplyFixForVersion(bufnr(''), ['1.6.0'])
+
+Execute(Should set --parser based on filetype, Vue):
+  call ale#test#SetFilename('../prettier-test-files/testfile')
+
+  set filetype=vue
+
+  AssertEqual
+  \ {
+  \   'command': 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \     . ale#Escape(g:ale_javascript_prettier_executable)
+  \     . ' --parser vue'
+  \     . ' --stdin-filepath %s --stdin',
+  \ },
+  \ ale#fixers#prettier#ApplyFixForVersion(bufnr(''), ['1.6.0'])
+
+Execute(Should set --parser based on first filetype of multiple filetypes):
+  call ale#test#SetFilename('../prettier-test-files/testfile')
+
+  set filetype=css.scss
+
+  AssertEqual
+  \ {
+  \   'command': 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \     . ale#Escape(g:ale_javascript_prettier_executable)
+  \     . ' --parser css'
+  \     . ' --stdin-filepath %s --stdin',
+  \ },
+  \ ale#fixers#prettier#ApplyFixForVersion(bufnr(''), ['1.6.0'])

--- a/test/fixers/test_prettier_fixer_callback.vader
+++ b/test/fixers/test_prettier_fixer_callback.vader
@@ -26,6 +26,7 @@ Execute(The prettier callback should return the correct default values):
   \   'read_temporary_file': 1,
   \   'command': ale#Escape(g:ale_javascript_prettier_executable)
   \     . ' %t'
+  \     . ' --parser babylon',
   \     . ' --write',
   \ },
   \ ale#fixers#prettier#ApplyFixForVersion(bufnr(''), [])
@@ -39,6 +40,7 @@ Execute(The --config option should not be set automatically):
   \   'read_temporary_file': 1,
   \   'command': ale#Escape(g:ale_javascript_prettier_executable)
   \     . ' %t'
+  \     . ' --parser babylon',
   \     . ' --write',
   \ },
   \ ale#fixers#prettier#ApplyFixForVersion(bufnr(''), [])
@@ -53,6 +55,7 @@ Execute(The prettier callback should include custom prettier options):
   \   'command': ale#Escape(g:ale_javascript_prettier_executable)
   \     . ' %t'
   \     . ' --no-semi'
+  \     . ' --parser babylon',
   \     . ' --write',
   \ },
   \ ale#fixers#prettier#ApplyFixForVersion(bufnr(''), [])
@@ -77,6 +80,7 @@ Execute(--stdin-filepath should be used when prettier is new enough):
   \   'command': 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
   \     . ale#Escape(g:ale_javascript_prettier_executable)
   \     . ' --no-semi'
+  \     . ' --parser babylon',
   \     . ' --stdin-filepath %s --stdin',
   \ },
   \ ale#fixers#prettier#ApplyFixForVersion(bufnr(''), ['1.6.0'])
@@ -92,6 +96,7 @@ Execute(The version number should be cached):
   \ {
   \   'command': 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
   \     . ale#Escape(g:ale_javascript_prettier_executable)
+  \     . ' --parser babylon',
   \     . ' --stdin-filepath %s --stdin',
   \ },
   \ ale#fixers#prettier#ApplyFixForVersion(bufnr(''), [])

--- a/test/fixers/test_prettier_fixer_callback.vader
+++ b/test/fixers/test_prettier_fixer_callback.vader
@@ -26,7 +26,7 @@ Execute(The prettier callback should return the correct default values):
   \   'read_temporary_file': 1,
   \   'command': ale#Escape(g:ale_javascript_prettier_executable)
   \     . ' %t'
-  \     . ' --parser babylon',
+  \     . ' --parser babylon'
   \     . ' --write',
   \ },
   \ ale#fixers#prettier#ApplyFixForVersion(bufnr(''), [])
@@ -40,7 +40,7 @@ Execute(The --config option should not be set automatically):
   \   'read_temporary_file': 1,
   \   'command': ale#Escape(g:ale_javascript_prettier_executable)
   \     . ' %t'
-  \     . ' --parser babylon',
+  \     . ' --parser babylon'
   \     . ' --write',
   \ },
   \ ale#fixers#prettier#ApplyFixForVersion(bufnr(''), [])
@@ -55,7 +55,7 @@ Execute(The prettier callback should include custom prettier options):
   \   'command': ale#Escape(g:ale_javascript_prettier_executable)
   \     . ' %t'
   \     . ' --no-semi'
-  \     . ' --parser babylon',
+  \     . ' --parser babylon'
   \     . ' --write',
   \ },
   \ ale#fixers#prettier#ApplyFixForVersion(bufnr(''), [])
@@ -80,7 +80,7 @@ Execute(--stdin-filepath should be used when prettier is new enough):
   \   'command': 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
   \     . ale#Escape(g:ale_javascript_prettier_executable)
   \     . ' --no-semi'
-  \     . ' --parser babylon',
+  \     . ' --parser babylon'
   \     . ' --stdin-filepath %s --stdin',
   \ },
   \ ale#fixers#prettier#ApplyFixForVersion(bufnr(''), ['1.6.0'])
@@ -96,7 +96,7 @@ Execute(The version number should be cached):
   \ {
   \   'command': 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
   \     . ale#Escape(g:ale_javascript_prettier_executable)
-  \     . ' --parser babylon',
+  \     . ' --parser babylon'
   \     . ' --stdin-filepath %s --stdin',
   \ },
   \ ale#fixers#prettier#ApplyFixForVersion(bufnr(''), [])

--- a/test/fixers/test_prettier_fixer_callback.vader
+++ b/test/fixers/test_prettier_fixer_callback.vader
@@ -26,7 +26,6 @@ Execute(The prettier callback should return the correct default values):
   \   'read_temporary_file': 1,
   \   'command': ale#Escape(g:ale_javascript_prettier_executable)
   \     . ' %t'
-  \     . ' --parser babylon'
   \     . ' --write',
   \ },
   \ ale#fixers#prettier#ApplyFixForVersion(bufnr(''), [])
@@ -40,7 +39,6 @@ Execute(The --config option should not be set automatically):
   \   'read_temporary_file': 1,
   \   'command': ale#Escape(g:ale_javascript_prettier_executable)
   \     . ' %t'
-  \     . ' --parser babylon'
   \     . ' --write',
   \ },
   \ ale#fixers#prettier#ApplyFixForVersion(bufnr(''), [])
@@ -55,7 +53,6 @@ Execute(The prettier callback should include custom prettier options):
   \   'command': ale#Escape(g:ale_javascript_prettier_executable)
   \     . ' %t'
   \     . ' --no-semi'
-  \     . ' --parser babylon'
   \     . ' --write',
   \ },
   \ ale#fixers#prettier#ApplyFixForVersion(bufnr(''), [])
@@ -80,7 +77,6 @@ Execute(--stdin-filepath should be used when prettier is new enough):
   \   'command': 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
   \     . ale#Escape(g:ale_javascript_prettier_executable)
   \     . ' --no-semi'
-  \     . ' --parser babylon'
   \     . ' --stdin-filepath %s --stdin',
   \ },
   \ ale#fixers#prettier#ApplyFixForVersion(bufnr(''), ['1.6.0'])
@@ -96,7 +92,6 @@ Execute(The version number should be cached):
   \ {
   \   'command': 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
   \     . ale#Escape(g:ale_javascript_prettier_executable)
-  \     . ' --parser babylon'
   \     . ' --stdin-filepath %s --stdin',
   \ },
   \ ale#fixers#prettier#ApplyFixForVersion(bufnr(''), [])

--- a/test/fixers/test_prettier_fixer_callback.vader
+++ b/test/fixers/test_prettier_fixer_callback.vader
@@ -95,3 +95,15 @@ Execute(The version number should be cached):
   \     . ' --stdin-filepath %s --stdin',
   \ },
   \ ale#fixers#prettier#ApplyFixForVersion(bufnr(''), [])
+
+Execute(If no file extension, --parser should be set based on filetype, TypeScript):
+  setf typescript
+
+  AssertEqual
+  \ {
+  \   'command': 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \     . ale#Escape(g:ale_javascript_prettier_executable)
+  \     . ' --parser typescript'
+  \     . ' --stdin-filepath %s --stdin',
+  \ },
+  \ ale#fixers#prettier#ApplyFixForVersion(bufnr(''), [])

--- a/test/fixers/test_prettier_fixer_callback.vader
+++ b/test/fixers/test_prettier_fixer_callback.vader
@@ -95,15 +95,3 @@ Execute(The version number should be cached):
   \     . ' --stdin-filepath %s --stdin',
   \ },
   \ ale#fixers#prettier#ApplyFixForVersion(bufnr(''), [])
-
-Execute(If no file extension, --parser should be set based on filetype, TypeScript):
-  setf typescript
-
-  AssertEqual
-  \ {
-  \   'command': 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
-  \     . ale#Escape(g:ale_javascript_prettier_executable)
-  \     . ' --parser typescript'
-  \     . ' --stdin-filepath %s --stdin',
-  \ },
-  \ ale#fixers#prettier#ApplyFixForVersion(bufnr(''), [])


### PR DESCRIPTION
Fixes: https://github.com/w0rp/ale/issues/1515

The `--parser` option was removed in 520541cd2d8ebd22a9990875655fb2d10289fd22. I brought it back and refactored according to the latest filetypes that Prettier supports.

[Prettier v1.13.3](https://www.npmjs.com/package/prettier)
> --parser <flow|babylon|typescript|css|less|scss|json|json5|json-stringify|graphql|markdown|vue>
> &nbsp;&nbsp;&nbsp;Which parser to use.