### PR TITLE
fix non-. prefix triggers overfiltering results

### DIFF
--- a/autoload/ale/completion.vim
+++ b/autoload/ale/completion.vim
@@ -98,14 +98,15 @@ function! ale#completion#GetTriggerCharacter(filetype, prefix) abort
     return ''
 endfunction
 
-function! ale#completion#Filter(buffer, suggestions, prefix) abort
+function! ale#completion#Filter(buffer, filetype, suggestions, prefix) abort
     let l:excluded_words = ale#Var(a:buffer, 'completion_excluded_words')
+    let l:triggers = s:GetFiletypeValue(s:trigger_character_map, a:filetype)
 
     " For completing...
     "   foo.
     "       ^
     " We need to include all of the given suggestions.
-    if a:prefix is# '.'
+    if index(l:triggers, a:prefix) >= 0
         let l:filtered_suggestions = a:suggestions
     else
         let l:filtered_suggestions = []
@@ -369,7 +370,7 @@ function! ale#completion#ParseLSPCompletions(response) abort
     endfor
 
     if has_key(l:info, 'prefix')
-        return ale#completion#Filter(l:buffer, l:results, l:info.prefix)
+        return ale#completion#Filter(l:buffer, &filetype, l:results, l:info.prefix)
     endif
 
     return l:results
@@ -390,6 +391,7 @@ function! ale#completion#HandleTSServerResponse(conn_id, response) abort
     if l:command is# 'completions'
         let l:names = ale#completion#Filter(
         \   l:buffer,
+        \   &filetype,
         \   ale#completion#ParseTSServerCompletions(a:response),
         \   b:ale_completion_info.prefix,
         \)[: g:ale_completion_max_suggestions - 1]

--- a/test/completion/test_completion_filtering.vader
+++ b/test/completion/test_completion_filtering.vader
@@ -12,16 +12,17 @@ After:
 Execute(Prefix filtering should work for Lists of strings):
   AssertEqual
   \ ['FooBar', 'foo'],
-  \ ale#completion#Filter(bufnr(''), ['FooBar', 'FongBar', 'baz', 'foo'], 'foo')
+  \ ale#completion#Filter(bufnr(''), '', ['FooBar', 'FongBar', 'baz', 'foo'], 'foo')
   AssertEqual
   \ ['FooBar', 'FongBar', 'baz', 'foo'],
-  \ ale#completion#Filter(bufnr(''), ['FooBar', 'FongBar', 'baz', 'foo'], '.')
+  \ ale#completion#Filter(bufnr(''), '', ['FooBar', 'FongBar', 'baz', 'foo'], '.')
 
 Execute(Prefix filtering should work for completion items):
   AssertEqual
   \ [{'word': 'FooBar'}, {'word': 'foo'}],
   \ ale#completion#Filter(
   \   bufnr(''),
+  \   '',
   \   [
   \     {'word': 'FooBar'},
   \     {'word': 'FongBar'},
@@ -40,6 +41,7 @@ Execute(Prefix filtering should work for completion items):
   \ ],
   \ ale#completion#Filter(
   \   bufnr(''),
+  \   '',
   \   [
   \     {'word': 'FooBar'},
   \     {'word': 'FongBar'},
@@ -56,6 +58,7 @@ Execute(Excluding words from completion results should work):
   \ [{'word': 'Italian'}],
   \ ale#completion#Filter(
   \   bufnr(''),
+  \   '',
   \   [
   \     {'word': 'Italian'},
   \     {'word': 'it'},
@@ -67,6 +70,7 @@ Execute(Excluding words from completion results should work):
   \ [{'word': 'Deutsch'}],
   \ ale#completion#Filter(
   \   bufnr(''),
+  \   '',
   \   [
   \     {'word': 'describe'},
   \     {'word': 'Deutsch'},
@@ -78,6 +82,7 @@ Execute(Excluding words from completion results should work):
   \ [{'word': 'Deutsch'}],
   \ ale#completion#Filter(
   \   bufnr(''),
+  \   '',
   \   [
   \     {'word': 'describe'},
   \     {'word': 'Deutsch'},
@@ -90,19 +95,26 @@ Execute(Excluding words from completion results should work with lists of String
 
   AssertEqual
   \ ['Italian'],
-  \ ale#completion#Filter(bufnr(''), ['Italian', 'it'], 'it')
+  \ ale#completion#Filter(bufnr(''), '', ['Italian', 'it'], 'it')
   AssertEqual
   \ ['Deutsch'],
-  \ ale#completion#Filter(bufnr(''), ['describe', 'Deutsch'], 'de')
+  \ ale#completion#Filter(bufnr(''), '', ['describe', 'Deutsch'], 'de')
   AssertEqual
   \ ['Deutsch'],
-  \ ale#completion#Filter(bufnr(''), ['describe', 'Deutsch'], '.')
+  \ ale#completion#Filter(bufnr(''), '', ['describe', 'Deutsch'], '.')
 
 Execute(Filtering shouldn't modify the original list):
   let b:ale_completion_excluded_words = ['it', 'describe']
   let b:suggestions = [{'word': 'describe'}]
 
-  AssertEqual [], ale#completion#Filter(bufnr(''), b:suggestions, '.')
+  AssertEqual [], ale#completion#Filter(bufnr(''), '', b:suggestions, '.')
   AssertEqual b:suggestions, [{'word': 'describe'}]
-  AssertEqual [], ale#completion#Filter(bufnr(''), b:suggestions, 'de')
+  AssertEqual [], ale#completion#Filter(bufnr(''), '', b:suggestions, 'de')
   AssertEqual b:suggestions, [{'word': 'describe'}]
+
+Execute(Filtering should respect filetype triggers):
+  let b:suggestions = [{'word': 'describe'}]
+
+  AssertEqual b:suggestions, ale#completion#Filter(bufnr(''), '', b:suggestions, '.')
+  AssertEqual b:suggestions, ale#completion#Filter(bufnr(''), 'rust', b:suggestions, '.')
+  AssertEqual b:suggestions, ale#completion#Filter(bufnr(''), 'rust', b:suggestions, '::')


### PR DESCRIPTION
Currently, ALE overfilters results that come from `trigger_character_map` queries when the trigger character isn't `.`.

As an example, in Hack (if you add the proper trigger characters in, which I will do in a separate diff), typing `FooClass::` won't actually show any completion suggestions. This makes it hard to seamlessly chain the autocompletions, since you need to guess the first character of the method you're looking for in order for any suggestions to show up.

Fixes #1904.