### PR TITLE
Fix #2011 MS Windows, lint error when current drive and target file drive is different.

### DIFF
--- a/autoload/ale/path.vim
+++ b/autoload/ale/path.vim
@@ -65,11 +65,11 @@ endfunction
 " Output 'cd <directory> && '
 " This function can be used changing the directory for a linter command.
 function! ale#path#CdString(directory) abort
-	if has('win32')
-       return 'cd /d ' . ale#Escape(a:directory) . ' && '
-   else
-       return 'cd ' . ale#Escape(a:directory) . ' && '
-   endif
+    if has('win32')
+        return 'cd /d ' . ale#Escape(a:directory) . ' && '
+    else
+        return 'cd ' . ale#Escape(a:directory) . ' && '
+    endif
 endfunction
 
 " Output 'cd <buffer_filename_directory> && '

--- a/autoload/ale/path.vim
+++ b/autoload/ale/path.vim
@@ -65,7 +65,11 @@ endfunction
 " Output 'cd <directory> && '
 " This function can be used changing the directory for a linter command.
 function! ale#path#CdString(directory) abort
-    return 'cd ' . ale#Escape(a:directory) . ' && '
+	if has('win32')
+       return 'cd /d ' . ale#Escape(a:directory) . ' && '
+   else
+       return 'cd ' . ale#Escape(a:directory) . ' && '
+   endif
 endfunction
 
 " Output 'cd <buffer_filename_directory> && '

--- a/run-tests.bat
+++ b/run-tests.bat
@@ -13,7 +13,7 @@ set VADER_OUTPUT_FILE=%~dp0\vader_output
 REM Automatically re-run Windows tests, which can fail some times.
 set tries=0
 
-RUN_TESTS:
+:RUN_TESTS
 set /a tries=%tries%+1
 type nul > "%VADER_OUTPUT_FILE%"
 C:\vim\vim\vim80\vim.exe -u test/vimrc "+Vader! %tests%"
@@ -23,7 +23,7 @@ IF %code% EQU 0 GOTO :SHOW_RESULTS
 IF %tries%  GEQ 2 GOTO :SHOW_RESULTS
 GOTO :RUN_TESTS
 
-SHOW_RESULTS:
+:SHOW_RESULTS
 type "%VADER_OUTPUT_FILE%"
 del "%VADER_OUTPUT_FILE%"
 

--- a/test/command_callback/test_c_cppcheck_command_callbacks.vader
+++ b/test/command_callback/test_c_cppcheck_command_callbacks.vader
@@ -19,6 +19,6 @@ Execute(cppcheck for C++ should detect compile_commands.json files):
   call ale#test#SetFilename('cppcheck_paths/one/foo.cpp')
 
   AssertLinter 'cppcheck',
-  \ 'cd ' . ale#Escape(ale#path#Simplify(g:dir . '/cppcheck_paths/one')) . ' && '
+  \ ale#path#CdString(ale#Escape(ale#path#Simplify(g:dir . '/cppcheck_paths/one')))
   \   . ale#Escape('cppcheck')
   \   . ' -q --language=c --project=compile_commands.json --enable=style %t'

--- a/test/command_callback/test_cpp_cppcheck_command_callbacks.vader
+++ b/test/command_callback/test_cpp_cppcheck_command_callbacks.vader
@@ -17,6 +17,6 @@ Execute(cppcheck for C++ should detect compile_commands.json files):
   call ale#test#SetFilename('cppcheck_paths/one/foo.cpp')
 
   AssertLinter 'cppcheck',
-  \ 'cd ' . ale#Escape(ale#path#Simplify(g:dir . '/cppcheck_paths/one')) . ' && '
+  \ ale#path#CdString(ale#Escape(ale#path#Simplify(g:dir . '/cppcheck_paths/one'))) 
   \   . ale#Escape('cppcheck')
   \   . ' -q --language=c++ --project=compile_commands.json --enable=style %t'

--- a/test/command_callback/test_cs_mcsc_command_callbacks.vader
+++ b/test/command_callback/test_cs_mcsc_command_callbacks.vader
@@ -5,43 +5,43 @@ After:
   call ale#assert#TearDownLinterTest()
 
 Execute(The mcsc linter should return the correct default command):
-  AssertLinter 'mcs', 'cd ' . ale#Escape(g:dir) . ' && '
+  AssertLinter 'mcs', ale#path#CdString(ale#Escape(g:dir))
   \ . 'mcs -unsafe -out:TEMP -t:module -recurse:' . ale#Escape('*.cs')
 
 Execute(The options should be be used in the command):
   let g:ale_cs_mcsc_options = '-pkg:dotnet'
 
-  AssertLinter 'mcs', 'cd ' . ale#Escape(g:dir) . ' && '
+  AssertLinter 'mcs', ale#path#CdString(ale#Escape(g:dir))
   \ . 'mcs -unsafe -pkg:dotnet -out:TEMP -t:module -recurse:' . ale#Escape('*.cs')
 
 Execute(The souce path should be be used in the command):
   let g:ale_cs_mcsc_source = '../foo/bar'
 
-  AssertLinter 'mcs', 'cd ' . ale#Escape('../foo/bar') . ' && '
+  AssertLinter 'mcs', ale#path#CdString(ale#Escape('../foo/bar'))
   \ . 'mcs -unsafe -out:TEMP -t:module -recurse:' . ale#Escape('*.cs')
 
 Execute(The list of search pathes for assemblies should be be used in the command if not empty):
   let g:ale_cs_mcsc_assembly_path = ['/usr/lib/mono', '../foo/bar']
 
-  AssertLinter 'mcs', 'cd ' . ale#Escape(g:dir) . ' && '
+  AssertLinter 'mcs', ale#path#CdString(ale#Escape(g:dir))
   \ . 'mcs -unsafe'
   \ . ' -lib:' . ale#Escape('/usr/lib/mono') . ',' . ale#Escape('../foo/bar')
   \ . ' -out:TEMP -t:module -recurse:' . ale#Escape('*.cs')
 
   let g:ale_cs_mcsc_assembly_path = []
 
-  AssertLinter 'mcs', 'cd ' . ale#Escape(g:dir) . ' && '
+  AssertLinter 'mcs', ale#path#CdString(ale#Escape(g:dir))
   \ . 'mcs -unsafe -out:TEMP -t:module -recurse:' . ale#Escape('*.cs')
 
 Execute(The list of assemblies should be be used in the command if not empty):
   let g:ale_cs_mcsc_assemblies = ['foo.dll', 'bar.dll']
 
-  AssertLinter 'mcs', 'cd ' . ale#Escape(g:dir) . ' && '
+  AssertLinter 'mcs', ale#path#CdString(ale#Escape(g:dir))
   \ . 'mcs -unsafe'
   \ . ' -r:' . ale#Escape('foo.dll') . ',' . ale#Escape('bar.dll')
   \ . ' -out:TEMP -t:module -recurse:' . ale#Escape('*.cs')
 
   let g:ale_cs_mcsc_assemblies = []
 
-  AssertLinter 'mcs', 'cd ' . ale#Escape(g:dir) . ' && '
+  AssertLinter 'mcs', ale#path#CdString(ale#Escape(g:dir))
   \ . 'mcs -unsafe -out:TEMP -t:module -recurse:' . ale#Escape('*.cs')

--- a/test/command_callback/test_gobuild_command_callback.vader
+++ b/test/command_callback/test_gobuild_command_callback.vader
@@ -11,14 +11,14 @@ After:
 
 Execute(The default commands should be correct):
   AssertLinter 'go',
-  \ 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \ ale#path#CdString(ale#Escape(expand('%:p:h')))
   \   . 'go test -c -o /dev/null ./'
 
 Execute(Extra options should be supported):
   let g:ale_go_gobuild_options = '--foo-bar'
 
   AssertLinter 'go',
-  \ 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \ ale#path#CdString(ale#Escape(expand('%:p:h')))
   \   . 'go test --foo-bar -c -o /dev/null ./'
 
   let g:ale_go_gobuild_options = ''
@@ -27,5 +27,5 @@ Execute(The executable should be configurable):
   let g:ale_go_go_executable = 'foobar'
 
   AssertLinter 'foobar',
-  \ 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \ ale#path#CdString(ale#Escape(expand('%:p:h')))
   \   . 'foobar test -c -o /dev/null ./'

--- a/test/command_callback/test_golangci_lint_command_callback.vader
+++ b/test/command_callback/test_golangci_lint_command_callback.vader
@@ -7,7 +7,7 @@ After:
 
 Execute(The golangci-lint defaults should be correct):
   AssertLinter 'golangci-lint',
-  \ 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \ ale#path#CdString(ale#Escape(expand('%:p:h')))
   \   . ale#Escape('golangci-lint')
   \   . ' run ' . ale#Escape(expand('%' . ':t'))
   \   . ' --enable-all'
@@ -16,7 +16,7 @@ Execute(The golangci-lint callback should use a configured executable):
   let b:ale_go_golangci_lint_executable = 'something else'
 
   AssertLinter 'something else',
-  \ 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \ ale#path#CdString(ale#Escape(expand('%:p:h')))
   \   . ale#Escape('something else')
   \   . ' run ' . ale#Escape(expand('%' . ':t'))
   \   . ' --enable-all'
@@ -25,7 +25,7 @@ Execute(The golangci-lint callback should use configured options):
   let b:ale_go_golangci_lint_options = '--foobar'
 
   AssertLinter 'golangci-lint',
-  \ 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \ ale#path#CdString(ale#Escape(expand('%:p:h')))
   \   . ale#Escape('golangci-lint')
   \   . ' run ' . ale#Escape(expand('%' . ':t'))
   \   . ' --foobar'
@@ -34,5 +34,5 @@ Execute(The golangci-lint `lint_package` option should use the correct command):
   let b:ale_go_golangci_lint_package = 1
 
   AssertLinter 'golangci-lint',
-  \ 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \ ale#path#CdString(ale#Escape(expand('%:p:h')))
   \   . ale#Escape('golangci-lint') . ' run --enable-all'

--- a/test/command_callback/test_gometalinter_command_callback.vader
+++ b/test/command_callback/test_gometalinter_command_callback.vader
@@ -7,7 +7,7 @@ After:
 
 Execute(The gometalinter defaults should be correct):
   AssertLinter 'gometalinter',
-  \ 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \ ale#path#CdString(ale#Escape(expand('%:p:h')))
   \   . ale#Escape('gometalinter')
   \   . ' --include=' . ale#Escape(ale#util#EscapePCRE(expand('%' . ':t')))
   \   . ' .'
@@ -16,7 +16,7 @@ Execute(The gometalinter callback should use a configured executable):
   let b:ale_go_gometalinter_executable = 'something else'
 
   AssertLinter 'something else',
-  \ 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \ ale#path#CdString(ale#Escape(expand('%:p:h')))
   \   . ale#Escape('something else')
   \   . ' --include=' . ale#Escape(ale#util#EscapePCRE(expand('%' . ':t')))
   \   . ' .'
@@ -25,7 +25,7 @@ Execute(The gometalinter callback should use configured options):
   let b:ale_go_gometalinter_options = '--foobar'
 
   AssertLinter 'gometalinter',
-  \ 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \ ale#path#CdString(ale#Escape(expand('%:p:h')))
   \   . ale#Escape('gometalinter')
   \   . ' --include=' . ale#Escape(ale#util#EscapePCRE(expand('%' . ':t')))
   \   . ' --foobar' . ' .'
@@ -34,5 +34,5 @@ Execute(The gometalinter `lint_package` option should use the correct command):
   let b:ale_go_gometalinter_lint_package = 1
 
   AssertLinter 'gometalinter',
-  \ 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \ ale#path#CdString(ale#Escape(expand('%:p:h')))
   \   . ale#Escape('gometalinter') . ' .'

--- a/test/command_callback/test_gosimple_command_callback.vader
+++ b/test/command_callback/test_gosimple_command_callback.vader
@@ -7,4 +7,4 @@ After:
 
 Execute(The default gosimple command should be correct):
   AssertLinter 'gosimple',
-  \ 'cd ' . ale#Escape(expand('%:p:h')) . ' &&  gosimple .'
+  \ ale#path#CdString(ale#Escape(expand('%:p:h'))) . ' gosimple .'

--- a/test/command_callback/test_gotype_command_callback.vader
+++ b/test/command_callback/test_gotype_command_callback.vader
@@ -7,7 +7,7 @@ After:
 
 Execute(The default gotype command should be correct):
   AssertLinter 'gotype',
-  \ 'cd ' . ale#Escape(expand('%:p:h')) . ' &&  gotype .'
+  \ ale#path#CdString(ale#Escape(expand('%:p:h'))) . ' gotype .'
 
 Execute(The gotype callback should ignore test files):
   call ale#test#SetFilename('bla_test.go')

--- a/test/command_callback/test_govet_command_callback.vader
+++ b/test/command_callback/test_govet_command_callback.vader
@@ -8,12 +8,12 @@ After:
   call ale#assert#TearDownLinterTest()
 
 Execute(The default command should be correct):
-  AssertLinter 'go', 'cd ' . ale#Escape(expand('%:p:h')) . ' &&  go vet  .'
+  AssertLinter 'go', ale#path#CdString(ale#Escape(expand('%:p:h'))) . ' go vet  .'
 
 Execute(Extra options should be supported):
   let g:ale_go_govet_options = '--foo-bar'
-  AssertLinter 'go', 'cd ' . ale#Escape(expand('%:p:h')) . ' &&  go vet  --foo-bar .'
+  AssertLinter 'go', ale#path#CdString(ale#Escape(expand('%:p:h'))) . ' go vet  --foo-bar .'
 
 Execute(The executable should be configurable):
   let g:ale_go_go_executable = 'foobar'
-  AssertLinter 'foobar', 'cd ' . ale#Escape(expand('%:p:h')) . ' &&  foobar vet  .'
+  AssertLinter 'foobar', ale#path#CdString(ale#Escape(expand('%:p:h'))) . ' foobar vet  .'

--- a/test/command_callback/test_javac_command_callback.vader
+++ b/test/command_callback/test_javac_command_callback.vader
@@ -3,7 +3,7 @@ Before:
   call ale#test#SetFilename('dummy.java')
 
   let g:cp_sep = has('unix') ? ':' : ';'
-  let g:prefix = 'cd ' . ale#Escape(expand('%:p:h'))  . ' && '
+  let g:prefix = ale#path#CdString(ale#Escape(expand('%:p:h')))
   \ . ale#Escape('javac') . ' -Xlint'
 
   function! GetCommand(previous_output) abort
@@ -43,7 +43,7 @@ Execute(The executable should be configurable):
   let g:ale_java_javac_executable = 'foobar'
 
   AssertLinter 'foobar',
-  \ 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \ ale#path#CdString(ale#Escape(expand('%:p:h')))
   \ . ale#Escape('foobar') . ' -Xlint'
   \ . ' -d ' . ale#Escape('TEMP_DIR') . ' %t'
 
@@ -106,7 +106,7 @@ Execute(The javac callback should detect source directories):
   call ale#engine#InitBufferInfo(bufnr(''))
 
   AssertLinter 'javac',
-  \ 'cd ' . ale#Escape(expand('%:p:h')) . ' && ' . ale#Escape('javac') . ' -Xlint'
+  \ ale#path#CdString(ale#Escape(expand('%:p:h'))) . ale#Escape('javac') . ' -Xlint'
   \   . ' -sourcepath ' . ale#Escape(
   \     ale#path#Simplify(g:dir . '/java_paths/src/main/java/')
   \   )
@@ -124,7 +124,7 @@ Execute(The javac callback should combine detected source directories and classp
   \ '/xyz/abc.jar',
   \]
   AssertLinter 'javac',
-  \ 'cd ' . ale#Escape(expand('%:p:h')) . ' && ' . ale#Escape('javac') . ' -Xlint'
+  \ ale#path#CdString(ale#Escape(expand('%:p:h'))) . ale#Escape('javac') . ' -Xlint'
   \   . ' -cp ' . ale#Escape(join(['/foo/bar.jar', '/xyz/abc.jar'], g:cp_sep))
   \   . ' -sourcepath ' . ale#Escape(
   \     ale#path#Simplify(g:dir . '/java_paths/src/main/java/')
@@ -147,7 +147,7 @@ Execute(The javac callback should include src/test/java for test paths):
   call ale#engine#InitBufferInfo(bufnr(''))
 
   AssertLinter 'javac',
-  \ 'cd ' . ale#Escape(expand('%:p:h')) . ' && ' . ale#Escape('javac') . ' -Xlint'
+  \ ale#path#CdString(ale#Escape(expand('%:p:h'))) . ale#Escape('javac') . ' -Xlint'
   \   . ' -sourcepath ' . ale#Escape(join([
   \     ale#path#Simplify(g:dir . '/java_paths/src/main/java/'),
   \     ale#path#Simplify(g:dir . '/java_paths/src/test/java/'),
@@ -160,7 +160,7 @@ Execute(The javac callback should include src/main/jaxb when available):
   call ale#engine#InitBufferInfo(bufnr(''))
 
   AssertLinter 'javac',
-  \ 'cd ' . ale#Escape(expand('%:p:h')) . ' && ' . ale#Escape('javac') . ' -Xlint'
+  \ ale#path#CdString(ale#Escape(expand('%:p:h'))) . ale#Escape('javac') . ' -Xlint'
   \   . ' -sourcepath ' . ale#Escape(join([
   \     ale#path#Simplify(g:dir . '/java_paths_with_jaxb/src/main/java/'),
   \     ale#path#Simplify(g:dir . '/java_paths_with_jaxb/src/main/jaxb/'),

--- a/test/command_callback/test_lintr_command_callback.vader
+++ b/test/command_callback/test_lintr_command_callback.vader
@@ -6,7 +6,7 @@ After:
 
 Execute(The default lintr command should be correct):
   AssertLinter 'Rscript',
-  \   'cd ' . ale#Escape(getcwd()) . ' && '
+  \   ale#path#CdString(ale#Escape(getcwd()))
   \   . 'Rscript --vanilla -e '
   \   . ale#Escape('suppressPackageStartupMessages(library(lintr));'
   \   .            'lint(cache = FALSE, commandArgs(TRUE), '
@@ -17,7 +17,7 @@ Execute(The lintr options should be configurable):
   let b:ale_r_lintr_options = 'with_defaults(object_usage_linter = NULL)'
 
   AssertLinter 'Rscript',
-  \   'cd ' . ale#Escape(getcwd()) . ' && '
+  \   ale#path#CdString(ale#Escape(getcwd()))
   \   . 'Rscript --vanilla -e '
   \   . ale#Escape('suppressPackageStartupMessages(library(lintr));'
   \   .            'lint(cache = FALSE, commandArgs(TRUE), '
@@ -28,7 +28,7 @@ Execute(If the lint_package flag is set, lintr::lint_package should be called):
   let b:ale_r_lintr_lint_package = 1
 
   AssertLinter 'Rscript',
-  \   'cd ' . ale#Escape(getcwd()) . ' && '
+  \   ale#path#CdString(ale#Escape(getcwd()))
   \   . 'Rscript --vanilla -e '
   \   . ale#Escape('suppressPackageStartupMessages(library(lintr));'
   \   .            'lint_package(cache = FALSE, '

--- a/test/command_callback/test_mypy_command_callback.vader
+++ b/test/command_callback/test_mypy_command_callback.vader
@@ -12,7 +12,7 @@ After:
 
 Execute(The mypy callbacks should return the correct default values):
   AssertLinter 'mypy',
-  \ 'cd ' . ale#Escape(g:dir) . ' && ' . ale#Escape('mypy')
+  \ ale#path#CdString(ale#Escape(g:dir)) . ale#Escape('mypy')
   \   . ' --show-column-numbers  '
   \   . '--shadow-file %s %t %s'
 
@@ -20,7 +20,7 @@ Execute(The mypy executable should be configurable, and escaped properly):
   let g:ale_python_mypy_executable = 'executable with spaces'
 
   AssertLinter 'executable with spaces',
-  \ 'cd ' . ale#Escape(g:dir) . ' && ' . ale#Escape('executable with spaces')
+  \ ale#path#CdString(ale#Escape(g:dir)) . ale#Escape('executable with spaces')
   \   . ' --show-column-numbers  '
   \   . '--shadow-file %s %t %s'
 
@@ -28,7 +28,7 @@ Execute(The mypy command callback should let you set options):
   let g:ale_python_mypy_options = '--some-option'
 
   AssertLinter 'mypy',
-  \ 'cd ' . ale#Escape(g:dir) . ' && ' . ale#Escape('mypy')
+  \ ale#path#CdString(ale#Escape(g:dir)) . ale#Escape('mypy')
   \   . ' --show-column-numbers --some-option '
   \   . '--shadow-file %s %t %s'
 
@@ -36,8 +36,8 @@ Execute(The mypy command should switch directories to the detected project root)
   silent execute 'file ' . fnameescape(g:dir . '/python_paths/no_virtualenv/subdir/foo/bar.py')
 
   AssertLinter 'mypy',
-  \ 'cd ' . ale#Escape(ale#path#Simplify(g:dir . '/python_paths/no_virtualenv/subdir'))
-  \   . ' && ' . ale#Escape('mypy')
+  \ ale#path#CdString(ale#Escape(ale#path#Simplify(g:dir . '/python_paths/no_virtualenv/subdir')))
+  \   . ale#Escape('mypy')
   \   . ' --show-column-numbers  '
   \   . '--shadow-file %s %t %s'
 
@@ -47,8 +47,8 @@ Execute(The mypy callbacks should detect virtualenv directories and switch to th
   let b:executable = ale#path#Simplify(g:dir . '/python_paths/with_virtualenv/env/' . b:bin_dir . '/mypy')
 
   AssertLinter b:executable,
-  \   'cd ' . ale#Escape(ale#path#Simplify(g:dir . '/python_paths/with_virtualenv/subdir'))
-  \   . ' && ' . ale#Escape(b:executable)
+  \   ale#path#CdString(ale#Escape(ale#path#Simplify(g:dir . '/python_paths/with_virtualenv/subdir')))
+  \   . ale#Escape(b:executable)
   \   . ' --show-column-numbers  '
   \   . '--shadow-file %s %t %s'
 
@@ -57,8 +57,8 @@ Execute(You should able able to use the global mypy instead):
   let g:ale_python_mypy_use_global = 1
 
   AssertLinter 'mypy',
-  \   'cd ' . ale#Escape(ale#path#Simplify(g:dir . '/python_paths/with_virtualenv/subdir'))
-  \   . ' && ' . ale#Escape('mypy')
+  \   ale#path#CdString(ale#Escape(ale#path#Simplify(g:dir . '/python_paths/with_virtualenv/subdir')))
+  \   . ale#Escape('mypy')
   \   . ' --show-column-numbers  '
   \   . '--shadow-file %s %t %s'
 

--- a/test/command_callback/test_sasslint_command_callback.vader
+++ b/test/command_callback/test_sasslint_command_callback.vader
@@ -7,5 +7,5 @@ After:
 
 Execute(The default sasslint command should be correct):
   AssertLinter 'sass-lint',
-  \ 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \ ale#path#CdString(ale#Escape(expand('%:p:h')))
   \   . ale#Escape('sass-lint') . ' -v -q -f compact %t'

--- a/test/command_callback/test_shellcheck_command_callback.vader
+++ b/test/command_callback/test_shellcheck_command_callback.vader
@@ -2,7 +2,7 @@ Before:
   call ale#assert#SetUpLinterTest('sh', 'shellcheck')
   call ale#test#SetFilename('test.sh')
 
-  let b:prefix = 'cd ' . ale#Escape(ale#path#Simplify(g:dir)) . ' && '
+  let b:prefix = ale#path#CdString(ale#Escape(ale#path#Simplify(g:dir)))
   let b:suffix = ' -f gcc -'
 
 After:

--- a/test/command_callback/test_staticcheck_command_callback.vader
+++ b/test/command_callback/test_staticcheck_command_callback.vader
@@ -7,7 +7,7 @@ After:
 
 Execute(The staticcheck callback should return the right defaults):
   AssertLinter 'staticcheck',
-  \ 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \ ale#path#CdString(ale#Escape(expand('%:p:h')))
   \   . 'staticcheck '
   \   . ale#Escape(expand('%' . ':t'))
 
@@ -15,7 +15,7 @@ Execute(The staticcheck callback should use configured options):
   let b:ale_go_staticcheck_options = '-test'
 
   AssertLinter 'staticcheck',
-  \ 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \ ale#path#CdString(ale#Escape(expand('%:p:h')))
   \   . 'staticcheck '
   \   . '-test ' . ale#Escape(expand('%' . ':t'))
 
@@ -23,4 +23,4 @@ Execute(The staticcheck `lint_package` option should use the correct command):
   let b:ale_go_staticcheck_lint_package = 1
 
   AssertLinter 'staticcheck',
-  \ 'cd ' . ale#Escape(expand('%:p:h')) . ' && staticcheck .',
+  \ ale#path#CdString(ale#Escape(expand('%:p:h'))) . 'staticcheck .',

--- a/test/command_callback/test_tslint_command_callback.vader
+++ b/test/command_callback/test_tslint_command_callback.vader
@@ -7,14 +7,14 @@ After:
 
 Execute(The default tslint command should be correct):
   AssertLinter 'tslint',
-  \ 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \ ale#path#CdString(ale#Escape(expand('%:p:h')))
   \   . ale#Escape('tslint') . ' --format json %t'
 
 Execute(The rules directory option should be included if set):
   let b:ale_typescript_tslint_rules_dir = '/foo/bar'
 
   AssertLinter 'tslint',
-  \ 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \ ale#path#CdString(ale#Escape(expand('%:p:h')))
   \   . ale#Escape('tslint') . ' --format json'
   \   . ' -r ' . ale#Escape('/foo/bar')
   \   . ' %t'
@@ -23,5 +23,5 @@ Execute(The executable should be configurable and escaped):
   let b:ale_typescript_tslint_executable = 'foo bar'
 
   AssertLinter 'foo bar',
-  \ 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \ ale#path#CdString(ale#Escape(expand('%:p:h')))
   \   . ale#Escape('foo bar') . ' --format json %t'

--- a/test/fixers/test_isort_fixer_callback.vader
+++ b/test/fixers/test_isort_fixer_callback.vader
@@ -27,7 +27,7 @@ Execute(The isort callback should return the correct default values):
   silent execute 'file ' . fnameescape(g:dir . '/python_paths/with_virtualenv/subdir/foo/bar.py')
   AssertEqual
   \ {
-  \   'command': 'cd ' . ale#Escape(ale#path#Simplify(g:dir . '/python_paths/with_virtualenv/subdir/foo')) .  ' && '
+  \   'command': ale#path#CdString(ale#Escape(ale#path#Simplify(g:dir . '/python_paths/with_virtualenv/subdir/foo')))
   \     . ale#Escape(ale#path#Simplify(g:dir . '/python_paths/with_virtualenv/env/' . b:bin_dir . '/isort')) . ' -',
   \ },
   \ ale#fixers#isort#Fix(bufnr(''))
@@ -42,7 +42,7 @@ Execute(The isort callback should respect custom options):
   silent execute 'file ' . fnameescape(g:dir . '/python_paths/with_virtualenv/subdir/foo/bar.py')
   AssertEqual
   \ {
-  \   'command': 'cd ' . ale#Escape(ale#path#Simplify(g:dir . '/python_paths/with_virtualenv/subdir/foo')) .  ' && '
+  \   'command': ale#path#CdString(ale#Escape(ale#path#Simplify(g:dir . '/python_paths/with_virtualenv/subdir/foo')))
   \     . ale#Escape(ale#path#Simplify(g:dir . '/python_paths/with_virtualenv/env/' . b:bin_dir . '/isort'))
   \     . ' --multi-line=3 --trailing-comma -',
   \ },

--- a/test/fixers/test_prettier_eslint_fixer.callback.vader
+++ b/test/fixers/test_prettier_eslint_fixer.callback.vader
@@ -85,7 +85,7 @@ Execute(The new --stdin-filepath option should be used when the version is new e
 
   AssertEqual
   \ {
-  \   'command': 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \   'command': ale#path#CdString(ale#Escape(expand('%:p:h')))
   \     . ale#Escape('prettier-eslint')
   \     . ' --eslint-config-path ' . ale#Escape(ale#path#Simplify(g:dir . '/eslint-test-files/react-app/.eslintrc.js'))
   \     . ' --stdin-filepath %s --stdin',
@@ -106,7 +106,7 @@ Execute(The version number should be cached):
   " The newer command should be used.
   AssertEqual
   \ {
-  \   'command': 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \   'command': ale#path#CdString(ale#Escape(expand('%:p:h')))
   \     . ale#Escape('prettier-eslint')
   \     . ' --stdin-filepath %s --stdin',
   \ },

--- a/test/fixers/test_prettier_fixer_callback.vader
+++ b/test/fixers/test_prettier_fixer_callback.vader
@@ -74,7 +74,7 @@ Execute(--stdin-filepath should be used when prettier is new enough):
 
   AssertEqual
   \ {
-  \   'command': 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \   'command': ale#path#CdString(ale#Escape(expand('%:p:h')))
   \     . ale#Escape(g:ale_javascript_prettier_executable)
   \     . ' --no-semi'
   \     . ' --stdin-filepath %s --stdin',
@@ -90,7 +90,7 @@ Execute(The version number should be cached):
   " Call it again without the version output. We should use the newer command.
   AssertEqual
   \ {
-  \   'command': 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \   'command': ale#path#CdString(ale#Escape(expand('%:p:h')))
   \     . ale#Escape(g:ale_javascript_prettier_executable)
   \     . ' --stdin-filepath %s --stdin',
   \ },
@@ -103,7 +103,7 @@ Execute(Should set --parser based on filetype, TypeScript):
 
   AssertEqual
   \ {
-  \   'command': 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \   'command': ale#path#CdString(ale#Escape(expand('%:p:h')))
   \     . ale#Escape(g:ale_javascript_prettier_executable)
   \     . ' --parser typescript'
   \     . ' --stdin-filepath %s --stdin',
@@ -117,7 +117,7 @@ Execute(Should set --parser based on filetype, CSS):
 
   AssertEqual
   \ {
-  \   'command': 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \   'command': ale#path#CdString(ale#Escape(expand('%:p:h')))
   \     . ale#Escape(g:ale_javascript_prettier_executable)
   \     . ' --parser css'
   \     . ' --stdin-filepath %s --stdin',
@@ -131,7 +131,7 @@ Execute(Should set --parser based on filetype, LESS):
 
   AssertEqual
   \ {
-  \   'command': 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \   'command': ale#path#CdString(ale#Escape(expand('%:p:h')))
   \     . ale#Escape(g:ale_javascript_prettier_executable)
   \     . ' --parser less'
   \     . ' --stdin-filepath %s --stdin',
@@ -145,7 +145,7 @@ Execute(Should set --parser based on filetype, SCSS):
 
   AssertEqual
   \ {
-  \   'command': 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \   'command': ale#path#CdString(ale#Escape(expand('%:p:h')))
   \     . ale#Escape(g:ale_javascript_prettier_executable)
   \     . ' --parser scss'
   \     . ' --stdin-filepath %s --stdin',
@@ -159,7 +159,7 @@ Execute(Should set --parser based on filetype, JSON):
 
   AssertEqual
   \ {
-  \   'command': 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \   'command': ale#path#CdString(ale#Escape(expand('%:p:h')))
   \     . ale#Escape(g:ale_javascript_prettier_executable)
   \     . ' --parser json'
   \     . ' --stdin-filepath %s --stdin',
@@ -173,7 +173,7 @@ Execute(Should set --parser based on filetype, JSON5):
 
   AssertEqual
   \ {
-  \   'command': 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \   'command': ale#path#CdString(ale#Escape(expand('%:p:h')))
   \     . ale#Escape(g:ale_javascript_prettier_executable)
   \     . ' --parser json5'
   \     . ' --stdin-filepath %s --stdin',
@@ -187,7 +187,7 @@ Execute(Should set --parser based on filetype, GraphQL):
 
   AssertEqual
   \ {
-  \   'command': 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \   'command': ale#path#CdString(ale#Escape(expand('%:p:h')))
   \     . ale#Escape(g:ale_javascript_prettier_executable)
   \     . ' --parser graphql'
   \     . ' --stdin-filepath %s --stdin',
@@ -201,7 +201,7 @@ Execute(Should set --parser based on filetype, Markdown):
 
   AssertEqual
   \ {
-  \   'command': 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \   'command': ale#path#CdString(ale#Escape(expand('%:p:h')))
   \     . ale#Escape(g:ale_javascript_prettier_executable)
   \     . ' --parser markdown'
   \     . ' --stdin-filepath %s --stdin',
@@ -215,7 +215,7 @@ Execute(Should set --parser based on filetype, Vue):
 
   AssertEqual
   \ {
-  \   'command': 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \   'command': ale#path#CdString(ale#Escape(expand('%:p:h')))
   \     . ale#Escape(g:ale_javascript_prettier_executable)
   \     . ' --parser vue'
   \     . ' --stdin-filepath %s --stdin',
@@ -229,7 +229,7 @@ Execute(Should set --parser based on filetype, YAML):
 
   AssertEqual
   \ {
-  \   'command': 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \   'command': ale#path#CdString(ale#Escape(expand('%:p:h')))
   \     . ale#Escape(g:ale_javascript_prettier_executable)
   \     . ' --parser yaml'
   \     . ' --stdin-filepath %s --stdin',
@@ -243,7 +243,7 @@ Execute(Should set --parser based on first filetype of multiple filetypes):
 
   AssertEqual
   \ {
-  \   'command': 'cd ' . ale#Escape(expand('%:p:h')) . ' && '
+  \   'command': ale#path#CdString(ale#Escape(expand('%:p:h')))
   \     . ale#Escape(g:ale_javascript_prettier_executable)
   \     . ' --parser css'
   \     . ' --stdin-filepath %s --stdin',

--- a/test/test_gradle_build_classpath_command.vader
+++ b/test/test_gradle_build_classpath_command.vader
@@ -25,8 +25,8 @@ Execute(Should return 'gradlew' command if project includes gradle wapper):
   call ale#test#SetFilename('gradle-test-files/wrapped-project/src/main/kotlin/dummy.kt')
 
   AssertEqual
-  \ 'cd ' . ale#Escape(ale#path#Simplify(g:dir . '/gradle-test-files/wrapped-project'))
-  \   . ' && ' . ale#Escape(ale#path#Simplify(g:dir . '/gradle-test-files/wrapped-project/gradlew'))
+  \ ale#path#CdString(ale#Escape(ale#path#Simplify(g:dir . '/gradle-test-files/wrapped-project')))
+  \   . ale#Escape(ale#path#Simplify(g:dir . '/gradle-test-files/wrapped-project/gradlew'))
   \   . g:command_tail,
   \ ale#gradle#BuildClasspathCommand(bufnr(''))
 
@@ -36,8 +36,8 @@ Execute(Should return 'gradle' command if project does not include gradle wapper
   \ . ale#path#Simplify(g:dir . '/gradle-test-files')
 
   AssertEqual
-  \ 'cd ' . ale#Escape(ale#path#Simplify(g:dir . '/gradle-test-files/unwrapped-project'))
-  \   . ' && ' . ale#Escape('gradle')
+  \ ale#path#CdString(ale#Escape(ale#path#Simplify(g:dir . '/gradle-test-files/unwrapped-project')))
+  \   . ale#Escape('gradle')
   \   . g:command_tail,
   \ ale#gradle#BuildClasspathCommand(bufnr(''))
 

--- a/test/util/test_cd_string_commands.vader
+++ b/test/util/test_cd_string_commands.vader
@@ -8,11 +8,21 @@ After:
 
 Execute(CdString should output the correct command string):
   " We will check that escaping is done correctly for each platform.
-  AssertEqual
-  \ has('unix') ? 'cd ''/foo bar/baz'' && ' : 'cd "/foo bar/baz" && ',
-  \ ale#path#CdString('/foo bar/baz')
+  if has('win32')
+    AssertEqual
+    \ 'cd /d "/foo bar/baz" && ',
+    \ ale#path#CdString('/foo bar/baz')
+  else
+    AssertEqual
+    \ has('unix') ? 'cd ''/foo bar/baz'' && ' : 'cd "/foo bar/baz" && ',
+    \ ale#path#CdString('/foo bar/baz')
+  endif
 
 Execute(BufferCdString should output the correct command string):
   call ale#test#SetFilename('foo.txt')
 
-  AssertEqual 'cd ' . ale#Escape(g:dir) . ' && ', ale#path#BufferCdString(bufnr(''))
+  if has('win32')
+    AssertEqual 'cd /d ' .ale#Escape(g:dir) . ' && ', ale#path#BufferCdString(bufnr(''))
+  else
+    AssertEqual 'cd ' . ale#Escape(g:dir) . ' && ', ale#path#BufferCdString(bufnr(''))
+  endif


### PR DESCRIPTION
<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-development`.

Have fun!
-->
Fix: #2011 MS Windows, lint error when current drive and target file drive is different. 

fix some test.
`ale#path#CdString` is tested `test/util/test_cd_string_commands.vader`.
I think another testcase need not test `ale#path#CdString`.

run teset windows & vim8.1.487 :
```
Success/Total: 1584/1588 (assertions: 2217/2221)
Elapsed time: 91.619582 sec.
```
Some testcase faild, because My Windows Language is not English.

And not test on linux.