### PR TITLE
Allow configuration of hamllint executable

### DIFF
--- a/ale_linters/haml/hamllint.vim
+++ b/ale_linters/haml/hamllint.vim
@@ -1,6 +1,5 @@
 " Author: Patrick Lewis - https://github.com/patricklewis, thenoseman - https://github.com/thenoseman
 " Description: haml-lint for Haml files
-"
 
 call ale#Set('haml_hamllint_executable', 'haml-lint')
 

--- a/ale_linters/haml/hamllint.vim
+++ b/ale_linters/haml/hamllint.vim
@@ -1,5 +1,12 @@
 " Author: Patrick Lewis - https://github.com/patricklewis, thenoseman - https://github.com/thenoseman
 " Description: haml-lint for Haml files
+"
+
+call ale#Set('haml_hamllint_executable', 'haml-lint')
+
+function! ale_linters#haml#hamllint#GetExecutable(buffer) abort
+    return ale#Var(a:buffer, 'haml_hamllint_executable')
+endfunction
 
 function! ale_linters#haml#hamllint#GetCommand(buffer) abort
     let l:prefix = ''
@@ -21,7 +28,7 @@ function! ale_linters#haml#hamllint#GetCommand(buffer) abort
     endif
 
     return (!empty(l:prefix) ? l:prefix . ' ' : '')
-    \   . 'haml-lint'
+    \   . ale_linters#haml#hamllint#GetExecutable(a:buffer)
     \   . (!empty(l:hamllint_config_file_path) ? ' --config ' . ale#Escape(l:hamllint_config_file_path) : '')
     \   . ' %t'
 endfunction
@@ -45,7 +52,7 @@ endfunction
 
 call ale#linter#Define('haml', {
 \   'name': 'hamllint',
-\   'executable': 'haml-lint',
+\   'executable_callback': 'ale_linters#haml#hamllint#GetExecutable',
 \   'command_callback': 'ale_linters#haml#hamllint#GetCommand',
 \   'callback': 'ale_linters#haml#hamllint#Handle'
 \})

--- a/test/command_callback/test_haml_hamllint_command_callback.vader
+++ b/test/command_callback/test_haml_hamllint_command_callback.vader
@@ -35,3 +35,7 @@ Execute(The command should include a .rubocop.yml and a .haml-lint if both are f
   AssertLinter 'haml-lint',
   \ ale#Env('HAML_LINT_RUBOCOP_CONF', b:conf_rubocop)
   \   .  'haml-lint --config ' . ale#Escape(b:conf_hamllint) .  ' %t'
+
+Execute(The executable can be overridden):
+  let b:ale_haml_hamllint_executable = 'bin/haml-lint'
+  AssertLinter 'bin/haml-lint', 'bin/haml-lint %t'


### PR DESCRIPTION
The hamllint executable was hard-coded, preventing it from being
overridden. Fix the executable to be dynamic to allow custom executable
paths.