### PR TITLE
Replace removed function in dart#language_server

### DIFF
--- a/ale_linters/dart/language_server.vim
+++ b/ale_linters/dart/language_server.vim
@@ -15,6 +15,6 @@ call ale#linter#Define('dart', {
 \   'name': 'language_server',
 \   'lsp': 'stdio',
 \   'executable_callback': ale#VarFunc('dart_language_server_executable'),
-\   'command_callback': 'ale_linters#dart#language_server#GetExecutable',
+\   'command_callback': ale#VarFunc('dart_language_server_executable'),
 \   'project_root_callback': 'ale_linters#dart#language_server#GetProjectRoot',
 \})


### PR DESCRIPTION
Replaces removed `ale_linters#dart#language_server#GetExecutable`.

Fixes #1881

<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-development`.

Have fun!
-->
