### PR TITLE
Added linting of tests and examples for rust cargo linter

### DIFF
--- a/ale_linters/rust/cargo.vim
+++ b/ale_linters/rust/cargo.vim
@@ -4,6 +4,8 @@
 
 call ale#Set('rust_cargo_use_check', 1)
 call ale#Set('rust_cargo_check_all_targets', 0)
+call ale#Set('rust_cargo_check_examples', 0)
+call ale#Set('rust_cargo_check_tests', 0)
 call ale#Set('rust_cargo_default_feature_behavior', 'default')
 call ale#Set('rust_cargo_include_features', '')
 
@@ -31,6 +33,12 @@ function! ale_linters#rust#cargo#GetCommand(buffer, version_output) abort
     let l:use_all_targets = l:use_check
     \   && ale#Var(a:buffer, 'rust_cargo_check_all_targets')
     \   && ale#semver#GTE(l:version, [0, 22, 0])
+    let l:use_examples = l:use_check
+    \   && ale#Var(a:buffer, 'rust_cargo_check_examples')
+    \   && ale#semver#GTE(l:version, [0, 22, 0])
+    let l:use_tests = l:use_check
+    \   && ale#Var(a:buffer, 'rust_cargo_check_tests')
+    \   && ale#semver#GTE(l:version, [0, 22, 0])
 
     let l:include_features = ale#Var(a:buffer, 'rust_cargo_include_features')
     if !empty(l:include_features)
@@ -50,6 +58,8 @@ function! ale_linters#rust#cargo#GetCommand(buffer, version_output) abort
     return 'cargo '
     \   . (l:use_check ? 'check' : 'build')
     \   . (l:use_all_targets ? ' --all-targets' : '')
+    \   . (l:use_examples ? ' --examples' : '')
+    \   . (l:use_tests ? ' --tests' : '')
     \   . ' --frozen --message-format=json -q'
     \   . l:default_feature
     \   . l:include_features

--- a/doc/ale-rust.txt
+++ b/doc/ale-rust.txt
@@ -59,6 +59,26 @@ g:ale_rust_cargo_check_all_targets         *g:ale_rust_cargo_check_all_targets*
   is used. See |g:ale_rust_cargo_use_check|,
 
 
+g:ale_rust_cargo_check_tests                     *g:ale_rust_cargo_check_tests*
+                                                 *b:ale_rust_cargo_check_tests*
+  Type: |Number|
+  Default: `0`
+
+  When set to `1`, ALE will set the `--tests` option when `cargo check`
+  is used. This allows for linting of tests which are normally excluded.
+  See |g:ale_rust_cargo_use_check|,
+
+
+g:ale_rust_cargo_check_examples               *g:ale_rust_cargo_check_examples*
+                                              *b:ale_rust_cargo_check_examples*
+  Type: |Number|
+  Default: `0`
+
+  When set to `1`, ALE will set the `--examples` option when `cargo check`
+  is used. This allows for linting of examples which are normally excluded.
+  See |g:ale_rust_cargo_use_check|,
+
+
 g:ale_rust_cargo_default_feature_behavior
                                     *g:ale_rust_cargo_default_feature_behavior*
                                     *b:ale_rust_cargo_default_feature_behavior*

--- a/test/command_callback/test_cargo_command_callbacks.vader
+++ b/test/command_callback/test_cargo_command_callbacks.vader
@@ -1,11 +1,15 @@
 Before:
   Save g:ale_rust_cargo_use_check
   Save g:ale_rust_cargo_check_all_targets
+  Save g:ale_rust_cargo_check_tests
+  Save g:ale_rust_cargo_check_examples
   Save g:ale_rust_cargo_default_feature_behavior
   Save g:ale_rust_cargo_include_features
 
   unlet! g:ale_rust_cargo_use_check
-  unlet! g:ale_cargo_check_all_targets
+  unlet! g:ale_rust_cargo_check_all_targets
+  unlet! g:ale_rust_cargo_check_tests
+  unlet! g:ale_rust_cargo_check_examples
   unlet! g:ale_rust_cargo_default_feature_behavior
   unlet! g:ale_rust_cargo_include_features
 
@@ -115,6 +119,38 @@ Execute(--all-targets should be used when g:ale_rust_cargo_check_all_targets is 
   " We should cache the version check
   AssertEqual
   \ 'cargo check --all-targets' . g:suffix,
+  \ ale_linters#rust#cargo#GetCommand(bufnr(''), [])
+
+  AssertEqual '', ale_linters#rust#cargo#VersionCheck(bufnr(''))
+
+Execute(--tests should be used when g:ale_rust_cargo_check_tests is set to 1):
+  let g:ale_rust_cargo_check_tests = 1
+
+  AssertEqual
+  \ 'cargo check --tests' . g:suffix,
+  \ ale_linters#rust#cargo#GetCommand(bufnr(''), [
+  \   'cargo 0.22.0 (3423351a5 2017-10-06)',
+  \ ])
+
+  " We should cache the version check
+  AssertEqual
+  \ 'cargo check --tests' . g:suffix,
+  \ ale_linters#rust#cargo#GetCommand(bufnr(''), [])
+
+  AssertEqual '', ale_linters#rust#cargo#VersionCheck(bufnr(''))
+
+Execute(--examples should be used when g:ale_rust_cargo_check_examples is set to 1):
+  let g:ale_rust_cargo_check_examples = 1
+
+  AssertEqual
+  \ 'cargo check --examples' . g:suffix,
+  \ ale_linters#rust#cargo#GetCommand(bufnr(''), [
+  \   'cargo 0.22.0 (3423351a5 2017-10-06)',
+  \ ])
+
+  " We should cache the version check
+  AssertEqual
+  \ 'cargo check --examples' . g:suffix,
   \ ale_linters#rust#cargo#GetCommand(bufnr(''), [])
 
   AssertEqual '', ale_linters#rust#cargo#VersionCheck(bufnr(''))


### PR DESCRIPTION
Hi,

I've added `rust_cargo_check_examples` and `rust_cargo_check_tests` which allow to enable linting on 
rust tests and examples.
This is my first PR for a vim repo so I might have messed something up. I'll gladly fix any problems!

Regards