### PR TITLE
To avoid blocking build tools, suspend ALE when suspending vim

### DIFF
--- a/autoload/ale/engine.vim
+++ b/autoload/ale/engine.vim
@@ -18,6 +18,22 @@ if !has_key(s:, 'executable_cache_map')
     let s:executable_cache_map = {}
 endif
 
+
+function! ale#engine#CleanupEveryBuffer() abort
+    for l:key in keys(g:ale_buffer_info)
+        " The key could be a filename or a buffer number, so try and
+        " convert it to a number. We need a number for the other
+        " functions.
+        let l:buffer = str2nr(l:key)
+
+        if l:buffer > 0
+            " Stop all jobs and clear the results for everything, and delete
+            " all of the data we stored for the buffer.
+            call ale#engine#Cleanup(l:buffer)
+        endif
+    endfor
+endfunction
+
 function! ale#engine#ResetExecutableCache() abort
     let s:executable_cache_map = {}
 endfunction

--- a/autoload/ale/toggle.vim
+++ b/autoload/ale/toggle.vim
@@ -15,21 +15,6 @@ function! s:DisablePostamble() abort
     endif
 endfunction
 
-function! s:CleanupEveryBuffer() abort
-    for l:key in keys(g:ale_buffer_info)
-        " The key could be a filename or a buffer number, so try and
-        " convert it to a number. We need a number for the other
-        " functions.
-        let l:buffer = str2nr(l:key)
-
-        if l:buffer > 0
-            " Stop all jobs and clear the results for everything, and delete
-            " all of the data we stored for the buffer.
-            call ale#engine#Cleanup(l:buffer)
-        endif
-    endfor
-endfunction
-
 function! ale#toggle#Toggle() abort
     let g:ale_enabled = !get(g:, 'ale_enabled')
 
@@ -40,7 +25,7 @@ function! ale#toggle#Toggle() abort
             call ale#balloon#Enable()
         endif
     else
-        call s:CleanupEveryBuffer()
+        call ale#engine#CleanupEveryBuffer()
         call s:DisablePostamble()
 
         if exists('*ale#balloon#Disable')
@@ -64,7 +49,7 @@ function! ale#toggle#Disable() abort
 endfunction
 
 function! ale#toggle#Reset() abort
-    call s:CleanupEveryBuffer()
+    call ale#engine#CleanupEveryBuffer()
     call ale#highlight#UpdateHighlights()
 endfunction
 

--- a/plugin/ale.vim
+++ b/plugin/ale.vim
@@ -217,9 +217,8 @@ augroup ALECleanupGroup
     " Clean up buffers automatically when they are unloaded.
     autocmd BufDelete * if exists('*ale#engine#Cleanup') | call ale#engine#Cleanup(str2nr(expand('<abuf>'))) | endif
     autocmd QuitPre * call ale#events#QuitEvent(str2nr(expand('<abuf>')))
+
+    if exists('##VimSuspend')
+      autocmd VimSuspend * if exists('*ale#engine#CleanupEveryBuffer') | call ale#engine#CleanupEveryBuffer() | endif
+    endif
 augroup END
-
-if exists('##VimSuspend')
-   autocmd VimSuspend * call ale#engine#CleanupEveryBuffer()
-end
-

--- a/plugin/ale.vim
+++ b/plugin/ale.vim
@@ -218,3 +218,8 @@ augroup ALECleanupGroup
     autocmd BufDelete * if exists('*ale#engine#Cleanup') | call ale#engine#Cleanup(str2nr(expand('<abuf>'))) | endif
     autocmd QuitPre * call ale#events#QuitEvent(str2nr(expand('<abuf>')))
 augroup END
+
+if exists('##VimSuspend')
+   autocmd VimSuspend * call ale#engine#CleanupEveryBuffer()
+end
+

--- a/test/test_autocmd_commands.vader
+++ b/test/test_autocmd_commands.vader
@@ -175,10 +175,19 @@ Execute (g:ale_lint_on_filetype_changed = 1 should bind the FileType event):
   \ filter(CheckAutocmd('ALEEvents'), 'v:val =~ ''\v^FileType''')
 
 Execute (ALECleanupGroup should include the right commands):
-  AssertEqual [
-  \ 'BufDelete * if exists(''*ale#engine#Cleanup'') | call ale#engine#Cleanup(str2nr(expand(''<abuf>''))) | endif',
-  \ 'QuitPre * call ale#events#QuitEvent(str2nr(expand(''<abuf>'')))',
-  \], CheckAutocmd('ALECleanupGroup')
+  if exists('##VimSuspend')
+    AssertEqual [
+    \ 'BufDelete * if exists(''*ale#engine#Cleanup'') | call ale#engine#Cleanup(str2nr(expand(''<abuf>''))) | endif',
+    \ 'QuitPre * call ale#events#QuitEvent(str2nr(expand(''<abuf>'')))',
+    \ 'VimSuspend * if exists(''*ale#engine#CleanupEveryBuffer'') | call ale#engine#CleanupEveryBuffer() | endif',
+    \], CheckAutocmd('ALECleanupGroup')
+  else
+    AssertEqual [
+    \ 'BufDelete * if exists(''*ale#engine#Cleanup'') | call ale#engine#Cleanup(str2nr(expand(''<abuf>''))) | endif',
+    \ 'QuitPre * call ale#events#QuitEvent(str2nr(expand(''<abuf>'')))',
+    \], CheckAutocmd('ALECleanupGroup')
+  endif
+
 
 Execute(Enabling completion should set up autocmd events correctly):
   let g:ale_completion_enabled = 0


### PR DESCRIPTION
Adds support for having ALE stop any linting jobs when vim is dropped into the backgorund (CTRL-Z).

Closes #1898