### PR TITLE
lsp: handle missing "detail" key

### DIFF
--- a/autoload/ale/completion.vim
+++ b/autoload/ale/completion.vim
@@ -317,7 +317,7 @@ function! ale#completion#ParseLSPCompletions(response) abort
         \   'word': l:word,
         \   'kind': l:kind,
         \   'icase': 1,
-        \   'menu': l:item.detail,
+        \   'menu': get(l:item, 'detail', ''),
         \   'info': get(l:item, 'documentation', ''),
         \})
     endfor


### PR DESCRIPTION
I will happily write a test if you can point me at an example that does something similar.
<!--
READ THIS: Before creating a pull request, please consider the following first.

* The most important thing you can do is write tests. Code without tests
  probably doesn't work, and will almost certainly stop working later on. Pull
  requests without tests probably won't be accepted, although there are some
  exceptions.
* Read the Contributing guide linked above first.
* If you are adding a new linter, remember to update the README.md file and
  doc/ale.txt first.
* If you add or modify a function for converting error lines into loclist items
  that ALE can work with, please add Vader tests for them. Look at existing
  tests in the test/handler directory, etc.
* If you add or modify a function for computing a command line string for
  running a command, please add Vader tests for that. Look at existing
  tests in the test/command_callback directory, etc.
* Generally try and cover anything with Vader tests, although some things just
  can't be tested with Vader, or at least they can be hard to test. Consider
  breaking up your code so that some parts can be tested, and generally open up
  a discussion about it.
* Have fun!
-->