### PR TITLE
sh: add bash-language-server linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ formatting.
 | API Blueprint | [drafter](https://github.com/apiaryio/drafter) |
 | AsciiDoc | [alex](https://github.com/wooorm/alex) !!, [proselint](http://proselint.com/), [redpen](http://redpen.cc/), [write-good](https://github.com/btford/write-good) |
 | Awk | [gawk](https://www.gnu.org/software/gawk/)|
-| Bash | shell [-n flag](https://www.gnu.org/software/bash/manual/bash.html#index-set), [shellcheck](https://www.shellcheck.net/), [shfmt](https://github.com/mvdan/sh) |
+| Bash | [language-server](https://github.com/mads-hartmann/bash-language-server), shell [-n flag](https://www.gnu.org/software/bash/manual/bash.html#index-set), [shellcheck](https://www.shellcheck.net/), [shfmt](https://github.com/mvdan/sh) |
 | Bourne Shell | shell [-n flag](http://linux.die.net/man/1/sh), [shellcheck](https://www.shellcheck.net/), [shfmt](https://github.com/mvdan/sh) |
 | C | [cppcheck](http://cppcheck.sourceforge.net), [cpplint](https://github.com/google/styleguide/tree/gh-pages/cpplint), [clang](http://clang.llvm.org/), [clangtidy](http://clang.llvm.org/extra/clang-tidy/) !!, [clang-format](https://clang.llvm.org/docs/ClangFormat.html), [flawfinder](https://www.dwheeler.com/flawfinder/), [gcc](https://gcc.gnu.org/) |
 | C++ (filetype cpp) | [clang](http://clang.llvm.org/), [clangcheck](http://clang.llvm.org/docs/ClangCheck.html) !!, [clangtidy](http://clang.llvm.org/extra/clang-tidy/) !!, [clang-format](https://clang.llvm.org/docs/ClangFormat.html), [cppcheck](http://cppcheck.sourceforge.net), [cpplint](https://github.com/google/styleguide/tree/gh-pages/cpplint) !!, [cquery](https://github.com/cquery-project/cquery), [flawfinder](https://www.dwheeler.com/flawfinder/), [gcc](https://gcc.gnu.org/) |

--- a/ale_linters/sh/language_server.vim
+++ b/ale_linters/sh/language_server.vim
@@ -1,0 +1,33 @@
+" Author: Christian Höltje (https://docwhat.org/)
+" Description: BASH Language server integration for ALE
+scriptencoding utf-8
+
+call ale#Set('sh_language_server_executable', 'bash-language-server')
+call ale#Set('sh_language_server_use_global', get(g:, 'ale_use_global_executables', 0))
+
+function! ale_linters#sh#language_server#GetExecutable(buffer) abort
+    return ale#node#FindExecutable(a:buffer, 'sh_language_server', [
+    \   'node_modules/.bin/bash-language-server',
+    \])
+endfunction
+
+function! ale_linters#sh#language_server#GetCommand(buffer) abort
+    let l:exe = ale#Escape(ale_linters#sh#language_server#GetExecutable(a:buffer))
+
+    return l:exe . ' start'
+endfunction
+
+function! ale_linters#sh#language_server#GetProjectRoot(buffer) abort
+    let l:git_path = ale#path#FindNearestDirectory(a:buffer, '.git')
+
+    return !empty(l:git_path) ? fnamemodify(l:git_path, ':h:h') : ''
+endfunction
+
+call ale#linter#Define('sh', {
+\   'name': 'language_server',
+\   'lsp': 'stdio',
+\   'executable_callback': 'ale_linters#sh#language_server#GetExecutable',
+\   'command_callback': 'ale_linters#sh#language_server#GetCommand',
+\   'language': 'sh',
+\   'project_root_callback': 'ale_linters#sh#language_server#GetProjectRoot',
+\})

--- a/doc/ale-sh.txt
+++ b/doc/ale-sh.txt
@@ -3,6 +3,25 @@ ALE Shell Integration                                          *ale-sh-options*
 
 
 ===============================================================================
+sh-language-server                                     *ale-sh-language-server*
+
+g:ale_sh_language_server_executable        *g:ale_sh_language_server_executable*
+                                           *b:ale_sh_language_server_executable*
+  Type: |String|
+  Default: `'bash-language-server'`
+
+  See |ale-integrations-local-executables|
+
+
+g:ale_sh_language_server_use_global        *g:ale_sh_language_server_use_global*
+                                           *b:ale_sh_language_server_use_global*
+  Type: |Number|
+  Default: `get(g:, 'ale_use_global_executables', 0)`
+
+  See |ale-integrations-local-executables|
+
+
+===============================================================================
 shell                                                            *ale-sh-shell*
 
 g:ale_sh_shell_default_shell                     *g:ale_sh_shell_default_shell*

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -228,6 +228,7 @@ CONTENTS                                                         *ale-contents*
       prettier............................|ale-scss-prettier|
       stylelint...........................|ale-scss-stylelint|
     sh....................................|ale-sh-options|
+      sh-language-server..................|ale-sh-language-server|
       shell...............................|ale-sh-shell|
       shellcheck..........................|ale-sh-shellcheck|
       shfmt...............................|ale-sh-shfmt|
@@ -319,7 +320,7 @@ Notes:
 * API Blueprint: `drafter`
 * AsciiDoc: `alex`!!, `proselint`, `redpen`, `write-good`
 * Awk: `gawk`
-* Bash: `shell` (-n flag), `shellcheck`, `shfmt`
+* Bash: `language-server`, `shell` (-n flag), `shellcheck`, `shfmt`
 * Bourne Shell: `shell` (-n flag), `shellcheck`, `shfmt`
 * C: `cppcheck`, `cpplint`!!, `clang`, `clangtidy`!!, `clang-format`, `flawfinder`, `gcc`
 * C++ (filetype cpp): `clang`, `clangcheck`!!, `clangtidy`!!, `clang-format`, `cppcheck`, `cpplint`!!, `cquery`, `flawfinder`, `gcc`


### PR DESCRIPTION
I don't see any examples for how to add an LSP based fixer; feel free to point me at one.

This doesn't work without PR #1640

<!--
READ THIS: Before creating a pull request, please consider the following first.

* The most important thing you can do is write tests. Code without tests
  probably doesn't work, and will almost certainly stop working later on. Pull
  requests without tests probably won't be accepted, although there are some
  exceptions.
* Read the Contributing guide linked above first.
* If you are adding a new linter, remember to update the README.md file and
  doc/ale.txt first.
* If you add or modify a function for converting error lines into loclist items
  that ALE can work with, please add Vader tests for them. Look at existing
  tests in the test/handler directory, etc.
* If you add or modify a function for computing a command line string for
  running a command, please add Vader tests for that. Look at existing
  tests in the test/command_callback directory, etc.
* Generally try and cover anything with Vader tests, although some things just
  can't be tested with Vader, or at least they can be hard to test. Consider
  breaking up your code so that some parts can be tested, and generally open up
  a discussion about it.
* Have fun!
-->