### PR TITLE
Remove "go env" from gobuild linter

### DIFF
--- a/ale_linters/go/gobuild.vim
+++ b/ale_linters/go/gobuild.vim
@@ -5,35 +5,11 @@
 
 call ale#Set('go_gobuild_options', '')
 
-function! ale_linters#go#gobuild#ResetEnv() abort
-    unlet! s:go_env
-endfunction
-
-function! ale_linters#go#gobuild#GoEnv(buffer) abort
-    if exists('s:go_env')
-        return ''
-    endif
-
-    return 'go env GOPATH GOROOT'
-endfunction
-
-function! ale_linters#go#gobuild#GetCommand(buffer, goenv_output) abort
+function! ale_linters#go#gobuild#GetCommand(buffer) abort
     let l:options = ale#Var(a:buffer, 'go_gobuild_options')
 
-    if !exists('s:go_env')
-        let s:go_env = {
-        \   'GOPATH': a:goenv_output[0],
-        \   'GOROOT': a:goenv_output[1],
-        \}
-    endif
-
-    let l:gopath_env_command = has('win32')
-    \   ? 'set GOPATH=' . ale#Escape(s:go_env.GOPATH) . ' && '
-    \   : 'GOPATH=' . ale#Escape(s:go_env.GOPATH) . ' '
-
     " Run go test in local directory with relative path
-    return l:gopath_env_command
-    \   . ale#path#BufferCdString(a:buffer)
+    return ale#path#BufferCdString(a:buffer)
     \   . 'go test'
     \   . (!empty(l:options) ? ' ' . l:options : '')
     \   . ' -c -o /dev/null ./'
@@ -73,10 +49,8 @@ call ale#linter#Define('go', {
 \   'name': 'gobuild',
 \   'aliases': ['go build'],
 \   'executable': 'go',
-\   'command_chain': [
-\     {'callback': 'ale_linters#go#gobuild#GoEnv', 'output_stream': 'stdout'},
-\     {'callback': 'ale_linters#go#gobuild#GetCommand', 'output_stream': 'stderr'},
-\   ],
+\   'command_callback': 'ale_linters#go#gobuild#GetCommand',
+\   'output_stream': 'stderr',
 \   'callback': 'ale_linters#go#gobuild#Handler',
 \   'lint_file': 1,
 \})

--- a/test/command_callback/test_gobuild_command_callback.vader
+++ b/test/command_callback/test_gobuild_command_callback.vader
@@ -1,36 +1,19 @@
 Before:
   call ale#assert#SetUpLinterTest('go', 'gobuild')
 
-  let g:env_prefix = has('win32')
-  \ ? 'set GOPATH=' . ale#Escape('/foo/bar') . ' && '
-  \ : 'GOPATH=' . ale#Escape('/foo/bar') . ' '
-  call ale_linters#go#gobuild#ResetEnv()
-
   WithChainResults ['/foo/bar', '/foo/baz']
 
 After:
-  unlet! g:env_prefix
   call ale#assert#TearDownLinterTest()
 
 Execute(The default commands should be correct):
-  AssertLinter 'go', [
-  \ 'go env GOPATH GOROOT',
-  \ g:env_prefix . 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  AssertLinter 'go',
+  \ 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
   \   . 'go test -c -o /dev/null ./'
-  \]
-
-  " We shouldn't run `go env` many times after we've got it.
-  AssertLinter 'go', [
-  \ '',
-  \ g:env_prefix . 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
-  \   . 'go test -c -o /dev/null ./'
-  \]
 
 Execute(Extra options should be supported):
   let g:ale_go_gobuild_options = '--foo-bar'
 
-  AssertLinter 'go', [
-  \ 'go env GOPATH GOROOT',
-  \ g:env_prefix . 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  AssertLinter 'go',
+  \ 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
   \   . 'go test --foo-bar -c -o /dev/null ./'
-  \]


### PR DESCRIPTION
I see no reason to do this? It is just setting the environment to what
it already is?

It was originally added in #297, but that entire PR is not a great idea
in the first place; that PR (together with #270) tried to make the Go do
non-standard and non-supported stuff like compiling packages outside of
GOPATH.

That's not something that works well (I tried), so was eventually
removed in #465, but these "go env" calls remained, for no reason in
particular, as far as I can think of.

This will improve on #1834; you will now no longer get a confusing error
(but still won't get a meaningful error; need to think how to do that).

<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-development`.

Have fun!
-->
