### PR TITLE
Add `rust_cargo_use_clippy` option

### DIFF
--- a/ale_linters/rust/cargo.vim
+++ b/ale_linters/rust/cargo.vim
@@ -4,7 +4,7 @@
 " Description: rustc invoked by cargo for rust files
 
 call ale#Set('rust_cargo_use_check', 1)
-call ale#Set('rust_cargo_use_clippy', 0)
+call ale#Set('rust_cargo_use_clippy', 1)
 call ale#Set('rust_cargo_check_all_targets', 0)
 call ale#Set('rust_cargo_check_examples', 0)
 call ale#Set('rust_cargo_check_tests', 0)
@@ -30,10 +30,13 @@ endfunction
 
 function! ale_linters#rust#cargo#GetCommand(buffer, version_output) abort
     let l:version = ale#semver#GetVersion('cargo', a:version_output)
+    let l:clippy_version = ale#semver#GetVersion('cargo-clippy',
+    \   systemlist('cargo clippy -V'))
 
     let l:use_check = ale#Var(a:buffer, 'rust_cargo_use_check')
     \   && ale#semver#GTE(l:version, [0, 17, 0])
     let l:use_clippy = ale#Var(a:buffer, 'rust_cargo_use_clippy')
+    \   && ale#semver#GTE(l:clippy_version, [0, 0, 1])
     let l:use_all_targets = l:use_check
     \   && ale#Var(a:buffer, 'rust_cargo_check_all_targets')
     \   && ale#semver#GTE(l:version, [0, 22, 0])

--- a/ale_linters/rust/cargo.vim
+++ b/ale_linters/rust/cargo.vim
@@ -1,8 +1,10 @@
 " Author: Daniel Schemala <istjanichtzufassen@gmail.com>,
-" Ivan Petkov <ivanppetkov@gmail.com>
+" Ivan Petkov <ivanppetkov@gmail.com>,
+" Devon Hollowood <devonhollowood@gmail.com>
 " Description: rustc invoked by cargo for rust files
 
 call ale#Set('rust_cargo_use_check', 1)
+call ale#Set('rust_cargo_use_clippy', 0)
 call ale#Set('rust_cargo_check_all_targets', 0)
 call ale#Set('rust_cargo_check_examples', 0)
 call ale#Set('rust_cargo_check_tests', 0)
@@ -31,6 +33,7 @@ function! ale_linters#rust#cargo#GetCommand(buffer, version_output) abort
 
     let l:use_check = ale#Var(a:buffer, 'rust_cargo_use_check')
     \   && ale#semver#GTE(l:version, [0, 17, 0])
+    let l:use_clippy = ale#Var(a:buffer, 'rust_cargo_use_clippy')
     let l:use_all_targets = l:use_check
     \   && ale#Var(a:buffer, 'rust_cargo_check_all_targets')
     \   && ale#semver#GTE(l:version, [0, 22, 0])
@@ -71,7 +74,7 @@ function! ale_linters#rust#cargo#GetCommand(buffer, version_output) abort
     endif
 
     return l:nearest_cargo_prefix . 'cargo '
-    \   . (l:use_check ? 'check' : 'build')
+    \   . (l:use_clippy ? 'clippy' : (l:use_check ? 'check' : 'build'))
     \   . (l:use_all_targets ? ' --all-targets' : '')
     \   . (l:use_examples ? ' --examples' : '')
     \   . (l:use_tests ? ' --tests' : '')

--- a/doc/ale-rust.txt
+++ b/doc/ale-rust.txt
@@ -54,10 +54,10 @@ g:ale_rust_cargo_use_check                         *g:ale_rust_cargo_use_check*
 g:ale_rust_cargo_use_clippy                        *g:ale_rust_cargo_use_clippy*
                                                    *b:ale_rust_cargo_use_clippy*
   Type: |Number|
-  Default: `0`
+  Default: `1`
 
   When set to `1`, this option will cause ALE to use `cargo clippy` instead of
-  `cargo build` or `cargo check` . This will override
+  `cargo build` or `cargo check` if `cargo-clippy` is available. This will override
   |g:ale_rust_cargo_use_check|.
 
 

--- a/doc/ale-rust.txt
+++ b/doc/ale-rust.txt
@@ -51,6 +51,16 @@ g:ale_rust_cargo_use_check                         *g:ale_rust_cargo_use_check*
   0.17.0.
 
 
+g:ale_rust_cargo_use_clippy                        *g:ale_rust_cargo_use_clippy*
+                                                   *b:ale_rust_cargo_use_clippy*
+  Type: |Number|
+  Default: `0`
+
+  When set to `1`, this option will cause ALE to use `cargo clippy` instead of
+  `cargo build` or `cargo check` . This will override
+  |g:ale_rust_cargo_use_check|.
+
+
 g:ale_rust_cargo_check_all_targets         *g:ale_rust_cargo_check_all_targets*
                                            *b:ale_rust_cargo_check_all_targets*
   Type: |Number|

--- a/test/command_callback/test_cargo_command_callbacks.vader
+++ b/test/command_callback/test_cargo_command_callbacks.vader
@@ -51,6 +51,12 @@ Execute(`cargo build` should be used when g:ale_rust_cargo_use_check is set to 0
   WithChainResults []
   AssertLinter '', ['', 'cargo build' . g:suffix]
 
+Execute(`cargo clippy` should be used when g:ale_rust_cargo_use_clippy is set to 1):
+  let g:ale_rust_cargo_use_clippy = 1
+
+  WithChainResults []
+  AssertLinter '', ['cargo --version', 'cargo clippy' . g:suffix]
+
 Execute(`cargo check` should be used when the version is new enough):
   AssertLinter '', ['cargo --version', 'cargo check' . g:suffix]
 


### PR DESCRIPTION
<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-development`.

Have fun!
-->

I took a shot at #1922. Right now, this adds an option `ale_rust_cargo_use_clippy`, which defaults to `0`. If instead set to `1`, `ALE` uses `cargo clippy` instead of `cargo build` or `cargo check`.

Optimally, I'd like for this to check whether the `cargo-clippy` executable exists and if so default to using clippy, but there's a wrinkle: if `rustup` has `cargo-clippy` on one toolchain, but not all toolchains, then it's possible for `cargo-clippy` to exist but to exit with an error. So maybe a smarter way to handle the check is to see if `cargo-clippy -V` exits with status `0`, but I'm not sure the best way to do that (I'm new to vimscript, and it looks like `ALE` has it's own functions to handle this sort of thing anyways). Any advice there would be appreciated.

Edit: I figured out how to do the above with `systemlist()`. Let me know if that's acceptable, or if you would rather I use an `ALE`-specific function. Also, the tests no longer run successfully. I think this is because the docker image for ALE doesn't have `clippy` installed. 
