### PR TITLE
Change PCRE escape to simple escape

### DIFF
--- a/ale_linters/go/golangci_lint.vim
+++ b/ale_linters/go/golangci_lint.vim
@@ -18,7 +18,7 @@ function! ale_linters#go#golangci_lint#GetCommand(buffer) abort
 
     return ale#path#BufferCdString(a:buffer)
     \   . '%e run '
-    \   . ale#util#EscapePCRE(l:filename)
+    \   . ale#Escape(l:filename)
     \   . ' ' . l:options
 endfunction
 

--- a/test/command_callback/test_golangci_lint_command_callback.vader
+++ b/test/command_callback/test_golangci_lint_command_callback.vader
@@ -9,7 +9,7 @@ Execute(The golangci-lint defaults should be correct):
   AssertLinter 'golangci-lint',
   \ 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
   \   . ale#Escape('golangci-lint')
-  \   . ' run ' . ale#util#EscapePCRE(expand('%' . ':t'))
+  \   . ' run ' . ale#Escape(expand('%' . ':t'))
   \   . ' --enable-all'
 
 Execute(The golangci-lint callback should use a configured executable):
@@ -18,7 +18,7 @@ Execute(The golangci-lint callback should use a configured executable):
   AssertLinter 'something else',
   \ 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
   \   . ale#Escape('something else')
-  \   . ' run ' . ale#util#EscapePCRE(expand('%' . ':t'))
+  \   . ' run ' . ale#Escape(expand('%' . ':t'))
   \   . ' --enable-all'
 
 Execute(The golangci-lint callback should use configured options):
@@ -27,7 +27,7 @@ Execute(The golangci-lint callback should use configured options):
   AssertLinter 'golangci-lint',
   \ 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
   \   . ale#Escape('golangci-lint')
-  \   . ' run ' . ale#util#EscapePCRE(expand('%' . ':t'))
+  \   . ' run ' . ale#Escape(expand('%' . ':t'))
   \   . ' --foobar'
 
 Execute(The golangci-lint `lint_package` option should use the correct command):


### PR DESCRIPTION
As mentioned in https://github.com/w0rp/ale/pull/1890#discussion_r216167903, it would be more useful to use a simple escape here instead of PCRE.