### PR TITLE
shfmt: Use Vim's indent config as default indent width

### DIFF
--- a/autoload/ale/fixers/shfmt.vim
+++ b/autoload/ale/fixers/shfmt.vim
@@ -5,12 +5,27 @@ scriptencoding utf-8
 call ale#Set('sh_shfmt_executable', 'shfmt')
 call ale#Set('sh_shfmt_options', '')
 
+function! s:DefaultOption(buffer) abort
+    if getbufvar(a:buffer, '&expandtab') == 0
+        " Tab is used by default
+        return ''
+    endif
+
+    let l:tabsize = getbufvar(a:buffer, '&shiftwidth')
+
+    if l:tabsize == 0
+        let l:tabsize = getbufvar(a:buffer, '&tabstop')
+    endif
+
+    return ' -i ' . l:tabsize
+endfunction
+
 function! ale#fixers#shfmt#Fix(buffer) abort
     let l:executable = ale#Var(a:buffer, 'sh_shfmt_executable')
     let l:options = ale#Var(a:buffer, 'sh_shfmt_options')
 
     return {
     \   'command': ale#Escape(l:executable)
-    \       . (empty(l:options) ? '' : ' ' . l:options)
+    \       . (empty(l:options) ? s:DefaultOption(a:buffer) : ' ' . l:options)
     \}
 endfunction

--- a/test/fixers/test_shfmt_fixer_callback.vader
+++ b/test/fixers/test_shfmt_fixer_callback.vader
@@ -1,14 +1,49 @@
 Before:
   Save g:ale_sh_shfmt_executable
   Save g:ale_sh_shfmt_options
+  Save &l:expandtab
+  Save &l:shiftwidth
+  Save &l:tabstop
 
 After:
   Restore
 
-Execute(The shfmt callback should return the correct default values):
+Execute(The shfmt callback should return 'shfmt' as default command):
+  setlocal noexpandtab
+  Assert
+  \ ale#fixers#shfmt#Fix(bufnr('')).command =~# '^' . ale#Escape('shfmt'),
+  \ "Default command name is expected to be 'shfmt'"
+
+Execute(The shfmt callback should return the command with no option as default when noexpandtab is set):
+  let g:ale_sh_shfmt_executable = 'shfmt'
+  let g:ale_sh_shfmt_options = ''
+  setlocal noexpandtab
   AssertEqual
   \ {
   \   'command': ale#Escape('shfmt'),
+  \ },
+  \ ale#fixers#shfmt#Fix(bufnr(''))
+
+Execute(The shfmt callback should return the command specifying indent width by looking shiftwidth as default):
+  let g:ale_sh_shfmt_executable = 'shfmt'
+  let g:ale_sh_shfmt_options = ''
+  setlocal expandtab
+  setlocal shiftwidth=4
+  AssertEqual
+  \ {
+  \   'command': ale#Escape('shfmt') . ' -i 4',
+  \ },
+  \ ale#fixers#shfmt#Fix(bufnr(''))
+
+Execute(The shfmt callback should return the command specifying indent width by looking tabstop when shiftwidth is 0 as default):
+  let g:ale_sh_shfmt_executable = 'shfmt'
+  let g:ale_sh_shfmt_options = ''
+  setlocal expandtab
+  setlocal shiftwidth=0
+  setlocal tabstop=8
+  AssertEqual
+  \ {
+  \   'command': ale#Escape('shfmt') . ' -i 8',
   \ },
   \ ale#fixers#shfmt#Fix(bufnr(''))
 


### PR DESCRIPTION
<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-development`.

Have fun!
-->

[`shfmt`](https://github.com/mvdan/sh) uses a hard tab for indentation by default. To avoid this, `g:ale_sh_shfmt_options` variable can be set in vimrc. It's not bad. However, Vim already has a config for indentation. I thought it's better to set an indent value to `shfmt` command by looking Vim's indent option values.

This PR makes `shfmt` to format a `sh` buffer with the same indentation as its buffer's configuration as default behavior.