### PR TITLE
 Make CloudFormation linter work again with latest version

### DIFF
--- a/ale_linters/cloudformation/cfn_python_lint.vim
+++ b/ale_linters/cloudformation/cfn_python_lint.vim
@@ -4,8 +4,8 @@
 function! ale_linters#cloudformation#cfn_python_lint#Handle(buffer, lines) abort
     " Matches patterns line the following:
     "
-    " sample.template.yaml:96:7:96:15: [E3012] Property Resources/Sample/Properties/FromPort should be of type Integer
-    let l:pattern = '\v^(.*):(\d+):(\d+):(\d+):(\d+): \[([[:alnum:]]+)\] (.*)$'
+    " sample.template.yaml:96:7:96:15:E3012:Property Resources/Sample/Properties/FromPort should be of type Integer
+    let l:pattern = '\v^(.*):(\d+):(\d+):(\d+):(\d+):([[:alnum:]]+):(.*)$'
     let l:output = []
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)
@@ -13,13 +13,13 @@ function! ale_linters#cloudformation#cfn_python_lint#Handle(buffer, lines) abort
 
         if ale#path#IsBufferPath(a:buffer, l:match[1])
             call add(l:output, {
-            \   'lnum': l:match[2] + 0,
-            \   'col': l:match[3] + 0,
-            \   'end_lnum': l:match[4] + 0,
-            \   'end_col': l:match[5] + 0,
-            \   'text': l:match[7],
+            \   'lnum': l:match[2],
+            \   'col': l:match[3],
+            \   'end_lnum': l:match[4],
+            \   'end_col': l:match[5],
             \   'code': l:code,
             \   'type': l:code[:0] is# 'E' ? 'E' : 'W',
+            \   'text': l:match[7]
             \})
         endif
     endfor

--- a/test/handler/test_cfn_python_lint_handler.vader
+++ b/test/handler/test_cfn_python_lint_handler.vader
@@ -9,25 +9,25 @@ Execute(The cfn_python_lint handler should parse items correctly):
   AssertEqual
   \ [
   \   {
-  \     'lnum': 96,
-  \     'col': 7,
-  \     'end_lnum': 96,
-  \     'end_col': 15,
+  \     'lnum': '96',
+  \     'col': '7',
+  \     'end_lnum': '96',
+  \     'end_col': '15',
   \     'text': 'Property Resources/Sample/Properties/FromPort should be of type Integer',
   \     'code': 'E3012',
   \     'type': 'E',
   \   },
   \   {
-  \     'lnum': 97,
-  \     'col': 7,
-  \     'end_lnum': 97,
-  \     'end_col': 15,
+  \     'lnum': '97',
+  \     'col': '7',
+  \     'end_lnum': '97',
+  \     'end_col': '15',
   \     'text': 'AllowedPattern and/or AllowedValues for Parameter should be specified at Parameters/SampleIpAddress. Example for AllowedPattern "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$"',
   \     'code': 'W2509',
   \     'type': 'W',
   \   },
   \ ],
   \ ale_linters#cloudformation#cfn_python_lint#Handle(bufnr(''), [
-  \ fnamemodify(tempname(), ':h') . '/sample.template.yaml:96:7:96:15: [E3012] Property Resources/Sample/Properties/FromPort should be of type Integer',
-  \ fnamemodify(tempname(), ':h') . '/sample.template.yaml:97:7:97:15: [W2509] AllowedPattern and/or AllowedValues for Parameter should be specified at Parameters/SampleIpAddress. Example for AllowedPattern "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$"',
+  \ fnamemodify(tempname(), ':h') . '/sample.template.yaml:96:7:96:15:E3012:Property Resources/Sample/Properties/FromPort should be of type Integer',
+  \ fnamemodify(tempname(), ':h') . '/sample.template.yaml:97:7:97:15:W2509:AllowedPattern and/or AllowedValues for Parameter should be specified at Parameters/SampleIpAddress. Example for AllowedPattern "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$"',
   \ ])


### PR DESCRIPTION
As mentioned in the commit, I opted to not be smarter than ALE itself. Since ALE explicitly converts `lnum`, `col`, `end_lnum`, and `end_col` using `str2nr()`, let that do the heavy lifting. I opted to simply adjust the test to account for this by having the variables be strings, as they get out of the regexp matcher groups.