### PR TITLE
Add support for yang-lsp

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ formatting.
 | XHTML | [alex](https://github.com/wooorm/alex) !!, [proselint](http://proselint.com/), [write-good](https://github.com/btford/write-good) |
 | XML | [xmllint](http://xmlsoft.org/xmllint.html) |
 | YAML | [swaglint](https://github.com/byCedric/swaglint), [yamllint](https://yamllint.readthedocs.io/) |
+| YANG | [yang-lsp](https://github.com/theia-ide/yang-lsp) |
 
 <a name="usage"></a>
 

--- a/ale_linters/yang/yang_lsp.vim
+++ b/ale_linters/yang/yang_lsp.vim
@@ -1,0 +1,14 @@
+call ale#Set('yang_lsp_executable', 'yang-language-server')
+
+function! ale_linters#yang#yang_lsp#GetProjectRoot(buffer) abort
+    let l:project_root = ale#path#FindNearestFile(a:buffer, 'yang.settings')
+    return !empty(l:project_root) ? fnamemodify(l:project_root, ':h') : ''
+endfunction
+
+call ale#linter#Define('yang', {
+\   'name': 'yang_lsp',
+\   'lsp': 'stdio',
+\   'executable_callback': ale#VarFunc('yang_lsp_executable'),
+\   'project_root_callback': 'ale_linters#yang#yang_lsp#GetProjectRoot',
+\   'command': '%e',
+\})

--- a/doc/ale-yang.txt
+++ b/doc/ale-yang.txt
@@ -1,0 +1,17 @@
+===============================================================================
+ALE YANG Integration                                         *ale-yang-options*
+
+
+===============================================================================
+yang-lsp                                                         *ale-yang-lsp*
+
+g:ale_yang_lsp_executable                           *g:ale_yang_lsp_executable*
+                                                    *b:ale_yang_lsp_executable*
+  Type: |String|
+  Default: `'yang-language-server'`
+
+  This variable can be changed to use a different executable for yang-lsp.
+
+
+===============================================================================
+  vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -292,6 +292,8 @@ CONTENTS                                                         *ale-contents*
     yaml..................................|ale-yaml-options|
       swaglint............................|ale-yaml-swaglint|
       yamllint............................|ale-yaml-yamllint|
+    yang..................................|ale-yang-options|
+      yang-lsp............................|ale-yang-lsp|
   8. Commands/Keybinds....................|ale-commands|
   9. API..................................|ale-api|
   10. Special Thanks......................|ale-special-thanks|
@@ -435,6 +437,7 @@ Notes:
 * XHTML: `alex`!!, `proselint`, `write-good`
 * XML: `xmllint`
 * YAML: `swaglint`, `yamllint`
+* YANG: `yang-lsp`
 
 ===============================================================================
 3. Linting                                                           *ale-lint*

--- a/test/command_callback/test_yang_lsp_command_callbacks.vader
+++ b/test/command_callback/test_yang_lsp_command_callbacks.vader
@@ -1,0 +1,12 @@
+Before:
+  call ale#assert#SetUpLinterTest('yang', 'yang_lsp')
+
+After:
+  call ale#assert#TearDownLinterTest()
+
+Execute(The executable should be configurable):
+  AssertLinter 'yang-language-server', ale#Escape('yang-language-server')
+
+  let b:ale_yang_lsp_executable = 'foobar'
+
+  AssertLinter 'foobar', ale#Escape('foobar')


### PR DESCRIPTION
[yang-lsp](https://github.com/theia-ide/yang-lsp)

I hope I've done everything right!  

One thing I did hesitate over: I've gone with just `ale-yang-lsp` etc where perhaps the consistent thing would be to spell out the filetype and the linter both in full - giving `ale-yang-yang-lsp` etc.  But that stutter seemed pretty ugly to me, so that's why I made the choice that I did.  Happy to change if that's preferred.

(This particular language server will be more useful if and when theia-ide/yang-lsp#140 is fixed, allowing us to benefit from going to definitions, finding references, etc.  Meanwhile we still get linting via `publishDiagnostics` so it's not nothing).