### PR TITLE
Remove test vars that cover bug

### DIFF
--- a/test/command_callback/test_haskell_hlint_command_callbacks.vader
+++ b/test/command_callback/test_haskell_hlint_command_callbacks.vader
@@ -1,9 +1,6 @@
 Before:
   call ale#assert#SetUpLinterTest('haskell', 'hlint')
 
-  let g:ale_haskell_hlint_executable = 'hlint'
-  let g:ale_haskell_hlint_options = ''
-
   let b:base_opts = '--color=never --json -'
 
 After:


### PR DESCRIPTION
These test vars were covering up a bug in the `hlint` linter
implementation. Without these vars we can see the behavior that is
exhibited in `vim` proper.

It seems that the exectuable var being defined in the handler is preventing
it from being intialized for the linter.

@w0rp do you know a way to resolve shared vars between linters and fixers?

```
  Starting Vader: /testplugin/test/command_callback/test_haskell_hlint_command_callbacks.vader
    (1/2) [EXECUTE] executable should be configurable
    (1/2) [EXECUTE] (X) Vim(return):E716: Key not present in Dictionary: ale_haskell_hlint_executable
      > function ale#assert#Linter[3]..ale#linter#GetExecutable[1]..<lambda>323[1]..ale#Var, line 4
    (2/2) [EXECUTE] should accept options
    (2/2) [EXECUTE] (X) Vim(return):E716: Key not present in Dictionary: ale_haskell_hlint_executable
      > function ale#assert#Linter[3]..ale#linter#GetExecutable[1]..<lambda>324[1]..ale#Var, line 4
```