### PR TITLE
purescript linter

### DIFF
--- a/ale_linters/purescript/pure_ls.vim
+++ b/ale_linters/purescript/pure_ls.vim
@@ -1,0 +1,39 @@
+" Author: David Komer <david.komer@gmail.com> 
+" Description: Integrate ALE with purescript-language-server.
+
+call ale#Set('pure_ls_executable', 'purescript-language-server')
+call ale#Set('pure_ls_use_global',
+\    get(g:, 'ale_use_global_executables', 0)
+\)
+
+function! ale_linters#purescript#pure_ls#GetExecutable(buffer) abort
+    return ale#node#FindExecutable(a:buffer, 'pure_ls', [
+    \   'node_modules/.bin/purescript-language-server',
+    \])
+endfunction
+
+function! ale_linters#purescript#pure_ls#GetCommand(buffer) abort
+    let l:executable = ale_linters#purescript#pure_ls#GetExecutable(a:buffer)
+
+    return ale#Escape(l:executable) . ' --stdio'
+endfunction
+
+function! ale_linters#purescript#pure_ls#FindProjectRoot(buffer) abort
+    let l:pure_config = ale#path#FindNearestFile(a:buffer, 'psc-package.json')
+
+    if !empty(l:pure_config)
+        return fnamemodify(l:pure_config, ':h')
+    endif
+
+    return ''
+endfunction
+
+call ale#linter#Define('purescript', {
+\   'name': 'pure_ls',
+\   'lsp': 'stdio',
+\   'executable_callback': 'ale_linters#purescript#pure_ls#GetExecutable',
+\   'command_callback': 'ale_linters#purescript#pure_ls#GetCommand',
+\   'project_root_callback': 'ale_linters#purescript#pure_ls#FindProjectRoot',
+\   'language': 'purescript',
+\   'output_stream': 'both'
+\})

--- a/ale_linters/purescript/pure_ls.vim
+++ b/ale_linters/purescript/pure_ls.vim
@@ -35,5 +35,4 @@ call ale#linter#Define('purescript', {
 \   'command_callback': 'ale_linters#purescript#pure_ls#GetCommand',
 \   'project_root_callback': 'ale_linters#purescript#pure_ls#FindProjectRoot',
 \   'language': 'purescript',
-\   'output_stream': 'both'
 \})

--- a/ale_linters/purescript/pure_ls.vim
+++ b/ale_linters/purescript/pure_ls.vim
@@ -15,7 +15,7 @@ endfunction
 function! ale_linters#purescript#pure_ls#GetCommand(buffer) abort
     let l:executable = ale_linters#purescript#pure_ls#GetExecutable(a:buffer)
 
-    return ale#Escape(l:executable) . ' --stdio'
+    return ale#Escape(l:executable) . ' --stdio --config ' . ale#Escape('{}')
 endfunction
 
 function! ale_linters#purescript#pure_ls#FindProjectRoot(buffer) abort


### PR DESCRIPTION
This is a starting point for the purescript linter, which _should_ work since it passes all the checkboxes on
https://langserver.org/ and relies on the same server used in the VSCode and Atom plugins.

It requires that [purescript-language-server](https://github.com/nwolverson/purescript-language-server) be installed, as well as the purescript runtime.

However - I am not getting any actual reporting from Ale, despite the server being correctly started/stopped when I open/close vim with a valid purescript file.

Help is appreciated!