### PR TITLE
Fix E712 error in ale#lsp#response#GetErrorMessage when receiving string primitives in the error.data field

### DIFF
--- a/autoload/ale/lsp/response.vim
+++ b/autoload/ale/lsp/response.vim
@@ -105,11 +105,17 @@ function! ale#lsp#response#GetErrorMessage(response) abort
         return ''
     endif
 
-    " Include the traceback as details, if it's there.
-    let l:traceback = get(get(a:response.error, 'data', {}), 'traceback', [])
+    " Include the traceback or error data as details, if present.
+    let l:error_data = get(a:response.error, 'data', {})
 
-    if type(l:traceback) is type([]) && !empty(l:traceback)
-        let l:message .= "\n" . join(l:traceback, "\n")
+    if type(l:error_data) is type('')
+        let l:message .= "\n" . l:error_data
+    else
+        let l:traceback = get(l:error_data, 'traceback', [])
+
+        if type(l:traceback) is type([]) && !empty(l:traceback)
+            let l:message .= "\n" . join(l:traceback, "\n")
+        endif
     endif
 
     return l:message

--- a/test/lsp/test_lsp_error_parsing.vader
+++ b/test/lsp/test_lsp_error_parsing.vader
@@ -63,3 +63,12 @@ Execute(Messages with tracebacks should be handled):
   \   },
   \ },
   \})
+
+Execute(Messages with string data should be handled):
+  AssertEqual "xyz\nUncaught Exception", ale#lsp#response#GetErrorMessage({
+  \ 'error': {
+  \   'code': -32602,
+  \   'message': 'xyz',
+  \   'data': 'Uncaught Exception',
+  \ },
+  \})


### PR DESCRIPTION
The `error.data` field in error messages can contain primitive values in addition to dictionaries/objects.

```javascript
/**
 * A Primitive or Structured value that contains additional
 * information about the error. Can be omitted.
 */
data?: D;
```


The Kotlin Language Server (https://github.com/fwcd/KotlinLanguageServer) returns a string containing the JVM stack trace in case of error, and this causes the following error in the ale#lsp#response#GetErrorMessage function:
`E712: Argument of get() must be a List or Dictionary`

