### PR TITLE
Allow flake8 executable to be set to `pipenv`.

### DIFF
--- a/ale_linters/python/flake8.vim
+++ b/ale_linters/python/flake8.vim
@@ -52,6 +52,10 @@ function! ale_linters#python#flake8#GetCommand(buffer, version_output) abort
     let l:executable = ale_linters#python#flake8#GetExecutable(a:buffer)
     let l:version = ale#semver#GetVersion(l:executable, a:version_output)
 
+    let l:exec_args = l:executable =~? 'pipenv$'
+    \   ? ' run flake8'
+    \   : ''
+
     " Only include the --stdin-display-name argument if we can parse the
     " flake8 version, and it is recent enough to support it.
     let l:display_name_args = ale#semver#GTE(l:version, [3, 0, 0])
@@ -61,7 +65,7 @@ function! ale_linters#python#flake8#GetCommand(buffer, version_output) abort
     let l:options = ale#Var(a:buffer, 'python_flake8_options')
 
     return l:cd_string
-    \   . ale#Escape(l:executable)
+    \   . ale#Escape(l:executable) . l:exec_args
     \   . (!empty(l:options) ? ' ' . l:options : '')
     \   . ' --format=default'
     \   . l:display_name_args . ' -'

--- a/test/command_callback/test_flake8_command_callback.vader
+++ b/test/command_callback/test_flake8_command_callback.vader
@@ -174,3 +174,11 @@ Execute(Using `python -m flake8` should be supported for running flake8):
   \ ale#path#BufferCdString(bufnr(''))
   \   . ale#Escape('python') . '   -m flake8 --some-option --format=default -',
   \ ale_linters#python#flake8#GetCommand(bufnr(''), ['2.9.9'])
+
+Execute(Setting executable to 'pipenv' appends 'run flake8'):
+  let g:ale_python_flake8_executable = 'path/to/pipenv'
+
+  AssertEqual
+  \ ale#path#BufferCdString(bufnr(''))
+  \   . ale#Escape('path/to/pipenv') . ' run flake8 --format=default --stdin-display-name %s -',
+  \ ale_linters#python#flake8#GetCommand(bufnr(''), ['3.0.0'])


### PR DESCRIPTION
It appends ` run flake8`, analogously to the Ruby tools when the executable is set to `bundle`