### PR TITLE
Reek: --force-exclusion flag

### DIFF
--- a/ale_linters/ruby/reek.vim
+++ b/ale_linters/ruby/reek.vim
@@ -30,7 +30,7 @@ function! ale_linters#ruby#reek#GetCommand(buffer, version_output) abort
     \   : ''
 
     return ale#handlers#ruby#EscapeExecutable(l:executable, 'reek')
-    \   . ' -f json --no-progress --no-color'
+    \   . ' -f json --no-progress --no-color --force-exclusion'
     \   . l:display_name_args
 endfunction
 

--- a/test/command_callback/test_reek_command_callback.vader
+++ b/test/command_callback/test_reek_command_callback.vader
@@ -8,7 +8,7 @@ Execute(The reek callbacks should return the correct default values):
   WithChainResults ['reek 5.0.0']
   AssertLinter 'reek', [
   \ ale#Escape('reek') . ' --version',
-  \ ale#Escape('reek') . ' -f json --no-progress --no-color --stdin-filename %s',
+  \ ale#Escape('reek') . ' -f json --no-progress --no-color --force-exclusion --stdin-filename %s',
   \]
 
   " Try with older versions.
@@ -17,7 +17,7 @@ Execute(The reek callbacks should return the correct default values):
   WithChainResults ['reek 4.8.2']
   AssertLinter 'reek', [
   \ ale#Escape('reek') . ' --version',
-  \ ale#Escape('reek') . ' -f json --no-progress --no-color',
+  \ ale#Escape('reek') . ' -f json --no-progress --no-color --force-exclusion',
   \]
 
 Execute(Setting bundle appends 'exec reek'):
@@ -26,7 +26,7 @@ Execute(Setting bundle appends 'exec reek'):
   WithChainResults ['reek 5.0.0']
   AssertLinter 'bundle', ale#Escape('bundle')
   \ . ' exec reek'
-  \ . ' -f json --no-progress --no-color --stdin-filename %s',
+  \ . ' -f json --no-progress --no-color --force-exclusion --stdin-filename %s',
 
   " Try with older versions.
   call ale#semver#ResetVersionCache()
@@ -34,17 +34,17 @@ Execute(Setting bundle appends 'exec reek'):
   WithChainResults ['reek 4.8.2']
   AssertLinter 'bundle', ale#Escape('bundle')
   \ . ' exec reek'
-  \ . ' -f json --no-progress --no-color'
+  \ . ' -f json --no-progress --no-color --force-exclusion'
 
 Execute(The reek version check should be cached):
   WithChainResults ['reek 5.0.0']
   AssertLinter 'reek', [
   \ ale#Escape('reek') . ' --version',
-  \ ale#Escape('reek') . ' -f json --no-progress --no-color --stdin-filename %s',
+  \ ale#Escape('reek') . ' -f json --no-progress --no-color --force-exclusion --stdin-filename %s',
   \]
 
   WithChainResults []
   AssertLinter 'reek', [
   \ '',
-  \ ale#Escape('reek') . ' -f json --no-progress --no-color --stdin-filename %s',
+  \ ale#Escape('reek') . ' -f json --no-progress --no-color --force-exclusion --stdin-filename %s',
   \]


### PR DESCRIPTION
Expand the current buffer's full path name for the `--stdin-filename` argument. This is basically identical to how Rubocop does it. Before the `%s` wasn't being interpolated, but the pathname given to reek was '%s'. Now it gets the full pathname of the current buffer.

I also added the `--force-exclusion` argument to ensure any configured `excluded_paths` are respected. However, there's currently an issue open with Reed re: piped in source not respecting the configured `excluded_paths`: https://github.com/troessner/reek/issues/1429