### PR TITLE
Allow extra options to be passed to haskell:hlint

### DIFF
--- a/ale_linters/haskell/hlint.vim
+++ b/ale_linters/haskell/hlint.vim
@@ -1,6 +1,9 @@
 " Author: jparoz <jesse.paroz@gmail.com>
 " Description: hlint for Haskell files
 
+call ale#Set('haskell_hlint_executable', 'hlint')
+call ale#Set('haskell_hlint_options', get(g:, 'hlint_options', ''))
+
 function! ale_linters#haskell#hlint#Handle(buffer, lines) abort
     let l:output = []
 
@@ -26,9 +29,17 @@ function! ale_linters#haskell#hlint#Handle(buffer, lines) abort
     return l:output
 endfunction
 
+function! ale_linters#haskell#hlint#GetCommand(buffer) abort
+    let l:hlintopts = '--color=never --json'
+
+    return '%e'
+    \      . ' ' . ale#Var(a:buffer, 'haskell_hlint_options')
+    \      . ' ' . l:hlintopts . ' -'
+endfunction
+
 call ale#linter#Define('haskell', {
 \   'name': 'hlint',
-\   'executable': 'hlint',
-\   'command': 'hlint --color=never --json -',
+\   'executable_callback': ale#VarFunc('haskell_hlint_executable'),
+\   'command_callback': 'ale_linters#haskell#hlint#GetCommand',
 \   'callback': 'ale_linters#haskell#hlint#Handle',
 \})

--- a/doc/ale-haskell.txt
+++ b/doc/ale-haskell.txt
@@ -77,6 +77,15 @@ g:ale_haskell_hlint_executable                 *g:ale_haskell_hlint_executable*
 
   This variable can be changed to use a different executable for hlint.
 
+
+g:ale_haskell_hlint_options                       g:ale_haskell_hlint_options
+                                                  b:ale_haskell_hlint_options
+  Type: String
+  Default: ''
+
+  This variable can be used to pass extra options to the underlying hlint
+  executable.
+
 ===============================================================================
 stack-build                                           *ale-haskell-stack-build*
 

--- a/test/command_callback/test_haskell_hlint_command_callbacks.vader
+++ b/test/command_callback/test_haskell_hlint_command_callbacks.vader
@@ -1,0 +1,16 @@
+Before:
+  call ale#assert#SetUpLinterTest('haskell', 'hlint')
+  let b:base_opts = '--color=never --json -'
+
+After:
+  unlet! b:base_opts
+  call ale#assert#TearDownLinterTest()
+
+Execute(executable should be configurable):
+  AssertLinter 'hlint', ale#Escape('hlint') . '  ' . b:base_opts
+  let b:ale_haskell_hlint_executable = 'myHlint'
+  AssertLinter 'myHlint', ale#Escape('myHlint') . '  ' . b:base_opts
+
+Execute(should accept options):
+  let b:ale_haskell_hlint_options= '-h myhlintfile.yaml'
+  AssertLinter 'hlint', ale#Escape('hlint') . ' -h myhlintfile.yaml ' . b:base_opts


### PR DESCRIPTION
Highly inspired by the work done in haskell:hdevtools
