### PR TITLE
Pipenv virtualenv and project path detection

### DIFF
--- a/autoload/ale/python.vim
+++ b/autoload/ale/python.vim
@@ -6,6 +6,7 @@ let s:sep = has('win32') ? '\' : '/'
 let s:bin_dir = has('unix') ? 'bin' : 'Scripts'
 let g:ale_virtualenv_dir_names = get(g:, 'ale_virtualenv_dir_names', [
 \   '.env',
+\   '.venv',
 \   'env',
 \   've-py3',
 \   've',

--- a/autoload/ale/python.vim
+++ b/autoload/ale/python.vim
@@ -24,6 +24,8 @@ function! ale#python#FindProjectRootIni(buffer) abort
         \|| filereadable(l:path . '/mypy.ini')
         \|| filereadable(l:path . '/pycodestyle.cfg')
         \|| filereadable(l:path . '/flake8.cfg')
+        \|| filereadable(l:path . '/Pipfile')
+        \|| filereadable(l:path . '/Pipfile.lock')
             return l:path
         endif
     endfor


### PR DESCRIPTION
Added support for Pipenv's local virtualenv paths (.venv/).

The project directory can also be detected by the presence of Pipenv or Pipenv.lock files.