### PR TITLE
Fix PMD not working with classes without package

### DIFF
--- a/ale_linters/java/pmd.vim
+++ b/ale_linters/java/pmd.vim
@@ -2,7 +2,7 @@
 " Description: PMD for Java files
 
 function! ale_linters#java#pmd#Handle(buffer, lines) abort
-    let l:pattern = '"\(\d\+\)",".\+","\(.\+\)","\(\d\+\)","\(\d\+\)","\(.\+\)","\(.\+\)","\(.\+\)"$'
+    let l:pattern = '"\(\d\+\)",".*","\(.\+\)","\(\d\+\)","\(\d\+\)","\(.\+\)","\(.\+\)","\(.\+\)"$'
     let l:output = []
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)

--- a/test/handler/test_pmd_handler.vader
+++ b/test/handler/test_pmd_handler.vader
@@ -25,3 +25,18 @@ Execute(The pmd handler should parse lines correctly):
   \    '"1","rsb.performance.test.ros","/home/languitar/src/rsb-performance-test-api-ros/src/main/java/rsb/performance/test/ros/NodeHolder.java","3","18","Each class should declare at least one constructor","Code Style","AtLeastOneConstructor"',
   \    '"2","rsb.performance.test.ros","/home/languitar/src/rsb-performance-test-api-ros/src/main/java/rsb/performance/test/ros/NodeHolder.java","1","36","Local variable ''node'' could be declared final","Code Style","LocalVariableCouldBeFinal"'
   \ ])
+
+Execute(The pmd handler should parse lines correctly for java files that use unnamed packages):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 8,
+  \     'text': 'Avoid unused local variables such as ''stest''.',
+  \     'code': 'Best Practices - UnusedLocalVariable',
+  \     'type': 'W',
+  \   },
+  \ ],
+  \ ale_linters#java#pmd#Handle(666, [
+  \    '"Problem","Package","File","Priority","Line","Description","Rule set","Rule"',
+  \    '"1","","/Users/diego/Projects/github.com/dlresende/kata-fizz-buzz/src/main/java/App.java","3","8","Avoid unused local variables such as ''stest''.","Best Practices","UnusedLocalVariable"'
+  \ ])


### PR DESCRIPTION
PMD is currently not working properly for Java classes that use [unnamed packages](https://docs.oracle.com/javase/specs/jls/se11/html/jls-7.html#jls-7.4.2).

Consider the following Java class that does not contain a `package` declaration:

```java
public class App {
  String getGreeting() {
    return "Hello world.";
  }

  static void main(String... args) {
    System.out.println(new App().getGreeting());
  }
}
```

Running PMD in the command line agaist the Java class above produces an output with empty string `""` in the `"Package"` column:

```sh
$ pmd -R category/java/bestpractices.xml -f csv -d './src/main/java/App.java'
Oct 02, 2018 9:10:39 PM net.sourceforge.pmd.PMD processFiles
WARNING: This analysis could be faster, please consider using Incremental Analysis: https://pmd.github.io/pmd-6.7.0/pmd_userdocs_incremental_analysis.html
"Problem","Package","File","Priority","Line","Description","Rule set","Rule"
"1","","/Users/diego/Projects/github.com/dlresende/kata-fizz-buzz/src/main/java/App.java","2","7","System.out.println is used","Best Practices","SystemPrintln"
```

But the pmd.vim handler's current pattern refuses everything coming from a Java class that does not have a package name (2nd column):

```vim
let l:pattern = '"\(\d\+\)",".\+","\(.\+\)","\(\d\+\)","\(\d\+\)","\(.\+\)","\(.\+\)","\(.\+\)"$'
```

The solution I am proposing is to also accept empty strings as package names.

<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-development`.

Have fun!
-->
