### PR TITLE
Support remark-lint installed locally with new test

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ formatting.
 | Lua | [luac](https://www.lua.org/manual/5.1/luac.html), [luacheck](https://github.com/mpeterv/luacheck) |
 | Mail | [alex](https://github.com/wooorm/alex) !!, [proselint](http://proselint.com/), [vale](https://github.com/ValeLint/vale) |
 | Make | [checkmake](https://github.com/mrtazz/checkmake) |
-| Markdown | [alex](https://github.com/wooorm/alex) !!, [markdownlint](https://github.com/DavidAnson/markdownlint) !!, [mdl](https://github.com/mivok/markdownlint), [prettier](https://github.com/prettier/prettier), [proselint](http://proselint.com/), [redpen](http://redpen.cc/), [remark-lint](https://github.com/wooorm/remark-lint) !!, [textlint](https://textlint.github.io/), [vale](https://github.com/ValeLint/vale), [write-good](https://github.com/btford/write-good) |
+| Markdown | [alex](https://github.com/wooorm/alex) !!, [markdownlint](https://github.com/DavidAnson/markdownlint) !!, [mdl](https://github.com/mivok/markdownlint), [prettier](https://github.com/prettier/prettier), [proselint](http://proselint.com/), [redpen](http://redpen.cc/), [remark-lint](https://github.com/wooorm/remark-lint), [textlint](https://textlint.github.io/), [vale](https://github.com/ValeLint/vale), [write-good](https://github.com/btford/write-good) |
 | MATLAB | [mlint](https://www.mathworks.com/help/matlab/ref/mlint.html) |
 | Mercury | [mmc](http://mercurylang.org) !! |
 | NASM | [nasm](https://www.nasm.us/) !! |

--- a/ale_linters/markdown/remark_lint.vim
+++ b/ale_linters/markdown/remark_lint.vim
@@ -1,5 +1,23 @@
 " Author rhysd https://rhysd.github.io/, Dirk Roorda (dirkroorda), Adrián González Rus (@adrigzr)
 " Description: remark-lint for Markdown files
+call ale#Set('markdown_remark_lint_executable', 'remark')
+call ale#Set('markdown_remark_lint_use_global', get(g:, 'ale_use_global_executables', 0))
+call ale#Set('markdown_remark_lint_options', '')
+
+function! ale_linters#markdown#remark_lint#GetExecutable(buffer) abort
+    return ale#node#FindExecutable(a:buffer, 'markdown_remark_lint', [
+    \   'node_modules/.bin/remark',
+    \])
+endfunction
+
+function! ale_linters#markdown#remark_lint#GetCommand(buffer) abort
+    let l:executable = ale_linters#markdown#remark_lint#GetExecutable(a:buffer)
+    let l:options = ale#Var(a:buffer, 'markdown_remark_lint_options')
+
+    return ale#node#Executable(a:buffer, l:executable)
+    \    . (!empty(l:options) ? ' ' . l:options : '')
+    \    . ' --no-stdout --no-color %s'
+endfunction
 
 function! ale_linters#markdown#remark_lint#Handle(buffer, lines) abort
     " matches: '  1:4  warning  Incorrect list-item indent: add 1 space  list-item-indent  remark-lint'
@@ -26,8 +44,8 @@ endfunction
 
 call ale#linter#Define('markdown', {
 \   'name': 'remark-lint',
-\   'executable': 'remark',
-\   'command': 'remark --no-stdout --no-color %s',
+\   'executable_callback': 'ale_linters#markdown#remark_lint#GetExecutable',
+\   'command_callback': 'ale_linters#markdown#remark_lint#GetCommand',
 \   'callback': 'ale_linters#markdown#remark_lint#Handle',
 \   'lint_file': 1,
 \   'output_stream': 'stderr',

--- a/ale_linters/markdown/remark_lint.vim
+++ b/ale_linters/markdown/remark_lint.vim
@@ -16,7 +16,7 @@ function! ale_linters#markdown#remark_lint#GetCommand(buffer) abort
 
     return ale#node#Executable(a:buffer, l:executable)
     \    . (!empty(l:options) ? ' ' . l:options : '')
-    \    . ' --no-stdout --no-color %s'
+    \    . ' --no-stdout --no-color'
 endfunction
 
 function! ale_linters#markdown#remark_lint#Handle(buffer, lines) abort
@@ -47,6 +47,5 @@ call ale#linter#Define('markdown', {
 \   'executable_callback': 'ale_linters#markdown#remark_lint#GetExecutable',
 \   'command_callback': 'ale_linters#markdown#remark_lint#GetCommand',
 \   'callback': 'ale_linters#markdown#remark_lint#Handle',
-\   'lint_file': 1,
 \   'output_stream': 'stderr',
 \})

--- a/doc/ale-markdown.txt
+++ b/doc/ale-markdown.txt
@@ -29,6 +29,33 @@ See |ale-javascript-prettier| for information about the available options.
 
 
 ===============================================================================
+remark-lint                                          *ale-markdown-remark-lint*
+
+g:ale_markdown_remark_lint_executable   *g:ale_markdown_remark_lint_executable*
+                                        *b:ale_markdown_remark_lint_executable*
+  Type: |String|
+  Default: `'remark'`
+
+  See |ale-integrations-local-executables|
+
+
+g:ale_markdown_remark_lint_options         *g:ale_markdown_remark_lint_options*
+                                           *b:ale_markdown_remark_lint_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be set to pass additional options to remark-lint.
+
+
+g:ale_markdown_remark_lint_use_global   *g:ale_markdown_remark_lint_use_global*
+                                        *b:ale_markdown_remark_lint_use_global*
+  Type: |Number|
+  Default: `get(g:, 'ale_use_global_executables', 0)`
+
+  See |ale-integrations-local-executables|
+
+
+===============================================================================
 textlint                                                *ale-markdown-textlint*
 
 See |ale-text-textlint|

--- a/test/command_callback/test_remark_lint_command_callbacks.vader
+++ b/test/command_callback/test_remark_lint_command_callbacks.vader
@@ -7,19 +7,19 @@ After:
 
 Execute(The default command should be correct):
   AssertLinter 'remark',
-  \ ale#Escape('remark') . ' --no-stdout --no-color %s'
+  \ ale#Escape('remark') . ' --no-stdout --no-color'
 
 Execute(The executable should be configurable):
   let b:ale_markdown_remark_lint_executable = 'foobar'
 
   AssertLinter 'foobar',
-  \ ale#Escape('foobar') . ' --no-stdout --no-color %s'
+  \ ale#Escape('foobar') . ' --no-stdout --no-color'
 
 Execute(The options should be configurable):
   let b:ale_markdown_remark_lint_options = '--something'
 
   AssertLinter 'remark',
-  \ ale#Escape('remark') . ' --something --no-stdout --no-color %s'
+  \ ale#Escape('remark') . ' --something --no-stdout --no-color'
 
 Execute(The local executable from .bin should be used if available):
   call ale#test#SetFilename('remark_lint_paths/with_bin_path/foo.md')
@@ -27,11 +27,11 @@ Execute(The local executable from .bin should be used if available):
   AssertLinter
   \ ale#path#Simplify(g:dir . '/remark_lint_paths/with_bin_path/node_modules/.bin/remark'),
   \ ale#Escape(ale#path#Simplify(g:dir . '/remark_lint_paths/with_bin_path/node_modules/.bin/remark'))
-  \   . ' --no-stdout --no-color %s'
+  \   . ' --no-stdout --no-color'
 
 Execute(The global executable should be uesd if the option is set):
   let b:ale_markdown_remark_lint_use_global = 1
   call ale#test#SetFilename('remark_lint_paths/with_bin_path/foo.md')
 
   AssertLinter 'remark', ale#Escape('remark')
-  \   . ' --no-stdout --no-color %s'
+  \   . ' --no-stdout --no-color'

--- a/test/command_callback/test_remark_lint_command_callbacks.vader
+++ b/test/command_callback/test_remark_lint_command_callbacks.vader
@@ -1,0 +1,37 @@
+Before:
+  " This is just one language for the linter.
+  call ale#assert#SetUpLinterTest('markdown', 'remark_lint')
+
+After:
+  call ale#assert#TearDownLinterTest()
+
+Execute(The default command should be correct):
+  AssertLinter 'remark',
+  \ ale#Escape('remark') . ' --no-stdout --no-color %s'
+
+Execute(The executable should be configurable):
+  let b:ale_markdown_remark_lint_executable = 'foobar'
+
+  AssertLinter 'foobar',
+  \ ale#Escape('foobar') . ' --no-stdout --no-color %s'
+
+Execute(The options should be configurable):
+  let b:ale_markdown_remark_lint_options = '--something'
+
+  AssertLinter 'remark',
+  \ ale#Escape('remark') . ' --something --no-stdout --no-color %s'
+
+Execute(The local executable from .bin should be used if available):
+  call ale#test#SetFilename('remark_lint_paths/with_bin_path/foo.md')
+
+  AssertLinter
+  \ ale#path#Simplify(g:dir . '/remark_lint_paths/with_bin_path/node_modules/.bin/remark'),
+  \ ale#Escape(ale#path#Simplify(g:dir . '/remark_lint_paths/with_bin_path/node_modules/.bin/remark'))
+  \   . ' --no-stdout --no-color %s'
+
+Execute(The global executable should be uesd if the option is set):
+  let b:ale_markdown_remark_lint_use_global = 1
+  call ale#test#SetFilename('remark_lint_paths/with_bin_path/foo.md')
+
+  AssertLinter 'remark', ale#Escape('remark')
+  \   . ' --no-stdout --no-color %s'


### PR DESCRIPTION
<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-development`.

Have fun!
-->

Support remark-lint installed locally and enables lint without saving it to disk.

I rebased #1711 onto master, and applied feedback.
