### PR TITLE
Fix joker finding .joker file in project root

### DIFF
--- a/ale_linters/clojure/joker.vim
+++ b/ale_linters/clojure/joker.vim
@@ -27,6 +27,6 @@ call ale#linter#Define('clojure', {
 \   'name': 'joker',
 \   'output_stream': 'stderr',
 \   'executable': 'joker',
-\   'command': 'joker --lint %t',
+\   'command': 'joker --working-dir %s --lint %t',
 \   'callback': 'ale_linters#clojure#joker#HandleJokerFormat',
 \})


### PR DESCRIPTION
Add --working-dir option so joker can find a .joker file in the project root directory.  On my linux box without the working-dir option, joker will find a .joker file in my home directory but not in the project root directory.