### PR TITLE
Add force exclusions flag to rubocop fixer

### DIFF
--- a/autoload/ale/fixers/rubocop.vim
+++ b/autoload/ale/fixers/rubocop.vim
@@ -9,7 +9,7 @@ function! ale#fixers#rubocop#GetCommand(buffer) abort
     return ale#handlers#ruby#EscapeExecutable(l:executable, 'rubocop')
     \   . (!empty(l:config) ? ' --config ' . ale#Escape(l:config) : '')
     \   . (!empty(l:options) ? ' ' . l:options : '')
-    \   . ' --auto-correct %t'
+    \   . ' --auto-correct --force-exclusion %t'
 endfunction
 
 function! ale#fixers#rubocop#Fix(buffer) abort

--- a/test/fixers/test_rubocop_fixer_callback.vader
+++ b/test/fixers/test_rubocop_fixer_callback.vader
@@ -23,7 +23,7 @@ Execute(The rubocop callback should return the correct default values):
   \ {
   \   'read_temporary_file': 1,
   \   'command': ale#Escape(g:ale_ruby_rubocop_executable)
-  \     . ' --auto-correct %t',
+  \     . ' --auto-correct --force-exclusion %t',
   \ },
   \ ale#fixers#rubocop#Fix(bufnr(''))
 
@@ -35,7 +35,7 @@ Execute(The rubocop callback should include configuration files):
   \   'read_temporary_file': 1,
   \   'command': ale#Escape(g:ale_ruby_rubocop_executable)
   \     . ' --config ' . ale#Escape(ale#path#Simplify(g:dir . '/ruby_paths/with_config/.rubocop.yml'))
-  \     . ' --auto-correct %t',
+  \     . ' --auto-correct --force-exclusion %t',
   \ },
   \ ale#fixers#rubocop#Fix(bufnr(''))
 
@@ -49,6 +49,6 @@ Execute(The rubocop callback should include custom rubocop options):
   \   'command': ale#Escape(g:ale_ruby_rubocop_executable)
   \     . ' --config ' . ale#Escape(ale#path#Simplify(g:dir . '/ruby_paths/with_config/.rubocop.yml'))
   \     . ' --except Lint/Debugger'
-  \     . ' --auto-correct %t',
+  \     . ' --auto-correct --force-exclusion %t',
   \ },
   \ ale#fixers#rubocop#Fix(bufnr(''))


### PR DESCRIPTION
This makes the fixer behavior consistent with the linter. Tests updated.

closes #1580