### PR TITLE
add ocamlformat support

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ formatting.
 | nroff | [alex](https://github.com/wooorm/alex) !!, [proselint](http://proselint.com/), [write-good](https://github.com/btford/write-good)|
 | Objective-C | [clang](http://clang.llvm.org/), [clangd](https://clang.llvm.org/extra/clangd.html) |
 | Objective-C++ | [clang](http://clang.llvm.org/), [clangd](https://clang.llvm.org/extra/clangd.html) |
-| OCaml | [merlin](https://github.com/the-lambda-church/merlin) see `:help ale-ocaml-merlin` for configuration instructions, [ols](https://github.com/freebroccolo/ocaml-language-server) |
+| OCaml | [merlin](https://github.com/the-lambda-church/merlin) see `:help ale-ocaml-merlin` for configuration instructions, [ols](https://github.com/freebroccolo/ocaml-language-server), [ocamlformat](https://github.com/ocaml-ppx/ocamlformat) |
 | Perl | [perl -c](https://perl.org/), [perl-critic](https://metacpan.org/pod/Perl::Critic), [perltidy](https://metacpan.org/pod/distribution/Perl-Tidy/bin/perltidy) |
 | PHP | [langserver](https://github.com/felixfbecker/php-language-server), [phan](https://github.com/phan/phan) see `:help ale-php-phan` to instructions, [php -l](https://secure.php.net/), [phpcs](https://github.com/squizlabs/PHP_CodeSniffer), [phpmd](https://phpmd.org), [phpstan](https://github.com/phpstan/phpstan), [phpcbf](https://github.com/squizlabs/PHP_CodeSniffer), [php-cs-fixer](http://cs.sensiolabs.org/) |
 | PO | [alex](https://github.com/wooorm/alex) !!, [msgfmt](https://www.gnu.org/software/gettext/manual/html_node/msgfmt-Invocation.html), [proselint](http://proselint.com/), [write-good](https://github.com/btford/write-good) |

--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -180,6 +180,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['haskell'],
 \       'description': 'Refactor Haskell files with stylish-haskell.',
 \   },
+\   'ocamlformat': {
+\       'function': 'ale#fixers#ocamlformat#Fix',
+\       'suggested_filetypes': ['ocaml'],
+\       'description': 'Fix OCaml files with ocamlformat.',
+\   },
 \   'refmt': {
 \       'function': 'ale#fixers#refmt#Fix',
 \       'suggested_filetypes': ['reason'],

--- a/autoload/ale/fixers/ocamlformat.vim
+++ b/autoload/ale/fixers/ocamlformat.vim
@@ -1,0 +1,18 @@
+" Author: Stephen Lumenta <@sbl>
+" Description: Integration of ocamlformat with ALE.
+
+call ale#Set('ocaml_ocamlformat_executable', 'ocamlformat')
+call ale#Set('ocaml_ocamlformat_options', '')
+
+function! ale#fixers#ocamlformat#Fix(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'ocaml_ocamlformat_executable')
+    let l:options = ale#Var(a:buffer, 'ocaml_ocamlformat_options')
+
+    return {
+    \   'command': ale#Escape(l:executable)
+    \       . (empty(l:options) ? '' : ' ' . l:options)
+    \       . ' --inplace'
+    \       . ' %t',
+    \   'read_temporary_file': 1,
+    \}
+endfunction

--- a/doc/ale-ocaml.txt
+++ b/doc/ale-ocaml.txt
@@ -34,4 +34,21 @@ g:ale_ocaml_ols_use_global                         *g:ale_ocaml_ols_use_global*
   executable. See also |ale-integrations-local-executables|.
 
 ===============================================================================
+ocamlformat                                             *ale-ocaml-ocamlformat*
+
+g:ale_ocaml_ocamlformat_executable         *g:ale_ocaml_ocamlformat_executable*
+                                           *b:ale_ocaml_ocamlformat_executable*
+  Type: |String|
+  Default: `'ocamlformat'`
+
+  This variable can be set to pass the path of the ocamlformat fixer.
+
+g:ale_ocaml_ocamlformat_options               *g:ale_ocaml_ocamlformat_options*
+                                              *b:ale_ocaml_ocamlformat_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be set to pass additional options to the ocamlformat fixer.
+
+===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -179,6 +179,7 @@ CONTENTS                                                         *ale-contents*
     ocaml.................................|ale-ocaml-options|
       merlin..............................|ale-ocaml-merlin|
       ols.................................|ale-ocaml-ols|
+      ocamlformat.........................|ale-ocaml-ocamlformat|
     perl..................................|ale-perl-options|
       perl................................|ale-perl-perl|
       perlcritic..........................|ale-perl-perlcritic|
@@ -406,7 +407,7 @@ Notes:
 * nroff: `alex`!!, `proselint`, `write-good`
 * Objective-C: `clang`, `clangd`
 * Objective-C++: `clang`, `clangd`
-* OCaml: `merlin` (see |ale-ocaml-merlin|), `ols`
+* OCaml: `merlin` (see |ale-ocaml-merlin|), `ols`, `ocamlformat`
 * Perl: `perl -c`, `perl-critic`, `perltidy`
 * PHP: `langserver`, `phan`, `php -l`, `phpcs`, `phpmd`, `phpstan`, `phpcbf`, `php-cs-fixer`
 * PO: `alex`!!, `msgfmt`, `proselint`, `write-good`

--- a/test/fixers/test_ocamlformat_fixer_callback.vader
+++ b/test/fixers/test_ocamlformat_fixer_callback.vader
@@ -23,7 +23,7 @@ Execute(The ocamlformat callback should return the correct default values):
   \     . ' --inplace'
   \     . ' %t',
   \ },
-  \ ale#fixers#ocamlformat(bufnr(''))
+  \ ale#fixers#ocamlformat#Fix(bufnr(''))
 
 Execute(The ocamlformat callback should include custom ocamlformat options):
   let g:ale_ocaml_ocamlformat_options = "-m 78"
@@ -37,4 +37,4 @@ Execute(The ocamlformat callback should include custom ocamlformat options):
   \     . ' --inplace'
   \     . ' %t',
   \ },
-  \ ale#fixers#ocamlformat(bufnr(''))
+  \ ale#fixers#ocamlformat#Fix(bufnr(''))

--- a/test/fixers/test_ocamlformat_fixer_callback.vader
+++ b/test/fixers/test_ocamlformat_fixer_callback.vader
@@ -1,0 +1,40 @@
+Before:
+  Save g:ale_ocaml_ocamlformat_executable
+  Save g:ale_ocaml_ocamlformat_options
+
+  " Use an invalid global executable, so we don't match it.
+  let g:ale_ocaml_ocamlformat_executable = 'xxxinvalid'
+  let g:ale_ocaml_ocamlformat_options = ''
+
+  call ale#test#SetDirectory('/testplugin/test/fixers')
+
+After:
+  Restore
+
+  call ale#test#RestoreDirectory()
+
+Execute(The ocamlformat callback should return the correct default values):
+  call ale#test#SetFilename('../ocaml-test-files/testfile.re')
+
+  AssertEqual
+  \ {
+  \   'read_temporary_file': 1,
+  \   'command': ale#Escape('xxxinvalid')
+  \     . ' --inplace'
+  \     . ' %t',
+  \ },
+  \ ale#fixers#ocamlformat(bufnr(''))
+
+Execute(The ocamlformat callback should include custom ocamlformat options):
+  let g:ale_ocaml_ocamlformat_options = "-m 78"
+  call ale#test#SetFilename('../ocaml-test-files/testfile.re')
+
+  AssertEqual
+  \ {
+  \   'read_temporary_file': 1,
+  \   'command': ale#Escape('xxxinvalid')
+  \     . ' ' . g:ale_ocaml_ocamlformat_options
+  \     . ' --inplace'
+  \     . ' %t',
+  \ },
+  \ ale#fixers#ocamlformat(bufnr(''))


### PR DESCRIPTION
This PR adds fixer support for [ocamlformat](https://github.com/ocaml-ppx/ocamlformat) for `ocaml`.