### PR TITLE
Add python_[linter]_auto_pipenv options for python linters (fixes #1656)

### DIFF
--- a/ale_linters/python/flake8.vim
+++ b/ale_linters/python/flake8.vim
@@ -5,12 +5,17 @@ call ale#Set('python_flake8_executable', 'flake8')
 call ale#Set('python_flake8_options', '')
 call ale#Set('python_flake8_use_global', get(g:, 'ale_use_global_executables', 0))
 call ale#Set('python_flake8_change_directory', 1)
+call ale#Set('python_flake8_auto_pipenv', 0)
 
 function! s:UsingModule(buffer) abort
     return ale#Var(a:buffer, 'python_flake8_options') =~# ' *-m flake8'
 endfunction
 
 function! ale_linters#python#flake8#GetExecutable(buffer) abort
+    if ale#Var(a:buffer, 'python_flake8_auto_pipenv') && ale#python#PipenvPresent(a:buffer)
+        return 'pipenv'
+    endif
+
     if !s:UsingModule(a:buffer)
         return ale#python#FindExecutable(a:buffer, 'python_flake8', ['flake8'])
     endif

--- a/ale_linters/python/flake8.vim
+++ b/ale_linters/python/flake8.vim
@@ -12,7 +12,8 @@ function! s:UsingModule(buffer) abort
 endfunction
 
 function! ale_linters#python#flake8#GetExecutable(buffer) abort
-    if ale#Var(a:buffer, 'python_flake8_auto_pipenv') && ale#python#PipenvPresent(a:buffer)
+    if (ale#Var(a:buffer, 'python_auto_pipenv') || ale#Var(a:buffer, 'python_flake8_auto_pipenv'))
+    \ && ale#python#PipenvPresent(a:buffer)
         return 'pipenv'
     endif
 

--- a/ale_linters/python/mypy.vim
+++ b/ale_linters/python/mypy.vim
@@ -8,7 +8,8 @@ call ale#Set('python_mypy_use_global', get(g:, 'ale_use_global_executables', 0))
 call ale#Set('python_mypy_auto_pipenv', 0)
 
 function! ale_linters#python#mypy#GetExecutable(buffer) abort
-    if ale#Var(a:buffer, 'python_mypy_auto_pipenv') && ale#python#PipenvPresent(a:buffer)
+    if (ale#Var(a:buffer, 'python_auto_pipenv') || ale#Var(a:buffer, 'python_mypy_auto_pipenv'))
+    \ && ale#python#PipenvPresent(a:buffer)
         return 'pipenv'
     endif
 

--- a/ale_linters/python/mypy.vim
+++ b/ale_linters/python/mypy.vim
@@ -5,8 +5,13 @@ call ale#Set('python_mypy_executable', 'mypy')
 call ale#Set('python_mypy_ignore_invalid_syntax', 0)
 call ale#Set('python_mypy_options', '')
 call ale#Set('python_mypy_use_global', get(g:, 'ale_use_global_executables', 0))
+call ale#Set('python_mypy_auto_pipenv', 0)
 
 function! ale_linters#python#mypy#GetExecutable(buffer) abort
+    if ale#Var(a:buffer, 'python_mypy_auto_pipenv') && ale#python#PipenvPresent(a:buffer)
+        return 'pipenv'
+    endif
+
     return ale#python#FindExecutable(a:buffer, 'python_mypy', ['mypy'])
 endfunction
 

--- a/ale_linters/python/prospector.vim
+++ b/ale_linters/python/prospector.vim
@@ -1,6 +1,8 @@
 " Author: chocoelho <carlospecter@gmail.com>
 " Description: prospector linter python files
 
+call ale#Set('python_prospector_auto_pipenv', 0)
+
 let g:ale_python_prospector_executable =
 \   get(g:, 'ale_python_prospector_executable', 'prospector')
 
@@ -10,6 +12,10 @@ let g:ale_python_prospector_options =
 let g:ale_python_prospector_use_global = get(g:, 'ale_python_prospector_use_global', get(g:, 'ale_use_global_executables', 0))
 
 function! ale_linters#python#prospector#GetExecutable(buffer) abort
+    if ale#Var(a:buffer, 'python_prospector_auto_pipenv') && ale#python#PipenvPresent(a:buffer)
+        return 'pipenv'
+    endif
+
     return ale#python#FindExecutable(a:buffer, 'python_prospector', ['prospector'])
 endfunction
 

--- a/ale_linters/python/prospector.vim
+++ b/ale_linters/python/prospector.vim
@@ -12,7 +12,8 @@ let g:ale_python_prospector_options =
 let g:ale_python_prospector_use_global = get(g:, 'ale_python_prospector_use_global', get(g:, 'ale_use_global_executables', 0))
 
 function! ale_linters#python#prospector#GetExecutable(buffer) abort
-    if ale#Var(a:buffer, 'python_prospector_auto_pipenv') && ale#python#PipenvPresent(a:buffer)
+    if (ale#Var(a:buffer, 'python_auto_pipenv') || ale#Var(a:buffer, 'python_prospector_auto_pipenv'))
+    \ && ale#python#PipenvPresent(a:buffer)
         return 'pipenv'
     endif
 

--- a/ale_linters/python/pycodestyle.vim
+++ b/ale_linters/python/pycodestyle.vim
@@ -4,8 +4,13 @@
 call ale#Set('python_pycodestyle_executable', 'pycodestyle')
 call ale#Set('python_pycodestyle_options', '')
 call ale#Set('python_pycodestyle_use_global', get(g:, 'ale_use_global_executables', 0))
+call ale#Set('python_pycodestyle_auto_pipenv', 0)
 
 function! ale_linters#python#pycodestyle#GetExecutable(buffer) abort
+    if ale#Var(a:buffer, 'python_pycodestyle_auto_pipenv') && ale#python#PipenvPresent(a:buffer)
+        return 'pipenv'
+    endif
+
     return ale#python#FindExecutable(a:buffer, 'python_pycodestyle', ['pycodestyle'])
 endfunction
 

--- a/ale_linters/python/pycodestyle.vim
+++ b/ale_linters/python/pycodestyle.vim
@@ -7,7 +7,8 @@ call ale#Set('python_pycodestyle_use_global', get(g:, 'ale_use_global_executable
 call ale#Set('python_pycodestyle_auto_pipenv', 0)
 
 function! ale_linters#python#pycodestyle#GetExecutable(buffer) abort
-    if ale#Var(a:buffer, 'python_pycodestyle_auto_pipenv') && ale#python#PipenvPresent(a:buffer)
+    if (ale#Var(a:buffer, 'python_auto_pipenv') || ale#Var(a:buffer, 'python_pycodestyle_auto_pipenv'))
+    \ && ale#python#PipenvPresent(a:buffer)
         return 'pipenv'
     endif
 

--- a/ale_linters/python/pyflakes.vim
+++ b/ale_linters/python/pyflakes.vim
@@ -3,8 +3,13 @@
 
 call ale#Set('python_pyflakes_executable', 'pyflakes')
 call ale#Set('python_pyflakes_use_global', get(g:, 'ale_use_global_executables', 0))
+call ale#Set('python_pyflakes_auto_pipenv', 0)
 
 function! ale_linters#python#pyflakes#GetExecutable(buffer) abort
+    if ale#Var(a:buffer, 'python_pyflakes_auto_pipenv') && ale#python#PipenvPresent(a:buffer)
+        return 'pipenv'
+    endif
+
     return ale#python#FindExecutable(a:buffer, 'python_pyflakes', ['pyflakes'])
 endfunction
 

--- a/ale_linters/python/pyflakes.vim
+++ b/ale_linters/python/pyflakes.vim
@@ -6,7 +6,8 @@ call ale#Set('python_pyflakes_use_global', get(g:, 'ale_use_global_executables',
 call ale#Set('python_pyflakes_auto_pipenv', 0)
 
 function! ale_linters#python#pyflakes#GetExecutable(buffer) abort
-    if ale#Var(a:buffer, 'python_pyflakes_auto_pipenv') && ale#python#PipenvPresent(a:buffer)
+    if (ale#Var(a:buffer, 'python_auto_pipenv') || ale#Var(a:buffer, 'python_pyflakes_auto_pipenv'))
+    \ && ale#python#PipenvPresent(a:buffer)
         return 'pipenv'
     endif
 

--- a/ale_linters/python/pylint.vim
+++ b/ale_linters/python/pylint.vim
@@ -5,8 +5,13 @@ call ale#Set('python_pylint_executable', 'pylint')
 call ale#Set('python_pylint_options', '')
 call ale#Set('python_pylint_use_global', get(g:, 'ale_use_global_executables', 0))
 call ale#Set('python_pylint_change_directory', 1)
+call ale#Set('python_pylint_auto_pipenv', 0)
 
 function! ale_linters#python#pylint#GetExecutable(buffer) abort
+    if ale#Var(a:buffer, 'python_pylint_auto_pipenv') && ale#python#PipenvPresent(a:buffer)
+        return 'pipenv'
+    endif
+
     return ale#python#FindExecutable(a:buffer, 'python_pylint', ['pylint'])
 endfunction
 

--- a/ale_linters/python/pylint.vim
+++ b/ale_linters/python/pylint.vim
@@ -8,7 +8,8 @@ call ale#Set('python_pylint_change_directory', 1)
 call ale#Set('python_pylint_auto_pipenv', 0)
 
 function! ale_linters#python#pylint#GetExecutable(buffer) abort
-    if ale#Var(a:buffer, 'python_pylint_auto_pipenv') && ale#python#PipenvPresent(a:buffer)
+    if (ale#Var(a:buffer, 'python_auto_pipenv') || ale#Var(a:buffer, 'python_pylint_auto_pipenv'))
+    \ && ale#python#PipenvPresent(a:buffer)
         return 'pipenv'
     endif
 

--- a/ale_linters/python/pyls.vim
+++ b/ale_linters/python/pyls.vim
@@ -3,8 +3,13 @@
 
 call ale#Set('python_pyls_executable', 'pyls')
 call ale#Set('python_pyls_use_global', get(g:, 'ale_use_global_executables', 0))
+call ale#Set('python_pyls_auto_pipenv', 0)
 
 function! ale_linters#python#pyls#GetExecutable(buffer) abort
+    if ale#Var(a:buffer, 'python_pyls_auto_pipenv') && ale#python#PipenvPresent(a:buffer)
+        return 'pipenv'
+    endif
+
     return ale#python#FindExecutable(a:buffer, 'python_pyls', ['pyls'])
 endfunction
 

--- a/ale_linters/python/pyls.vim
+++ b/ale_linters/python/pyls.vim
@@ -6,7 +6,8 @@ call ale#Set('python_pyls_use_global', get(g:, 'ale_use_global_executables', 0))
 call ale#Set('python_pyls_auto_pipenv', 0)
 
 function! ale_linters#python#pyls#GetExecutable(buffer) abort
-    if ale#Var(a:buffer, 'python_pyls_auto_pipenv') && ale#python#PipenvPresent(a:buffer)
+    if (ale#Var(a:buffer, 'python_auto_pipenv') || ale#Var(a:buffer, 'python_pyls_auto_pipenv'))
+    \ && ale#python#PipenvPresent(a:buffer)
         return 'pipenv'
     endif
 

--- a/ale_linters/python/pyre.vim
+++ b/ale_linters/python/pyre.vim
@@ -3,8 +3,13 @@
 
 call ale#Set('python_pyre_executable', 'pyre')
 call ale#Set('python_pyre_use_global', get(g:, 'ale_use_global_executables', 0))
+call ale#Set('python_pyre_auto_pipenv', 0)
 
 function! ale_linters#python#pyre#GetExecutable(buffer) abort
+    if ale#Var(a:buffer, 'python_pyre_auto_pipenv') && ale#python#PipenvPresent(a:buffer)
+        return 'pipenv'
+    endif
+
     return ale#python#FindExecutable(a:buffer, 'python_pyre', ['pyre'])
 endfunction
 

--- a/ale_linters/python/pyre.vim
+++ b/ale_linters/python/pyre.vim
@@ -6,7 +6,8 @@ call ale#Set('python_pyre_use_global', get(g:, 'ale_use_global_executables', 0))
 call ale#Set('python_pyre_auto_pipenv', 0)
 
 function! ale_linters#python#pyre#GetExecutable(buffer) abort
-    if ale#Var(a:buffer, 'python_pyre_auto_pipenv') && ale#python#PipenvPresent(a:buffer)
+    if (ale#Var(a:buffer, 'python_auto_pipenv') || ale#Var(a:buffer, 'python_pyre_auto_pipenv'))
+    \ && ale#python#PipenvPresent(a:buffer)
         return 'pipenv'
     endif
 

--- a/autoload/ale/python.vim
+++ b/autoload/ale/python.vim
@@ -1,6 +1,8 @@
 " Author: w0rp <devw0rp@gmail.com>
 " Description: Functions for integrating with Python linters.
 
+call ale#Set('python_auto_pipenv', '0')
+
 let s:sep = has('win32') ? '\' : '/'
 " bin is used for Unix virtualenv directories, and Scripts is for Windows.
 let s:bin_dir = has('unix') ? 'bin' : 'Scripts'

--- a/autoload/ale/python.vim
+++ b/autoload/ale/python.vim
@@ -107,3 +107,8 @@ function! ale#python#FindExecutable(buffer, base_var_name, path_list) abort
 
     return ale#Var(a:buffer, a:base_var_name . '_executable')
 endfunction
+
+" Detects whether a pipenv environment is present.
+function! ale#python#PipenvPresent(buffer) abort
+    return findfile('Pipfile.lock', expand('#' . a:buffer . ':p:h') . ';') isnot# ''
+endfunction

--- a/doc/ale-python.txt
+++ b/doc/ale-python.txt
@@ -2,6 +2,14 @@
 ALE Python Integration                                     *ale-python-options*
 
 
+g:ale_python_auto_pipenv                             *g:ale_python_auto_pipenv*
+                                                     *b:ale_python_auto_pipenv*
+  Type: |Number|
+  Default: `0`
+
+  Detect whether the file is inside a pipenv, and set the executable to `pipenv`
+  if true. This is overridden by a manually-set executable.
+
 ===============================================================================
 ALE Python Project Root Behavior                              *ale-python-root*
 

--- a/doc/ale-python.txt
+++ b/doc/ale-python.txt
@@ -137,6 +137,15 @@ g:ale_python_flake8_use_global                 *g:ale_python_flake8_use_global*
   Both variables can be set with `b:` buffer variables instead.
 
 
+g:ale_python_flake8_auto_pipenv               *g:ale_python_flake8_auto_pipenv*
+                                              *b:ale_python_flake8_auto_pipenv*
+  Type: |Number|
+  Default: `0`
+
+  Detect whether the file is inside a pipenv, and set the executable to `pipenv`
+  if true. This is overridden by a manually-set executable.
+
+
 ===============================================================================
 isort                                                        *ale-python-isort*
 
@@ -211,6 +220,15 @@ g:ale_python_mypy_use_global                     *g:ale_python_mypy_use_global*
   See |ale-integrations-local-executables|
 
 
+g:ale_python_mypy_auto_pipenv                   *g:ale_python_mypy_auto_pipenv*
+                                                *b:ale_python_mypy_auto_pipenv*
+  Type: |Number|
+  Default: `0`
+
+  Detect whether the file is inside a pipenv, and set the executable to `pipenv`
+  if true. This is overridden by a manually-set executable.
+
+
 ===============================================================================
 prospector                                              *ale-python-prospector*
 
@@ -253,6 +271,15 @@ g:ale_python_prospector_use_global         *g:ale_python_prospector_use_global*
   See |ale-integrations-local-executables|
 
 
+g:ale_python_prospector_auto_pipenv       *g:ale_python_prospector_auto_pipenv*
+                                          *b:ale_python_prospector_auto_pipenv*
+  Type: |Number|
+  Default: `0`
+
+  Detect whether the file is inside a pipenv, and set the executable to `pipenv`
+  if true. This is overridden by a manually-set executable.
+
+
 ===============================================================================
 pycodestyle                                            *ale-python-pycodestyle*
 
@@ -284,6 +311,15 @@ g:ale_python_pycodestyle_use_global       *g:ale_python_pycodestyle_use_global*
   See |ale-integrations-local-executables|
 
 
+g:ale_python_pycodestyle_auto_pipenv     *g:ale_python_pycodestyle_auto_pipenv*
+                                         *b:ale_python_pycodestyle_auto_pipenv*
+  Type: |Number|
+  Default: `0`
+
+  Detect whether the file is inside a pipenv, and set the executable to `pipenv`
+  if true. This is overridden by a manually-set executable.
+
+
 ===============================================================================
 pyflakes                                                  *ale-python-pyflakes*
 
@@ -296,6 +332,15 @@ g:ale_python_pyflakes_executable             *g:ale_python_pyflakes_executable*
   See |ale-integrations-local-executables|
 
   Set this to `'pipenv'` to invoke `'pipenv` `run` `pyflakes'`.
+
+
+g:ale_python_pyflakes_auto_pipenv           *g:ale_python_pyflakes_auto_pipenv*
+                                            *b:ale_python_pyflakes_auto_pipenv*
+  Type: |Number|
+  Default: `0`
+
+  Detect whether the file is inside a pipenv, and set the executable to `pipenv`
+  if true. This is overridden by a manually-set executable.
 
 
 ===============================================================================
@@ -350,6 +395,15 @@ g:ale_python_pylint_use_global                 *g:ale_python_pylint_use_global*
   See |ale-integrations-local-executables|
 
 
+g:ale_python_pylint_auto_pipenv               *g:ale_python_pylint_auto_pipenv*
+                                              *b:ale_python_pylint_auto_pipenv*
+  Type: |Number|
+  Default: `0`
+
+  Detect whether the file is inside a pipenv, and set the executable to `pipenv`
+  if true. This is overridden by a manually-set executable.
+
+
 ===============================================================================
 pyls                                                          *ale-python-pyls*
 
@@ -374,6 +428,15 @@ g:ale_python_pyls_use_global                     *g:ale_python_pyls_use_global*
   See |ale-integrations-local-executables|
 
 
+g:ale_python_pyls_auto_pipenv                   *g:ale_python_pyls_auto_pipenv*
+                                                *b:ale_python_pyls_auto_pipenv*
+  Type: |Number|
+  Default: `0`
+
+  Detect whether the file is inside a pipenv, and set the executable to `pipenv`
+  if true. This is overridden by a manually-set executable.
+
+
 ===============================================================================
 pyre                                                          *ale-python-pyre*
 
@@ -396,6 +459,15 @@ g:ale_python_pyre_use_global                     *g:ale_python_pyre_use_global*
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
   See |ale-integrations-local-executables|
+
+
+g:ale_python_pyre_auto_pipenv                   *g:ale_python_pyre_auto_pipenv*
+                                                *b:ale_python_pyre_auto_pipenv*
+  Type: |Number|
+  Default: `0`
+
+  Detect whether the file is inside a pipenv, and set the executable to `pipenv`
+  if true. This is overridden by a manually-set executable.
 
 
 ===============================================================================

--- a/test/command_callback/test_flake8_command_callback.vader
+++ b/test/command_callback/test_flake8_command_callback.vader
@@ -1,5 +1,6 @@
 Before:
   call ale#assert#SetUpLinterTest('python', 'flake8')
+
   let b:bin_dir = has('win32') ? 'Scripts' : 'bin'
 
   WithChainResults ['3.0.0']
@@ -152,8 +153,16 @@ Execute(Using `python -m flake8` should be supported for running flake8):
 Execute(Setting executable to 'pipenv' should append 'run flake8'):
   let g:ale_python_flake8_executable = 'path/to/pipenv'
 
-  " FIXME: pipenv should check the vresion with flake8.
+  " FIXME: pipenv should check the version with flake8.
   WithChainResults []
   AssertLinter 'path/to/pipenv',
   \ ale#path#BufferCdString(bufnr(''))
   \   .  ale#Escape('path/to/pipenv') . ' run flake8 --format=default -'
+
+Execute(Pipenv is detected when python_flake8_auto_pipenv is set):
+  let g:ale_python_flake8_auto_pipenv = 1
+  call ale#test#SetFilename('/testplugin/test/python_fixtures/pipenv/whatever.py')
+
+  AssertLinter 'pipenv',
+  \ ale#path#BufferCdString(bufnr(''))
+  \   . ale#Escape('pipenv') . ' run flake8 --format=default --stdin-display-name %s -'

--- a/test/command_callback/test_mypy_command_callback.vader
+++ b/test/command_callback/test_mypy_command_callback.vader
@@ -69,3 +69,11 @@ Execute(Setting executable to 'pipenv' appends 'run mypy'):
   \ ale#path#BufferCdString(bufnr(''))
   \   . ale#Escape('path/to/pipenv') . ' run mypy'
   \   . ' --show-column-numbers  --shadow-file %s %t %s'
+
+Execute(Pipenv is detected when python_mypy_auto_pipenv is set):
+  let g:ale_python_mypy_auto_pipenv = 1
+  call ale#test#SetFilename('/testplugin/test/python_fixtures/pipenv/whatever.py')
+
+  AssertLinter 'pipenv',
+  \ ale#path#BufferCdString(bufnr(''))
+  \   . ale#Escape('pipenv') . ' run mypy --show-column-numbers  --shadow-file %s %t %s'

--- a/test/command_callback/test_prospector_command_callback.vader
+++ b/test/command_callback/test_prospector_command_callback.vader
@@ -10,3 +10,11 @@ Execute(Setting executable to 'pipenv' appends 'run prospector'):
   AssertLinter 'path/to/pipenv',
   \ ale#Escape('path/to/pipenv') . ' run prospector'
   \   .  '  --messages-only --absolute-paths --zero-exit --output-format json %s'
+
+Execute(Pipenv is detected when python_prospector_auto_pipenv is set):
+  let g:ale_python_prospector_auto_pipenv = 1
+  call ale#test#SetFilename('/testplugin/test/python_fixtures/pipenv/whatever.py')
+
+  AssertLinter 'pipenv',
+  \ ale#Escape('pipenv') . ' run prospector'
+  \   .  '  --messages-only --absolute-paths --zero-exit --output-format json %s'

--- a/test/command_callback/test_pycodestyle_command_callback.vader
+++ b/test/command_callback/test_pycodestyle_command_callback.vader
@@ -24,3 +24,10 @@ Execute(Setting executable to 'pipenv' appends 'run pycodestyle'):
 
   AssertLinter 'path/to/pipenv',
   \ ale#Escape('path/to/pipenv') . ' run pycodestyle  -'
+
+Execute(Pipenv is detected when python_pycodestyle_auto_pipenv is set):
+  let g:ale_python_pycodestyle_auto_pipenv = 1
+  call ale#test#SetFilename('/testplugin/test/python_fixtures/pipenv/whatever.py')
+
+  AssertLinter 'pipenv',
+  \ ale#Escape('pipenv') . ' run pycodestyle  -'

--- a/test/command_callback/test_pyflakes_command_callback.vader
+++ b/test/command_callback/test_pyflakes_command_callback.vader
@@ -37,3 +37,10 @@ Execute(Setting executable to 'pipenv' appends 'run pyflakes'):
 
   AssertLinter 'path/to/pipenv',
   \ ale#Escape('path/to/pipenv') . ' run pyflakes %t',
+
+Execute(Pipenv is detected when python_pyflakes_auto_pipenv is set):
+  let g:ale_python_pyflakes_auto_pipenv = 1
+  call ale#test#SetFilename('/testplugin/test/python_fixtures/pipenv/whatever.py')
+
+  AssertLinter 'pipenv',
+  \ ale#Escape('pipenv') . ' run pyflakes %t'

--- a/test/command_callback/test_pylint_command_callback.vader
+++ b/test/command_callback/test_pylint_command_callback.vader
@@ -68,3 +68,12 @@ Execute(Setting executable to 'pipenv' appends 'run pylint'):
   \ ale#path#BufferCdString(bufnr(''))
   \   . ale#Escape('path/to/pipenv') . ' run pylint'
   \   . '  --output-format text --msg-template="{path}:{line}:{column}: {msg_id} ({symbol}) {msg}" --reports n %s'
+
+Execute(Pipenv is detected when python_pylint_auto_pipenv is set):
+  let g:ale_python_pylint_auto_pipenv = 1
+  call ale#test#SetFilename('/testplugin/test/python_fixtures/pipenv/whatever.py')
+
+  AssertLinter 'pipenv',
+  \ ale#path#BufferCdString(bufnr(''))
+  \   . ale#Escape('pipenv') . ' run pylint'
+  \   . '  --output-format text --msg-template="{path}:{line}:{column}: {msg_id} ({symbol}) {msg}" --reports n %s'

--- a/test/command_callback/test_pyls_command_callback.vader
+++ b/test/command_callback/test_pyls_command_callback.vader
@@ -38,3 +38,10 @@ Execute(Setting executable to 'pipenv' appends 'run pyls'):
   let g:ale_python_pyls_executable = 'path/to/pipenv'
 
   AssertLinter 'path/to/pipenv', ale#Escape('path/to/pipenv') . ' run pyls'
+
+Execute(Pipenv is detected when python_pyls_auto_pipenv is set):
+  let g:ale_python_pyls_auto_pipenv = 1
+  call ale#test#SetFilename('/testplugin/test/python_fixtures/pipenv/whatever.py')
+
+  AssertLinter 'pipenv',
+  \ ale#Escape('pipenv') . ' run pyls'

--- a/test/command_callback/test_pyre_command_callback.vader
+++ b/test/command_callback/test_pyre_command_callback.vader
@@ -37,3 +37,10 @@ Execute(Setting executable to 'pipenv' appends 'run pyre'):
 
   AssertLinter 'path/to/pipenv',
   \ ale#Escape('path/to/pipenv') . ' run pyre persistent'
+
+Execute(Pipenv is detected when python_pyre_auto_pipenv is set):
+  let g:ale_python_pyre_auto_pipenv = 1
+  call ale#test#SetFilename('/testplugin/test/python_fixtures/pipenv/whatever.py')
+
+  AssertLinter 'pipenv',
+  \ ale#Escape('pipenv') . ' run pyre persistent'

--- a/test/test_python_pipenv.vader
+++ b/test/test_python_pipenv.vader
@@ -1,0 +1,13 @@
+Execute(ale#python#PipenvPresent is true when a pipenv environment is present):
+  call ale#test#SetFilename('/testplugin/test/python_fixtures/pipenv/whatever.py')
+
+  AssertEqual
+  \  ale#python#PipenvPresent(bufnr('%')),
+  \  1
+
+Execute(ale#python#PipenvPresent is false true when no pipenv environment is present):
+  call ale#test#SetFilename('/testplugin/test/python_fixtures/no_pipenv/whatever.py')
+
+  AssertEqual
+  \  ale#python#PipenvPresent(bufnr('%')),
+  \  0


### PR DESCRIPTION
When set to true, and the buffer is currently inside a pipenv, GetExecutable will return "pipenv", which will trigger the existing functionality to append the correct pipenv arguments to run each linter.

Defaults to false.

I was going to implement ale#python#PipenvPresent by invoking `pipenv --venv` or `pipenv --where`, but it seemed to be abominably slow, even to the point where the test suite wasn't even finishing ("Tried to run tests 3 times"). The diff is:

```diff
diff --git a/autoload/ale/python.vim b/autoload/ale/python.vim
index 7baae079..8c100d41 100644
--- a/autoload/ale/python.vim
+++ b/autoload/ale/python.vim
@@ -106,5 +106,9 @@ endfunction

" Detects whether a pipenv environment is present.
function! ale#python#PipenvPresent(buffer) abort
-    return findfile('Pipfile.lock', expand('#' . a:buffer . ':p:h') . ';') isnot# ''
+    let l:cd_string = ale#path#BufferCdString(a:buffer)
+    let l:output = systemlist(l:cd_string . 'pipenv --where')[0]
+    " `pipenv --where` returns the path to the dir containing the Pipfile
+    " if in a pipenv, or some error text otherwise.
+    return strpart(l:output, 0, 18) !=# "No Pipfile present"
 endfunction
```

Using vim's `findfile` is much faster, behaves correctly in the majority of situations, and also works reliably when the `pipenv` command doesn't exist.