### PR TITLE
Never write to location list when disabled

### DIFF
--- a/autoload/ale/list.vim
+++ b/autoload/ale/list.vim
@@ -75,6 +75,13 @@ function! s:BufWinId(buffer) abort
 endfunction
 
 function! s:SetListsImpl(timer_id, buffer, loclist) abort
+    if ale#ShouldDoNothing(a:buffer)
+        " It's possible someone tried to turn off ale in a buffer and then
+        " immediately populated the location list. Do nothing to ensure we
+        " don't clobber the list.
+        return
+    endif
+
     let l:title = expand('#' . a:buffer . ':p')
 
     if g:ale_set_quickfix


### PR DESCRIPTION
Improves #1482.

Fixes ale clobbering populated location-list value when ale's disabled
immediately before populating.

Consider a command that pipes disable with populating (`GV?` is
junegunn/gv.vim's command to populate the location-list):

    command! Ghistory ALEDisableBuffer| echo "ALEDisableBuffer"| GV?

On execution, the location-list is opened, but empty. Running the
command again works (because ALE is still disabled).

Also reproducible with a simple loclist:

    :ALEDisableBuffer | call setloclist(0, [{'lnum': 1, 'text': 'important text'}])

<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-development`.

Have fun!
-->
