### PR TITLE
Fix tsserver `className` responses 

### DIFF
--- a/autoload/ale/completion.vim
+++ b/autoload/ale/completion.vim
@@ -264,7 +264,7 @@ function! ale#completion#ParseTSServerCompletionEntryDetails(response) abort
             call add(l:documentationParts, l:part.text)
         endfor
 
-        if l:suggestion.kind is# 'clasName'
+        if l:suggestion.kind is# 'className'
             let l:kind = 'f'
         elseif l:suggestion.kind is# 'parameterName'
             let l:kind = 'f'

--- a/test/completion/test_tsserver_completion_parsing.vader
+++ b/test/completion/test_tsserver_completion_parsing.vader
@@ -32,6 +32,13 @@ Execute(TypeScript completion details responses should be parsed correctly):
   \     'kind': 'f',
   \     'icase': 1,
   \   },
+  \   {
+  \     'word': 'ghi',
+  \     'menu': '(class) Foo',
+  \     'info': '',
+  \     'kind': 'f',
+  \     'icase': 1,
+  \   },
   \ ],
   \ ale#completion#ParseTSServerCompletionEntryDetails({
   \ 'body': [
@@ -72,6 +79,17 @@ Execute(TypeScript completion details responses should be parsed correctly):
   \       {'text': 'bar'},
   \       {'text': ' '},
   \       {'text': 'baz'},
+  \     ],
+  \   },
+  \   {
+  \     'name': 'ghi',
+  \     'kind': 'className',
+  \     'displayParts': [
+  \       {'text': '('},
+  \       {'text': 'class'},
+  \       {'text': ')'},
+  \       {'text': ' '},
+  \       {'text': 'Foo'},
   \     ],
   \   },
   \ ],


### PR DESCRIPTION
While I was reading this file to look into another issue I had, I noticed that this was misspelled. I compared with the `tsserver` spec and verified that it really should be `className`. Minor bug, but it does mean that classname references were being miscategorized in the omnifunc dropdown.