### PR TITLE
Pass the filename of the current file into jshint

### DIFF
--- a/ale_linters/javascript/jshint.vim
+++ b/ale_linters/javascript/jshint.vim
@@ -18,7 +18,7 @@ function! ale_linters#javascript#jshint#GetCommand(buffer) abort
         let l:command .= ' --config ' . ale#Escape(l:jshint_config)
     endif
 
-    let l:command .= ' -'
+    let l:command .= ' --filename %s -'
 
     return l:command
 endfunction

--- a/test/command_callback/test_jshint_command_callback.vader
+++ b/test/command_callback/test_jshint_command_callback.vader
@@ -1,0 +1,14 @@
+Before:
+  call ale#assert#SetUpLinterTest('javascript', 'jshint')
+
+After:
+  call ale#assert#TearDownLinterTest()
+
+Execute(The default command should be correct):
+
+  AssertLinter 'jshint', '''jshint'' --reporter unix --extract auto --filename %s -'
+
+Execute(Setting a config location should add the config parameter):
+  let g:ale_jshint_config_loc = '/some/file'
+
+  AssertLinter 'jshint', '''jshint'' --reporter unix --extract auto --config ''/some/file'' --filename %s -'


### PR DESCRIPTION
This MR updates the `jshint` linter so that the filename of the file being linted is passed in on the command line. Doing this allows file-specific override config to be used, which is helpful on large projects.

(Note that jshint is currently bugged in this area, so there will probably be little visible change to the end user until https://github.com/jshint/jshint/pull/3335 goes in).

I haven't added tests for this function, as there did not seem to be any existing ones in this area to jump off from - I'd be happy to add some with guidance if needed.
