### PR TITLE
feat(ale_linters): add xo support for typescript files

### DIFF
--- a/ale_linters/typescript/xo.vim
+++ b/ale_linters/typescript/xo.vim
@@ -1,7 +1,7 @@
 " Author: Daniel Lupu <lupu.daniel.f@gmail.com>
 " Description: xo for JavaScript files
 
-call ale#linter#Define('javascript', {
+call ale#linter#Define('typescript', {
 \   'name': 'xo',
 \   'executable_callback': 'ale#handlers#xo#GetExecutable',
 \   'command_callback': 'ale#handlers#xo#GetCommand',

--- a/autoload/ale/handlers/xo.vim
+++ b/autoload/ale/handlers/xo.vim
@@ -1,0 +1,18 @@
+" Author: Daniel Lupu <lupu.daniel.f@gmail.com>
+" Description: xo for JavaScript files
+
+call ale#Set('javascript_xo_executable', 'xo')
+call ale#Set('javascript_xo_use_global', get(g:, 'ale_use_global_executables', 0))
+call ale#Set('javascript_xo_options', '')
+
+function! ale#handlers#xo#GetExecutable(buffer) abort
+    return ale#node#FindExecutable(a:buffer, 'javascript_xo', [
+    \   'node_modules/.bin/xo',
+    \])
+endfunction
+
+function! ale#handlers#xo#GetCommand(buffer) abort
+    return ale#Escape(ale#handlers#xo#GetExecutable(a:buffer))
+    \   . ' ' . ale#Var(a:buffer, 'javascript_xo_options')
+    \   . ' --reporter unix --stdin --stdin-filename %s'
+endfunction

--- a/doc/ale-typescript.txt
+++ b/doc/ale-typescript.txt
@@ -110,4 +110,31 @@ g:ale_typescript_tsserver_use_global     *g:ale_typescript_tsserver_use_global*
 
 
 ===============================================================================
+xo                                                          *ale-javascript-xo*
+
+g:ale_javascript_xo_executable                 *g:ale_javascript_xo_executable*
+                                               *b:ale_javascript_xo_executable*
+  Type: |String|
+  Default: `'xo'`
+
+  See |ale-integrations-local-executables|
+
+
+g:ale_javascript_xo_options                       *g:ale_javascript_xo_options*
+                                                  *b:ale_javascript_xo_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be set to pass additional options to xo.
+
+
+g:ale_javascript_xo_use_global                 *g:ale_javascript_xo_use_global*
+                                               *b:ale_javascript_xo_use_global*
+  Type: |Number|
+  Default: `get(g:, 'ale_use_global_executables', 0)`
+
+  See |ale-integrations-local-executables|
+
+
+===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -321,6 +321,7 @@ CONTENTS                                                         *ale-contents*
       prettier............................|ale-typescript-prettier|
       tslint..............................|ale-typescript-tslint|
       tsserver............................|ale-typescript-tsserver|
+      xo..................................|ale-javascript-xo|
     vala..................................|ale-vala-options|
       uncrustify..........................|ale-vala-uncrustify|
     verilog/systemverilog.................|ale-verilog-options|
@@ -483,7 +484,7 @@ Notes:
 * Texinfo: `alex`!!, `proselint`, `write-good`
 * Text^: `alex`!!, `proselint`, `redpen`, `textlint`, `vale`, `write-good`
 * Thrift: `thrift`
-* TypeScript: `eslint`, `prettier`, `tslint`, `tsserver`, `typecheck`
+* TypeScript: `eslint`, `prettier`, `tslint`, `tsserver`, `typecheck`, `xo`
 * VALA: `uncrustify`
 * Verilog: `iverilog`, `verilator`
 * Vim: `vint`


### PR DESCRIPTION
This PR extends [XO](https://github.com/xojs/xo/) linter support for typescript files besides javascript.
`ale_linters#javascript#xo#` methods were moved to `ale#handlers#xo#` to avoid duplication