### PR TITLE
add nargs=* to ALEHover to allow it to be ran as keywordprg

### DIFF
--- a/plugin/ale.vim
+++ b/plugin/ale.vim
@@ -191,7 +191,7 @@ command! -bar ALEGoToDefinitionInTab :call ale#definition#GoTo({'open_in_tab': 1
 command! -bar ALEFindReferences :call ale#references#Find()
 
 " Get information for the cursor.
-command! -bar ALEHover :call ale#hover#Show(bufnr(''), getcurpos()[1],
+command! -bar -nargs=* ALEHover :call ale#hover#Show(bufnr(''), getcurpos()[1],
                                             \ getcurpos()[2], {})
 
 " <Plug> mappings for commands


### PR DESCRIPTION
This PR simply adds `-nargs=*` to `:ALEHover` to allow it to be set as the `keywordprg` for any given filetype in ftplugins.

**Example:**

```vim
" ftplugin/typescript.vim

setlocal keywordprg=:ALEHover
```

This is useful particularly for LSP linters to allow the normal `K` mapping to remain `keywordprg` so that it still remains intelligent on filetypes where ALE isn't around (specifically helpfiles).

Let me know if you have any questions.