### PR TITLE
Support options for puppet parser validate

### DIFF
--- a/ale_linters/puppet/puppet.vim
+++ b/ale_linters/puppet/puppet.vim
@@ -1,5 +1,8 @@
 " Author: Alexander Olofsson <alexander.olofsson@liu.se>
 
+call ale#Set('puppet_puppet_executable', 'puppet')
+call ale#Set('puppet_puppet_options', '--color=false')
+
 function! ale_linters#puppet#puppet#Handle(buffer, lines) abort
     " Matches patterns like the following:
     " Error: Could not parse for environment production: Syntax error at ':' at /root/puppetcode/modules/nginx/manifests/init.pp:43:12
@@ -20,10 +23,16 @@ function! ale_linters#puppet#puppet#Handle(buffer, lines) abort
     return l:output
 endfunction
 
+function! ale_linters#puppet#puppet#GetCommand(buffer) abort
+    return '%e parser validate '
+    \    . ale#Pad(ale#Var(a:buffer, 'puppet_puppet_options'))
+    \    . ' %t'
+endfunction
+
 call ale#linter#Define('puppet', {
 \   'name': 'puppet',
-\   'executable': 'puppet',
+\   'executable_callback': ale#VarFunc('puppet_puppet_executable'),
 \   'output_stream': 'stderr',
-\   'command': 'puppet parser validate --color=false %t',
+\   'command_callback': 'ale_linters#puppet#puppet#GetCommand',
 \   'callback': 'ale_linters#puppet#puppet#Handle',
 \})

--- a/doc/ale-puppet.txt
+++ b/doc/ale-puppet.txt
@@ -3,6 +3,26 @@ ALE Puppet Integration                                     *ale-puppet-options*
 
 
 ===============================================================================
+puppet                                                      *ale-puppet-puppet*
+
+g:ale_puppet_puppet_executable                 *g:ale_puppet_puppet_executable*
+                                               *b:ale_puppet_puppet_executable*
+  Type: |String|
+  Default: `'puppet'`
+
+  This variable can be changed to specify the executable used for puppet.
+
+
+g:ale_puppet_puppet_options                       *g:ale_puppet_puppet_options*
+                                                  *b:ale_puppet_puppet_options*
+  Type: |String|
+  Default: `'--color=false'`
+
+  This variable can be changed to add command-line arguments to the
+  puppet parser validate invocation.
+
+
+===============================================================================
 puppetlint                                              *ale-puppet-puppetlint*
 
 g:ale_puppet_puppetlint_executable         *g:ale_puppet_puppetlint_executable*


### PR DESCRIPTION
It can be necessary to pass options to the puppet parser validation. The
most glaring example of this is when using Puppet 3, with the
`parser = future` option enabled. This update allows adding
`--parser=future` to the options passed to Puppet.