### PR TITLE
Additionally adjust the jumplist with line numbers when opening a new file

### DIFF
--- a/autoload/ale/util.vim
+++ b/autoload/ale/util.vim
@@ -88,10 +88,10 @@ endfunction
 
 function! ale#util#Open(filename, line, column, options) abort
     if get(a:options, 'open_in_tab', 0)
-        call ale#util#Execute('tabedit ' . fnameescape(a:filename))
+        call ale#util#Execute('tabedit +' . a:line . ' ' . fnameescape(a:filename))
     elseif bufnr(a:filename) isnot bufnr('')
         " Open another file only if we need to.
-        call ale#util#Execute('edit ' . fnameescape(a:filename))
+        call ale#util#Execute('edit +' . a:line . ' ' . fnameescape(a:filename))
     else
         normal! m`
     endif

--- a/test/test_go_to_definition.vader
+++ b/test/test_go_to_definition.vader
@@ -111,7 +111,7 @@ Execute(Other files should be jumped to for definition responses):
 
   AssertEqual
   \ [
-  \   'edit +3' . fnameescape(ale#path#Simplify(g:dir . '/completion_dummy_file')),
+  \   'edit +3 ' . fnameescape(ale#path#Simplify(g:dir . '/completion_dummy_file')),
   \ ],
   \ g:expr_list
   AssertEqual [3, 7], getpos('.')[1:2]
@@ -136,7 +136,7 @@ Execute(Other files should be jumped to for definition responses in tabs too):
 
   AssertEqual
   \ [
-  \   'tabedit +3' . fnameescape(ale#path#Simplify(g:dir . '/completion_dummy_file')),
+  \   'tabedit +3 ' . fnameescape(ale#path#Simplify(g:dir . '/completion_dummy_file')),
   \ ],
   \ g:expr_list
   AssertEqual [3, 7], getpos('.')[1:2]
@@ -206,7 +206,7 @@ Execute(Other files should be jumped to for LSP definition responses):
 
   AssertEqual
   \ [
-  \   'edit +3' . fnameescape(ale#path#Simplify(g:dir . '/completion_dummy_file')),
+  \   'edit +3 ' . fnameescape(ale#path#Simplify(g:dir . '/completion_dummy_file')),
   \ ],
   \ g:expr_list
   AssertEqual [3, 7], getpos('.')[1:2]
@@ -251,7 +251,7 @@ Execute(Other files should be jumped to in tabs for LSP definition responses):
 
   AssertEqual
   \ [
-  \   'tabedit +3' . fnameescape(ale#path#Simplify(g:dir . '/completion_dummy_file')),
+  \   'tabedit +3 ' . fnameescape(ale#path#Simplify(g:dir . '/completion_dummy_file')),
   \ ],
   \ g:expr_list
   AssertEqual [3, 7], getpos('.')[1:2]
@@ -282,7 +282,7 @@ Execute(Definition responses with lists should be handled):
 
   AssertEqual
   \ [
-  \   'edit +3' . fnameescape(ale#path#Simplify(g:dir . '/completion_dummy_file')),
+  \   'edit +3 ' . fnameescape(ale#path#Simplify(g:dir . '/completion_dummy_file')),
   \ ],
   \ g:expr_list
   AssertEqual [3, 7], getpos('.')[1:2]

--- a/test/test_go_to_definition.vader
+++ b/test/test_go_to_definition.vader
@@ -111,7 +111,7 @@ Execute(Other files should be jumped to for definition responses):
 
   AssertEqual
   \ [
-  \   'edit ' . fnameescape(ale#path#Simplify(g:dir . '/completion_dummy_file')),
+  \   'edit +3' . fnameescape(ale#path#Simplify(g:dir . '/completion_dummy_file')),
   \ ],
   \ g:expr_list
   AssertEqual [3, 7], getpos('.')[1:2]
@@ -136,7 +136,7 @@ Execute(Other files should be jumped to for definition responses in tabs too):
 
   AssertEqual
   \ [
-  \   'tabedit ' . fnameescape(ale#path#Simplify(g:dir . '/completion_dummy_file')),
+  \   'tabedit +3' . fnameescape(ale#path#Simplify(g:dir . '/completion_dummy_file')),
   \ ],
   \ g:expr_list
   AssertEqual [3, 7], getpos('.')[1:2]
@@ -206,7 +206,7 @@ Execute(Other files should be jumped to for LSP definition responses):
 
   AssertEqual
   \ [
-  \   'edit ' . fnameescape(ale#path#Simplify(g:dir . '/completion_dummy_file')),
+  \   'edit +3' . fnameescape(ale#path#Simplify(g:dir . '/completion_dummy_file')),
   \ ],
   \ g:expr_list
   AssertEqual [3, 7], getpos('.')[1:2]
@@ -251,7 +251,7 @@ Execute(Other files should be jumped to in tabs for LSP definition responses):
 
   AssertEqual
   \ [
-  \   'tabedit ' . fnameescape(ale#path#Simplify(g:dir . '/completion_dummy_file')),
+  \   'tabedit +3' . fnameescape(ale#path#Simplify(g:dir . '/completion_dummy_file')),
   \ ],
   \ g:expr_list
   AssertEqual [3, 7], getpos('.')[1:2]
@@ -282,7 +282,7 @@ Execute(Definition responses with lists should be handled):
 
   AssertEqual
   \ [
-  \   'edit ' . fnameescape(ale#path#Simplify(g:dir . '/completion_dummy_file')),
+  \   'edit +3' . fnameescape(ale#path#Simplify(g:dir . '/completion_dummy_file')),
   \ ],
   \ g:expr_list
   AssertEqual [3, 7], getpos('.')[1:2]


### PR DESCRIPTION
This further addresses Issue #1758.

In particular, without these changes, when you use `ALEGoToDefinition` and you are taken to a different buffer, the particular line you end up on in that buffer isn't included in the position in the jump list.  So, while you can jump back to where you were with C-o, once you do that, you can't return to where you jumped with C-i — instead, C-i takes you to the top of the buffer containing the definition in question.

These changes use the optional `+LINE_NUM` argument to the `:edit` and `:tabedit` commands, which adjusts the jumplist with the line number as well as the buffer, making C-o and C-i both work as expected.  (Well, not strictly true, as the particular column number isn't preserved in the jump list in these cases.  But at least we get line numbers now.)

<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-development`.

Have fun!
-->
