### PR TITLE
Allow custom filters for the jq fixer

### DIFF
--- a/autoload/ale/fixers/jq.vim
+++ b/autoload/ale/fixers/jq.vim
@@ -1,5 +1,6 @@
 call ale#Set('json_jq_executable', 'jq')
 call ale#Set('json_jq_options', '')
+call ale#Set('json_jq_filters', '.')
 
 function! ale#fixers#jq#GetExecutable(buffer) abort
     return ale#Var(a:buffer, 'json_jq_executable')
@@ -7,9 +8,15 @@ endfunction
 
 function! ale#fixers#jq#Fix(buffer) abort
      let l:options = ale#Var(a:buffer, 'json_jq_options')
+     let l:filters = ale#Var(a:buffer, 'json_jq_filters')
+
+     if empty(l:filters)
+         return 0
+     endif
 
      return {
      \  'command': ale#Escape(ale#fixers#jq#GetExecutable(a:buffer))
-     \      . ' . ' . l:options,
+     \      . ' ' . l:filters . ' '
+     \      . l:options,
      \}
 endfunction

--- a/doc/ale-json.txt
+++ b/doc/ale-json.txt
@@ -73,6 +73,13 @@ g:ale_json_jq_options                                   *g:ale_json_jq_options*
 
   This option can be changed to pass extra options to `jq`.
 
+g:ale_json_jq_filters                                   *g:ale_json_jq_filters*
+                                                        *b:ale_json_jq_filters*
+  Type: |String|
+  Default: `'.'`
+
+  This option can be changed to pass custom filters to `jq`.
+
 
 ===============================================================================
 prettier                                                    *ale-json-prettier*

--- a/test/fixers/test_jq_fixer_callback.vader
+++ b/test/fixers/test_jq_fixer_callback.vader
@@ -1,6 +1,7 @@
 Before:
   Save g:ale_json_jq_executable
   Save g:ale_json_jq_options
+  Save g:ale_json_jq_filters
 
 After:
   Restore
@@ -8,7 +9,18 @@ After:
 Execute(The jq fixer should use the options you set):
   let g:ale_json_jq_executable = 'foo'
   let g:ale_json_jq_options = '--bar'
+  let g:ale_json_jq_filters = '.baz'
 
   AssertEqual
-  \ {'command': ale#Escape('foo') . ' . --bar'},
+  \ {'command': ale#Escape('foo') . ' .baz --bar'},
+  \ ale#fixers#jq#Fix(bufnr(''))
+
+Execute(The jq fixer should return 0 when there are not filters):
+  let g:ale_json_jq_executable = 'jq'
+  let g:ale_json_jq_options = ''
+
+  let g:ale_json_jq_filters = ''
+
+  AssertEqual
+  \ 0,
   \ ale#fixers#jq#Fix(bufnr(''))

--- a/test/fixers/test_jq_fixer_callback.vader
+++ b/test/fixers/test_jq_fixer_callback.vader
@@ -15,7 +15,7 @@ Execute(The jq fixer should use the options you set):
   \ {'command': ale#Escape('foo') . ' .baz --bar'},
   \ ale#fixers#jq#Fix(bufnr(''))
 
-Execute(The jq fixer should return 0 when there are not filters):
+Execute(The jq fixer should return 0 when there are no filters):
   let g:ale_json_jq_executable = 'jq'
   let g:ale_json_jq_options = ''
 


### PR DESCRIPTION
Hello, this PR adds support for [custom filters](https://stedolan.github.io/jq/manual/#Basicfilters) for the `jq` fixer. Because `jq` cannot work without a filter, the fixer callback returns when the filter option is empty.

Let me know I need to add something to the documentation or more tests.

Thanks!