### PR TITLE
Fixed error when quitting vim after perl script edit

### DIFF
--- a/ale_linters/perl/perl.vim
+++ b/ale_linters/perl/perl.vim
@@ -18,6 +18,10 @@ function! ale_linters#perl#perl#Handle(buffer, lines) abort
     let l:output = []
     let l:basename = expand('#' . a:buffer . ':t')
 
+    if (!len(a:lines))
+        return l:output
+    endif
+
     let l:type = 'E'
 
     if a:lines[-1] =~# 'syntax OK'


### PR DESCRIPTION
Fixed the below error when quickly quiting vim/neovim after a perl script change with :wq

Error detected while processing function <SNR>101_NeoVimCallback[29]..<SNR>98_HandleExit[43]..ale_linters#perl#perl#Handle:
line    6:
E684: list index out of range: -1
E15: Invalid expression: a:lines[-1] =~# 'syntax OK'

<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-development`.

Have fun!
-->
