### PR TITLE
Use the same options for all Clang tools

### DIFF
--- a/ale_linters/cpp/clangcheck.vim
+++ b/ale_linters/cpp/clangcheck.vim
@@ -2,7 +2,7 @@
 " Description: clang-check linter for cpp files
 
 call ale#Set('cpp_clangcheck_executable', 'clang-check')
-call ale#Set('cpp_clangcheck_options', '')
+call ale#Set('cpp_clangcheck_options', '-- -std=c++14 -Wall')
 call ale#Set('c_build_dir', '')
 
 function! ale_linters#cpp#clangcheck#GetExecutable(buffer) abort

--- a/ale_linters/cpp/clangtidy.vim
+++ b/ale_linters/cpp/clangtidy.vim
@@ -7,7 +7,7 @@ call ale#Set('cpp_clangtidy_executable', 'clang-tidy')
 call ale#Set('cpp_clangtidy_checks', ['*'])
 " Set this option to manually set some options for clang-tidy.
 " This will disable compile_commands.json detection.
-call ale#Set('cpp_clangtidy_options', '')
+call ale#Set('cpp_clangtidy_options', '-std=c++14 -Wall')
 call ale#Set('c_build_dir', '')
 
 function! ale_linters#cpp#clangtidy#GetExecutable(buffer) abort

--- a/doc/ale-cpp.txt
+++ b/doc/ale-cpp.txt
@@ -53,7 +53,7 @@ g:ale_cpp_clangcheck_executable               *g:ale_cpp_clangcheck_executable*
 g:ale_cpp_clangcheck_options                     *g:ale_cpp_clangcheck_options*
                                                  *b:ale_cpp_clangcheck_options*
   Type: |String|
-  Default: `''`
+  Default: `'-- -std=c++14 -Wall'`
 
   This variable can be changed to modify flags given to clang-check.
 
@@ -103,7 +103,7 @@ g:ale_cpp_clangtidy_executable                 *g:ale_cpp_clangtidy_executable*
 g:ale_cpp_clangtidy_options                       *g:ale_cpp_clangtidy_options*
                                                   *b:ale_cpp_clangtidy_options*
   Type: |String|
-  Default: `''`
+  Default: `'-std=c++14 -Wall'`
 
   This variable can be changed to modify flags given to clang-tidy.
 

--- a/test/command_callback/test_clang_tidy_command_callback.vader
+++ b/test/command_callback/test_clang_tidy_command_callback.vader
@@ -26,7 +26,8 @@ After:
 Execute(The clangtidy command default should be correct):
   AssertEqual
   \ ale#Escape('clang-tidy')
-  \   . ' -checks=' . ale#Escape('*') . ' %s',
+  \   . ' -checks=' . ale#Escape('*') . ' %s'
+  \   . ' -- -std=c++14 -Wall',
   \ ale_linters#cpp#clangtidy#GetCommand(bufnr(''))
 
 Execute(You should be able to remove the -checks option for clang-tidy):
@@ -34,7 +35,8 @@ Execute(You should be able to remove the -checks option for clang-tidy):
 
   AssertEqual
   \ ale#Escape('clang-tidy')
-  \   . ' %s',
+  \   . ' %s'
+  \   . ' -- -std=c++14 -Wall',
   \ ale_linters#cpp#clangtidy#GetCommand(bufnr(''))
 
 Execute(You should be able to set other checks for clang-tidy):
@@ -42,7 +44,8 @@ Execute(You should be able to set other checks for clang-tidy):
 
   AssertEqual
   \ ale#Escape('clang-tidy')
-  \   . ' -checks=' . ale#Escape('-*,clang-analyzer-*') . ' %s',
+  \   . ' -checks=' . ale#Escape('-*,clang-analyzer-*') . ' %s'
+  \   . ' -- -std=c++14 -Wall',
   \ ale_linters#cpp#clangtidy#GetCommand(bufnr(''))
 
 Execute(You should be able to manually set compiler flags for clang-tidy):
@@ -93,5 +96,6 @@ Execute(The executable should be configurable):
 
   AssertEqual
   \ ale#Escape('foobar')
-  \   . ' -checks=' . ale#Escape('*') . ' %s',
+  \   . ' -checks=' . ale#Escape('*') . ' %s'
+  \   . ' -- -std=c++14 -Wall',
   \ ale_linters#cpp#clangtidy#GetCommand(bufnr(''))

--- a/test/command_callback/test_cpp_clangcheck_command_callbacks.vader
+++ b/test/command_callback/test_cpp_clangcheck_command_callbacks.vader
@@ -28,7 +28,8 @@ Execute(The executable should be used in the command):
   AssertEqual
   \ ale#Escape('clang-check')
   \   . ' -analyze %s'
-  \   . ' -extra-arg -Xclang -extra-arg -analyzer-output=text',
+  \   . ' -extra-arg -Xclang -extra-arg -analyzer-output=text'
+  \   . ' -- -std=c++14 -Wall',
   \ ale_linters#cpp#clangcheck#GetCommand(bufnr(''))
 
   let b:ale_cpp_clangcheck_executable = 'foobar'
@@ -38,7 +39,8 @@ Execute(The executable should be used in the command):
   AssertEqual
   \ ale#Escape('foobar')
   \   . ' -analyze %s'
-  \   . ' -extra-arg -Xclang -extra-arg -analyzer-output=text',
+  \   . ' -extra-arg -Xclang -extra-arg -analyzer-output=text'
+  \   . ' -- -std=c++14 -Wall',
   \ ale_linters#cpp#clangcheck#GetCommand(bufnr(''))
 
 Execute(The options should be configurable):


### PR DESCRIPTION
The Clang compiler (and GCC) both use C++14 and -Wall, so clang-tidy and
clang-check should have the same options.