### PR TITLE
Use .cquery file to detect the project root

### DIFF
--- a/ale_linters/c/cquery.vim
+++ b/ale_linters/c/cquery.vim
@@ -6,6 +6,9 @@ call ale#Set('c_cquery_cache_directory', expand('~/.cache/cquery'))
 
 function! ale_linters#c#cquery#GetProjectRoot(buffer) abort
     let l:project_root = ale#path#FindNearestFile(a:buffer, 'compile_commands.json')
+    if empty(l:project_root)
+        let l:project_root = ale#path#FindNearestFile(a:buffer, '.cquery')
+    endif
     return !empty(l:project_root) ? fnamemodify(l:project_root, ':h') : ''
 endfunction
 

--- a/ale_linters/cpp/cquery.vim
+++ b/ale_linters/cpp/cquery.vim
@@ -6,7 +6,9 @@ call ale#Set('cpp_cquery_cache_directory', expand('~/.cache/cquery'))
 
 function! ale_linters#cpp#cquery#GetProjectRoot(buffer) abort
     let l:project_root = ale#path#FindNearestFile(a:buffer, 'compile_commands.json')
-
+    if empty(l:project_root)
+        let l:project_root = ale#path#FindNearestFile(a:buffer, '.cquery')
+    endif
     return !empty(l:project_root) ? fnamemodify(l:project_root, ':h') : ''
 endfunction
 


### PR DESCRIPTION
Hi @w0rp,

In addition to `compile_commands.json` cquery also supports `.cquery` file placed into the project root. This is a simple text file containing a list of clang compilation options.

https://github.com/cquery-project/cquery/wiki/.cquery

I have several projects using `.cquery` files so it would be good to support them in ALE as well.

Thanks!