### PR TITLE
Bugfix: python add blank lines

### DIFF
--- a/autoload/ale/fixers/generic_python.vim
+++ b/autoload/ale/fixers/generic_python.vim
@@ -6,11 +6,26 @@ function! ale#fixers#generic_python#AddLinesBeforeControlStatements(buffer, line
     let l:new_lines = []
     let l:last_indent_size = 0
     let l:last_line_is_blank = 0
+    let l:in_docstring = 0
 
     for l:line in a:lines
         let l:indent_size = len(matchstr(l:line, '^ *'))
 
+        if !l:in_docstring
+            " Make sure it is not just a single line docstring and then verify
+            " it's starting a new docstring
+            if match(l:line, '\v^ *("""|'''''').*("""|'''''')') == -1
+            \&& match(l:line, '\v^ *("""|'''''')') >= 0
+                let l:in_docstring = 1
+            endif
+        else
+            if match(l:line, '\v^ *.*("""|'''''')') >= 0
+                let l:in_docstring = 0
+            endif
+        endif
+
         if !l:last_line_is_blank
+        \&& !l:in_docstring
         \&& l:indent_size <= l:last_indent_size
         \&& match(l:line, '\v^ *(return|if|for|while|break|continue)(\(| |$)') >= 0
             call add(l:new_lines, '')

--- a/autoload/ale/fixers/generic_python.vim
+++ b/autoload/ale/fixers/generic_python.vim
@@ -12,7 +12,7 @@ function! ale#fixers#generic_python#AddLinesBeforeControlStatements(buffer, line
 
         if !l:last_line_is_blank
         \&& l:indent_size <= l:last_indent_size
-        \&& match(l:line, '\v^ *(return|if|for|while|break|continue)') >= 0
+        \&& match(l:line, '\v^ *(return|if|for|while|break|continue)(\(| |$)') >= 0
             call add(l:new_lines, '')
         endif
 

--- a/test/fixers/test_python_add_blank_lines_fixer.vader
+++ b/test/fixers/test_python_add_blank_lines_fixer.vader
@@ -109,3 +109,31 @@ Expect python(extra newlines shouldn't be added to the main block):
 
   if __name__ == '__main__':
       main()
+
+
+Given python(A file with variables/docstring that start with a control statement):
+  def some():
+      continue_some_var = True
+      forward_something = False
+
+      if (
+          continue_some_var and
+          forwarded_something
+      ):
+          return True
+
+
+Execute(Fix the file):
+  let g:ale_fixers = {'python': ['add_blank_lines_for_python_control_statements']}
+  ALEFix
+
+Expect python(Extra new lines are not added to the file):
+  def some():
+      continue_some_var = True
+      forward_something = False
+
+      if (
+          continue_some_var and
+          forwarded_something
+      ):
+          return True

--- a/test/fixers/test_python_add_blank_lines_fixer.vader
+++ b/test/fixers/test_python_add_blank_lines_fixer.vader
@@ -6,15 +6,22 @@ After:
 
 Given python(Some Python without blank lines):
   def foo():
+      """ This is a simple test docstring """
       return 1
 
 
   def bar():
+      '''This is another simple test docstring'''
       return 1
       return 4
 
 
   def bar():
+      """
+      This is a multi-line
+      docstring
+      """
+
       if x:
           pass
           for l in x:
@@ -44,16 +51,25 @@ Execute(Blank lines should be added appropriately):
 
 Expect python(Newlines should be added):
   def foo():
+      """ This is a simple test docstring """
+
       return 1
 
 
   def bar():
+      '''This is another simple test docstring'''
+
       return 1
 
       return 4
 
 
   def bar():
+      """
+      This is a multi-line
+      docstring
+      """
+
       if x:
           pass
 
@@ -113,6 +129,12 @@ Expect python(extra newlines shouldn't be added to the main block):
 
 Given python(A file with variables/docstring that start with a control statement):
   def some():
+      """
+      This is a docstring that contains an
+      break control statement and also contains a
+      return something funny.
+      """
+
       continue_some_var = True
       forward_something = False
 
@@ -129,6 +151,12 @@ Execute(Fix the file):
 
 Expect python(Extra new lines are not added to the file):
   def some():
+      """
+      This is a docstring that contains an
+      break control statement and also contains a
+      return something funny.
+      """
+
       continue_some_var = True
       forward_something = False
 


### PR DESCRIPTION
This fixes one issue I've had for a long time:

```

def some():
    continue_some_var = True
    forward_something = False

    if (
        continue_some_var and
        forward_something
    ):
        return True

    return False
```

would become:

```

def some():
    continue_some_var = True

    forward_something = False

    if (
        continue_some_var and

        forward_something
    ):
        return True

    return False
```

This commit also fixes the issue of adding extra newlines to docstrings accidentally by detecting when we are inside a docstring and not adding newlines even if we do match on control statements.