### PR TITLE
add uncrustify fixer for several languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,8 +185,8 @@ formatting.
 | Text^ | [alex](https://github.com/wooorm/alex) !!, [proselint](http://proselint.com/), [redpen](http://redpen.cc/), [textlint](https://textlint.github.io/), [vale](https://github.com/ValeLint/vale), [write-good](https://github.com/btford/write-good) |
 | Thrift | [thrift](http://thrift.apache.org/) |
 | TypeScript | [eslint](http://eslint.org/), [prettier](https://github.com/prettier/prettier), [tslint](https://github.com/palantir/tslint), tsserver, typecheck |
-| Verilog | [iverilog](https://github.com/steveicarus/iverilog), [verilator](http://www.veripool.org/projects/verilator/wiki/Intro) |
 | VALA | [uncrustify](https://github.com/uncrustify/uncrustify) |
+| Verilog | [iverilog](https://github.com/steveicarus/iverilog), [verilator](http://www.veripool.org/projects/verilator/wiki/Intro) |
 | Vim | [vint](https://github.com/Kuniwak/vint) |
 | Vim help^ | [alex](https://github.com/wooorm/alex) !!, [proselint](http://proselint.com/), [write-good](https://github.com/btford/write-good) |
 | Vue | [prettier](https://github.com/prettier/prettier), [vls](https://github.com/vuejs/vetur/tree/master/server) |

--- a/README.md
+++ b/README.md
@@ -97,10 +97,10 @@ formatting.
 | Awk | [gawk](https://www.gnu.org/software/gawk/)|
 | Bash | [language-server](https://github.com/mads-hartmann/bash-language-server), shell [-n flag](https://www.gnu.org/software/bash/manual/bash.html#index-set), [shellcheck](https://www.shellcheck.net/), [shfmt](https://github.com/mvdan/sh) |
 | Bourne Shell | shell [-n flag](http://linux.die.net/man/1/sh), [shellcheck](https://www.shellcheck.net/), [shfmt](https://github.com/mvdan/sh) |
-| C | [cppcheck](http://cppcheck.sourceforge.net), [cpplint](https://github.com/google/styleguide/tree/gh-pages/cpplint), [clang](http://clang.llvm.org/), [clangd](https://clang.llvm.org/extra/clangd.html), [clangtidy](http://clang.llvm.org/extra/clang-tidy/) !!, [clang-format](https://clang.llvm.org/docs/ClangFormat.html), [cquery](https://github.com/cquery-project/cquery), [flawfinder](https://www.dwheeler.com/flawfinder/), [gcc](https://gcc.gnu.org/) |
-| C++ (filetype cpp) | [clang](http://clang.llvm.org/), [clangd](https://clang.llvm.org/extra/clangd.html), [clangcheck](http://clang.llvm.org/docs/ClangCheck.html) !!, [clangtidy](http://clang.llvm.org/extra/clang-tidy/) !!, [clang-format](https://clang.llvm.org/docs/ClangFormat.html), [clazy](https://github.com/KDE/clazy) !!, [cppcheck](http://cppcheck.sourceforge.net), [cpplint](https://github.com/google/styleguide/tree/gh-pages/cpplint) !!, [cquery](https://github.com/cquery-project/cquery), [flawfinder](https://www.dwheeler.com/flawfinder/), [gcc](https://gcc.gnu.org/) |
+| C | [cppcheck](http://cppcheck.sourceforge.net), [cpplint](https://github.com/google/styleguide/tree/gh-pages/cpplint), [clang](http://clang.llvm.org/), [clangd](https://clang.llvm.org/extra/clangd.html), [clangtidy](http://clang.llvm.org/extra/clang-tidy/) !!, [clang-format](https://clang.llvm.org/docs/ClangFormat.html), [cquery](https://github.com/cquery-project/cquery), [flawfinder](https://www.dwheeler.com/flawfinder/), [gcc](https://gcc.gnu.org/), [uncrustify](https://github.com/uncrustify/uncrustify) |
+| C++ (filetype cpp) | [clang](http://clang.llvm.org/), [clangd](https://clang.llvm.org/extra/clangd.html), [clangcheck](http://clang.llvm.org/docs/ClangCheck.html) !!, [clangtidy](http://clang.llvm.org/extra/clang-tidy/) !!, [clang-format](https://clang.llvm.org/docs/ClangFormat.html), [clazy](https://github.com/KDE/clazy) !!, [cppcheck](http://cppcheck.sourceforge.net), [cpplint](https://github.com/google/styleguide/tree/gh-pages/cpplint) !!, [cquery](https://github.com/cquery-project/cquery), [flawfinder](https://www.dwheeler.com/flawfinder/), [gcc](https://gcc.gnu.org/), [uncrustify](https://github.com/uncrustify/uncrustify) |
 | CUDA | [nvcc](http://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html) |
-| C# | [mcs](http://www.mono-project.com/docs/about-mono/languages/csharp/) see:`help ale-cs-mcs` for details, [mcsc](http://www.mono-project.com/docs/about-mono/languages/csharp/) !! see:`help ale-cs-mcsc` for details and configuration|
+| C# | [mcs](http://www.mono-project.com/docs/about-mono/languages/csharp/) see:`help ale-cs-mcs` for details, [mcsc](http://www.mono-project.com/docs/about-mono/languages/csharp/) !! see:`help ale-cs-mcsc` for details and configuration, [uncrustify](https://github.com/uncrustify/uncrustify) |
 | Chef | [foodcritic](http://www.foodcritic.io/) |
 | Clojure | [joker](https://github.com/candid82/joker) |
 | CloudFormation | [cfn-python-lint](https://github.com/awslabs/cfn-python-lint) |
@@ -110,7 +110,7 @@ formatting.
 | CSS | [csslint](http://csslint.net/), [prettier](https://github.com/prettier/prettier), [stylelint](https://github.com/stylelint/stylelint) |
 | Cucumber | [cucumber](https://cucumber.io/) |
 | Cython (pyrex filetype) | [cython](http://cython.org/) |
-| D | [dmd](https://dlang.org/dmd-linux.html) |
+| D | [dmd](https://dlang.org/dmd-linux.html), [uncrustify](https://github.com/uncrustify/uncrustify) |
 | Dafny | [dafny](https://rise4fun.com/Dafny) !! |
 | Dart | [dartanalyzer](https://github.com/dart-lang/sdk/tree/master/pkg/analyzer_cli) !!, [language_server](https://github.com/natebosch/dart_language_server), [dartfmt](https://github.com/dart-lang/sdk/tree/master/utils/dartfmt) |
 | Dockerfile | [hadolint](https://github.com/hadolint/hadolint) |
@@ -132,7 +132,7 @@ formatting.
 | Haskell | [brittany](https://github.com/lspitzner/brittany), [ghc](https://www.haskell.org/ghc/), [cabal-ghc](https://www.haskell.org/cabal/), [stylish-haskell](https://github.com/jaspervdj/stylish-haskell), [stack-ghc](https://haskellstack.org/), [stack-build](https://haskellstack.org/) !!, [ghc-mod](https://github.com/DanielG/ghc-mod), [stack-ghc-mod](https://github.com/DanielG/ghc-mod), [hlint](https://hackage.haskell.org/package/hlint), [hdevtools](https://hackage.haskell.org/package/hdevtools), [hfmt](https://github.com/danstiner/hfmt), [hie](https://github.com/haskell/haskell-ide-engine) |
 | HTML | [alex](https://github.com/wooorm/alex) !!, [HTMLHint](http://htmlhint.com/), [proselint](http://proselint.com/), [tidy](http://www.html-tidy.org/), [write-good](https://github.com/btford/write-good) |
 | Idris | [idris](http://www.idris-lang.org/) |
-| Java | [checkstyle](http://checkstyle.sourceforge.net), [javac](http://www.oracle.com/technetwork/java/javase/downloads/index.html), [google-java-format](https://github.com/google/google-java-format), [PMD](https://pmd.github.io/), [javalsp](https://github.com/georgewfraser/vscode-javac) |
+| Java | [checkstyle](http://checkstyle.sourceforge.net), [javac](http://www.oracle.com/technetwork/java/javase/downloads/index.html), [google-java-format](https://github.com/google/google-java-format), [PMD](https://pmd.github.io/), [javalsp](https://github.com/georgewfraser/vscode-javac), [uncrustify](https://github.com/uncrustify/uncrustify) |
 | JavaScript | [eslint](http://eslint.org/), [flow](https://flowtype.org/), [jscs](http://jscs.info/), [jshint](http://jshint.com/), [prettier](https://github.com/prettier/prettier), [prettier-eslint](https://github.com/prettier/prettier-eslint-cli), [prettier-standard](https://github.com/sheerun/prettier-standard), [standard](http://standardjs.com/), [xo](https://github.com/sindresorhus/xo)
 | JSON | [fixjson](https://github.com/rhysd/fixjson), [jsonlint](http://zaa.ch/jsonlint/), [jq](https://stedolan.github.io/jq/), [prettier](https://github.com/prettier/prettier) |
 | Kotlin | [kotlinc](https://kotlinlang.org) !!, [ktlint](https://ktlint.github.io) !!, [languageserver](https://github.com/fwcd/KotlinLanguageServer) see `:help ale-integration-kotlin` for configuration instructions |
@@ -149,8 +149,8 @@ formatting.
 | Nim | [nim check](https://nim-lang.org/docs/nimc.html) !! |
 | nix | [nix-instantiate](http://nixos.org/nix/manual/#sec-nix-instantiate) |
 | nroff | [alex](https://github.com/wooorm/alex) !!, [proselint](http://proselint.com/), [write-good](https://github.com/btford/write-good)|
-| Objective-C | [clang](http://clang.llvm.org/), [clangd](https://clang.llvm.org/extra/clangd.html) |
-| Objective-C++ | [clang](http://clang.llvm.org/), [clangd](https://clang.llvm.org/extra/clangd.html) |
+| Objective-C | [clang](http://clang.llvm.org/), [clangd](https://clang.llvm.org/extra/clangd.html), [uncrustify](https://github.com/uncrustify/uncrustify) |
+| Objective-C++ | [clang](http://clang.llvm.org/), [clangd](https://clang.llvm.org/extra/clangd.html), [uncrustify](https://github.com/uncrustify/uncrustify) |
 | OCaml | [merlin](https://github.com/the-lambda-church/merlin) see `:help ale-ocaml-merlin` for configuration instructions, [ols](https://github.com/freebroccolo/ocaml-language-server), [ocamlformat](https://github.com/ocaml-ppx/ocamlformat) |
 | Perl | [perl -c](https://perl.org/), [perl-critic](https://metacpan.org/pod/Perl::Critic), [perltidy](https://metacpan.org/pod/distribution/Perl-Tidy/bin/perltidy) |
 | PHP | [langserver](https://github.com/felixfbecker/php-language-server), [phan](https://github.com/phan/phan) see `:help ale-php-phan` to instructions, [php -l](https://secure.php.net/), [phpcs](https://github.com/squizlabs/PHP_CodeSniffer), [phpmd](https://phpmd.org), [phpstan](https://github.com/phpstan/phpstan), [phpcbf](https://github.com/squizlabs/PHP_CodeSniffer), [php-cs-fixer](http://cs.sensiolabs.org/) |

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ formatting.
 | Objective-C | [clang](http://clang.llvm.org/), [clangd](https://clang.llvm.org/extra/clangd.html), [uncrustify](https://github.com/uncrustify/uncrustify) |
 | Objective-C++ | [clang](http://clang.llvm.org/), [clangd](https://clang.llvm.org/extra/clangd.html), [uncrustify](https://github.com/uncrustify/uncrustify) |
 | OCaml | [merlin](https://github.com/the-lambda-church/merlin) see `:help ale-ocaml-merlin` for configuration instructions, [ols](https://github.com/freebroccolo/ocaml-language-server), [ocamlformat](https://github.com/ocaml-ppx/ocamlformat) |
+| Pawn | [uncrustify](https://github.com/uncrustify/uncrustify) |
 | Perl | [perl -c](https://perl.org/), [perl-critic](https://metacpan.org/pod/Perl::Critic), [perltidy](https://metacpan.org/pod/distribution/Perl-Tidy/bin/perltidy) |
 | PHP | [langserver](https://github.com/felixfbecker/php-language-server), [phan](https://github.com/phan/phan) see `:help ale-php-phan` to instructions, [php -l](https://secure.php.net/), [phpcs](https://github.com/squizlabs/PHP_CodeSniffer), [phpmd](https://phpmd.org), [phpstan](https://github.com/phpstan/phpstan), [phpcbf](https://github.com/squizlabs/PHP_CodeSniffer), [php-cs-fixer](http://cs.sensiolabs.org/) |
 | PO | [alex](https://github.com/wooorm/alex) !!, [msgfmt](https://www.gnu.org/software/gettext/manual/html_node/msgfmt-Invocation.html), [proselint](http://proselint.com/), [write-good](https://github.com/btford/write-good) |
@@ -185,6 +186,7 @@ formatting.
 | Thrift | [thrift](http://thrift.apache.org/) |
 | TypeScript | [eslint](http://eslint.org/), [prettier](https://github.com/prettier/prettier), [tslint](https://github.com/palantir/tslint), tsserver, typecheck |
 | Verilog | [iverilog](https://github.com/steveicarus/iverilog), [verilator](http://www.veripool.org/projects/verilator/wiki/Intro) |
+| VALA | [uncrustify](https://github.com/uncrustify/uncrustify) |
 | Vim | [vint](https://github.com/Kuniwak/vint) |
 | Vim help^ | [alex](https://github.com/wooorm/alex) !!, [proselint](http://proselint.com/), [write-good](https://github.com/btford/write-good) |
 | Vue | [prettier](https://github.com/prettier/prettier), [vls](https://github.com/vuejs/vetur/tree/master/server) |

--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -235,6 +235,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['xml'],
 \       'description': 'Fix XML files with xmllint.',
 \   },
+\   'uncrustify': {
+\       'function': 'ale#fixers#uncrustify#Fix',
+\       'suggested_filetypes': ['c', 'cpp', 'cs', 'objc', 'objcpp', 'd', 'java', 'p', 'vala' ],
+\       'description': 'Fix C, C++, C#, ObjectiveC, ObjectiveC++, D, Java, Pawn, and VALA files with uncrustify.',
+\   },
 \}
 
 " Reset the function registry to the default entries.

--- a/autoload/ale/fixers/uncrustify.vim
+++ b/autoload/ale/fixers/uncrustify.vim
@@ -1,0 +1,16 @@
+" Author: Derek P Sifford <dereksifford@gmail.com>
+" Description: Fixer for C, C++, C#, ObjectiveC, D, Java, Pawn, and VALA.
+
+call ale#Set('c_uncrustify_executable', 'uncrustify')
+call ale#Set('c_uncrustify_options', '')
+
+function! ale#fixers#uncrustify#Fix(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'c_uncrustify_executable')
+    let l:options = ale#Var(a:buffer, 'c_uncrustify_options')
+
+    return {
+    \   'command': ale#Escape(l:executable)
+    \       . ' --no-backup'
+    \       . (empty(l:options) ? '' : ' ' . l:options)
+    \}
+endfunction

--- a/doc/ale-c.txt
+++ b/doc/ale-c.txt
@@ -263,4 +263,23 @@ g:ale_c_gcc_options                                       *g:ale_c_gcc_options*
 
 
 ===============================================================================
+uncrustify                                                   *ale-c-uncrustify*
+
+g:ale_c_uncrustify_executable                   *g:ale_c_uncrustify_executable*
+                                                *b:ale_c_uncrustify_executable*
+  Type: |String|
+  Default: `'uncrustify'`
+
+  This variable can be changed to use a different executable for uncrustify.
+
+
+g:ale_c_uncrustify_options                         *g:ale_c_uncrustify_options*
+                                                   *b:ale_c_uncrustify_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be change to modify flags given to uncrustify.
+
+
+===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-cpp.txt
+++ b/doc/ale-cpp.txt
@@ -274,4 +274,10 @@ g:ale_cpp_gcc_options                                   *g:ale_cpp_gcc_options*
 
 
 ===============================================================================
+uncrustify                                                 *ale-cpp-uncrustify*
+
+See |ale-c-uncrustify| for information about the available options.
+
+
+===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-cs.txt
+++ b/doc/ale-cs.txt
@@ -99,4 +99,10 @@ g:ale_cs_mcsc_assemblies                             *g:ale_cs_mcsc_assemblies*
 <
 
 ===============================================================================
+uncrustify                                                  *ale-cs-uncrustify*
+
+See |ale-c-uncrustify| for information about the available options.
+
+
+===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-d.txt
+++ b/doc/ale-d.txt
@@ -1,0 +1,12 @@
+===============================================================================
+ALE D Integration                                               *ale-d-options*
+
+
+===============================================================================
+uncrustify                                                   *ale-d-uncrustify*
+
+See |ale-c-uncrustify| for information about the available options.
+
+
+===============================================================================
+vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-java.txt
+++ b/doc/ale-java.txt
@@ -99,4 +99,10 @@ g:ale_java_javalsp_jar                                 *g:ale_java_javalsp_jar*
 
 
 ===============================================================================
+uncrustify                                                *ale-java-uncrustify*
+
+See |ale-c-uncrustify| for information about the available options.
+
+
+===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-objc.txt
+++ b/doc/ale-objc.txt
@@ -33,4 +33,10 @@ g:ale_objc_clangd_options                           *g:ale_objc_clangd_options*
 
 
 ===============================================================================
+uncrustify                                                *ale-objc-uncrustify*
+
+See |ale-c-uncrustify| for information about the available options.
+
+
+===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-objcpp.txt
+++ b/doc/ale-objcpp.txt
@@ -33,4 +33,10 @@ g:ale_objcpp_clangd_options                       *g:ale_objcpp_clangd_options*
 
 
 ===============================================================================
+uncrustify                                                *ale-objc-uncrustify*
+
+See |ale-c-uncrustify| for information about the available options.
+
+
+===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-objcpp.txt
+++ b/doc/ale-objcpp.txt
@@ -33,7 +33,7 @@ g:ale_objcpp_clangd_options                       *g:ale_objcpp_clangd_options*
 
 
 ===============================================================================
-uncrustify                                                *ale-objc-uncrustify*
+uncrustify                                              *ale-objcpp-uncrustify*
 
 See |ale-c-uncrustify| for information about the available options.
 

--- a/doc/ale-pawn.txt
+++ b/doc/ale-pawn.txt
@@ -1,0 +1,12 @@
+===============================================================================
+ALE Pawn Integration                                         *ale-pawn-options*
+
+
+===============================================================================
+uncrustify                                                *ale-pawn-uncrustify*
+
+See |ale-c-uncrustify| for information about the available options.
+
+
+===============================================================================
+vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-vala.txt
+++ b/doc/ale-vala.txt
@@ -1,0 +1,12 @@
+===============================================================================
+ALE VALA Integration                                         *ale-vala-options*
+
+
+===============================================================================
+uncrustify                                                *ale-vala-uncrustify*
+
+See |ale-c-uncrustify| for information about the available options.
+
+
+===============================================================================
+vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -34,8 +34,6 @@ CONTENTS                                                         *ale-contents*
       flawfinder..........................|ale-c-flawfinder|
       gcc.................................|ale-c-gcc|
       uncrustify..........................|ale-c-uncrustify|
-    d.....................................|ale-d-options|
-      uncrustify..........................|ale-d-uncrustify|
     chef..................................|ale-chef-options|
       foodcritic..........................|ale-chef-foodcritic|
     clojure...............................|ale-clojure-options|
@@ -67,6 +65,7 @@ CONTENTS                                                         *ale-contents*
     cuda..................................|ale-cuda-options|
       nvcc................................|ale-cuda-nvcc|
     d.....................................|ale-d-options|
+      uncrustify..........................|ale-d-uncrustify|
     dart..................................|ale-dart-options|
       dartanalyzer........................|ale-dart-dartanalyzer|
       dartfmt.............................|ale-dart-dartfmt|

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -33,6 +33,7 @@ CONTENTS                                                         *ale-contents*
       cquery..............................|ale-c-cquery|
       flawfinder..........................|ale-c-flawfinder|
       gcc.................................|ale-c-gcc|
+      uncrustify..........................|ale-c-uncrustify|
     chef..................................|ale-chef-options|
       foodcritic..........................|ale-chef-foodcritic|
     clojure...............................|ale-clojure-options|
@@ -53,14 +54,17 @@ CONTENTS                                                         *ale-contents*
       cquery..............................|ale-cpp-cquery|
       flawfinder..........................|ale-cpp-flawfinder|
       gcc.................................|ale-cpp-gcc|
+      uncrustify..........................|ale-c-uncrustify|
     c#....................................|ale-cs-options|
       mcs.................................|ale-cs-mcs|
       mcsc................................|ale-cs-mcsc|
+      uncrustify..........................|ale-c-uncrustify|
     css...................................|ale-css-options|
       prettier............................|ale-css-prettier|
       stylelint...........................|ale-css-stylelint|
     cuda..................................|ale-cuda-options|
       nvcc................................|ale-cuda-nvcc|
+    d.....................................|ale-d-options|
     dart..................................|ale-dart-options|
       dartanalyzer........................|ale-dart-dartanalyzer|
       dartfmt.............................|ale-dart-dartfmt|
@@ -128,6 +132,7 @@ CONTENTS                                                         *ale-contents*
       google-java-format..................|ale-java-google-java-format|
       pmd.................................|ale-java-pmd|
       javalsp.............................|ale-java-javalsp|
+      uncrustify..........................|ale-c-uncrustify|
     javascript............................|ale-javascript-options|
       eslint..............................|ale-javascript-eslint|
       flow................................|ale-javascript-flow|
@@ -174,6 +179,7 @@ CONTENTS                                                         *ale-contents*
     objc..................................|ale-objc-options|
       clang...............................|ale-objc-clang|
       clangd..............................|ale-objc-clangd|
+      uncrustify..........................|ale-c-uncrustify|
     objcpp................................|ale-objcpp-options|
       clang...............................|ale-objcpp-clang|
       clangd..............................|ale-objcpp-clangd|
@@ -181,6 +187,7 @@ CONTENTS                                                         *ale-contents*
       merlin..............................|ale-ocaml-merlin|
       ols.................................|ale-ocaml-ols|
       ocamlformat.........................|ale-ocaml-ocamlformat|
+    pawn..................................|ale-pawn-options|
     perl..................................|ale-perl-options|
       perl................................|ale-perl-perl|
       perlcritic..........................|ale-perl-perlcritic|
@@ -288,6 +295,7 @@ CONTENTS                                                         *ale-contents*
       prettier............................|ale-typescript-prettier|
       tslint..............................|ale-typescript-tslint|
       tsserver............................|ale-typescript-tsserver|
+    vala..................................|ale-vala-options|
     verilog/systemverilog.................|ale-verilog-options|
       iverilog............................|ale-verilog-iverilog|
       verilator...........................|ale-verilog-verilator|
@@ -357,10 +365,10 @@ Notes:
 * Awk: `gawk`
 * Bash: `language-server`, `shell` (-n flag), `shellcheck`, `shfmt`
 * Bourne Shell: `shell` (-n flag), `shellcheck`, `shfmt`
-* C: `cppcheck`, `cpplint`!!, `clang`, `clangd`, `clangtidy`!!, `clang-format`, `cquery`, `flawfinder`, `gcc`
-* C++ (filetype cpp): `clang`, `clangd`, `clangcheck`!!, `clangtidy`!!, `clang-format`, `clazy`!!, `cppcheck`, `cpplint`!!, `cquery`, `flawfinder`, `gcc`
+* C: `cppcheck`, `cpplint`!!, `clang`, `clangd`, `clangtidy`!!, `clang-format`, `cquery`, `flawfinder`, `gcc`, `uncrustify`
+* C++ (filetype cpp): `clang`, `clangd`, `clangcheck`!!, `clangtidy`!!, `clang-format`, `clazy`!!, `cppcheck`, `cpplint`!!, `cquery`, `flawfinder`, `gcc`, `uncrustify`
 * CUDA: `nvcc`!!
-* C#: `mcs`, `mcsc`!!
+* C#: `mcs`, `mcsc`!!, `uncrustify`
 * Chef: `foodcritic`
 * Clojure: `joker`
 * CloudFormation: `cfn-python-lint`
@@ -370,7 +378,7 @@ Notes:
 * CSS: `csslint`, `prettier`, `stylelint`
 * Cucumber: `cucumber`
 * Cython (pyrex filetype): `cython`
-* D: `dmd`
+* D: `dmd`, `uncrustify`
 * Dafny: `dafny`!!
 * Dart: `dartanalyzer`!!, `language_server`, dartfmt!!
 * Dockerfile: `hadolint`
@@ -392,7 +400,7 @@ Notes:
 * Haskell: `brittany`, `ghc`, `cabal-ghc`, `stylish-haskell`, `stack-ghc`, `stack-build`!!, `ghc-mod`, `stack-ghc-mod`, `hlint`, `hdevtools`, `hfmt`, `hie`
 * HTML: `alex`!!, `HTMLHint`, `proselint`, `tidy`, `write-good`
 * Idris: `idris`
-* Java: `checkstyle`, `javac`, `google-java-format`, `PMD`, `javalsp`
+* Java: `checkstyle`, `javac`, `google-java-format`, `PMD`, `javalsp`, `uncrustify`
 * JavaScript: `eslint`, `flow`, `jscs`, `jshint`, `prettier`, `prettier-eslint`, `prettier-standard`, `standard`, `xo`
 * JSON: `fixjson`, `jsonlint`, `jq`, `prettier`
 * Kotlin: `kotlinc`!!, `ktlint`!!, `languageserver`
@@ -409,9 +417,10 @@ Notes:
 * Nim: `nim check`!!
 * nix: `nix-instantiate`
 * nroff: `alex`!!, `proselint`, `write-good`
-* Objective-C: `clang`, `clangd`
+* Objective-C: `clang`, `clangd`, `uncrustify`
 * Objective-C++: `clang`, `clangd`
 * OCaml: `merlin` (see |ale-ocaml-merlin|), `ols`, `ocamlformat`
+* Pawn: `uncrustify`
 * Perl: `perl -c`, `perl-critic`, `perltidy`
 * PHP: `langserver`, `phan`, `php -l`, `phpcs`, `phpmd`, `phpstan`, `phpcbf`, `php-cs-fixer`
 * PO: `alex`!!, `msgfmt`, `proselint`, `write-good`
@@ -444,6 +453,7 @@ Notes:
 * Text^: `alex`!!, `proselint`, `redpen`, `textlint`, `vale`, `write-good`
 * Thrift: `thrift`
 * TypeScript: `eslint`, `prettier`, `tslint`, `tsserver`, `typecheck`
+* VALA: `uncrustify`
 * Verilog: `iverilog`, `verilator`
 * Vim: `vint`
 * Vim help^: `alex`!!, `proselint`, `write-good`

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -34,6 +34,8 @@ CONTENTS                                                         *ale-contents*
       flawfinder..........................|ale-c-flawfinder|
       gcc.................................|ale-c-gcc|
       uncrustify..........................|ale-c-uncrustify|
+    d.....................................|ale-d-options|
+      uncrustify..........................|ale-d-uncrustify|
     chef..................................|ale-chef-options|
       foodcritic..........................|ale-chef-foodcritic|
     clojure...............................|ale-clojure-options|
@@ -54,11 +56,11 @@ CONTENTS                                                         *ale-contents*
       cquery..............................|ale-cpp-cquery|
       flawfinder..........................|ale-cpp-flawfinder|
       gcc.................................|ale-cpp-gcc|
-      uncrustify..........................|ale-c-uncrustify|
+      uncrustify..........................|ale-cpp-uncrustify|
     c#....................................|ale-cs-options|
       mcs.................................|ale-cs-mcs|
       mcsc................................|ale-cs-mcsc|
-      uncrustify..........................|ale-c-uncrustify|
+      uncrustify..........................|ale-cs-uncrustify|
     css...................................|ale-css-options|
       prettier............................|ale-css-prettier|
       stylelint...........................|ale-css-stylelint|
@@ -132,7 +134,7 @@ CONTENTS                                                         *ale-contents*
       google-java-format..................|ale-java-google-java-format|
       pmd.................................|ale-java-pmd|
       javalsp.............................|ale-java-javalsp|
-      uncrustify..........................|ale-c-uncrustify|
+      uncrustify..........................|ale-java-uncrustify|
     javascript............................|ale-javascript-options|
       eslint..............................|ale-javascript-eslint|
       flow................................|ale-javascript-flow|
@@ -179,15 +181,17 @@ CONTENTS                                                         *ale-contents*
     objc..................................|ale-objc-options|
       clang...............................|ale-objc-clang|
       clangd..............................|ale-objc-clangd|
-      uncrustify..........................|ale-c-uncrustify|
+      uncrustify..........................|ale-objc-uncrustify|
     objcpp................................|ale-objcpp-options|
       clang...............................|ale-objcpp-clang|
       clangd..............................|ale-objcpp-clangd|
+      uncrustify..........................|ale-objcpp-uncrustify|
     ocaml.................................|ale-ocaml-options|
       merlin..............................|ale-ocaml-merlin|
       ols.................................|ale-ocaml-ols|
       ocamlformat.........................|ale-ocaml-ocamlformat|
     pawn..................................|ale-pawn-options|
+      uncrustify..........................|ale-pawn-uncrustify|
     perl..................................|ale-perl-options|
       perl................................|ale-perl-perl|
       perlcritic..........................|ale-perl-perlcritic|
@@ -296,6 +300,7 @@ CONTENTS                                                         *ale-contents*
       tslint..............................|ale-typescript-tslint|
       tsserver............................|ale-typescript-tsserver|
     vala..................................|ale-vala-options|
+      uncrustify..........................|ale-vala-uncrustify|
     verilog/systemverilog.................|ale-verilog-options|
       iverilog............................|ale-verilog-iverilog|
       verilator...........................|ale-verilog-verilator|
@@ -418,7 +423,7 @@ Notes:
 * nix: `nix-instantiate`
 * nroff: `alex`!!, `proselint`, `write-good`
 * Objective-C: `clang`, `clangd`, `uncrustify`
-* Objective-C++: `clang`, `clangd`
+* Objective-C++: `clang`, `clangd`, `uncrustify`
 * OCaml: `merlin` (see |ale-ocaml-merlin|), `ols`, `ocamlformat`
 * Pawn: `uncrustify`
 * Perl: `perl -c`, `perl-critic`, `perltidy`

--- a/test/fixers/test_uncrustify_fixer_callback.vader
+++ b/test/fixers/test_uncrustify_fixer_callback.vader
@@ -1,0 +1,36 @@
+Before:
+  Save g:ale_c_uncrustify_executable
+
+  " Use an invalid global executable, so we don't match it.
+  let g:ale_c_uncrustify_executable = 'xxxinvalid'
+
+  call ale#test#SetDirectory('/testplugin/test/fixers')
+  silent cd ..
+  silent cd command_callback
+  let g:dir = getcwd()
+
+After:
+  Restore
+
+  call ale#test#RestoreDirectory()
+
+Execute(The clang-format callback should return the correct default values):
+  call ale#test#SetFilename('c_paths/dummy.c')
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape(g:ale_c_uncrustify_executable)
+  \       . ' --no-backup'
+  \ },
+  \ ale#fixers#uncrustify#Fix(bufnr(''))
+
+Execute(The uncrustify callback should include any additional options):
+  call ale#test#SetFilename('c_paths/dummy.c')
+  let b:ale_c_uncrustify_options = '--some-option'
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape(g:ale_c_uncrustify_executable)
+  \     . ' --no-backup --some-option',
+  \ },
+  \ ale#fixers#uncrustify#Fix(bufnr(''))


### PR DESCRIPTION
This PR adds fixer support for [uncrustify](https://github.com/uncrustify/uncrustify) for all languages supported by uncrustify.

A list of the supported languages are as follows:
- C
- C++
- C#
- ObjectiveC
- ObjectiveC++
- D
- Java
- Pawn
- VALA

I'm fairly certain the docs are all caught up, but please double check and let me know if I've missed something.

Also, currently there only exists a very rudimentary test for this fixer (more or less cold-copied from another similar fixer). Let me know if you think it needs more and I'd be glad to add to it.

Thanks again for your work on this fantastic project!

<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-development`.

Have fun!
-->