### PR TITLE
Add configuration dictionary support to elixir-ls

### DIFF
--- a/ale_linters/elixir/elixir_ls.vim
+++ b/ale_linters/elixir/elixir_ls.vim
@@ -1,7 +1,8 @@
 " Author: Jon Parise <jon@indelible.org>
-" Description: elixir-ls integration (https://github.com/JakeBecker/elixir-ls)
+" Description: ElixirLS integration (https://github.com/JakeBecker/elixir-ls)
 
 call ale#Set('elixir_elixir_ls_release', 'elixir-ls')
+call ale#Set('elixir_elixir_ls_config', {})
 
 function! ale_linters#elixir#elixir_ls#GetExecutable(buffer) abort
     let l:dir = ale#path#Simplify(ale#Var(a:buffer, 'elixir_elixir_ls_release'))
@@ -16,4 +17,5 @@ call ale#linter#Define('elixir', {
 \   'executable_callback': 'ale_linters#elixir#elixir_ls#GetExecutable',
 \   'command_callback': 'ale_linters#elixir#elixir_ls#GetExecutable',
 \   'project_root_callback': 'ale#handlers#elixir#FindMixProjectRoot',
+\   'lsp_config_callback': ale#VarFunc('elixir_elixir_ls_config'),
 \})

--- a/doc/ale-elixir.txt
+++ b/doc/ale-elixir.txt
@@ -53,5 +53,20 @@ g:ale_elixir_elixir_ls_release                 *g:ale_elixir_elixir_ls_release*
   Location of the elixir-ls release directory. This directory must contain
   the language server scripts (language_server.sh and language_server.bat).
 
+g:ale_elixir_elixir_ls_config                   *g:ale_elixir_elixir_ls_config*
+                                                *b:ale_elixir_elixir_ls_config*
+  Type: |Dictionary|
+  Default: `{}`
+
+  Dictionary containing configuration settings that will be passed to the
+  language server. For example, to disable Dialyzer: >
+      {
+    \   'elixirLS': {
+    \     'dialyzerEnabled': v:false,
+    \   },
+    \ }
+<
+  Consult the ElixirLS documentation for more information about settings.
+
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/test/command_callback/test_elixir_ls_command_callbacks.vader
+++ b/test/command_callback/test_elixir_ls_command_callbacks.vader
@@ -28,3 +28,8 @@ Execute(should set correct LSP values):
   AssertLSPOptions {}
   AssertLSPConfig {}
   AssertLSPProject ale#path#Simplify(g:dir . '/mix_paths/wrapped_project')
+
+Execute(should accept configuration settings):
+  AssertLSPConfig {}
+  let b:ale_elixir_elixir_ls_config = {'elixirLS': {'dialyzerEnabled': v:false}}
+  AssertLSPConfig {'elixirLS': {'dialyzerEnabled': v:false}}


### PR DESCRIPTION
This adds generic configuration dictionary support to the elixir-ls
linter. This is useful for disabling its built-in Dialyzer support, for
example, which can improve startup time.

The configuration dictionary is a little verbose. I considered reducing
the user configuration to only the nested settings dictionary (and
having the linter implementation wrap it in the top-level `elixirLS`
dictionary), but leaving it fully configurable simplifies the code and
removes any assumptions about current or future ElixirLS behavior.

<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-development`.

Have fun!
-->

Where are the tests? Have you added tests? Have you updated the tests? Read the
comment above and the documentation referenced in it first. Write tests!

Seriously, read `:help ale-development` and write tests.
