### PR TITLE
Fix #1684: Use the correct flag name in rustc linter

### DIFF
--- a/ale_linters/rust/rustc.vim
+++ b/ale_linters/rust/rustc.vim
@@ -1,7 +1,7 @@
 " Author: Daniel Schemala <istjanichtzufassen@gmail.com>
 " Description: rustc for rust files
 
-call ale#Set('rust_rustc_options', '-Z no-trans')
+call ale#Set('rust_rustc_options', '-Z no-codegen')
 
 function! ale_linters#rust#rustc#RustcCommand(buffer) abort
     " Try to guess the library search path. If the project is managed by cargo,

--- a/doc/ale-rust.txt
+++ b/doc/ale-rust.txt
@@ -147,11 +147,11 @@ rustc                                                          *ale-rust-rustc*
 g:ale_rust_rustc_options                             *g:ale_rust_rustc_options*
                                                      *b:ale_rust_rustc_options*
   Type: |String|
-  Default: `'-Z no-trans'`
+  Default: `'-Z no-codegen'`
 
   The variable can be used to change the options passed to `rustc`.
 
-  `-Z no-trans` should only work with nightly builds of Rust. Be careful when
+  `-Z no-codegen` should only work with nightly builds of Rust. Be careful when
   setting the options, as running `rustc` could execute code or generate
   binary files.
 

--- a/test/command_callback/test_rustc_command_callback.vader
+++ b/test/command_callback/test_rustc_command_callback.vader
@@ -5,7 +5,7 @@ After:
   call ale#assert#TearDownLinterTest()
 
 Execute(The default command should be correct):
-  AssertLinter 'rustc', 'rustc --error-format=json -Z no-trans -'
+  AssertLinter 'rustc', 'rustc --error-format=json -Z no-codegen -'
 
 Execute(The options should be configurable):
   let b:ale_rust_rustc_options = '--foo'
@@ -15,7 +15,7 @@ Execute(The options should be configurable):
 Execute(Some default paths should be included when the project is a Cargo project):
   call ale#test#SetFilename('cargo_paths/test.rs')
 
-  AssertLinter 'rustc', 'rustc --error-format=json -Z no-trans'
+  AssertLinter 'rustc', 'rustc --error-format=json -Z no-codegen'
   \   . ' -L ' . ale#Escape(ale#path#GetAbsPath(g:dir,  'cargo_paths/target/debug/deps'))
   \   . ' -L ' . ale#Escape(ale#path#GetAbsPath(g:dir, 'cargo_paths/target/release/deps'))
   \   . ' -'


### PR DESCRIPTION
The rust compiler renamed the option '-Z no-trans' to '-Z no-codegen'.

https://github.com/rust-lang/rust-enhanced/issues/281

<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-development`.

Have fun!
-->
