### PR TITLE
Tell HHAST to only look at open files

### DIFF
--- a/ale_linters/hack/hhast.vim
+++ b/ale_linters/hack/hhast.vim
@@ -26,10 +26,15 @@ function! ale_linters#hack#hhast#GetExecutable(buffer) abort
     return !empty(l:absolute) ? l:absolute : ''
 endfunction
 
+function! ale_linters#hack#hhast#GetInitializationOptions(buffer) abort
+    return {'lintMode': 'open-files'}
+endfunction
+
 call ale#linter#Define('hack', {
 \   'name': 'hhast',
 \   'lsp': 'stdio',
 \   'executable_callback': 'ale_linters#hack#hhast#GetExecutable',
 \   'command': '%e --mode lsp --from vim-ale',
 \   'project_root_callback': 'ale_linters#hack#hhast#GetProjectRoot',
+\   'initialization_options_callback': 'ale_linters#hack#hhast#GetInitializationOptions',
 \})


### PR DESCRIPTION
Given ALE only cares about open files, this has no observable change,
except for significantly reduced resource usage.

Didn't include this in the original PR as I thought there was some subtle incompatibly. Turns out that actually, HHAST was ignoring `rootUri`/`rootPath`, and always used $CWD - vscode and atom spawn it from `cwd`, but that's not required. Have hopefully fixed that issue in the next release of hhast.
