### PR TITLE
Enabling clangd for cpp, objc and objcpp

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ formatting.
 | Bash | [language-server](https://github.com/mads-hartmann/bash-language-server), shell [-n flag](https://www.gnu.org/software/bash/manual/bash.html#index-set), [shellcheck](https://www.shellcheck.net/), [shfmt](https://github.com/mvdan/sh) |
 | Bourne Shell | shell [-n flag](http://linux.die.net/man/1/sh), [shellcheck](https://www.shellcheck.net/), [shfmt](https://github.com/mvdan/sh) |
 | C | [cppcheck](http://cppcheck.sourceforge.net), [cpplint](https://github.com/google/styleguide/tree/gh-pages/cpplint), [clang](http://clang.llvm.org/), [clangd](https://clang.llvm.org/extra/clangd.html), [clangtidy](http://clang.llvm.org/extra/clang-tidy/) !!, [clang-format](https://clang.llvm.org/docs/ClangFormat.html), [cquery](https://github.com/cquery-project/cquery), [flawfinder](https://www.dwheeler.com/flawfinder/), [gcc](https://gcc.gnu.org/) |
-| C++ (filetype cpp) | [clang](http://clang.llvm.org/), [clangcheck](http://clang.llvm.org/docs/ClangCheck.html) !!, [clangtidy](http://clang.llvm.org/extra/clang-tidy/) !!, [clang-format](https://clang.llvm.org/docs/ClangFormat.html), [cppcheck](http://cppcheck.sourceforge.net), [cpplint](https://github.com/google/styleguide/tree/gh-pages/cpplint) !!, [cquery](https://github.com/cquery-project/cquery), [flawfinder](https://www.dwheeler.com/flawfinder/), [gcc](https://gcc.gnu.org/) |
+| C++ (filetype cpp) | [clang](http://clang.llvm.org/), [clangd](https://clang.llvm.org/extra/clangd.html), [clangcheck](http://clang.llvm.org/docs/ClangCheck.html) !!, [clangtidy](http://clang.llvm.org/extra/clang-tidy/) !!, [clang-format](https://clang.llvm.org/docs/ClangFormat.html), [cppcheck](http://cppcheck.sourceforge.net), [cpplint](https://github.com/google/styleguide/tree/gh-pages/cpplint) !!, [cquery](https://github.com/cquery-project/cquery), [flawfinder](https://www.dwheeler.com/flawfinder/), [gcc](https://gcc.gnu.org/) |
 | CUDA | [nvcc](http://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html) |
 | C# | [mcs](http://www.mono-project.com/docs/about-mono/languages/csharp/) see:`help ale-cs-mcs` for details, [mcsc](http://www.mono-project.com/docs/about-mono/languages/csharp/) !! see:`help ale-cs-mcsc` for details and configuration|
 | Chef | [foodcritic](http://www.foodcritic.io/) |
@@ -149,8 +149,8 @@ formatting.
 | Nim | [nim check](https://nim-lang.org/docs/nimc.html) !! |
 | nix | [nix-instantiate](http://nixos.org/nix/manual/#sec-nix-instantiate) |
 | nroff | [alex](https://github.com/wooorm/alex) !!, [proselint](http://proselint.com/), [write-good](https://github.com/btford/write-good)|
-| Objective-C | [clang](http://clang.llvm.org/) |
-| Objective-C++ | [clang](http://clang.llvm.org/) |
+| Objective-C | [clang](http://clang.llvm.org/), [clangd](https://clang.llvm.org/extra/clangd.html) |
+| Objective-C++ | [clang](http://clang.llvm.org/), [clangd](https://clang.llvm.org/extra/clangd.html) |
 | OCaml | [merlin](https://github.com/the-lambda-church/merlin) see `:help ale-ocaml-merlin` for configuration instructions, [ols](https://github.com/freebroccolo/ocaml-language-server) |
 | Perl | [perl -c](https://perl.org/), [perl-critic](https://metacpan.org/pod/Perl::Critic), [perltidy](https://metacpan.org/pod/distribution/Perl-Tidy/bin/perltidy) |
 | PHP | [langserver](https://github.com/felixfbecker/php-language-server), [phan](https://github.com/phan/phan) see `:help ale-php-phan` to instructions, [php -l](https://secure.php.net/), [phpcs](https://github.com/squizlabs/PHP_CodeSniffer), [phpmd](https://phpmd.org), [phpstan](https://github.com/phpstan/phpstan), [phpcbf](https://github.com/squizlabs/PHP_CodeSniffer), [php-cs-fixer](http://cs.sensiolabs.org/) |

--- a/ale_linters/cpp/clangd.vim
+++ b/ale_linters/cpp/clangd.vim
@@ -1,0 +1,22 @@
+" Author: Andrey Melentyev <andrey.melentyev@protonmail.com>
+" Description: Clangd language server
+
+call ale#Set('cpp_clangd_executable', 'clangd')
+call ale#Set('cpp_clangd_options', '')
+
+function! ale_linters#cpp#clangd#GetProjectRoot(buffer) abort
+    let l:project_root = ale#path#FindNearestFile(a:buffer, 'compile_commands.json')
+    return !empty(l:project_root) ? fnamemodify(l:project_root, ':h') : ''
+endfunction
+
+function! ale_linters#cpp#clangd#GetCommand(buffer) abort
+    return '%e' . ale#Pad(ale#Var(a:buffer, 'cpp_clangd_options'))
+endfunction
+
+call ale#linter#Define('cpp', {
+\   'name': 'clangd',
+\   'lsp': 'stdio',
+\   'executable_callback': ale#VarFunc('cpp_clangd_executable'),
+\   'command_callback': 'ale_linters#cpp#clangd#GetCommand',
+\   'project_root_callback': 'ale_linters#cpp#clangd#GetProjectRoot',
+\})

--- a/ale_linters/objc/clangd.vim
+++ b/ale_linters/objc/clangd.vim
@@ -1,0 +1,22 @@
+" Author: Andrey Melentyev <andrey.melentyev@protonmail.com>
+" Description: Clangd language server
+
+call ale#Set('objc_clangd_executable', 'clangd')
+call ale#Set('objc_clangd_options', '')
+
+function! ale_linters#objc#clangd#GetProjectRoot(buffer) abort
+    let l:project_root = ale#path#FindNearestFile(a:buffer, 'compile_commands.json')
+    return !empty(l:project_root) ? fnamemodify(l:project_root, ':h') : ''
+endfunction
+
+function! ale_linters#objc#clangd#GetCommand(buffer) abort
+    return '%e' . ale#Pad(ale#Var(a:buffer, 'objc_clangd_options'))
+endfunction
+
+call ale#linter#Define('objc', {
+\   'name': 'clangd',
+\   'lsp': 'stdio',
+\   'executable_callback': ale#VarFunc('objc_clangd_executable'),
+\   'command_callback': 'ale_linters#objc#clangd#GetCommand',
+\   'project_root_callback': 'ale_linters#objc#clangd#GetProjectRoot',
+\})

--- a/ale_linters/objcpp/clangd.vim
+++ b/ale_linters/objcpp/clangd.vim
@@ -1,0 +1,22 @@
+" Author: Andrey Melentyev <andrey.melentyev@protonmail.com>
+" Description: Clangd language server
+
+call ale#Set('objcpp_clangd_executable', 'clangd')
+call ale#Set('objcpp_clangd_options', '')
+
+function! ale_linters#objcpp#clangd#GetProjectRoot(buffer) abort
+    let l:project_root = ale#path#FindNearestFile(a:buffer, 'compile_commands.json')
+    return !empty(l:project_root) ? fnamemodify(l:project_root, ':h') : ''
+endfunction
+
+function! ale_linters#objcpp#clangd#GetCommand(buffer) abort
+    return '%e' . ale#Pad(ale#Var(a:buffer, 'objcpp_clangd_options'))
+endfunction
+
+call ale#linter#Define('objcpp', {
+\   'name': 'clangd',
+\   'lsp': 'stdio',
+\   'executable_callback': ale#VarFunc('objcpp_clangd_executable'),
+\   'command_callback': 'ale_linters#objcpp#clangd#GetCommand',
+\   'project_root_callback': 'ale_linters#objcpp#clangd#GetProjectRoot',
+\})

--- a/doc/ale-cpp.txt
+++ b/doc/ale-cpp.txt
@@ -33,6 +33,25 @@ g:ale_cpp_clang_options                               *g:ale_cpp_clang_options*
 
 
 ===============================================================================
+clangd                                                         *ale-cpp-clangd*
+
+g:ale_cpp_clangd_executable                       *g:ale_cpp_clangd_executable*
+                                                  *b:ale_cpp_clangd_executable*
+  Type: |String|
+  Default: `'clangd'`
+
+  This variable can be changed to use a different executable for clangd.
+
+
+g:ale_cpp_clangd_options                             *g:ale_cpp_clangd_options*
+                                                     *b:ale_cpp_clangd_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be changed to modify flags given to clangd.
+
+
+===============================================================================
 clangcheck                                                 *ale-cpp-clangcheck*
 
 `clang-check` will be run only when files are saved to disk, so that

--- a/doc/ale-objc.txt
+++ b/doc/ale-objc.txt
@@ -14,4 +14,23 @@ g:ale_objc_clang_options                             *g:ale_objc_clang_options*
 
 
 ===============================================================================
+clangd                                                        *ale-objc-clangd*
+
+g:ale_objc_clangd_executable                     *g:ale_objc_clangd_executable*
+                                                 *b:ale_objc_clangd_executable*
+  Type: |String|
+  Default: `'clangd'`
+
+  This variable can be changed to use a different executable for clangd.
+
+
+g:ale_objc_clangd_options                           *g:ale_objc_clangd_options*
+                                                    *b:ale_objc_clangd_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be changed to modify flags given to clangd.
+
+
+===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-objcpp.txt
+++ b/doc/ale-objcpp.txt
@@ -14,4 +14,23 @@ g:ale_objcpp_clang_options                         *g:ale_objcpp_clang_options*
 
 
 ===============================================================================
+clangd                                                      *ale-objcpp-clangd*
+
+g:ale_objcpp_clangd_executable                 *g:ale_objcpp_clangd_executable*
+                                               *b:ale_objcpp_clangd_executable*
+  Type: |String|
+  Default: `'clangd'`
+
+  This variable can be changed to use a different executable for clangd.
+
+
+g:ale_objcpp_clangd_options                       *g:ale_objcpp_clangd_options*
+                                                  *b:ale_objcpp_clangd_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be changed to modify flags given to clangd.
+
+
+===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -43,6 +43,7 @@ CONTENTS                                                         *ale-contents*
       cmakelint...........................|ale-cmake-cmakelint|
     cpp...................................|ale-cpp-options|
       clang...............................|ale-cpp-clang|
+      clangd..............................|ale-cpp-clangd|
       clangcheck..........................|ale-cpp-clangcheck|
       clang-format........................|ale-cpp-clangformat|
       clangtidy...........................|ale-cpp-clangtidy|
@@ -167,8 +168,10 @@ CONTENTS                                                         *ale-contents*
       write-good..........................|ale-nroff-write-good|
     objc..................................|ale-objc-options|
       clang...............................|ale-objc-clang|
+      clangd..............................|ale-objc-clangd|
     objcpp................................|ale-objcpp-options|
       clang...............................|ale-objcpp-clang|
+      clangd..............................|ale-objcpp-clangd|
     ocaml.................................|ale-ocaml-options|
       merlin..............................|ale-ocaml-merlin|
       ols.................................|ale-ocaml-ols|
@@ -346,7 +349,7 @@ Notes:
 * Bash: `language-server`, `shell` (-n flag), `shellcheck`, `shfmt`
 * Bourne Shell: `shell` (-n flag), `shellcheck`, `shfmt`
 * C: `cppcheck`, `cpplint`!!, `clang`, `clangd`, `clangtidy`!!, `clang-format`, `cquery`, `flawfinder`, `gcc`
-* C++ (filetype cpp): `clang`, `clangcheck`!!, `clangtidy`!!, `clang-format`, `cppcheck`, `cpplint`!!, `cquery`, `flawfinder`, `gcc`
+* C++ (filetype cpp): `clang`, `clangd`, `clangcheck`!!, `clangtidy`!!, `clang-format`, `cppcheck`, `cpplint`!!, `cquery`, `flawfinder`, `gcc`
 * CUDA: `nvcc`!!
 * C#: `mcs`, `mcsc`!!
 * Chef: `foodcritic`
@@ -397,8 +400,8 @@ Notes:
 * Nim: `nim check`!!
 * nix: `nix-instantiate`
 * nroff: `alex`!!, `proselint`, `write-good`
-* Objective-C: `clang`
-* Objective-C++: `clang`
+* Objective-C: `clang`, `clangd`
+* Objective-C++: `clang`, `clangd`
 * OCaml: `merlin` (see |ale-ocaml-merlin|), `ols`
 * Perl: `perl -c`, `perl-critic`, `perltidy`
 * PHP: `langserver`, `phan`, `php -l`, `phpcs`, `phpmd`, `phpstan`, `phpcbf`, `php-cs-fixer`


### PR DESCRIPTION
I hope this patch is okay, pretty much a copy and paste from ale-linters/clangd.vim.

It's still a fair amount of code duplication, but I have no presumptions of refactoring stuff around to have a linter work across languages.