### PR TITLE
Fixed NASM linter from outputting junk file

### DIFF
--- a/ale_linters/nasm/nasm.vim
+++ b/ale_linters/nasm/nasm.vim
@@ -8,10 +8,12 @@ function! ale_linters#nasm#nasm#GetCommand(buffer) abort
     " Note that NASM requires a trailing slash for the -I option.
     let l:separator = has('win32') ? '\' : '/'
     let l:path = fnamemodify(bufname(a:buffer), ':p:h') . l:separator
+    let l:output_null = has('win32') ? 'NUL' : '/dev/null'
 
     return '%e -X gnu -I ' . ale#Escape(l:path)
     \   . ale#Pad(ale#Var(a:buffer, 'nasm_nasm_options'))
     \   . ' %s'
+    \   . ' -o ' . l:output_null
 endfunction
 
 function! ale_linters#nasm#nasm#Handle(buffer, lines) abort


### PR DESCRIPTION
Fixes issue #1895 so that the NASM compiler no longer generates junk binary files in the same directory as the file being edited.
The fix simply outputs the junk file to `NUL` on Win32 and `/dev/null` for Unix like systems.
