### PR TITLE
Support remark-lint installed locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ formatting.
 | Lua | [luac](https://www.lua.org/manual/5.1/luac.html), [luacheck](https://github.com/mpeterv/luacheck) |
 | Mail | [alex](https://github.com/wooorm/alex) !!, [proselint](http://proselint.com/), [vale](https://github.com/ValeLint/vale) |
 | Make | [checkmake](https://github.com/mrtazz/checkmake) |
-| Markdown | [alex](https://github.com/wooorm/alex) !!, [markdownlint](https://github.com/DavidAnson/markdownlint) !!, [mdl](https://github.com/mivok/markdownlint), [prettier](https://github.com/prettier/prettier), [proselint](http://proselint.com/), [redpen](http://redpen.cc/), [remark-lint](https://github.com/wooorm/remark-lint) !!, [textlint](https://textlint.github.io/), [vale](https://github.com/ValeLint/vale), [write-good](https://github.com/btford/write-good) |
+| Markdown | [alex](https://github.com/wooorm/alex) !!, [markdownlint](https://github.com/DavidAnson/markdownlint) !!, [mdl](https://github.com/mivok/markdownlint), [prettier](https://github.com/prettier/prettier), [proselint](http://proselint.com/), [redpen](http://redpen.cc/), [remark-lint](https://github.com/wooorm/remark-lint), [textlint](https://textlint.github.io/), [vale](https://github.com/ValeLint/vale), [write-good](https://github.com/btford/write-good) |
 | MATLAB | [mlint](https://www.mathworks.com/help/matlab/ref/mlint.html) |
 | Mercury | [mmc](http://mercurylang.org) !! |
 | NASM | [nasm](https://www.nasm.us/) !! |

--- a/ale_linters/markdown/remark_lint.vim
+++ b/ale_linters/markdown/remark_lint.vim
@@ -1,34 +1,11 @@
 " Author rhysd https://rhysd.github.io/, Dirk Roorda (dirkroorda), Adrián González Rus (@adrigzr)
 " Description: remark-lint for Markdown files
 
-function! ale_linters#markdown#remark_lint#Handle(buffer, lines) abort
-    " matches: '  1:4  warning  Incorrect list-item indent: add 1 space  list-item-indent  remark-lint'
-    " matches: '  18:71-19:1  error  Missing new line after list item  list-item-spacing  remark-lint',
-    let l:pattern = '^ \+\(\d\+\):\(\d\+\)\(-\(\d\+\):\(\d\+\)\)\?  \(warning\|error\)  \(.\+\)$'
-    let l:output = []
-
-    for l:match in ale#util#GetMatches(a:lines, l:pattern)
-        let l:item = {
-        \   'lnum': l:match[1] + 0,
-        \   'col': l:match[2] + 0,
-        \   'type': l:match[6] is# 'error' ? 'E' : 'W',
-        \   'text': l:match[7],
-        \}
-        if l:match[3] isnot# ''
-            let l:item.end_lnum = l:match[4] + 0
-            let l:item.end_col = l:match[5] + 0
-        endif
-        call add(l:output, l:item)
-    endfor
-
-    return l:output
-endfunction
-
 call ale#linter#Define('markdown', {
 \   'name': 'remark-lint',
-\   'executable': 'remark',
-\   'command': 'remark --no-stdout --no-color %s',
-\   'callback': 'ale_linters#markdown#remark_lint#Handle',
+\   'executable_callback': 'ale#handlers#remark_lint#GetExecutable',
+\   'command_callback': 'ale#handlers#remark_lint#GetCommand',
+\   'callback': 'ale#handlers#remark_lint#Handle',
 \   'lint_file': 1,
 \   'output_stream': 'stderr',
 \})

--- a/ale_linters/markdown/remark_lint.vim
+++ b/ale_linters/markdown/remark_lint.vim
@@ -6,6 +6,5 @@ call ale#linter#Define('markdown', {
 \   'executable_callback': 'ale#handlers#remark_lint#GetExecutable',
 \   'command_callback': 'ale#handlers#remark_lint#GetCommand',
 \   'callback': 'ale#handlers#remark_lint#Handle',
-\   'lint_file': 1,
 \   'output_stream': 'stderr',
 \})

--- a/autoload/ale/handlers/remark_lint.vim
+++ b/autoload/ale/handlers/remark_lint.vim
@@ -16,7 +16,7 @@ function! ale#handlers#remark_lint#GetCommand(buffer) abort
 
     return ale#node#Executable(a:buffer, l:executable)
     \    . (!empty(l:options) ? ' ' . l:options : '')
-    \    . ' --no-stdout --no-color %s'
+    \    . ' --no-stdout --no-color'
 endfunction
 
 function! ale#handlers#remark_lint#Handle(buffer, lines) abort

--- a/autoload/ale/handlers/remark_lint.vim
+++ b/autoload/ale/handlers/remark_lint.vim
@@ -1,0 +1,43 @@
+" Description: remark-lint for Markdown files
+"
+call ale#Set('remark_lint_executable', 'remark')
+call ale#Set('remark_lint_use_global', get(g:, 'ale_use_global_executables', 0))
+call ale#Set('remark_lint_options', '')
+
+function! ale#handlers#remark_lint#GetExecutable(buffer) abort
+    return ale#node#FindExecutable(a:buffer, 'remark_lint', [
+    \   'node_modules/.bin/remark',
+    \])
+endfunction
+
+function! ale#handlers#remark_lint#GetCommand(buffer) abort
+    let l:executable = ale#handlers#remark_lint#GetExecutable(a:buffer)
+    let l:options = ale#Var(a:buffer, 'remark_lint_options')
+
+    return ale#node#Executable(a:buffer, l:executable)
+    \    . (!empty(l:options) ? ' ' . l:options : '')
+    \    . ' --no-stdout --no-color %s'
+endfunction
+
+function! ale#handlers#remark_lint#Handle(buffer, lines) abort
+    " matches: '  1:4  warning  Incorrect list-item indent: add 1 space  list-item-indent  remark-lint'
+    " matches: '  18:71-19:1  error  Missing new line after list item  list-item-spacing  remark-lint',
+    let l:pattern = '^ \+\(\d\+\):\(\d\+\)\(-\(\d\+\):\(\d\+\)\)\?  \(warning\|error\)  \(.\+\)$'
+    let l:output = []
+
+    for l:match in ale#util#GetMatches(a:lines, l:pattern)
+        let l:item = {
+        \   'lnum': l:match[1] + 0,
+        \   'col': l:match[2] + 0,
+        \   'type': l:match[6] is# 'error' ? 'E' : 'W',
+        \   'text': l:match[7],
+        \}
+        if l:match[3] isnot# ''
+            let l:item.end_lnum = l:match[4] + 0
+            let l:item.end_col = l:match[5] + 0
+        endif
+        call add(l:output, l:item)
+    endfor
+
+    return l:output
+endfunction

--- a/test/command_callback/test_remark_lint_command_callbacks.vader
+++ b/test/command_callback/test_remark_lint_command_callbacks.vader
@@ -1,0 +1,64 @@
+Before:
+  Save g:ale_remark_lint_executable
+  Save g:ale_remark_lint_use_global
+  Save g:ale_remark_lint_options
+
+  unlet! g:ale_remark_lint_executable
+  unlet! b:ale_remark_lint_executable
+  unlet! g:ale_remark_lint_use_global
+  unlet! b:ale_remark_lint_use_global
+  unlet! g:ale_remark_lint_options
+  unlet! b:ale_remark_lint_options
+
+  runtime autoload/ale/handlers/remark_lint.vim
+
+  call ale#test#SetDirectory('/testplugin/test/command_callback')
+
+After:
+  Restore
+
+  unlet! b:command_tail
+  unlet! b:ale_remark_lint_executable
+  unlet! b:ale_remark_lint_use_global
+  unlet! b:ale_remark_lint_options
+
+  call ale#test#RestoreDirectory()
+  call ale#linter#Reset()
+
+Execute(The executable should be configurable):
+  AssertEqual 'remark', ale#handlers#remark_lint#GetExecutable(bufnr(''))
+
+  let b:ale_remark_lint_executable = 'foobar'
+
+  AssertEqual 'foobar', ale#handlers#remark_lint#GetExecutable(bufnr(''))
+
+Execute(The executable should be used in the command):
+  AssertEqual
+  \ ale#Escape('remark') . ' --no-stdout --no-color %s',
+  \ ale#handlers#remark_lint#GetCommand(bufnr(''))
+
+  let b:ale_remark_lint_executable = 'foobar'
+
+  AssertEqual
+  \ ale#Escape('foobar') . ' --no-stdout --no-color %s',
+  \ ale#handlers#remark_lint#GetCommand(bufnr(''))
+  \
+
+Execute(The options should be configurable):
+  let b:ale_remark_lint_options = '--something'
+
+  AssertEqual
+  \ ale#Escape('remark') . ' --something --no-stdout --no-color %s',
+  \ ale#handlers#remark_lint#GetCommand(bufnr(''))
+
+Execute(The local executable from .bin should be used if available):
+  call ale#test#SetFilename('remark_lint_paths/with_bin_path/foo.md')
+
+  AssertEqual
+  \ ale#path#Simplify(g:dir . '/remark_lint_paths/with_bin_path/node_modules/.bin/remark'),
+  \ ale#handlers#remark_lint#GetExecutable(bufnr(''))
+
+  AssertEqual
+  \ ale#Escape(ale#path#Simplify(g:dir . '/remark_lint_paths/with_bin_path/node_modules/.bin/remark'))
+  \   . ' --no-stdout --no-color %s',
+  \ ale#handlers#remark_lint#GetCommand(bufnr(''))

--- a/test/command_callback/test_remark_lint_command_callbacks.vader
+++ b/test/command_callback/test_remark_lint_command_callbacks.vader
@@ -34,13 +34,13 @@ Execute(The executable should be configurable):
 
 Execute(The executable should be used in the command):
   AssertEqual
-  \ ale#Escape('remark') . ' --no-stdout --no-color %s',
+  \ ale#Escape('remark') . ' --no-stdout --no-color',
   \ ale#handlers#remark_lint#GetCommand(bufnr(''))
 
   let b:ale_remark_lint_executable = 'foobar'
 
   AssertEqual
-  \ ale#Escape('foobar') . ' --no-stdout --no-color %s',
+  \ ale#Escape('foobar') . ' --no-stdout --no-color',
   \ ale#handlers#remark_lint#GetCommand(bufnr(''))
   \
 
@@ -48,7 +48,7 @@ Execute(The options should be configurable):
   let b:ale_remark_lint_options = '--something'
 
   AssertEqual
-  \ ale#Escape('remark') . ' --something --no-stdout --no-color %s',
+  \ ale#Escape('remark') . ' --something --no-stdout --no-color',
   \ ale#handlers#remark_lint#GetCommand(bufnr(''))
 
 Execute(The local executable from .bin should be used if available):
@@ -60,5 +60,5 @@ Execute(The local executable from .bin should be used if available):
 
   AssertEqual
   \ ale#Escape(ale#path#Simplify(g:dir . '/remark_lint_paths/with_bin_path/node_modules/.bin/remark'))
-  \   . ' --no-stdout --no-color %s',
+  \   . ' --no-stdout --no-color',
   \ ale#handlers#remark_lint#GetCommand(bufnr(''))

--- a/test/handler/test_remark_lint_handler.vader
+++ b/test/handler/test_remark_lint_handler.vader
@@ -28,7 +28,7 @@ Execute(Warning and error messages should be handled correctly):
   \     'text': 'Missing new line after list item  list-item-spacing  remark-lint',
   \   },
   \ ],
-  \ ale_linters#markdown#remark_lint#Handle(1, [
+  \ ale#handlers#remark_lint#Handle(1, [
   \   'foo.md',
   \   '  1:4  warning  Incorrect list-item indent: add 1 space  list-item-indent  remark-lint',
   \   '  3:5  error  Incorrect list-item indent: remove 1 space  list-item-indent  remark-lint',


### PR DESCRIPTION
<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-development`.

Have fun!
-->

Support remark-lint installed locally and enables lint without saving it to disk.
It is like textlint.