### PR TITLE
Fix E523 on asynchronous truncated echo with getchar()

### DIFF
--- a/autoload/ale/cursor.vim
+++ b/autoload/ale/cursor.vim
@@ -26,7 +26,20 @@ function! ale#cursor#TruncatedEcho(original_message) abort
 
         " The message is truncated and saved to the history.
         setlocal shortmess+=T
-        exec "norm! :echomsg l:message\n"
+
+        try
+            exec "norm! :echomsg l:message\n"
+        catch /^Vim\%((\a\+)\)\=:E523/
+            " Fallback into manual truncate (#1987)
+            let l:winwidth = winwidth(0)
+
+            if l:winwidth < strdisplaywidth(l:message)
+                " Truncate message longer than window width with trailing '...'
+                let l:message = l:message[:l:winwidth - 4] . '...'
+            endif
+
+            exec 'echomsg l:message'
+        endtry
 
         " Reset the cursor position if we moved off the end of the line.
         " Using :norm and :echomsg can move the cursor off the end of the


### PR DESCRIPTION
<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-development`.

Have fun!
-->

## Problem

I have a mapping in my vimrc as follows:

```vim
nnoremap <silent><expr>m 'i'.nr2char(getchar())."\<Esc>"
```

The simple mapping gets one character from user with `getchar()` and put it to buffer. However, it seems that, when using this mapping at the same timing as ALE tries to echo linter warning, it sometimes causes an error as follows:

```
Error detected while processing function <SNR>184_VimCloseCallback[11]..<SNR>184_VimExitCallback[14]..<SNR>179_HandleExit[50]..ale#engine#Han
dleLoclist[33]..ale#engine#SetResults[26]..ale#cursor#EchoCursorWarning[22]..ale#cursor#TruncatedEcho:
line   15:
E523: Not allowed here
Error detected while processing function <SNR>184_VimCloseCallback:
line   11:
E171: Missing :endif
```

The similar issue was reported to my clever-f.vim plugin.

https://github.com/rhysd/clever-f.vim/issues/38


## Investigation

I did not know when `E523` occurs. So I dug Vim source code and found the line causing the error:

https://github.com/vim/vim/blob/b9464821901623f983528acaed9e4dc2cea7387b/src/normal.c#L799

This is a part of `:normal` command implementation. `:normal` command shows the error message (`text_locked_msg()` does) when it is executed while editing cmdline. (`getchar()` gets user's input via cmdline)

This was usually not a problem since Vim script is a synchronous language. `:normal` command was executed from insert mode or normal mode generally. While getting user input with `getchar()`, Vim script could do nothing since it's blocking.

However, situation was changed by asynchronous features such as job or channel. Asynchronous callback is run at arbitrary timing, even while blocking operation such as calling `getchar()`.

So what happens would be:

1. ALE automatically runs some linters and finds some warnings
2. User does something which runs `getchar()`
3. `getchar()` waits user input with blocking
4. ALE outputs warning to command line via `ale#cursor#TruncatedEcho()`
5. The function executes `:normal` and causes `E523`

## Fix

It seems that only `ale#cursor#TruncatedEcho` causes this issue. And I could not got why `TruncatedEcho` uses `:normal` here. It seems that removing `normal` (Does the last `\n` do something?). Executing `echomsg` directly looks working on my environment.
And after this fix, I haven't seen the `E523` error any more.