### PR TITLE
Add ale_php_phpmd_suffixes option for phpmd linter

### DIFF
--- a/ale_linters/php/phpmd.vim
+++ b/ale_linters/php/phpmd.vim
@@ -6,9 +6,18 @@ let g:ale_php_phpmd_executable = get(g:, 'ale_php_phpmd_executable', 'phpmd')
 " Set to change the ruleset
 let g:ale_php_phpmd_ruleset = get(g:, 'ale_php_phpmd_ruleset', 'cleancode,codesize,controversial,design,naming,unusedcode')
 
+" Set to tell phpmd files with which suffixes to check
+let g:ale_php_phpmd_suffixes = get(g:, 'ale_php_phpmd_suffixes', '')
+
 function! ale_linters#php#phpmd#GetCommand(buffer) abort
+    let l:suffixes = ale#Var(a:buffer, 'php_phpmd_suffixes')
+    let l:suffixes_option = !empty(l:suffixes)
+    \   ? ' --suffixes ' . l:suffixes
+    \   : ''
+
     return '%e %s text'
     \   . ale#Pad(ale#Var(a:buffer, 'php_phpmd_ruleset'))
+    \   . l:suffixes_option
     \   . ' --ignore-violations-on-exit %t'
 endfunction
 

--- a/test/command_callback/test_phpmd_command_callbacks.vader
+++ b/test/command_callback/test_phpmd_command_callbacks.vader
@@ -10,3 +10,10 @@ Execute(Custom executables should be used for the executable and command):
   AssertLinter 'phpmd_test',
   \ ale#Escape('phpmd_test')
   \ . ' %s text cleancode,codesize,controversial,design,naming,unusedcode --ignore-violations-on-exit %t'
+
+Execute(--suffixes option should be added to the final command):
+  let g:ale_php_phpmd_suffixes = 'php,module,theme'
+
+  AssertLinter 'phpmd',
+  \ ale#Escape('phpmd')
+  \ . ' %s text cleancode,codesize,controversial,design,naming,unusedcode --suffixes php,module,theme --ignore-violations-on-exit %t'


### PR DESCRIPTION
Hey!

This PR adds functionality to specify extensions of the files to check with phpmd (by default it only checks `.php` files)

Cheers! :beers: