### PR TITLE
vue: Add the Vue 'vls' Language Server (#1296)

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ formatting.
 | Verilog | [iverilog](https://github.com/steveicarus/iverilog), [verilator](http://www.veripool.org/projects/verilator/wiki/Intro) |
 | Vim | [vint](https://github.com/Kuniwak/vint) |
 | Vim help^ | [alex](https://github.com/wooorm/alex) !!, [proselint](http://proselint.com/), [write-good](https://github.com/btford/write-good) |
-| Vue | [prettier](https://github.com/prettier/prettier) |
+| Vue | [prettier](https://github.com/prettier/prettier), [vls](https://github.com/vuejs/vetur/tree/master/server) |
 | XHTML | [alex](https://github.com/wooorm/alex) !!, [proselint](http://proselint.com/), [write-good](https://github.com/btford/write-good) |
 | XML | [xmllint](http://xmlsoft.org/xmllint.html) |
 | YAML | [swaglint](https://github.com/byCedric/swaglint), [yamllint](https://yamllint.readthedocs.io/) |

--- a/ale_linters/vue/vls.vim
+++ b/ale_linters/vue/vls.vim
@@ -1,0 +1,32 @@
+" Author: Alexander Olofsson <alexander.olofsson@liu.se>
+" Description: Vue vls Language Server integration for ALE
+
+call ale#Set('vue_vls_executable', 'vls')
+call ale#Set('vue_vls_use_global', get(g:, 'ale_use_global_executables', 0))
+
+function! ale_linters#vue#vls#GetExecutable(buffer) abort
+    return ale#node#FindExecutable(a:buffer, 'vue_vls', [
+    \   'node_modules/.bin/vls',
+    \])
+endfunction
+
+function! ale_linters#vue#vls#GetCommand(buffer) abort
+    let l:exe = ale#Escape(ale_linters#vue#vls#GetExecutable(a:buffer))
+
+    return l:exe . ' --stdio'
+endfunction
+
+function! ale_linters#vue#vls#GetProjectRoot(buffer) abort
+    let l:package_path = ale#path#FindNearestFile(a:buffer, 'package.json')
+
+    return !empty(l:package_path) ? fnamemodify(l:package_path, ':h') : ''
+endfunction
+
+call ale#linter#Define('vue', {
+\   'name': 'vls',
+\   'lsp': 'stdio',
+\   'executable_callback': 'ale_linters#vue#vls#GetExecutable',
+\   'command_callback': 'ale_linters#vue#vls#GetCommand',
+\   'language': 'vue',
+\   'project_root_callback': 'ale_linters#vue#vls#GetProjectRoot',
+\})

--- a/doc/ale-vue.txt
+++ b/doc/ale-vue.txt
@@ -7,5 +7,25 @@ prettier                                                     *ale-vue-prettier*
 
 See |ale-javascript-prettier| for information about the available options.
 
+
+===============================================================================
+vls                                                               *ale-vue-vls*
+
+g:ale_vue_vls_executable                             *g:ale_vue_vls_executable*
+                                                     *b:ale_vue_vls_executable*
+  Type: |String|
+  Default: `'vls'`
+
+  See |ale-integrations-local-executables|
+
+
+g:ale_vue_vls_use_global                             *g:ale_vue_vls_use_global*
+                                                     *b:ale_vue_vls_use_global*
+  Type: |Number|
+  Default: `get(g:, 'ale_use_global_executables', 0)`
+
+  See |ale-integrations-local-executables|
+
+
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -273,6 +273,7 @@ CONTENTS                                                         *ale-contents*
       write-good..........................|ale-vim-help-write-good|
     vue...................................|ale-vue-options|
       prettier............................|ale-vue-prettier|
+      vls.................................|ale-vue-vls|
     xhtml.................................|ale-xhtml-options|
       write-good..........................|ale-xhtml-write-good|
     xml...................................|ale-xml-options|
@@ -418,7 +419,7 @@ Notes:
 * Verilog: `iverilog`, `verilator`
 * Vim: `vint`
 * Vim help^: `alex`!!, `proselint`, `write-good`
-* Vue: `prettier`
+* Vue: `prettier`, `vls`
 * XHTML: `alex`!!, `proselint`, `write-good`
 * XML: `xmllint`
 * YAML: `swaglint`, `yamllint`


### PR DESCRIPTION
Sadly there's currently an [issue with the vim-vue plugin](https://github.com/posva/vim-vue/blob/master/ftplugin/vue.vim#L24-L25), where it will alias `'vue'` to `'javascript'` for ALE, which means vue-specific linters aren't checked.

As vls is not intended to be used for anything but vue code, adding it as a javascript linter doesn't really make sense, so most likely people will have to explicitly alias `'vue'` to `'vue'` in case they want to use vls while also using `vim-vue` or `vim-polyglot` (Which bundles `vim-vue`).

Perhaps ALE should read available linters from both the alias, and the real language name, if there are linters available for both?