### PR TITLE
Don't use error output from prettier_d for fixing files

### DIFF
--- a/autoload/ale/fixers/prettier.vim
+++ b/autoload/ale/fixers/prettier.vim
@@ -27,6 +27,17 @@ function! ale#fixers#prettier#Fix(buffer) abort
     \}
 endfunction
 
+function! ale#fixers#prettier#ProcessPrettierDOutput(buffer, output) abort
+    " If the output is an error message, don't use it.
+    for l:line in a:output[:10]
+        if l:line =~# '^\w*Error:'
+            return []
+        endif
+    endfor
+
+    return a:output
+endfunction
+
 function! ale#fixers#prettier#ApplyFixForVersion(buffer, version_output) abort
     let l:executable = ale#fixers#prettier#GetExecutable(a:buffer)
     let l:options = ale#Var(a:buffer, 'javascript_prettier_options')
@@ -60,6 +71,17 @@ function! ale#fixers#prettier#ApplyFixForVersion(buffer, version_output) abort
 
     if !empty(l:parser)
         let l:options = (!empty(l:options) ? l:options . ' ' : '') . '--parser ' . l:parser
+    endif
+
+    " Special error handling needed for prettier_d
+    if l:executable =~# 'prettier_d$'
+        return {
+        \   'command': ale#path#BufferCdString(a:buffer)
+        \       . ale#Escape(l:executable)
+        \       . (!empty(l:options) ? ' ' . l:options : '')
+        \       . ' --stdin-filepath %s --stdin',
+        \   'process_with': 'ale#fixers#prettier#ProcessPrettierDOutput',
+        \}
     endif
 
     " 1.4.0 is the first version with --stdin-filepath

--- a/test/fixers/test_prettier_fixer_callback.vader
+++ b/test/fixers/test_prettier_fixer_callback.vader
@@ -249,3 +249,21 @@ Execute(Should set --parser based on first filetype of multiple filetypes):
   \     . ' --stdin-filepath %s --stdin',
   \ },
   \ ale#fixers#prettier#ApplyFixForVersion(bufnr(''), ['1.6.0'])
+
+Execute(The prettier_d post-processor should permit regular JavaScript content):
+  AssertEqual
+  \ [
+  \   'const x = ''Error: foo''',
+  \   'const y = 3',
+  \ ],
+  \ ale#fixers#prettier#ProcessPrettierDOutput(bufnr(''), [
+  \   'const x = ''Error: foo''',
+  \   'const y = 3',
+  \ ])
+
+Execute(The prettier_d post-processor should handle error messages correctly):
+  AssertEqual
+  \ [],
+  \ ale#fixers#prettier#ProcessPrettierDOutput(bufnr(''), [
+  \   'SyntaxError: Unexpected token, expected "," (36:28)',
+  \ ])


### PR DESCRIPTION
`prettier_d` has the same problem as `eslint_d` where errors are output via stdout instead of stderr.

This PR ports the eslint fix for #1178 to fix the problem for prettier_d.
