### PR TITLE
Fix 1844 - Fix broken kotlin lsp linter.

### DIFF
--- a/ale_linters/kotlin/languageserver.vim
+++ b/ale_linters/kotlin/languageserver.vim
@@ -23,7 +23,7 @@ call ale#linter#Define('kotlin', {
 \   'name': 'languageserver',
 \   'lsp': 'stdio',
 \   'executable_callback': ale#VarFunc('kotlin_languageserver_executable'),
-\   'command_callback': '%e',
+\   'command_callback': ale#VarFunc('kotlin_languageserver_executable'),
 \   'language': 'kotlin',
 \   'project_root_callback': 'ale_linters#kotlin#languageserver#GetProjectRoot',
 \})


### PR DESCRIPTION
This fixes kotlin lsb linter that broke three weeks ago after some heavy refactoring in ALE ( 2172843 ).
