### PR TITLE
Allow custom executable for ansible linters

### DIFF
--- a/ale_linters/ansible/ansible_lint.vim
+++ b/ale_linters/ansible/ansible_lint.vim
@@ -7,13 +7,6 @@ function! ale_linters#ansible#ansible_lint#GetExecutable(buffer) abort
     return ale#Var(a:buffer, 'ansible_ansible_lint_executable')
 endfunction
 
-function! ale_linters#ansible#ansible_lint#GetCommand(buffer) abort
-    let l:executable = ale_linters#ansible#ansible_lint#GetExecutable(a:buffer)
-
-    return ale#Escape(l:executable)
-    \  . ' -p %t'
-endfunction
-
 function! ale_linters#ansible#ansible_lint#Handle(buffer, lines) abort
     for l:line in a:lines[:10]
         if match(l:line, '^Traceback') >= 0
@@ -57,6 +50,6 @@ endfunction
 call ale#linter#Define('ansible', {
 \   'name': 'ansible',
 \   'executable_callback': 'ale_linters#ansible#ansible_lint#GetExecutable',
-\   'command_callback': 'ale_linters#ansible#ansible_lint#GetCommand',
+\   'command': '%e -p %t',
 \   'callback': 'ale_linters#ansible#ansible_lint#Handle',
 \})

--- a/ale_linters/ansible/ansible_lint.vim
+++ b/ale_linters/ansible/ansible_lint.vim
@@ -49,7 +49,7 @@ endfunction
 
 call ale#linter#Define('ansible', {
 \   'name': 'ansible_lint',
-\   'aliases': ['ansible'],
+\   'aliases': ['ansible', 'ansible-lint'],
 \   'executable_callback': 'ale_linters#ansible#ansible_lint#GetExecutable',
 \   'command': '%e -p %t',
 \   'callback': 'ale_linters#ansible#ansible_lint#Handle',

--- a/ale_linters/ansible/ansible_lint.vim
+++ b/ale_linters/ansible/ansible_lint.vim
@@ -48,7 +48,8 @@ function! ale_linters#ansible#ansible_lint#Handle(buffer, lines) abort
 endfunction
 
 call ale#linter#Define('ansible', {
-\   'name': 'ansible',
+\   'name': 'ansible_lint',
+\   'aliases': ['ansible'],
 \   'executable_callback': 'ale_linters#ansible#ansible_lint#GetExecutable',
 \   'command': '%e -p %t',
 \   'callback': 'ale_linters#ansible#ansible_lint#Handle',

--- a/ale_linters/ansible/ansible_lint.vim
+++ b/ale_linters/ansible/ansible_lint.vim
@@ -1,6 +1,19 @@
 " Author: Bjorn Neergaard <bjorn@neersighted.com>
 " Description: ansible-lint for ansible-yaml files
 
+call ale#Set('ansible_ansible_lint_executable', 'ansible-lint')
+
+function! ale_linters#ansible#ansible_lint#GetExecutable(buffer) abort
+    return ale#Var(a:buffer, 'ansible_ansible_lint_executable')
+endfunction
+
+function! ale_linters#ansible#ansible_lint#GetCommand(buffer) abort
+    let l:executable = ale_linters#ansible#ansible_lint#GetExecutable(a:buffer)
+
+    return ale#Escape(l:executable)
+    \  . ' -p %t'
+endfunction
+
 function! ale_linters#ansible#ansible_lint#Handle(buffer, lines) abort
     for l:line in a:lines[:10]
         if match(l:line, '^Traceback') >= 0
@@ -43,7 +56,7 @@ endfunction
 
 call ale#linter#Define('ansible', {
 \   'name': 'ansible',
-\   'executable': 'ansible',
-\   'command': 'ansible-lint -p %t',
+\   'executable_callback': 'ale_linters#ansible#ansible_lint#GetExecutable',
+\   'command_callback': 'ale_linters#ansible#ansible_lint#GetCommand',
 \   'callback': 'ale_linters#ansible#ansible_lint#Handle',
 \})

--- a/doc/ale-ansible.txt
+++ b/doc/ale-ansible.txt
@@ -1,0 +1,16 @@
+===============================================================================
+ALE Ansible Integration                                   *ale-ansible-options*
+
+
+===============================================================================
+ansible-lint                                         *ale-ansible-ansible-lint*
+
+g:ale_ansible_ansible_lint_executable   *g:ale_ansible_ansible_lint_executable*
+                                        *b:ale_ansible_ansible_lint_executable*
+  Type: |String|
+  Default: `'ansible-lint'`
+
+  This variable can be changed to modify the executable used for ansible-lint.
+
+===============================================================================
+  vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -18,6 +18,8 @@ CONTENTS                                                         *ale-contents*
     6.1 Highlights........................|ale-highlights|
     6.2 Options for write-good Linter.....|ale-write-good-options|
   7. Integration Documentation............|ale-integrations|
+    ansible...............................|ale-ansible-options|
+      ansible-lint........................|ale-ansible-ansible-lint|
     asciidoc..............................|ale-asciidoc-options|
       write-good..........................|ale-asciidoc-write-good|
     asm...................................|ale-asm-options|

--- a/test/command_callback/test_ansible_lint_command_callback.vader
+++ b/test/command_callback/test_ansible_lint_command_callback.vader
@@ -1,0 +1,17 @@
+Before:
+  call ale#assert#SetUpLinterTest('ansible', 'ansible_lint')
+  let b:bin_dir = has('win32') ? 'Scripts' : 'bin'
+
+After:
+  unlet! b:bin_dir
+  unlet! b:executable
+  call ale#assert#TearDownLinterTest()
+
+Execute(The ansible_lint command callback should return default string):
+  AssertLinter 'ansible-lint', ale#Escape('ansible-lint') . ' -p %t'
+
+Execute(The ansible_lint executable should be configurable):
+  let g:ale_ansible_ansible_lint_executable = '~/.local/bin/ansible-lint'
+
+  AssertLinter '~/.local/bin/ansible-lint',
+  \ ale#Escape('~/.local/bin/ansible-lint') . ' -p %t'


### PR DESCRIPTION
Set `ale_ansible_ansible_lint_executable` to use ansible-lint from a virtualenv.

Tests are rudimentary, I don't know a thing about vader.

What do you think about renaming the linter to `ansible_lint`? It's already called that way internally, just the user-facing `name` attribute in
```
call ale#linter#Define('ansible', {
\   'name': 'ansible',
```
is confusing.