### PR TITLE
Make drafter linter use stdin instead of writing to tmp file

### DIFF
--- a/ale_linters/apiblueprint/drafter.vim
+++ b/ale_linters/apiblueprint/drafter.vim
@@ -31,6 +31,6 @@ call ale#linter#Define('apiblueprint', {
 \   'name': 'drafter',
 \   'output_stream': 'stderr',
 \   'executable': 'drafter',
-\   'command': 'drafter --use-line-num --validate %t',
+\   'command': 'drafter --use-line-num --validate',
 \   'callback': 'ale_linters#apiblueprint#drafter#HandleErrors',
 \})


### PR DESCRIPTION
Writing to a tmp file is unnecessary as drafter will use stdin if a path is not provided.

This can be demonstrated via:

```shell
$ cat test.apib | drafter -ul

OK.
warning: (6)  no identifier specified; line 8, column 11 - line 8, column 18
```