### PR TITLE
Expose ruby-solargraph's initialization options

### DIFF
--- a/ale_linters/ruby/solargraph.vim
+++ b/ale_linters/ruby/solargraph.vim
@@ -5,7 +5,7 @@
 " Description: updated to use stdio
 
 call ale#Set('ruby_solargraph_executable', 'solargraph')
-call ale#Set('ruby_solargraph_init_options', {})
+call ale#Set('ruby_solargraph_options', {})
 
 function! ale_linters#ruby#solargraph#GetCommand(buffer) abort
     return '%e' . ale#Pad('stdio')
@@ -18,5 +18,5 @@ call ale#linter#Define('ruby', {
 \   'executable_callback': ale#VarFunc('ruby_solargraph_executable'),
 \   'command_callback': 'ale_linters#ruby#solargraph#GetCommand',
 \   'project_root_callback': 'ale#ruby#FindProjectRoot',
-\   'initialization_options_callback': ale#VarFunc('ruby_solargraph_init_options'),
+\   'initialization_options_callback': ale#VarFunc('ruby_solargraph_options'),
 \})

--- a/ale_linters/ruby/solargraph.vim
+++ b/ale_linters/ruby/solargraph.vim
@@ -5,6 +5,7 @@
 " Description: updated to use stdio
 
 call ale#Set('ruby_solargraph_executable', 'solargraph')
+call ale#Set('ruby_solargraph_init_options', {})
 
 function! ale_linters#ruby#solargraph#GetCommand(buffer) abort
     return '%e' . ale#Pad('stdio')
@@ -17,4 +18,5 @@ call ale#linter#Define('ruby', {
 \   'executable_callback': ale#VarFunc('ruby_solargraph_executable'),
 \   'command_callback': 'ale_linters#ruby#solargraph#GetCommand',
 \   'project_root_callback': 'ale#ruby#FindProjectRoot',
+\   'initialization_options_callback': ale#VarFunc('ruby_solargraph_init_options'),
 \})

--- a/test/command_callback/test_ruby_solargraph.vader
+++ b/test/command_callback/test_ruby_solargraph.vader
@@ -37,3 +37,8 @@ Execute(should set solargraph for ruby app3):
   AssertLSPLanguage 'ruby'
   AssertLSPOptions {}
   AssertLSPProject ale#path#Simplify(g:dir . 'command_callback/../ruby_fixtures/valid_ruby_app3')
+
+Execute(should accept initialization options):
+  AssertLSPOptions {}
+  let b:ale_ruby_solargraph_init_options = { 'diagnostics': 'true' }
+  AssertLSPOptions { 'diagnostics': 'true' }

--- a/test/command_callback/test_ruby_solargraph.vader
+++ b/test/command_callback/test_ruby_solargraph.vader
@@ -40,5 +40,5 @@ Execute(should set solargraph for ruby app3):
 
 Execute(should accept initialization options):
   AssertLSPOptions {}
-  let b:ale_ruby_solargraph_init_options = { 'diagnostics': 'true' }
+  let b:ale_ruby_solargraph_options = { 'diagnostics': 'true' }
   AssertLSPOptions { 'diagnostics': 'true' }


### PR DESCRIPTION
Expose ruby-solargraph's initialization option as `ale_ruby_solargraph_init_options` as a dictionary with a default value of `{}` to help users on customizing solargraph's default configurations.
