### PR TITLE
Add support for black usage with pipenv

### DIFF
--- a/autoload/ale/fixers/black.vim
+++ b/autoload/ale/fixers/black.vim
@@ -25,7 +25,7 @@ function! ale#fixers#black#Fix(buffer) abort
     let l:options = ale#Var(a:buffer, 'python_black_options')
 
     return {
-    \   'command': ale#Escape(l:executable. l:exec_args)
+    \   'command': ale#Escape(l:executable) . l:exec_args
     \       . (!empty(l:options) ? ' ' . l:options : '')
     \       . ' -',
     \}

--- a/autoload/ale/fixers/black.vim
+++ b/autoload/ale/fixers/black.vim
@@ -18,10 +18,6 @@ endfunction
 function! ale#fixers#black#Fix(buffer) abort
     let l:executable = ale#fixers#black#GetExecutable(a:buffer)
 
-    if !executable(l:executable)
-        return 0
-    endif
-
     let l:exec_args = l:executable =~? 'pipenv$'
     \   ? ' run black'
     \   : ''
@@ -29,7 +25,7 @@ function! ale#fixers#black#Fix(buffer) abort
     let l:options = ale#Var(a:buffer, 'python_black_options')
 
     return {
-    \   'command': ale#Escape(l:executable) . l:exec_args
+    \   'command': ale#Escape(l:executable. l:exec_args)
     \       . (!empty(l:options) ? ' ' . l:options : '')
     \       . ' -',
     \}

--- a/autoload/ale/fixers/black.vim
+++ b/autoload/ale/fixers/black.vim
@@ -4,22 +4,32 @@
 call ale#Set('python_black_executable', 'black')
 call ale#Set('python_black_use_global', get(g:, 'ale_use_global_executables', 0))
 call ale#Set('python_black_options', '')
+call ale#Set('python_black_auto_pipenv', 0)
+
+function! ale#fixers#black#GetExecutable(buffer) abort
+    if (ale#Var(a:buffer, 'python_auto_pipenv') || ale#Var(a:buffer, 'python_black_auto_pipenv'))
+    \ && ale#python#PipenvPresent(a:buffer)
+        return 'pipenv'
+    endif
+
+    return ale#python#FindExecutable(a:buffer, 'python_black', ['black'])
+endfunction
 
 function! ale#fixers#black#Fix(buffer) abort
-    let l:executable = ale#python#FindExecutable(
-    \   a:buffer,
-    \   'python_black',
-    \   ['black'],
-    \)
+    let l:executable = ale#fixers#black#GetExecutable(a:buffer)
 
     if !executable(l:executable)
         return 0
     endif
 
+    let l:exec_args = l:executable =~? 'pipenv$'
+    \   ? ' run black'
+    \   : ''
+
     let l:options = ale#Var(a:buffer, 'python_black_options')
 
     return {
-    \   'command': ale#Escape(l:executable)
+    \   'command': ale#Escape(l:executable) . l:exec_args
     \       . (!empty(l:options) ? ' ' . l:options : '')
     \       . ' -',
     \}

--- a/doc/ale-python.txt
+++ b/doc/ale-python.txt
@@ -91,6 +91,14 @@ g:ale_python_black_use_global                   *g:ale_python_black_use_global*
 
   See |ale-integrations-local-executables|
 
+g:ale_python_black_auto_pipenv                  *g:ale_python_black_auto_pipenv*
+                                                *b:ale_python_black_auto_pipenv*
+  Type: |Number|
+  Default: `0`
+
+  Detect whether the file is inside a pipenv, and set the executable to `pipenv`
+  if true. This is overridden by a manually-set executable.
+
 
 ===============================================================================
 flake8                                                      *ale-python-flake8*

--- a/test/fixers/test_black_fixer_callback.vader
+++ b/test/fixers/test_black_fixer_callback.vader
@@ -37,3 +37,10 @@ Execute(The black callback should include options):
   AssertEqual
   \ {'command': ale#Escape(ale#path#Simplify(g:dir . '/python_paths/with_virtualenv/env/' . b:bin_dir . '/black')) . ' --some-option -' },
   \ ale#fixers#black#Fix(bufnr(''))
+
+Execute(Pipenv is detected when python_black_auto_pipenv is set):
+  let g:ale_python_black_auto_pipenv = 1
+
+  AssertEqual 
+  \ {'command': 'pipenv run mypy' },
+  \ ale#fixers#black#Fix(bufnr(''))

--- a/test/fixers/test_black_fixer_callback.vader
+++ b/test/fixers/test_black_fixer_callback.vader
@@ -40,5 +40,5 @@ Execute(Pipenv is detected when python_black_auto_pipenv is set):
   call ale#test#SetFilename('/testplugin/test/python_fixtures/pipenv/whatever.py')
 
   AssertEqual 
-  \ {'command': ale#Escape('pipenv run black') . ' -'},
+  \ {'command': ale#Escape('pipenv') . ' run black -'},
   \ ale#fixers#black#Fix(bufnr(''))

--- a/test/fixers/test_black_fixer_callback.vader
+++ b/test/fixers/test_black_fixer_callback.vader
@@ -5,6 +5,7 @@ Before:
   " Use an invalid global executable, so we don't match it.
   let g:ale_python_black_executable = 'xxxinvalid'
   let g:ale_python_black_options = ''
+  let g:ale_python_black_auto_pipenv = 0
 
   call ale#test#SetDirectory('/testplugin/test/fixers')
   silent cd ..
@@ -21,10 +22,6 @@ After:
   call ale#test#RestoreDirectory()
 
 Execute(The black callback should return the correct default values):
-  AssertEqual
-  \ 0,
-  \ ale#fixers#black#Fix(bufnr(''))
-
   silent execute 'file ' . fnameescape(g:dir . '/python_paths/with_virtualenv/subdir/foo/bar.py')
   AssertEqual
   \ {'command': ale#Escape(ale#path#Simplify(g:dir . '/python_paths/with_virtualenv/env/' . b:bin_dir . '/black')) . ' -'},
@@ -40,7 +37,8 @@ Execute(The black callback should include options):
 
 Execute(Pipenv is detected when python_black_auto_pipenv is set):
   let g:ale_python_black_auto_pipenv = 1
+  call ale#test#SetFilename('/testplugin/test/python_fixtures/pipenv/whatever.py')
 
   AssertEqual 
-  \ {'command': 'pipenv run mypy' },
+  \ {'command': ale#Escape('pipenv run black') . ' -'},
   \ ale#fixers#black#Fix(bufnr(''))


### PR DESCRIPTION
For many projects and just out of habit, I have black installed using pipenv - the standard black executable will work assuming `pipenv shell` has been run before opening vim, but I often forget or haven't run it. 

This adds support for `black` usage with `pipenv` the same way that it works with `mypy` and other python tools.
