### PR TITLE
Support Solargraph stdio

### DIFF
--- a/ale_linters/ruby/solargraph.vim
+++ b/ale_linters/ruby/solargraph.vim
@@ -1,20 +1,20 @@
 " Author: Horacio Sanson - https://github.com/hsanson
 " Description: Solargraph Language Server https://solargraph.org/
+"
+" Author: Devon Meunier <devon.meunier@gmail.com>
+" Description: updated to use stdio
 
-call ale#Set('ruby_solargraph_host', '127.0.0.1')
-call ale#Set('ruby_solargraph_port', '7658')
+call ale#Set('ruby_solargraph_executable', 'solargraph')
 
-function! ale_linters#ruby#solargraph#GetAddress(buffer) abort
-    let l:host = ale#Var(a:buffer, 'ruby_solargraph_host')
-    let l:port = ale#Var(a:buffer, 'ruby_solargraph_port')
-
-    return l:host . ':' . l:port
+function! ale_linters#ruby#solargraph#GetCommand(buffer) abort
+    return '%e' . ale#Pad('stdio')
 endfunction
 
 call ale#linter#Define('ruby', {
 \   'name': 'solargraph',
-\   'lsp': 'socket',
-\   'address_callback': 'ale_linters#ruby#solargraph#GetAddress',
+\   'lsp': 'stdio',
 \   'language': 'ruby',
-\   'project_root_callback': 'ale#ruby#FindProjectRoot'
+\   'executable_callback': ale#VarFunc('ruby_solargraph_executable'),
+\   'command_callback': 'ale_linters#ruby#solargraph#GetCommand',
+\   'project_root_callback': 'ale#ruby#FindProjectRoot',
 \})

--- a/doc/ale-ruby.txt
+++ b/doc/ale-ruby.txt
@@ -120,19 +120,13 @@ g:ale_ruby_rufo_executable                         *g:ale_ruby_rufo_executable*
 ===============================================================================
 solargraph                                                *ale-ruby-solargraph*
 
-g:ale_ruby_solargraph_host                         *g:ale_ruby_solargraph_host*
-                                                   *b:ale_ruby_solargraph_host*
+g:ale_ruby_solargraph_executable             *g:ale_ruby_solargraph_executable*
+                                             *b:ale_ruby_solargraph_executable*
   Type: String
-  Default: `'127.0.0.1'`
+  Default: `'solargraph'`
 
-  The host/ip where the solargraph language server is running.
-
-g:ale_ruby_solargraph_port                         *g:ale_ruby_solargraph_port*
-                                                   *b:ale_ruby_solargraph_port*
-  Type: String
-  Default: `'7658'`
-
-  The listening port where the solargraph language server is running.
+  Override the invoked solargraph binary. This is useful for running rufo from
+  binstubs or a bundle.
 
 
 ===============================================================================

--- a/test/command_callback/test_ruby_solargraph.vader
+++ b/test/command_callback/test_ruby_solargraph.vader
@@ -7,30 +7,33 @@ Before:
 After:
   call ale#assert#TearDownLinterTest()
 
+Execute(command callback should return default string):
+  AssertLinter 'solargraph', ale#Escape('solargraph') . ' stdio'
+
+Execute(command callback executable can be overridden):
+  let g:ale_ruby_solargraph_executable = 'foobar'
+  AssertLinter 'foobar', ale#Escape('foobar') . ' stdio'
+
 Execute(should set solargraph for rails app):
   call ale#test#SetFilename('../ruby_fixtures/valid_rails_app/app/models/thing.rb')
   AssertLSPLanguage 'ruby'
   AssertLSPOptions {}
   AssertLSPProject ale#path#Simplify(g:dir . 'command_callback/../ruby_fixtures/valid_rails_app')
-  AssertLSPAddress '127.0.0.1:7658'
 
 Execute(should set solargraph for ruby app1):
   call ale#test#SetFilename('../ruby_fixtures/valid_ruby_app1/lib/file.rb')
   AssertLSPLanguage 'ruby'
   AssertLSPOptions {}
   AssertLSPProject ale#path#Simplify(g:dir . 'command_callback/../ruby_fixtures/valid_ruby_app1')
-  AssertLSPAddress '127.0.0.1:7658'
 
 Execute(should set solargraph for ruby app2):
   call ale#test#SetFilename('../ruby_fixtures/valid_ruby_app2/lib/file.rb')
   AssertLSPLanguage 'ruby'
   AssertLSPOptions {}
   AssertLSPProject ale#path#Simplify(g:dir . 'command_callback/../ruby_fixtures/valid_ruby_app2')
-  AssertLSPAddress '127.0.0.1:7658'
 
 Execute(should set solargraph for ruby app3):
   call ale#test#SetFilename('../ruby_fixtures/valid_ruby_app3/lib/file.rb')
   AssertLSPLanguage 'ruby'
   AssertLSPOptions {}
   AssertLSPProject ale#path#Simplify(g:dir . 'command_callback/../ruby_fixtures/valid_ruby_app3')
-  AssertLSPAddress '127.0.0.1:7658'


### PR DESCRIPTION
It makes sense to only allow stdio since then there's no separate process to manage.