### PR TITLE
Use --vanilla switch for Rscript

### DIFF
--- a/ale_linters/r/lintr.vim
+++ b/ale_linters/r/lintr.vim
@@ -22,7 +22,7 @@ function! ale_linters#r#lintr#GetCommand(buffer) abort
     \   . l:lint_cmd
 
     return ale#path#BufferCdString(a:buffer)
-    \   . 'Rscript -e '
+    \   . 'Rscript --vanilla -e '
     \   . ale#Escape(l:cmd_string) . ' %t'
 endfunction
 

--- a/test/command_callback/test_lintr_command_callback.vader
+++ b/test/command_callback/test_lintr_command_callback.vader
@@ -16,7 +16,7 @@ After:
 Execute(The default lintr command should be correct):
   AssertEqual
   \   'cd ' . ale#Escape(getcwd()) . ' && '
-  \   . 'Rscript -e '
+  \   . 'Rscript --vanilla -e '
   \   . ale#Escape('suppressPackageStartupMessages(library(lintr));'
       \   .            'lint(cache = FALSE, commandArgs(TRUE), '
       \   .            'with_defaults())')
@@ -28,7 +28,7 @@ Execute(The lintr options should be configurable):
 
   AssertEqual
   \   'cd ' . ale#Escape(getcwd()) . ' && '
-  \   . 'Rscript -e '
+  \   . 'Rscript --vanilla -e '
   \   . ale#Escape('suppressPackageStartupMessages(library(lintr));'
       \   .            'lint(cache = FALSE, commandArgs(TRUE), '
       \   .            'with_defaults(object_usage_linter = NULL))')
@@ -40,7 +40,7 @@ Execute(If the lint_package flag is set, lintr::lint_package should be called):
 
   AssertEqual
   \   'cd ' . ale#Escape(getcwd()) . ' && '
-  \   . 'Rscript -e '
+  \   . 'Rscript --vanilla -e '
   \   . ale#Escape('suppressPackageStartupMessages(library(lintr));'
       \    .           'lint_package(cache = FALSE, '
       \    .           'linters = with_defaults())')


### PR DESCRIPTION
This prevents possibly bad interference with the user's R environment,
e.g. by an auto-activating packrat.
<!--
READ THIS: Before creating a pull request, please consider the following first.

* The most important thing you can do is write tests. Code without tests
  probably doesn't work, and will almost certainly stop working later on. Pull
  requests without tests probably won't be accepted, although there are some
  exceptions.
* Read the Contributing guide linked above first.
* If you are adding a new linter, remember to update the README.md file and
  doc/ale.txt first.
* If you add or modify a function for converting error lines into loclist items
  that ALE can work with, please add Vader tests for them. Look at existing
  tests in the test/handler directory, etc.
* If you add or modify a function for computing a command line string for
  running a command, please add Vader tests for that. Look at existing
  tests in the test/command_callback directory, etc.
* Generally try and cover anything with Vader tests, although some things just
  can't be tested with Vader, or at least they can be hard to test. Consider
  breaking up your code so that some parts can be tested, and generally open up
  a discussion about it.
* Have fun!
-->
