### PR TITLE
Support options when using Stylelint with SCSS

### DIFF
--- a/ale_linters/scss/stylelint.vim
+++ b/ale_linters/scss/stylelint.vim
@@ -1,13 +1,19 @@
 " Author: diartyz <diartyz@gmail.com>
 
 call ale#Set('scss_stylelint_executable', 'stylelint')
+call ale#Set('scss_stylelint_options', '')
 call ale#Set('scss_stylelint_use_global', get(g:, 'ale_use_global_executables', 0))
+
+function! ale_linters#scss#stylelint#GetCommand(buffer) abort
+    return '%e ' . ale#Pad(ale#Var(a:buffer, 'scss_stylelint_options'))
+    \   . ' --stdin-filename %s'
+endfunction
 
 call ale#linter#Define('scss', {
 \   'name': 'stylelint',
 \   'executable_callback': ale#node#FindExecutableFunc('scss_stylelint', [
 \       'node_modules/.bin/stylelint',
 \   ]),
-\   'command': '%e --stdin-filename %s',
+\   'command_callback': 'ale_linters#scss#stylelint#GetCommand',
 \   'callback': 'ale#handlers#css#HandleStyleLintFormat',
 \})

--- a/doc/ale-scss.txt
+++ b/doc/ale-scss.txt
@@ -18,6 +18,12 @@ g:ale_scss_stylelint_executable               *g:ale_scss_stylelint_executable*
 
   See |ale-integrations-local-executables|
 
+g:ale_scss_stylelint_options                     *g:ale_scss_stylelint_options*
+                                                 *b:ale_scss_stylelint_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be set to pass additional options to stylelint.
 
 g:ale_scss_stylelint_use_global               *g:ale_scss_stylelint_use_global*
                                               *b:ale_scss_stylelint_use_global*

--- a/test/command_callback/test_scss_stylelint_command_callback.vader
+++ b/test/command_callback/test_scss_stylelint_command_callback.vader
@@ -1,0 +1,31 @@
+Before:
+  call ale#assert#SetUpLinterTest('scss', 'stylelint')
+  unlet! b:executable
+
+After:
+  unlet! b:executable
+  call ale#assert#TearDownLinterTest()
+
+Execute(node_modules directories should be discovered):
+  call ale#test#SetFilename('stylelint_paths/nested/testfile.scss')
+
+  let b:executable = ale#path#Simplify(
+  \   g:dir
+  \   . '/stylelint_paths/node_modules/.bin/stylelint'
+  \)
+
+  AssertLinter b:executable, ale#Escape(b:executable) . '  --stdin-filename %s'
+
+Execute(The global override should work):
+  let b:ale_scss_stylelint_executable = 'foobar'
+  let b:ale_scss_stylelint_use_global = 1
+
+  call ale#test#SetFilename('stylelint_paths/nested/testfile.scss')
+
+  AssertLinter 'foobar', ale#Escape('foobar') . '  --stdin-filename %s'
+
+Execute(Extra options should be configurable):
+  let b:ale_scss_stylelint_options = '--configFile ''/absolute/path/to/file'''
+
+  AssertLinter 'stylelint',
+  \ ale#Escape('stylelint') . '  --configFile ''/absolute/path/to/file'' --stdin-filename %s'


### PR DESCRIPTION
Previous work done **for SCSS** with Stylelint did not account for options usage, unlike the linter definition for CSS on [ale_linters/css/stylelint.vim](https://github.com/w0rp/ale/blob/master/ale_linters/css/stylelint.vim).

This PR adds command option support through the variable 'scss_stylelint_options' and also complements it's respective documentation.