### PR TITLE
Improve pyrex cython linter.

### DIFF
--- a/ale_linters/pyrex/cython.vim
+++ b/ale_linters/pyrex/cython.vim
@@ -1,10 +1,27 @@
-" Author: w0rp <devw0rp@gmail.com>
+" Author: w0rp <devw0rp@gmail.com>,
+" Nicolas Pauss <https://github.com/nicopauss>
 " Description: cython syntax checking for cython files.
+
+call ale#Set('pyrex_cython_executable', 'cython')
+call ale#Set('pyrex_cython_options', '--warning-extra --warning-errors')
+
+function! ale_linters#pyrex#cython#GetExecutable(buffer) abort
+    return ale#Var(a:buffer, 'pyrex_cython_executable')
+endfunction
+
+function! ale_linters#pyrex#cython#GetCommand(buffer) abort
+    let l:local_dir = ale#Escape(fnamemodify(bufname(a:buffer), ':p:h'))
+
+    return ale#Escape(ale_linters#pyrex#cython#GetExecutable(a:buffer))
+    \   . ' --working ' . l:local_dir . ' --include-dir ' . l:local_dir
+    \   . ' ' . ale#Var(a:buffer, 'pyrex_cython_options')
+    \   . ' --output-file ' . g:ale#util#nul_file . ' %t'
+endfunction
 
 call ale#linter#Define('pyrex', {
 \   'name': 'cython',
 \   'output_stream': 'stderr',
-\   'executable': 'cython',
-\   'command': 'cython --warning-extra -o ' . g:ale#util#nul_file . ' %t',
+\   'executable_callback': 'ale_linters#pyrex#cython#GetExecutable',
+\   'command_callback': 'ale_linters#pyrex#cython#GetCommand',
 \   'callback': 'ale#handlers#unix#HandleAsError',
 \})

--- a/ale_linters/pyrex/cython.vim
+++ b/ale_linters/pyrex/cython.vim
@@ -3,7 +3,7 @@
 " Description: cython syntax checking for cython files.
 
 call ale#Set('pyrex_cython_executable', 'cython')
-call ale#Set('pyrex_cython_options', '--warning-extra --warning-errors')
+call ale#Set('pyrex_cython_options', '--warning-extra')
 
 function! ale_linters#pyrex#cython#GetExecutable(buffer) abort
     return ale#Var(a:buffer, 'pyrex_cython_executable')
@@ -18,10 +18,26 @@ function! ale_linters#pyrex#cython#GetCommand(buffer) abort
     \   . ' --output-file ' . g:ale#util#nul_file . ' %t'
 endfunction
 
+function! ale_linters#pyrex#cython#Handle(buffer, lines) abort
+    let l:pattern = '\v^(\w+: )?[^:]+:(\d+):?(\d+)?:? ?(.+)$'
+    let l:output = []
+
+    for l:match in ale#util#GetMatches(a:lines, l:pattern)
+        call add(l:output, {
+        \   'lnum': l:match[2] + 0,
+        \   'col': l:match[3] + 0,
+        \   'text': l:match[4],
+        \   'type': l:match[1][0] is# 'w' ? 'W' : 'E',
+        \})
+    endfor
+
+    return l:output
+endfunction
+
 call ale#linter#Define('pyrex', {
 \   'name': 'cython',
 \   'output_stream': 'stderr',
 \   'executable_callback': 'ale_linters#pyrex#cython#GetExecutable',
 \   'command_callback': 'ale_linters#pyrex#cython#GetCommand',
-\   'callback': 'ale#handlers#unix#HandleAsError',
+\   'callback': 'ale_linters#pyrex#cython#Handle',
 \})

--- a/doc/ale-pyrex.txt
+++ b/doc/ale-pyrex.txt
@@ -1,0 +1,25 @@
+===============================================================================
+ALE Pyrex (Cython) Integration                              *ale-pyrex-options*
+
+
+===============================================================================
+cython                                                       *ale-pyrex-cython*
+
+g:ale_pyrex_cython_executable                   *g:ale_pyrex_cython_executable*
+                                                *b:ale_pyrex_cython_executable*
+  Type: |String|
+  Default: `'cython'`
+
+  This variable can be changed to use a different executable for cython.
+
+
+g:ale_pyrex_cython_options                         *g:ale_pyrex_cython_options*
+                                                   *b:ale_pyrex_cython_options*
+  Type: |String|
+  Default: `'--warning-extra --warning-errors'`
+
+  This variable can be changed to modify flags given to cython.
+
+
+===============================================================================
+  vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -185,6 +185,8 @@ CONTENTS                                                         *ale-contents*
       puglint.............................|ale-pug-puglint|
     puppet................................|ale-puppet-options|
       puppetlint..........................|ale-puppet-puppetlint|
+    pyrex (cython)........................|ale-pyrex-options|
+      cython..............................|ale-pyrex-cython|
     python................................|ale-python-options|
       autopep8............................|ale-python-autopep8|
       black...............................|ale-python-black|

--- a/test/command_callback/test_pyrex_cython_command_callback.vader
+++ b/test/command_callback/test_pyrex_cython_command_callback.vader
@@ -1,0 +1,50 @@
+Before:
+  Save g:ale_pyrex_cython_executable
+  Save g:ale_pyrex_cython_options
+
+  unlet! g:ale_pyrex_cython_executable
+  unlet! b:ale_pyrex_cython_executable
+  unlet! g:ale_pyrex_cython_options
+  unlet! b:ale_pyrex_cython_options
+
+  runtime ale_linters/pyrex/cython.vim
+
+  call ale#test#SetDirectory('/testplugin/test/command_callback')
+
+After:
+  Restore
+  unlet! b:ale_pyrex_cython_options
+  unlet! b:ale_pyrex_cython_executable
+  call ale#linter#Reset()
+  call ale#test#RestoreDirectory()
+
+Execute(The default cython command should be correct):
+  AssertEqual
+  \ ale#Escape('cython')
+  \   . ' --working ' . ale#Escape(g:dir)
+  \   . ' --include-dir ' . ale#Escape(g:dir)
+  \   . ' --warning-extra'
+  \   . ' --output-file ' . g:ale#util#nul_file . ' %t',
+  \ ale_linters#pyrex#cython#GetCommand(bufnr(''))
+
+Execute(The cython executable should be configurable):
+  let b:ale_pyrex_cython_executable = 'cython_foobar'
+
+  AssertEqual
+  \ ale#Escape('cython_foobar')
+  \   . ' --working ' . ale#Escape(g:dir)
+  \   . ' --include-dir ' . ale#Escape(g:dir)
+  \   . ' --warning-extra'
+  \   . ' --output-file ' . g:ale#util#nul_file . ' %t',
+  \ ale_linters#pyrex#cython#GetCommand(bufnr(''))
+
+Execute(Additional cython options should be configurable):
+  let b:ale_pyrex_cython_options = '--foobar'
+
+  AssertEqual
+  \ ale#Escape('cython')
+  \   . ' --working ' . ale#Escape(g:dir)
+  \   . ' --include-dir ' . ale#Escape(g:dir)
+  \   . ' --foobar'
+  \   . ' --output-file ' . g:ale#util#nul_file . ' %t',
+  \ ale_linters#pyrex#cython#GetCommand(bufnr(''))

--- a/test/handler/test_pyrex_cython_handler.vader
+++ b/test/handler/test_pyrex_cython_handler.vader
@@ -1,0 +1,26 @@
+Before:
+  runtime ale_linters/pyrex/cython.vim
+
+After:
+  call ale#linter#Reset()
+
+Execute(The cython handler should handle warnings and errors):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 42,
+  \     'col': 7,
+  \     'text': 'some warning',
+  \     'type': 'W',
+  \   },
+  \   {
+  \     'lnum': 777,
+  \     'col': 21,
+  \     'text': 'some error',
+  \     'type': 'E',
+  \   },
+  \ ],
+  \ ale_linters#pyrex#cython#Handle(347, [
+  \   'warning: file:42:7: some warning',
+  \   'file:777:21: some error',
+  \ ])


### PR DESCRIPTION
Like many other linters, use variables for the executable and options
used by the linter.
By default, the linter now report every warnings as errors with
`--warning-errors`.
Also add include directory and set working directory to file directory.

<!--
READ THIS: Before creating a pull request, please consider the following first.

* The most important thing you can do is write tests. Code without tests
  probably doesn't work, and will almost certainly stop working later on. Pull
  requests without tests probably won't be accepted, although there are some
  exceptions.
* Read the Contributing guide linked above first.
* If you are adding a new linter, remember to update the README.md file and
  doc/ale.txt first.
* If you add or modify a function for converting error lines into loclist items
  that ALE can work with, please add Vader tests for them. Look at existing
  tests in the test/handler directory, etc.
* If you add or modify a function for computing a command line string for
  running a command, please add Vader tests for that. Look at existing
  tests in the test/command_callback directory, etc.
* Generally try and cover anything with Vader tests, although some things just
  can't be tested with Vader, or at least they can be hard to test. Consider
  breaking up your code so that some parts can be tested, and generally open up
  a discussion about it.
* Have fun!
-->
