### PR TITLE
Add linter for AWS CloudFormation template file

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ formatting.
 | C# | [mcs](http://www.mono-project.com/docs/about-mono/languages/csharp/) see:`help ale-cs-mcs` for details, [mcsc](http://www.mono-project.com/docs/about-mono/languages/csharp/) !! see:`help ale-cs-mcsc` for details and configuration|
 | Chef | [foodcritic](http://www.foodcritic.io/) |
 | Clojure | [joker](https://github.com/candid82/joker) |
+| CloudFormation | [cfn-python-lint](https://github.com/awslabs/cfn-python-lint) |
 | CMake | [cmakelint](https://github.com/richq/cmake-lint) |
 | CoffeeScript | [coffee](http://coffeescript.org/), [coffeelint](https://www.npmjs.com/package/coffeelint) |
 | Crystal | [crystal](https://crystal-lang.org/) !! |

--- a/ale_linters/cloudformation/cfn_python_lint.vim
+++ b/ale_linters/cloudformation/cfn_python_lint.vim
@@ -1,0 +1,33 @@
+" Author: Yasuhiro Kiyota <yasuhiroki.duck@gmail.com>
+" Description: Support cfn-python-lint for AWS Cloudformation template file
+
+function! ale_linters#cloudformation#cfn_python_lint#Handle(buffer, lines) abort
+    " Matches patterns line the following:
+    "
+    " sample.template.yaml:96:7:96:15: [E3012] Property Resources/Sample/Properties/FromPort should be of type Integer
+    let l:pattern = '\v^(.*):(\d+):(\d+):(\d+):(\d+): \[([[:alnum:]]+)\] (.*)$'
+    let l:output = []
+
+    for l:match in ale#util#GetMatches(a:lines, l:pattern)
+        let l:code = l:match[6]
+
+        if ale#path#IsBufferPath(a:buffer, l:match[1])
+            call add(l:output, {
+            \   'lnum': l:match[2] + 0,
+            \   'col': l:match[3] + 0,
+            \   'text': l:match[7],
+            \   'code': l:code,
+            \   'type': l:code[:0] is# 'E' ? 'E' : 'W',
+            \})
+        endif
+    endfor
+
+    return l:output
+endfunction
+
+call ale#linter#Define('cloudformation', {
+\   'name': 'cloudformation',
+\   'executable': 'cfn-lint',
+\   'command': 'cfn-lint --template %t --format parseable',
+\   'callback': 'ale_linters#cloudformation#cfn_python_lint#Handle',
+\})

--- a/ale_linters/cloudformation/cfn_python_lint.vim
+++ b/ale_linters/cloudformation/cfn_python_lint.vim
@@ -15,6 +15,8 @@ function! ale_linters#cloudformation#cfn_python_lint#Handle(buffer, lines) abort
             call add(l:output, {
             \   'lnum': l:match[2] + 0,
             \   'col': l:match[3] + 0,
+            \   'end_lnum': l:match[4] + 0,
+            \   'end_col': l:match[5] + 0,
             \   'text': l:match[7],
             \   'code': l:code,
             \   'type': l:code[:0] is# 'E' ? 'E' : 'W',

--- a/doc/ale-cloudformation.txt
+++ b/doc/ale-cloudformation.txt
@@ -1,0 +1,14 @@
+===============================================================================
+ALE CloudFormation Integration                      *ale-cloudformation-options*
+
+
+===============================================================================
+cfn-python-lint                             *ale-cloudformation-cfn-python-lint*
+
+cfn-python-lint is a linter for AWS CloudFormation template file.
+
+https://github.com/awslabs/cfn-python-lint
+
+===============================================================================
+  vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:
+

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -35,6 +35,8 @@ CONTENTS                                                         *ale-contents*
       foodcritic..........................|ale-chef-foodcritic|
     clojure...............................|ale-clojure-options|
       joker...............................|ale-clojure-joker|
+    cloudformation........................|ale-cloudformation-options|
+      cfn-python-lint.....................|ale-cloudformation-cfn-python-lint|
     cmake.................................|ale-cmake-options|
       cmakelint...........................|ale-cmake-cmakelint|
     cpp...................................|ale-cpp-options|
@@ -325,6 +327,7 @@ Notes:
 * C#: `mcs`, `mcsc`!!
 * Chef: `foodcritic`
 * Clojure: `joker`
+* CloudFormation: `cfn-python-lint`
 * CMake: `cmakelint`
 * CoffeeScript: `coffee`, `coffeelint`
 * Crystal: `crystal`!!

--- a/test/handler/test_cfn_python_lint_handler.vader
+++ b/test/handler/test_cfn_python_lint_handler.vader
@@ -1,0 +1,29 @@
+Before:
+  runtime! ale_linters/cloudformation/cfn_python_lint.vim
+  call ale#test#SetFilename('sample.template.yaml')
+
+After:
+  call ale#linter#Reset()
+
+Execute(The cfn_python_lint handler should parse items correctly):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 96,
+  \     'col': 7,
+  \     'text': 'Property Resources/Sample/Properties/FromPort should be of type Integer',
+  \     'code': 'E3012',
+  \     'type': 'E',
+  \   },
+  \   {
+  \     'lnum': 97,
+  \     'col': 7,
+  \     'text': 'AllowedPattern and/or AllowedValues for Parameter should be specified at Parameters/SampleIpAddress. Example for AllowedPattern "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$"',
+  \     'code': 'W2509',
+  \     'type': 'W',
+  \   },
+  \ ],
+  \ ale_linters#cloudformation#cfn_python_lint#Handle(bufnr(''), [
+  \ fnamemodify(tempname(), ':h') . '/sample.template.yaml:96:7:96:15: [E3012] Property Resources/Sample/Properties/FromPort should be of type Integer',
+  \ fnamemodify(tempname(), ':h') . '/sample.template.yaml:97:7:97:15: [W2509] AllowedPattern and/or AllowedValues for Parameter should be specified at Parameters/SampleIpAddress. Example for AllowedPattern "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$"',
+  \ ])

--- a/test/handler/test_cfn_python_lint_handler.vader
+++ b/test/handler/test_cfn_python_lint_handler.vader
@@ -11,6 +11,8 @@ Execute(The cfn_python_lint handler should parse items correctly):
   \   {
   \     'lnum': 96,
   \     'col': 7,
+  \     'end_lnum': 96,
+  \     'end_col': 15,
   \     'text': 'Property Resources/Sample/Properties/FromPort should be of type Integer',
   \     'code': 'E3012',
   \     'type': 'E',
@@ -18,6 +20,8 @@ Execute(The cfn_python_lint handler should parse items correctly):
   \   {
   \     'lnum': 97,
   \     'col': 7,
+  \     'end_lnum': 97,
+  \     'end_col': 15,
   \     'text': 'AllowedPattern and/or AllowedValues for Parameter should be specified at Parameters/SampleIpAddress. Example for AllowedPattern "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$"',
   \     'code': 'W2509',
   \     'type': 'W',


### PR DESCRIPTION
Add linter [cfn-python-lint](https://github.com/awslabs/cfn-python-lint) for AWS CloudFormation template file.

- [x] Update README.md and doc/ale.txt
- [x] Add doc/ale-cloudfomation.txt
- [x] Add new linter for `cfn-python-lint`
- [x] Add test for `cfn-python-lint` handler