### PR TITLE
Fix bug with RuboCop linter when options are not set

### DIFF
--- a/ale_linters/ruby/rubocop.vim
+++ b/ale_linters/ruby/rubocop.vim
@@ -1,6 +1,9 @@
 " Author: ynonp - https://github.com/ynonp, Eddie Lebow https://github.com/elebow
 " Description: RuboCop, a code style analyzer for Ruby files
 
+call ale#Set('ruby_rubocop_executable', 'rubocop')
+call ale#Set('ruby_rubocop_options', '')
+
 function! ale_linters#ruby#rubocop#GetCommand(buffer) abort
     let l:executable = ale#Var(a:buffer, 'ruby_rubocop_executable')
 


### PR DESCRIPTION
There appears to be a bug with the code that was merged in from #1850. The default values for `ruby_rubocop_executable` and `ruby_rubocop_options` are not being set. If you haven't specified them, the following error occurs. 
```vim
Error detected while processing function ale#events#LintOnEnter[5]..ale#Queue[49]..ale#Lint[34]..ale#engine#RunLinters[14]..<SNR>147_RunLinter[7]..<SNR>147_InvokeChain[1]..ale#engine#ProcessChain[51]..ale#linter#GetCommand[1]..ale_linte
rs#ruby#rubocop#GetCommand[3]..ale#Var:
line    4:
E716: Key not present in Dictionary: ale_ruby_rubocop_options
E116: Invalid arguments for function get
E15: Invalid expression: get(l:vars, l:full_name, g:[l:full_name])
```