### PR TITLE
importjs fixer not reading correct executable variable name

### DIFF
--- a/autoload/ale/fixers/importjs.vim
+++ b/autoload/ale/fixers/importjs.vim
@@ -1,7 +1,7 @@
 " Author: Jeff Willette <jrwillette88@gmail.com>
 " Description: Integration of importjs with ALE.
 
-call ale#Set('js_importjs_executable', 'importjs')
+call ale#Set('javascript_importjs_executable', 'importjs')
 
 function! ale#fixers#importjs#ProcessOutput(buffer, output) abort
     let l:result = ale#util#FuzzyJSONDecode(a:output, [])
@@ -9,7 +9,7 @@ function! ale#fixers#importjs#ProcessOutput(buffer, output) abort
 endfunction
 
 function! ale#fixers#importjs#Fix(buffer) abort
-    let l:executable = ale#Var(a:buffer, 'js_importjs_executable')
+    let l:executable = ale#Var(a:buffer, 'javascript_importjs_executable')
 
     if !executable(l:executable)
         return 0

--- a/test/fixers/test_importjs_fixer_callback.vader
+++ b/test/fixers/test_importjs_fixer_callback.vader
@@ -1,8 +1,8 @@
 Before:
-  Save g:ale_js_importjs_executable
+  Save g:ale_javascript_importjs_executable
 
   " Use an invalid global executable, so we don't match it.
-  let g:ale_js_importjs_executable = 'xxxinvalid'
+  let g:ale_javascript_importjs_executable = 'xxxinvalid'
 
   call ale#test#SetDirectory('/testplugin/test/fixers')
   call ale#test#SetFilename('../javascript_files/test.js')
@@ -18,12 +18,12 @@ Execute(The importjs callback should return 0 when the executable isn't executab
   \ ale#fixers#importjs#Fix(bufnr(''))
 
 Execute(The importjs callback should run the command when the executable test passes):
-  let g:ale_js_importjs_executable = has('win32') ? 'cmd' : 'echo'
+  let g:ale_javascript_importjs_executable = has('win32') ? 'cmd' : 'echo'
 
   AssertEqual
   \ {
   \   'process_with': 'ale#fixers#importjs#ProcessOutput',
-  \   'command': ale#Escape(g:ale_js_importjs_executable) . ' fix %s'
+  \   'command': ale#Escape(g:ale_javascript_importjs_executable) . ' fix %s'
   \ },
   \ ale#fixers#importjs#Fix(bufnr(''))
 


### PR DESCRIPTION
importjs fixer is not reading the correct executable variable name.
Like referenced in the help section the variable name should be "javascript_..." but not "js_..."
