### PR TITLE
Allow all Python linter executables to be set to `pipenv`.

### DIFF
--- a/ale_linters/python/mypy.vim
+++ b/ale_linters/python/mypy.vim
@@ -23,10 +23,14 @@ function! ale_linters#python#mypy#GetCommand(buffer) abort
     let l:dir = s:GetDir(a:buffer)
     let l:executable = ale_linters#python#mypy#GetExecutable(a:buffer)
 
+    let l:exec_args = l:executable =~? 'pipenv$'
+    \   ? ' run mypy'
+    \   : ''
+
     " We have to always switch to an explicit directory for a command so
     " we can know with certainty the base path for the 'filename' keys below.
     return ale#path#CdString(l:dir)
-    \   . ale#Escape(l:executable)
+    \   . ale#Escape(l:executable) . l:exec_args
     \   . ' --show-column-numbers '
     \   . ale#Var(a:buffer, 'python_mypy_options')
     \   . ' --shadow-file %s %t %s'

--- a/ale_linters/python/prospector.vim
+++ b/ale_linters/python/prospector.vim
@@ -14,7 +14,14 @@ function! ale_linters#python#prospector#GetExecutable(buffer) abort
 endfunction
 
 function! ale_linters#python#prospector#GetCommand(buffer) abort
-    return ale#Escape(ale_linters#python#prospector#GetExecutable(a:buffer))
+    let l:executable = ale_linters#python#prospector#GetExecutable(a:buffer)
+
+    let l:exec_args = l:executable =~? 'pipenv$'
+    \   ? ' run prospector'
+    \   : ''
+
+    return ale#Escape(l:executable)
+    \   . l:exec_args
     \   . ' ' . ale#Var(a:buffer, 'python_prospector_options')
     \   . ' --messages-only --absolute-paths --zero-exit --output-format json'
     \   . ' %s'

--- a/ale_linters/python/pycodestyle.vim
+++ b/ale_linters/python/pycodestyle.vim
@@ -10,7 +10,13 @@ function! ale_linters#python#pycodestyle#GetExecutable(buffer) abort
 endfunction
 
 function! ale_linters#python#pycodestyle#GetCommand(buffer) abort
-    return ale#Escape(ale_linters#python#pycodestyle#GetExecutable(a:buffer))
+    let l:executable = ale_linters#python#pycodestyle#GetExecutable(a:buffer)
+
+    let l:exec_args = l:executable =~? 'pipenv$'
+    \   ? ' run pycodestyle'
+    \   : ''
+
+    return ale#Escape(l:executable) . l:exec_args
     \   . ' '
     \   . ale#Var(a:buffer, 'python_pycodestyle_options')
     \   . ' -'

--- a/ale_linters/python/pyflakes.vim
+++ b/ale_linters/python/pyflakes.vim
@@ -11,7 +11,13 @@ endfunction
 function! ale_linters#python#pyflakes#GetCommand(buffer) abort
     let l:executable = ale_linters#python#pyflakes#GetExecutable(a:buffer)
 
-    return ale#Escape(l:executable) . ' %t'
+    let l:exec_args = l:executable =~? 'pipenv$'
+    \   ? ' run pyflakes'
+    \   : ''
+
+    return ale#Escape(l:executable)
+    \   . l:exec_args
+    \   . ' %t'
 endfunction
 
 function! ale_linters#python#pyflakes#Handle(buffer, lines) abort

--- a/ale_linters/python/pylint.vim
+++ b/ale_linters/python/pylint.vim
@@ -15,8 +15,14 @@ function! ale_linters#python#pylint#GetCommand(buffer) abort
     \   ? ale#path#BufferCdString(a:buffer)
     \   : ''
 
+    let l:executable = ale_linters#python#pylint#GetExecutable(a:buffer)
+
+    let l:exec_args = l:executable =~? 'pipenv$'
+    \   ? ' run pylint'
+    \   : ''
+
     return l:cd_string
-    \   . ale#Escape(ale_linters#python#pylint#GetExecutable(a:buffer))
+    \   . ale#Escape(l:executable) . l:exec_args
     \   . ' ' . ale#Var(a:buffer, 'python_pylint_options')
     \   . ' --output-format text --msg-template="{path}:{line}:{column}: {msg_id} ({symbol}) {msg}" --reports n'
     \   . ' %s'

--- a/ale_linters/python/pyls.vim
+++ b/ale_linters/python/pyls.vim
@@ -11,7 +11,11 @@ endfunction
 function! ale_linters#python#pyls#GetCommand(buffer) abort
     let l:executable = ale_linters#python#pyls#GetExecutable(a:buffer)
 
-    return ale#Escape(l:executable)
+    let l:exec_args = l:executable =~? 'pipenv$'
+    \   ? ' run pyls'
+    \   : ''
+
+    return ale#Escape(l:executable) . l:exec_args
 endfunction
 
 call ale#linter#Define('python', {

--- a/doc/ale-python.txt
+++ b/doc/ale-python.txt
@@ -100,7 +100,8 @@ g:ale_python_flake8_executable                 *g:ale_python_flake8_executable*
   Type: |String|
   Default: `'flake8'`
 
-  This variable can be changed to modify the executable used for flake8.
+  This variable can be changed to modify the executable used for flake8. Set
+  this to `'pipenv'` to invoke `'pipenv` `run` `flake8'`.
 
 
 g:ale_python_flake8_options                       *g:ale_python_flake8_options*
@@ -169,6 +170,8 @@ g:ale_python_mypy_executable                     *g:ale_python_mypy_executable*
 
   See |ale-integrations-local-executables|
 
+  Set this to `'pipenv'` to invoke `'pipenv` `run` `mypy'`.
+
 g:ale_python_mypy_ignore_invalid_syntax
                                       *g:ale_python_mypy_ignore_invalid_syntax*
                                       *b:ale_python_mypy_ignore_invalid_syntax*
@@ -206,6 +209,8 @@ g:ale_python_prospector_executable         *g:ale_python_prospector_executable*
   Default: `'prospector'`
 
   See |ale-integrations-local-executables|
+
+  Set this to `'pipenv'` to invoke `'pipenv` `run` `prospector'`.
 
 
 g:ale_python_prospector_options               *g:ale_python_prospector_options*
@@ -248,6 +253,8 @@ g:ale_python_pycodestyle_executable       *g:ale_python_pycodestyle_executable*
 
   See |ale-integrations-local-executables|
 
+  Set this to `'pipenv'` to invoke `'pipenv` `run` `pycodestyle'`.
+
 
 g:ale_python_pycodestyle_options             *g:ale_python_pycodestyle_options*
                                              *b:ale_python_pycodestyle_options*
@@ -264,6 +271,20 @@ g:ale_python_pycodestyle_use_global       *g:ale_python_pycodestyle_use_global*
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
   See |ale-integrations-local-executables|
+
+
+===============================================================================
+pyflakes                                                  *ale-python-pyflakes*
+
+
+g:ale_python_pyflakes_executable             *g:ale_python_pyflakes_executable*
+                                             *b:ale_python_pyflakes_executable*
+  Type: |String|
+  Default: `'pyflakes'`
+
+  See |ale-integrations-local-executables|
+
+  Set this to `'pipenv'` to invoke `'pipenv` `run` `pyflakes'`.
 
 
 ===============================================================================
@@ -286,6 +307,8 @@ g:ale_python_pylint_executable                 *g:ale_python_pylint_executable*
   Default: `'pylint'`
 
   See |ale-integrations-local-executables|
+
+  Set this to `'pipenv'` to invoke `'pipenv` `run` `pylint'`.
 
 
 g:ale_python_pylint_options                       *g:ale_python_pylint_options*
@@ -328,6 +351,8 @@ g:ale_python_pyls_executable                     *g:ale_python_pyls_executable*
   Default: `'pyls'`
 
   See |ale-integrations-local-executables|
+
+  Set this to `'pipenv'` to invoke `'pipenv` `run` `pyls'`.
 
 
 g:ale_python_pyls_use_global                     *g:ale_python_pyls_use_global*

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -190,6 +190,7 @@ CONTENTS                                                         *ale-contents*
       mypy................................|ale-python-mypy|
       prospector..........................|ale-python-prospector|
       pycodestyle.........................|ale-python-pycodestyle|
+      pyflakes............................|ale-python-pyflakes|
       pylint..............................|ale-python-pylint|
       pyls................................|ale-python-pyls|
       yapf................................|ale-python-yapf|

--- a/test/command_callback/test_mypy_command_callback.vader
+++ b/test/command_callback/test_mypy_command_callback.vader
@@ -95,3 +95,12 @@ Execute(You should able able to use the global mypy instead):
   \   . ' --show-column-numbers  '
   \   . '--shadow-file %s %t %s',
   \ ale_linters#python#mypy#GetCommand(bufnr(''))
+
+Execute(Setting executable to 'pipenv' appends 'run mypy'):
+  let g:ale_python_mypy_executable = 'path/to/pipenv'
+
+  AssertEqual
+  \ ale#path#BufferCdString(bufnr(''))
+  \   . ale#Escape('path/to/pipenv') . ' run mypy'
+  \   . ' --show-column-numbers  --shadow-file %s %t %s',
+  \ ale_linters#python#mypy#GetCommand(bufnr(''))

--- a/test/command_callback/test_prospector_command_callback.vader
+++ b/test/command_callback/test_prospector_command_callback.vader
@@ -1,0 +1,23 @@
+Before:
+  Save g:ale_python_mypy_executable
+  Save g:ale_python_mypy_options
+
+  unlet! g:ale_python_mypy_executable
+  unlet! g:ale_python_mypy_options
+
+  runtime ale_linters/python/prospector.vim
+
+After:
+  Restore
+
+  unlet! b:executable
+
+  call ale#linter#Reset()
+
+Execute(Setting executable to 'pipenv' appends 'run prospector'):
+  let g:ale_python_prospector_executable = 'path/to/pipenv'
+
+  AssertEqual
+  \ ale#Escape('path/to/pipenv') . ' run prospector'
+  \   .  '  --messages-only --absolute-paths --zero-exit --output-format json %s',
+  \ ale_linters#python#prospector#GetCommand(bufnr(''))

--- a/test/command_callback/test_pycodestyle_command_callback.vader
+++ b/test/command_callback/test_pycodestyle_command_callback.vader
@@ -25,3 +25,10 @@ Execute(The pycodestyle executable should be configurable):
 
   AssertEqual ale#Escape('~/.local/bin/pycodestyle') . '  -',
   \ ale_linters#python#pycodestyle#GetCommand(bufnr(''))
+
+Execute(Setting executable to 'pipenv' appends 'run pycodestyle'):
+  let g:ale_python_pycodestyle_executable = 'path/to/pipenv'
+
+  AssertEqual
+  \ ale#Escape('path/to/pipenv') . ' run pycodestyle  -',
+  \ ale_linters#python#pycodestyle#GetCommand(bufnr(''))

--- a/test/command_callback/test_pyflakes_command_callback.vader
+++ b/test/command_callback/test_pyflakes_command_callback.vader
@@ -47,3 +47,10 @@ Execute(You should be able to override the pyflakes virtualenv lookup):
 
   AssertEqual ale#Escape('pyflakes') . ' %t',
   \ ale_linters#python#pyflakes#GetCommand(bufnr(''))
+
+Execute(Setting executable to 'pipenv' appends 'run pyflakes'):
+  let g:ale_python_pyflakes_executable = 'path/to/pipenv'
+
+  AssertEqual
+  \ ale#Escape('path/to/pipenv') . ' run pyflakes %t',
+  \ ale_linters#python#pyflakes#GetCommand(bufnr(''))

--- a/test/command_callback/test_pylint_command_callback.vader
+++ b/test/command_callback/test_pylint_command_callback.vader
@@ -102,3 +102,12 @@ Execute(You should able able to use the global pylint instead):
   \ ale#path#BufferCdString(bufnr(''))
   \   . ale#Escape('pylint') . ' ' . b:command_tail,
   \ ale_linters#python#pylint#GetCommand(bufnr(''))
+
+Execute(Setting executable to 'pipenv' appends 'run pylint'):
+  let g:ale_python_pylint_executable = 'path/to/pipenv'
+
+  AssertEqual
+  \ ale#path#BufferCdString(bufnr(''))
+  \   . ale#Escape('path/to/pipenv') . ' run pylint'
+  \   . '  --output-format text --msg-template="{path}:{line}:{column}: {msg_id} ({symbol}) {msg}" --reports n %s',
+  \ ale_linters#python#pylint#GetCommand(bufnr(''))

--- a/test/command_callback/test_pyls_command_callback.vader
+++ b/test/command_callback/test_pyls_command_callback.vader
@@ -47,3 +47,10 @@ Execute(You should be able to override the pyls virtualenv lookup):
 
   AssertEqual ale#Escape('pyls'),
   \ ale_linters#python#pyls#GetCommand(bufnr(''))
+
+Execute(Setting executable to 'pipenv' appends 'run pyls'):
+  let g:ale_python_pyls_executable = 'path/to/pipenv'
+
+  AssertEqual
+  \ ale#Escape('path/to/pipenv') . ' run pyls',
+  \ ale_linters#python#pyls#GetCommand(bufnr(''))


### PR DESCRIPTION
It appends ` run {linter_name}`, analogously to the Ruby linters when the executable is set to `bundle`. Includes documentation update.