### PR TITLE
Add Palantir python-language-server

### DIFF
--- a/ale_linters/python/langserver.vim
+++ b/ale_linters/python/langserver.vim
@@ -1,0 +1,22 @@
+" Author: Devon Meunier <devon.meunier@gmail.com>
+" Description: Support for python-language-server https://github.com/palantir/python-language-server
+
+call ale#Set('python_langserver_executable', 'pyls')
+call ale#Set('python_langserver_options', '')
+
+function! ale_linters#python#langserver#GetCommand(buffer) abort
+    let l:executable = [ale#Escape(ale#Var(a:buffer, 'python_langserver_executable'))]
+    let l:options = ale#Var(a:buffer, 'python_langserver_options')
+    let l:options = filter(split(l:options, ' '), 'empty(v:val) != 1')
+    let l:options = uniq(sort(l:options))
+
+    return join(extend(l:executable, l:options), ' ')
+endfunction
+
+call ale#linter#Define('python', {
+\   'name': 'python-language-server',
+\   'lsp': 'stdio',
+\   'executable_callback': ale#VarFunc('python_langserver_executable'),
+\   'command_callback': 'ale_linters#python#langserver#GetCommand',
+\   'project_root_callback': 'ale#python#FindProjectRoot',
+\})

--- a/doc/ale-python.txt
+++ b/doc/ale-python.txt
@@ -165,6 +165,25 @@ g:ale_python_isort_use_global                   *g:ale_python_isort_use_global*
 
 
 ===============================================================================
+python-language-server                      *ale-python-python-language-server*
+
+g:ale_python_langserver_executable         *g:ale_python_langserver_executable*
+                                           *b:ale_python_langserver_executable*
+  Type: |String|
+  Default: `'pyls'`
+
+  Location of the python-language-server binary.
+
+g:ale_python_langserver_options               *g:ale_python_langserver_options*
+                                              *b:ale_python_langserver_options*
+
+  Type: |String|
+  Default: `''`
+
+  Additional options passed to the python-language-server command.
+
+
+===============================================================================
 mypy                                                          *ale-python-mypy*
 
 The minimum supported version of mypy that ALE supports is v0.4.4. This is

--- a/test/command_callback/test_pythonlangserver_command_callback.vader
+++ b/test/command_callback/test_pythonlangserver_command_callback.vader
@@ -1,0 +1,28 @@
+Before:
+  Save g:ale_completion_enabled
+  
+  let g:ale_completion_enabled = 0
+  call ale#assert#SetUpLinterTest('python', 'langserver')
+
+After:
+  Restore
+  unlet! b:ale_completion_enabled
+  call ale#assert#TearDownLinterTest()
+
+Execute(should set correct defaults):
+  AssertLinter 'pyls', ale#Escape('pyls')
+
+Execute(should configure python-language-server callback executable):
+  let b:ale_python_langserver_executable = 'foobar'
+  AssertLinter 'foobar', ale#Escape('foobar')
+
+Execute(should set python-language-server options):
+  let b:ale_completion_enabled = 1
+  let b:ale_python_langserver_options = ''
+
+  AssertLinter 'pyls', ale#Escape('pyls')
+
+  let b:ale_python_langserver_options = '--log-file FOOBAR'
+
+  AssertLinter 'pyls',
+  \ ale#Escape('pyls') . ' --log-file FOOBAR'


### PR DESCRIPTION
Adds support for Palantir's [python-language-server](https://github.com/palantir/python-language-server).

Feel free to close this as I wrote it before noticing #1741 