### PR TITLE
#1635 - Use the project base rather than its parent for cquery

### DIFF
--- a/ale_linters/cpp/cquery.vim
+++ b/ale_linters/cpp/cquery.vim
@@ -7,7 +7,7 @@ call ale#Set('cpp_cquery_cache_directory', expand('~/.cache/cquery'))
 function! ale_linters#cpp#cquery#GetProjectRoot(buffer) abort
     let l:project_root = ale#path#FindNearestFile(a:buffer, 'compile_commands.json')
 
-    return !empty(l:project_root) ? fnamemodify(l:project_root, ':h:h') : ''
+    return !empty(l:project_root) ? fnamemodify(l:project_root, ':h') : ''
 endfunction
 
 function! ale_linters#cpp#cquery#GetExecutable(buffer) abort


### PR DESCRIPTION
Sorry for the repeated pull request.  The cquery code was passing the parent of the project root rather than the project root itself.  @gagbo noticed that it didn't work quite as intended #1635).