### PR TITLE
Add cabal-ghc linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ formatting.
 | GraphQL | [eslint](http://eslint.org/), [gqlint](https://github.com/happylinks/gqlint), [prettier](https://github.com/prettier/prettier) |
 | Haml | [haml-lint](https://github.com/brigade/haml-lint) |
 | Handlebars | [ember-template-lint](https://github.com/rwjblue/ember-template-lint) |
-| Haskell | [brittany](https://github.com/lspitzner/brittany), [ghc](https://www.haskell.org/ghc/), [stack-ghc](https://haskellstack.org/), [stack-build](https://haskellstack.org/) !!, [ghc-mod](https://github.com/DanielG/ghc-mod), [stack-ghc-mod](https://github.com/DanielG/ghc-mod), [hlint](https://hackage.haskell.org/package/hlint), [hdevtools](https://hackage.haskell.org/package/hdevtools), [hfmt](https://github.com/danstiner/hfmt) |
+| Haskell | [brittany](https://github.com/lspitzner/brittany), [ghc](https://www.haskell.org/ghc/), [cabal-ghc](https://www.haskell.org/cabal/), [stack-ghc](https://haskellstack.org/), [stack-build](https://haskellstack.org/) !!, [ghc-mod](https://github.com/DanielG/ghc-mod), [stack-ghc-mod](https://github.com/DanielG/ghc-mod), [hlint](https://hackage.haskell.org/package/hlint), [hdevtools](https://hackage.haskell.org/package/hdevtools), [hfmt](https://github.com/danstiner/hfmt) |
 | HTML | [alex](https://github.com/wooorm/alex) !!, [HTMLHint](http://htmlhint.com/), [proselint](http://proselint.com/), [tidy](http://www.html-tidy.org/), [write-good](https://github.com/btford/write-good) |
 | Idris | [idris](http://www.idris-lang.org/) |
 | Java | [checkstyle](http://checkstyle.sourceforge.net), [javac](http://www.oracle.com/technetwork/java/javase/downloads/index.html), [google-java-format](https://github.com/google/google-java-format), [PMD](https://pmd.github.io/) |

--- a/ale_linters/haskell/cabal_ghc.vim
+++ b/ale_linters/haskell/cabal_ghc.vim
@@ -1,0 +1,18 @@
+" Author: Eric Wolf <ericwolf42@gmail.com>
+" Description: ghc for Haskell files called with cabal exec
+
+call ale#Set('haskell_cabal_ghc_options', '-fno-code -v0')
+
+function! ale_linters#haskell#cabal_ghc#GetCommand(buffer) abort
+    return 'cabal exec -- ghc '
+    \   . ale#Var(a:buffer, 'haskell_cabal_ghc_options')
+    \   . ' %t'
+endfunction
+
+call ale#linter#Define('haskell', {
+\   'name': 'cabal-ghc',
+\   'output_stream': 'stderr',
+\   'executable': 'cabal',
+\   'command_callback': 'ale_linters#haskell#cabal_ghc#GetCommand',
+\   'callback': 'ale#handlers#haskell#HandleGHCFormat',
+\})

--- a/doc/ale-haskell.txt
+++ b/doc/ale-haskell.txt
@@ -23,6 +23,17 @@ g:ale_haskell_ghc_options                           *g:ale_haskell_ghc_options*
   This variable can be changed to modify flags given to ghc.
 
 ===============================================================================
+cabal-ghc                                               *ale-haskell-cabal-ghc*
+
+g:ale_haskell_cabal_ghc_options               *g:ale_haskell_cabal_ghc_options*
+                                              *b:ale_haskell_cabal_ghc_options*
+  Type: |String|
+  Default: `'-fno-code -v0'`
+
+  This variable can be changed to modify flags given to ghc through cabal
+  exec.
+
+===============================================================================
 hdevtools                                               *ale-haskell-hdevtools*
 
 g:ale_haskell_hdevtools_executable         *g:ale_haskell_hdevtools_executable*

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -98,6 +98,7 @@ CONTENTS                                                         *ale-contents*
     haskell...............................|ale-haskell-options|
       brittany............................|ale-haskell-brittany|
       ghc.................................|ale-haskell-ghc|
+      cabal-ghc...........................|ale-haskell-cabal-ghc|
       hdevtools...........................|ale-haskell-hdevtools|
       hfmt................................|ale-haskell-hfmt|
       stack-build.........................|ale-haskell-stack-build|
@@ -364,7 +365,7 @@ Notes:
 * GraphQL: `eslint`, `gqlint`, `prettier`
 * Haml: `haml-lint`
 * Handlebars: `ember-template-lint`
-* Haskell: `brittany`, `ghc`, `stack-ghc`, `stack-build`!!, `ghc-mod`, `stack-ghc-mod`, `hlint`, `hdevtools`, `hfmt`
+* Haskell: `brittany`, `ghc`, `cabal-ghc`, `stack-ghc`, `stack-build`!!, `ghc-mod`, `stack-ghc-mod`, `hlint`, `hdevtools`, `hfmt`
 * HTML: `alex`!!, `HTMLHint`, `proselint`, `tidy`, `write-good`
 * Idris: `idris`
 * Java: `checkstyle`, `javac`, `google-java-format`, `PMD`

--- a/test/command_callback/test_haskell_cabal_ghc_command_callbacks.vader
+++ b/test/command_callback/test_haskell_cabal_ghc_command_callbacks.vader
@@ -1,0 +1,23 @@
+Before:
+  Save g:ale_haskell_cabal_ghc_options
+
+  unlet! g:ale_haskell_cabal_ghc_options
+  unlet! b:ale_haskell_cabal_ghc_options
+
+  runtime ale_linters/haskell/cabal_ghc.vim
+
+After:
+  Restore
+  unlet! b:ale_haskell_cabal_ghc_options
+  call ale#linter#Reset()
+
+Execute(The options should be used in the command):
+  AssertEqual
+  \ 'cabal exec -- ghc -fno-code -v0 %t',
+  \ ale_linters#haskell#cabal_ghc#GetCommand(bufnr(''))
+
+  let b:ale_haskell_cabal_ghc_options = 'foobar'
+
+  AssertEqual
+  \ 'cabal exec -- ghc foobar %t',
+  \ ale_linters#haskell#cabal_ghc#GetCommand(bufnr(''))


### PR DESCRIPTION
cabal-ghc calls ghc via cabal exec and so ghc has access to packages
in cabal sandboxes for example

<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-development`.

Have fun!
-->
