### PR TITLE
Add support for sqlfmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ formatting.
 | SML | [smlnj](http://www.smlnj.org/) |
 | Solidity | [solhint](https://github.com/protofire/solhint), [solium](https://github.com/duaraghav8/Solium) |
 | Stylus | [stylelint](https://github.com/stylelint/stylelint) |
-| SQL | [sqlint](https://github.com/purcell/sqlint) |
+| SQL | [sqlint](https://github.com/purcell/sqlint), [sqlfmt](https://github.com/jackc/sqlfmt) |
 | Swift | [swiftlint](https://github.com/realm/SwiftLint), [swiftformat](https://github.com/nicklockwood/SwiftFormat) |
 | Tcl | [nagelfar](http://nagelfar.sourceforge.net) !! |
 | Terraform | [tflint](https://github.com/wata727/tflint) |

--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -195,6 +195,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['sh'],
 \       'description': 'Fix sh files with shfmt.',
 \   },
+\   'sqlfmt': {
+\       'function': 'ale#fixers#sqlfmt#Fix',
+\       'suggested_filetypes': ['sql'],
+\       'description': 'Fix SQL files with sqlfmt.',
+\   },
 \   'google_java_format': {
 \       'function': 'ale#fixers#google_java_format#Fix',
 \       'suggested_filetypes': ['java'],

--- a/autoload/ale/fixers/sqlfmt.vim
+++ b/autoload/ale/fixers/sqlfmt.vim
@@ -1,0 +1,13 @@
+call ale#Set('sql_sqlfmt_executable', 'sqlfmt')
+call ale#Set('sql_sqlfmt_options', '')
+
+function! ale#fixers#sqlfmt#Fix(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'sql_sqlfmt_executable')
+    let l:options = ale#Var(a:buffer, 'sql_sqlfmt_options')
+
+    return {
+    \   'command': ale#Escape(l:executable)
+    \       . ' -w'
+    \       . (empty(l:options) ? '' : ' ' . l:options),
+    \}
+endfunction

--- a/doc/ale-sql.txt
+++ b/doc/ale-sql.txt
@@ -1,0 +1,25 @@
+===============================================================================
+ALE SQL Integration                                           *ale-sql-options*
+
+
+===============================================================================
+sqlfmt                                                         *ale-sql-sqlfmt*
+
+g:ale_sql_sqlfmt_executable                       *g:ale_sql_sqlfmt_executable*
+                                                  *b:ale_sql_sqlfmt_executable*
+  Type: |String|
+  Default: `'sqlfmt'`
+
+  This variable sets executable used for sqlfmt.
+
+g:ale_sql_sqlfmt_options                             *g:ale_sql_sqlfmt_options*
+                                                     *b:ale_sql_sqlfmt_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be set to pass additional options to the sqlfmt fixer.
+  At this time only the -u flag is available to format with upper-case.
+
+
+===============================================================================
+  vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -269,6 +269,8 @@ CONTENTS                                                         *ale-contents*
       solium..............................|ale-solidity-solium|
     spec..................................|ale-spec-options|
       rpmlint.............................|ale-spec-rpmlint|
+    sql...................................|ale-sql-options|
+      sqlfmt..............................|ale-sql-sqlfmt|
     stylus................................|ale-stylus-options|
       stylelint...........................|ale-stylus-stylelint|
     tcl...................................|ale-tcl-options|
@@ -438,7 +440,7 @@ Notes:
 * SML: `smlnj`
 * Solidity: `solhint`, `solium`
 * Stylus: `stylelint`
-* SQL: `sqlint`
+* SQL: `sqlint`, `sqlfmt`
 * Swift: `swiftlint`, `swiftformat`
 * Tcl: `nagelfar`!!
 * Terraform: `tflint`

--- a/test/fixers/test_sqlfmt_fixer_callback.vader
+++ b/test/fixers/test_sqlfmt_fixer_callback.vader
@@ -1,0 +1,26 @@
+Before:
+  Save g:ale_sql_sqlfmt_executable
+  Save g:ale_sql_sqlfmt_options
+
+After:
+  Restore
+
+Execute(The sqlfmt callback should return the correct default values):
+  AssertEqual
+  \ {
+  \   'command': ale#Escape('sqlfmt')
+  \     . ' -w',
+  \ },
+  \ ale#fixers#sqlfmt#Fix(bufnr(''))
+
+Execute(The sqlfmt executable and options should be configurable):
+  let g:ale_sql_sqlfmt_executable = '/path/to/sqlfmt'
+  let g:ale_sql_sqlfmt_options = '-u'
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape('/path/to/sqlfmt')
+  \     . ' -w'
+  \     . ' -u',
+  \ },
+  \ ale#fixers#sqlfmt#Fix(bufnr(''))


### PR DESCRIPTION
As a side note; I think [sqlint](https://github.com/purcell/sqlint) is missing from the list of integrations in `ale.txt`, and maybe the documentation should mention that:

> At this stage, SQLint checks SQL against the ANSI syntax, and uses the PostgreSQL SQL parser to achieve this. In time, we hope to add support for non-standard SQL variants (e.g. MySQL).