### PR TITLE
Fix prospector empty string error

### DIFF
--- a/ale_linters/python/prospector.vim
+++ b/ale_linters/python/prospector.vim
@@ -23,6 +23,10 @@ endfunction
 function! ale_linters#python#prospector#Handle(buffer, lines) abort
     let l:output = []
 
+    if empty(a:lines)
+        return []
+    endif
+
     let l:prospector_error = json_decode(join(a:lines, ''))
 
     for l:error in l:prospector_error.messages

--- a/test/handler/test_prospector_handler.vader
+++ b/test/handler/test_prospector_handler.vader
@@ -156,3 +156,8 @@ Execute(Ignoring trailing whitespace messages should work):
   \ '  ]',
   \ '}',
   \ ])
+
+Execute(The prospector handler should handle empty output):
+  AssertEqual
+  \ [],
+  \ ale_linters#python#prospector#Handle(bufnr(''), [])


### PR DESCRIPTION
Prospector linter is raising error when no warnings are present in file
(#1680). Copied fix from #779.

<!--
READ THIS: Before creating a pull request, please consider the following first.

* The most important thing you can do is write tests. Code without tests
  probably doesn't work, and will almost certainly stop working later on. Pull
  requests without tests probably won't be accepted, although there are some
  exceptions.
* Read the Contributing guide linked above first.
* If you are adding a new linter, remember to update the README.md file and
  doc/ale.txt first.
* If you add or modify a function for converting error lines into loclist items
  that ALE can work with, please add Vader tests for them. Look at existing
  tests in the test/handler directory, etc.
* If you add or modify a function for computing a command line string for
  running a command, please add Vader tests for that. Look at existing
  tests in the test/command_callback directory, etc.
* Generally try and cover anything with Vader tests, although some things just
  can't be tested with Vader, or at least they can be hard to test. Consider
  breaking up your code so that some parts can be tested, and generally open up
  a discussion about it.
* Have fun!
-->
