### PR TITLE
Add support for qmlfmt fixer

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -200,6 +200,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['javascript'],
 \       'description': 'Fix JavaScript files using xo --fix.',
 \   },
+\   'qmlfmt': {
+\       'function': 'ale#fixers#qmlfmt#Fix',
+\       'suggested_filetypes': ['qml'],
+\       'description': 'Fix QML files with qmlfmt.',
+\   },
 \}
 
 " Reset the function registry to the default entries.

--- a/autoload/ale/fixers/qmlfmt.vim
+++ b/autoload/ale/fixers/qmlfmt.vim
@@ -1,7 +1,7 @@
 call ale#Set('qml_qmlfmt_executable', 'qmlfmt')
 
 function! ale#fixers#qmlfmt#GetExecutable(buffer) abort
-    return ale#Var(a:buffer, 'ale_qml_qmlfmt_executable')
+    return ale#Var(a:buffer, 'qml_qmlfmt_executable')
 endfunction
 
 function! ale#fixers#qmlfmt#Fix(buffer) abort

--- a/autoload/ale/fixers/qmlfmt.vim
+++ b/autoload/ale/fixers/qmlfmt.vim
@@ -1,4 +1,4 @@
-call ale#Set('ale_qml_qmlfmt_executable', 'qmlfmt')
+call ale#Set('qml_qmlfmt_executable', 'qmlfmt')
 
 function! ale#fixers#qmlfmt#GetExecutable(buffer) abort
     return ale#Var(a:buffer, 'ale_qml_qmlfmt_executable')

--- a/autoload/ale/fixers/qmlfmt.vim
+++ b/autoload/ale/fixers/qmlfmt.vim
@@ -1,0 +1,11 @@
+call ale#Set('ale_qml_qmlfmt_executable', 'qmlfmt')
+
+function! ale#fixers#qmlfmt#GetExecutable(buffer) abort
+    return ale#Var(a:buffer, 'ale_qml_qmlfmt_executable')
+endfunction
+
+function! ale#fixers#qmlfmt#Fix(buffer) abort
+     return {
+     \  'command': ale#Escape(ale#fixers#qmlfmt#GetExecutable(a:buffer)),
+     \}
+endfunction

--- a/test/fixers/test_qmlfmt_fixer_callback.vader
+++ b/test/fixers/test_qmlfmt_fixer_callback.vader
@@ -1,0 +1,12 @@
+Before:
+  Save g:ale_qml_qmlfmt_executable
+
+After:
+  Restore
+
+Execute(The qmlfmt fixer should use the options you set):
+  let g:ale_qml_qmlfmt_executable = 'foo-exe'
+
+  AssertEqual
+  \ {'command': ale#Escape('foo-exe')},
+  \ ale#fixers#qmlfmt#Fix(bufnr(''))


### PR DESCRIPTION
Is it ok that `g:ale_qml_qmlfmt_executable` is also defined in
`ale_linters/qml/qmlfmt.vim`?