### PR TITLE
fix phpcs linter error: 'option --stdin-path' not known'

### DIFF
--- a/ale_linters/php/phpcs.vim
+++ b/ale_linters/php/phpcs.vim
@@ -14,7 +14,7 @@ function! ale_linters#php#phpcs#GetCommand(buffer) abort
     \   : ''
     let l:options = ale#Var(a:buffer, 'php_phpcs_options')
 
-    return '%e -s --report=emacs --stdin-path=%s'
+    return '%e -s --report=emacs %s'
     \    . ale#Pad(l:standard_option)
     \    . ale#Pad(l:options)
 endfunction

--- a/test/command_callback/test_phpcs_command_callback.vader
+++ b/test/command_callback/test_phpcs_command_callback.vader
@@ -12,7 +12,7 @@ Execute(The local phpcs executable should be used):
   let g:executable = ale#path#Simplify(g:dir . '/../phpcs-test-files/project-with-phpcs/vendor/bin/phpcs')
 
   AssertLinter g:executable,
-  \ ale#Escape(g:executable) . ' -s --report=emacs --stdin-path=%s'
+  \ ale#Escape(g:executable) . ' -s --report=emacs %s'
 
 Execute(use_global should override local executable detection):
   let g:ale_php_phpcs_use_global = 1
@@ -20,16 +20,16 @@ Execute(use_global should override local executable detection):
   call ale#test#SetFilename('../phpcs-test-files/project-with-phpcs/foo/test.php')
 
   AssertLinter 'phpcs',
-  \ ale#Escape('phpcs') . ' -s --report=emacs --stdin-path=%s'
+  \ ale#Escape('phpcs') . ' -s --report=emacs %s'
 
 Execute(Projects without local executables should use the global one):
   call ale#test#SetFilename('../phpcs-test-files/project-without-phpcs/foo/test.php')
 
   AssertLinter 'phpcs',
-  \ ale#Escape('phpcs') . ' -s --report=emacs --stdin-path=%s'
+  \ ale#Escape('phpcs') . ' -s --report=emacs %s'
 
 Execute(User provided options are used):
   let g:ale_php_phpcs_options = '--my-user-provided-option my-value'
 
   AssertLinter 'phpcs',
-  \ ale#Escape('phpcs') . ' -s --report=emacs --stdin-path=%s --my-user-provided-option my-value'
+  \ ale#Escape('phpcs') . ' -s --report=emacs %s --my-user-provided-option my-value'


### PR DESCRIPTION
Good afternoon! the syntax of phpcss has changed:
ERROR: option "--stdin-path=/home/me/project/update/load.php" not known.

I simple remove key "--stdin-path" and all work again.