### PR TITLE
Update README with the `*` ft option for the fixers object

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,22 +231,17 @@ let b:ale_fixers = ['prettier', 'eslint']
 let b:ale_fixers = {'javascript': ['prettier', 'eslint']}
 ```
 
-You can also configure your fixers from vimrc using `g:ale_fixers`, before
-or after ALE has been loaded.
+You can also configure your fixers from vimrc using `g:ale_fixers`, before or
+after ALE has been loaded. A `*` in place of the filetype will apply the
+corresponding list of fixers to all filetypes. If a subsequent specific filetype
+match is found it will be used instead of `*`. Note that using a plain list for
+`g:ale_fixers` is not supported.
 
 ```vim
 " In ~/.vim/vimrc, or somewhere similar.
 let g:ale_fixers = {
-\   'javascript': ['eslint'],
-\}
-```
-
-A `*` in place of the filetype will apply the corresponding list of fixers to
-all filetypes. Note that using a plain list for `g:ale_fixers` is not supported.
-
-```vim
-let g:ale_fixers = {
 \   '*': ['remove_trailing_lines', 'trim_whitespace'],
+\   'javascript': ['eslint'],
 \}
 ```
 

--- a/README.md
+++ b/README.md
@@ -241,6 +241,15 @@ let g:ale_fixers = {
 \}
 ```
 
+A `*` in place of the filetype will apply the corresponding list of fixers to
+all filetypes. Note that using a plain list for `g:ale_fixers` is not supported.
+
+```vim
+let g:ale_fixers = {
+\   '*': ['remove_trailing_lines', 'trim_whitespace'],
+\}
+```
+
 If you want to automatically fix files when you save them, you need to turn
 a setting on in vimrc.
 


### PR DESCRIPTION
It wasn't immediately obvious that the `g:ale_fixers` cannot be a list,
and would allow the use of `*` to match all filetypes. I was hoping to
add a bit more detail to the README to make this clearer.

<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-development`.

Have fun!
-->
