### PR TITLE
add options variable to isort

### DIFF
--- a/autoload/ale/fixers/isort.vim
+++ b/autoload/ale/fixers/isort.vim
@@ -5,6 +5,8 @@ call ale#Set('python_isort_executable', 'isort')
 call ale#Set('python_isort_use_global', get(g:, 'ale_use_global_executables', 0))
 
 function! ale#fixers#isort#Fix(buffer) abort
+    let l:options = ale#Var(a:buffer, 'python_isort_options')
+
     let l:executable = ale#python#FindExecutable(
     \   a:buffer,
     \   'python_isort',
@@ -17,6 +19,6 @@ function! ale#fixers#isort#Fix(buffer) abort
 
     return {
     \   'command': ale#path#BufferCdString(a:buffer)
-    \   .   ale#Escape(l:executable) . ' -',
+    \   .   ale#Escape(l:executable) . ' ' . l:options . ' -',
     \}
 endfunction

--- a/doc/ale-python.txt
+++ b/doc/ale-python.txt
@@ -145,6 +145,14 @@ g:ale_python_isort_executable                   *g:ale_python_isort_executable*
   See |ale-integrations-local-executables|
 
 
+g:ale_python_isort_options                      *g:ale_python_isort_options*
+                                                *b:ale_python_isort_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be set to pass extra options to isort.
+
+
 g:ale_python_isort_use_global                   *g:ale_python_isort_use_global*
                                                 *b:ale_python_isort_use_global*
   Type: |Number|


### PR DESCRIPTION
This PR simply adds the ability to pass options to isort.

This is particularly handy if also using the black linter (see https://github.com/ambv/black#the-black-code-style)

In short, black recommends the following:

```
[settings]
multi_line_output=3
include_trailing_comma=True
force_grid_wrap=0
combine_as_imports=True
line_length=88
```

which equates to the following from the command line:

```
$ isort --multi-line=3 --trailing-comma --force-grid-wrap=0 --combine-as --line-width=88 [ file.py ]
```

I updated the docs as well. Let me know if there's something I missed.

<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-development`.

Have fun!
-->