### PR TITLE
Support multiline text in loclist and quickfix

### DIFF
--- a/autoload/ale/list.vim
+++ b/autoload/ale/list.vim
@@ -60,7 +60,7 @@ function! s:FixList(buffer, list) abort
 
         let l:fixed_item.text = ale#GetLocItemMessage(l:item, l:format)
 
-        if l:item.bufnr == -1
+        if has_key(l:item, 'bufnr') && l:item.bufnr == -1
             " If the buffer number is invalid, remove it.
             call remove(l:fixed_item, 'bufnr')
         endif
@@ -80,6 +80,7 @@ function! s:SetListsImpl(timer_id, buffer, loclist) abort
 
     if g:ale_set_quickfix
         let l:quickfix_list = ale#list#GetCombinedList()
+        let l:quickfix_list = ale#util#LocItemExpandMultilineText(l:quickfix_list)
 
         if has('nvim')
             call setqflist(s:FixList(a:buffer, l:quickfix_list), ' ', l:title)
@@ -93,10 +94,12 @@ function! s:SetListsImpl(timer_id, buffer, loclist) abort
         " but it's better than nothing.
         let l:id = s:BufWinId(a:buffer)
 
+        let l:loclist = ale#util#LocItemExpandMultilineText(a:loclist)
+
         if has('nvim')
-            call setloclist(l:id, s:FixList(a:buffer, a:loclist), ' ', l:title)
+            call setloclist(l:id, s:FixList(a:buffer, l:loclist), ' ', l:title)
         else
-            call setloclist(l:id, s:FixList(a:buffer, a:loclist))
+            call setloclist(l:id, s:FixList(a:buffer, l:loclist))
             call setloclist(l:id, [], 'r', {'title': l:title})
         endif
     endif

--- a/autoload/ale/util.vim
+++ b/autoload/ale/util.vim
@@ -193,12 +193,30 @@ function! ale#util#LocItemCompareWithText(left, right) abort
         return l:cmp_value
     endif
 
-    if a:left.text < a:right.text
-        return -1
-    endif
+    if type(a:left.text) is v:t_string && type(a:right.text) is v:t_string
+        if a:left.text < a:right.text
+            return -1
+        endif
 
-    if a:left.text > a:right.text
+        if a:left.text > a:right.text
+            return 1
+        endif
+    elseif type(a:left.text) is v:t_string
+        return -1
+    elseif type(a:right.text) is v:t_string
         return 1
+    elseif type(a:left.text) is v:t_list && type(a:right.text) is v:t_list
+        if a:left.text == a:right.text
+            return 0
+        elseif empty(a:left.text)
+            return -1
+        elseif empty(a:right.text)
+            return 1
+        elseif a:left.text[0] < a:right.text[0]
+            return -1
+        else
+            return 1
+        endif
     endif
 
     return 0

--- a/autoload/ale/util.vim
+++ b/autoload/ale/util.vim
@@ -204,6 +204,25 @@ function! ale#util#LocItemCompareWithText(left, right) abort
     return 0
 endfunction
 
+function! ale#util#LocItemExpandMultilineText(loclist) abort
+  let l:expanded = []
+
+  for item in a:loclist
+    if has_key(item, 'text') && type(item.text) == type([])
+      let lines = item.text
+      for line in lines
+        let item.text = line
+        call add(l:expanded, item)
+        let item = {}
+      endfor
+    else
+      call add(l:expanded, item)
+    endif
+  endfor
+
+  return l:expanded
+endfunction
+
 " This function will perform a binary search and a small sequential search
 " on the list to find the last problem in the buffer and line which is
 " on or before the column. The index of the problem will be returned.

--- a/autoload/ale/util.vim
+++ b/autoload/ale/util.vim
@@ -205,22 +205,23 @@ function! ale#util#LocItemCompareWithText(left, right) abort
 endfunction
 
 function! ale#util#LocItemExpandMultilineText(loclist) abort
-  let l:expanded = []
+    let l:expanded = []
 
-  for item in a:loclist
-    if has_key(item, 'text') && type(item.text) == type([])
-      let lines = item.text
-      for line in lines
-        let item.text = line
-        call add(l:expanded, item)
-        let item = {}
-      endfor
-    else
-      call add(l:expanded, item)
-    endif
-  endfor
+    for l:item in a:loclist
+        if has_key(l:item, 'text') && type(l:item.text) is v:t_list
+            let l:lines = l:item.text
 
-  return l:expanded
+            for l:line in l:lines
+                let l:item.text = l:line
+                call add(l:expanded, l:item)
+                let l:item = {}
+            endfor
+        else
+            call add(l:expanded, l:item)
+        endif
+    endfor
+
+    return l:expanded
 endfunction
 
 " This function will perform a binary search and a small sequential search

--- a/test/test_list_multilinetext.vader
+++ b/test/test_list_multilinetext.vader
@@ -1,0 +1,54 @@
+Before:
+  Save g:ale_set_loclist
+  Save g:ale_set_quickfix
+  Save g:ale_buffer_info
+  Save g:ale_set_lists_synchronously
+
+  let g:ale_buffer_info = {}
+  let g:ale_set_loclist = 0
+  let g:ale_set_quickfix = 0
+  let g:ale_set_lists_synchronously = 1
+
+  call ale#test#SetDirectory('/testplugin/test')
+
+After:
+  Restore
+
+  call setloclist(0, [])
+  call setqflist([])
+
+  call ale#test#RestoreDirectory()
+
+Execute(The multiline text should be expanded in loclist):
+  let g:ale_set_loclist = 1
+
+  call ale#list#SetLists(bufnr(''), [
+  \ {'bufnr': bufnr(''), 'lnum': 1, 'text': ['1-1', '1-2', '1-3']},
+  \ {'bufnr': bufnr(''), 'lnum': 2, 'text': '2-1'},
+  \])
+
+  AssertEqual [
+  \ {'bufnr': bufnr(''), 'lnum': 1, 'col': 0, 'valid': 1, 'vcol': 0, 'nr': 0, 'type': '', 'pattern': '', 'text': '1-1'},
+  \ {'bufnr': 0, 'lnum': 0, 'col': 0, 'valid': 0, 'vcol': 0, 'nr': 0, 'type': '', 'pattern': '', 'text': '1-2'},
+  \ {'bufnr': 0, 'lnum': 0, 'col': 0, 'valid': 0, 'vcol': 0, 'nr': 0, 'type': '', 'pattern': '', 'text': '1-3'},
+  \ {'bufnr': bufnr(''), 'lnum': 2, 'col': 0, 'valid': 1, 'vcol': 0, 'nr': 0, 'type': '', 'pattern': '', 'text': '2-1'},
+  \], ale#test#GetLoclistWithoutModule()
+
+Execute(The multiline text should be expanded in quickfix):
+  let g:ale_set_quickfix = 1
+
+  let loclist = [
+  \ {'bufnr': bufnr(''), 'lnum': 1, 'text': ['1-1', '1-2', '1-3']},
+  \ {'bufnr': bufnr(''), 'lnum': 2, 'text': '2-1'},
+  \]
+
+  let g:ale_buffer_info[bufnr('')] = {'loclist': loclist}
+
+  call ale#list#SetLists(bufnr(''), loclist)
+
+  AssertEqual [
+  \ {'bufnr': bufnr(''), 'lnum': 1, 'col': 0, 'valid': 1, 'vcol': 0, 'nr': 0, 'type': '', 'pattern': '', 'text': '1-1'},
+  \ {'bufnr': 0, 'lnum': 0, 'col': 0, 'valid': 0, 'vcol': 0, 'nr': 0, 'type': '', 'pattern': '', 'text': '1-2'},
+  \ {'bufnr': 0, 'lnum': 0, 'col': 0, 'valid': 0, 'vcol': 0, 'nr': 0, 'type': '', 'pattern': '', 'text': '1-3'},
+  \ {'bufnr': bufnr(''), 'lnum': 2, 'col': 0, 'valid': 1, 'vcol': 0, 'nr': 0, 'type': '', 'pattern': '', 'text': '2-1'},
+  \], ale#test#GetQflistWithoutModule()

--- a/test/test_loclist_expand.vader
+++ b/test/test_loclist_expand.vader
@@ -1,0 +1,13 @@
+Execute(multiline text should be expanded):
+  AssertEqual ale#util#LocItemExpandMultilineText([
+  \   {'lnum': 1, 'text': '1-1'},
+  \   {'lnum': 2, 'text': ['2-1', '2-2', '2-3']},
+  \   {'lnum': 3, 'text': '3-1'},
+  \ ]),
+  \ [
+  \   {'lnum': 1, 'text': '1-1'},
+  \   {'lnum': 2, 'text': '2-1'},
+  \   {'text': '2-2'},
+  \   {'text': '2-3'},
+  \   {'lnum': 3, 'text': '3-1'},
+  \ ]

--- a/test/test_quickfix_deduplication.vader
+++ b/test/test_quickfix_deduplication.vader
@@ -20,6 +20,8 @@ Execute:
   \   {'type': 'E', 'bufnr': -1, 'filename': 'b', 'lnum': 4, 'col': 2, 'text': 'x'},
   \   {'type': 'E', 'bufnr': -1, 'filename': 'b', 'lnum': 5, 'col': 2, 'text': 'x'},
   \   {'type': 'E', 'bufnr': 3, 'lnum': 1, 'col': 1, 'text': 'foo'},
+  \   {'type': 'E', 'bufnr': 2, 'lnum': 5, 'col': 5, 'text': ['1', '2']},
+  \   {'type': 'E', 'bufnr': 2, 'lnum': 5, 'col': 5, 'text': []},
   \ ]},
   \ '2': {'loclist': [
   \   {'type': 'E', 'bufnr': 1, 'lnum': 2, 'col': 10, 'text': 'x'},
@@ -29,6 +31,8 @@ Execute:
   \   {'type': 'E', 'bufnr': 1, 'lnum': 5, 'col': 4, 'text': 'x'},
   \   {'type': 'E', 'bufnr': 2, 'lnum': 1, 'col': 5, 'text': 'bar'},
   \   {'type': 'E', 'bufnr': 2, 'lnum': 5, 'col': 5, 'text': 'another error'},
+  \   {'type': 'E', 'bufnr': 2, 'lnum': 5, 'col': 5, 'text': ['1', '2']},
+  \   {'type': 'E', 'bufnr': 2, 'lnum': 5, 'col': 5, 'text': ['2', '3']},
   \ ]},
   \}
 
@@ -45,6 +49,9 @@ Execute:
   \   {'type': 'E', 'bufnr': 2, 'lnum': 1, 'col': 5, 'text': 'bar'},
   \   {'type': 'E', 'bufnr': 2, 'lnum': 5, 'col': 5, 'text': 'another error'},
   \   {'type': 'E', 'bufnr': 2, 'lnum': 5, 'col': 5, 'text': 'foo'},
+  \   {'type': 'E', 'bufnr': 2, 'lnum': 5, 'col': 5, 'text': []},
+  \   {'type': 'E', 'bufnr': 2, 'lnum': 5, 'col': 5, 'text': ['1', '2']},
+  \   {'type': 'E', 'bufnr': 2, 'lnum': 5, 'col': 5, 'text': ['2', '3']},
   \   {'type': 'E', 'bufnr': 3, 'lnum': 1, 'col': 1, 'text': 'foo'},
   \ ],
   \ ale#list#GetCombinedList()


### PR DESCRIPTION
I want to pass multiple lines of text to loclist and quickfix. Some linters sometimes returns useful text of multiple lines.

### Output sample

![2018-10-04 17 14 22](https://user-images.githubusercontent.com/629993/46464015-49e37a00-c800-11e8-9b20-618b8c84a68a.png)

### loclist sample

```vim
let loclist = [
\ {'filename': 'Foo.swift', 'lnum': 100, 'col': 20, 'text': ['line 1', 'line 2', 'line 3']},
\]
```