### PR TITLE
Call QuickFixCmdPre and QuickFixCmdPost autocmds

### DIFF
--- a/autoload/ale/list.vim
+++ b/autoload/ale/list.vim
@@ -81,17 +81,23 @@ function! s:SetListsImpl(timer_id, buffer, loclist) abort
     if g:ale_set_quickfix
         let l:quickfix_list = ale#list#GetCombinedList()
 
+        silent doautocmd <nomodeline> QuickFixCmdPre cexpr
+
         if has('nvim')
             call setqflist(s:FixList(a:buffer, l:quickfix_list), ' ', l:title)
         else
             call setqflist(s:FixList(a:buffer, l:quickfix_list))
             call setqflist([], 'r', {'title': l:title})
         endif
+
+        silent doautocmd <nomodeline> QuickFixCmdPost cexpr
     elseif g:ale_set_loclist
         " If windows support is off, bufwinid() may not exist.
         " We'll set result in the current window, which might not be correct,
         " but it's better than nothing.
         let l:id = s:BufWinId(a:buffer)
+
+        silent doautocmd <nomodeline> QuickFixCmdPre lexpr
 
         if has('nvim')
             call setloclist(l:id, s:FixList(a:buffer, a:loclist), ' ', l:title)
@@ -99,6 +105,8 @@ function! s:SetListsImpl(timer_id, buffer, loclist) abort
             call setloclist(l:id, s:FixList(a:buffer, a:loclist))
             call setloclist(l:id, [], 'r', {'title': l:title})
         endif
+
+        silent doautocmd <nomodeline> QuickFixCmdPost lexpr
     endif
 
     " Open a window to show the problems if we need to.


### PR DESCRIPTION
The concrete problem that this solves is that I want to do "stuff" when
there are quickfix/location list errors. I initially tried hooking in to
ALELintPost, but that doesn't work as ALE sets errors asynchronously.

By hooking in to QuickFixCmd* this can be done in a generic (non-ALE
specific) way, that will work for e.g. :make as well; for example to
switch the colour of the statusline depending on the quickfix errors:

    fun! s:errcolor()
        if len(getloclist(bufnr('%'))) > 0 || len(getqflist()) > 0
            hi StatusLine term=bold,reverse cterm=bold,reverse gui=bold,reverse
                        \ ctermfg=1 guifg=#cd0000
        else
            hi StatusLine term=bold,reverse cterm=bold,reverse gui=bold,reverse
                        \ ctermfg=NONE guifg=NONE
        endif
    endfun

    autocmd QuickFixCmdPost ?expr,*make call s:errcolor() | redrawstatus

IMHO this is a more elegant/Vim-native solution than using ALELintPost
anyway (I saw there is an undocumented setting for excecuting it in
sync).

I'll add appropriate documentation and tests if the approach in this PR
is approved (no need to needlessly write docs/struggle with vader).