### PR TITLE
Add hlint refactoring as a fixer

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -170,6 +170,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['haskell'],
 \       'description': 'Fix Haskell files with brittany.',
 \   },
+\   'hlint': {
+\       'function': 'ale#fixers#hlint#Fix',
+\       'suggested_filetypes': ['haskell'],
+\       'description': 'Refactor Haskell files with hlint.',
+\   },
 \   'refmt': {
 \       'function': 'ale#fixers#refmt#Fix',
 \       'suggested_filetypes': ['reason'],

--- a/autoload/ale/fixers/hlint.vim
+++ b/autoload/ale/fixers/hlint.vim
@@ -1,0 +1,16 @@
+" Author: eborden <evan@evan-borden.com>
+" Description: Integration of hlint refactor with ALE.
+"
+call ale#Set('haskell_hlint_executable', 'hlint')
+
+function! ale#fixers#hlint#Fix(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'haskell_hlint_executable')
+
+    return {
+    \   'command': ale#Escape(l:executable)
+    \       . ' --refactor'
+    \       . ' --refactor-options="--inplace"'
+    \       . ' %t',
+    \   'read_temporary_file': 1,
+    \}
+endfunction

--- a/doc/ale-haskell.txt
+++ b/doc/ale-haskell.txt
@@ -68,6 +68,16 @@ g:ale_haskell_hfmt_executable                   *g:ale_haskell_hfmt_executable*
   This variable can be changed to use a different executable for hfmt.
 
 ===============================================================================
+hlint                                                       *ale-haskell-hlint*
+
+g:ale_haskell_hlint_executable                 *g:ale_haskell_hlint_executable*
+                                               *b:ale_haskell_hlint_executable*
+  Type: |String|
+  Default: `'hlint'`
+
+  This variable can be changed to use a different executable for hlint.
+
+===============================================================================
 stack-build                                           *ale-haskell-stack-build*
 
 g:ale_haskell_stack_build_options           *g:ale_haskell_stack_build_options*

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -109,6 +109,7 @@ CONTENTS                                                         *ale-contents*
       cabal-ghc...........................|ale-haskell-cabal-ghc|
       hdevtools...........................|ale-haskell-hdevtools|
       hfmt................................|ale-haskell-hfmt|
+      hlint...............................|ale-haskell-hlint|
       stack-build.........................|ale-haskell-stack-build|
       hie.................................|ale-haskell-hie|
     html..................................|ale-html-options|

--- a/test/fixers/test_hlint_fixer_callback.vader
+++ b/test/fixers/test_hlint_fixer_callback.vader
@@ -1,0 +1,25 @@
+Before:
+  Save g:ale_haskell_hlint_executable
+
+  " Use an invalid global executable, so we don't match it.
+  let g:ale_haskell_hlint_executable = 'xxxinvalid'
+
+  call ale#test#SetDirectory('/testplugin/test/fixers')
+
+After:
+  Restore
+
+  call ale#test#RestoreDirectory()
+
+Execute(The hlint callback should return the correct default values):
+  call ale#test#SetFilename('../haskell_files/testfile.hs')
+
+  AssertEqual
+  \ {
+  \   'read_temporary_file': 1,
+  \   'command': ale#Escape('xxxinvalid')
+  \     . ' --refactor'
+  \     . ' --refactor-options="--inplace"'
+  \     . ' %t',
+  \ },
+  \ ale#fixers#hlint#Fix(bufnr(''))


### PR DESCRIPTION
`hlint` exposes a command for automatically refactoring its lint
suggestions. This fits perfectly into the form of a fixer. This commit
provides `hlint` as a fixer with a simple invocation.

This commit presents two problems:

1. It introduces `haskell_hlint_executable` as a global var for setting
   the desired `hlint` executable. This global is not currently respected
   by the `hlint` linter.
2. `ale#Escape` does not play nicely with a common pattern in haskell
   executable usage. Many `stack` users invoke compiler tools via
   `stack exec [command] -- [options]`. `ale#Escape` wraps this command in
   quotes, because it includes spaces. This results in silent failure of
   the fixer.

This commit does not present resolutions for either of these problems.