### PR TITLE
Add initial support for ruumba in eruby files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ formatting.
 | Dockerfile | [dockerfile_lint](https://github.com/projectatomic/dockerfile_lint), [hadolint](https://github.com/hadolint/hadolint) |
 | Elixir | [credo](https://github.com/rrrene/credo), [dialyxir](https://github.com/jeremyjh/dialyxir), [dogma](https://github.com/lpil/dogma), [mix](https://hexdocs.pm/mix/Mix.html) !!, [elixir-ls](https://github.com/JakeBecker/elixir-ls) |
 | Elm | [elm-format](https://github.com/avh4/elm-format), [elm-make](https://github.com/elm-lang/elm-make) |
-| Erb | [erb](https://apidock.com/ruby/ERB), [erubi](https://github.com/jeremyevans/erubi), [erubis](https://github.com/kwatch/erubis) |
+| Erb | [erb](https://apidock.com/ruby/ERB), [erubi](https://github.com/jeremyevans/erubi), [erubis](https://github.com/kwatch/erubis), [ruumba](https://github.com/ericqweinstein/ruumba) |
 | Erlang | [erlc](http://erlang.org/doc/man/erlc.html), [SyntaxErl](https://github.com/ten0s/syntaxerl) |
 | Fish | fish [-n flag](https://linux.die.net/man/1/fish)
 | Fortran | [gcc](https://gcc.gnu.org/), [language_server](https://github.com/hansec/fortran-language-server) |

--- a/ale_linters/eruby/ruumba.vim
+++ b/ale_linters/eruby/ruumba.vim
@@ -1,0 +1,62 @@
+" Author: aclemons - https://github.com/aclemons
+" based on the ale rubocop linter
+" Description: Ruumba, RuboCop linting for ERB templates.
+
+call ale#Set('eruby_ruumba_executable', 'ruumba')
+call ale#Set('eruby_ruumba_options', '')
+
+function! ale_linters#eruby#ruumba#GetCommand(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'eruby_ruumba_executable')
+
+    return ale#handlers#ruby#EscapeExecutable(l:executable, 'ruumba')
+    \   . ' --format json --force-exclusion '
+    \   . ale#Var(a:buffer, 'eruby_ruumba_options')
+    \   . ' --stdin ' . ale#Escape(expand('#' . a:buffer . ':p'))
+endfunction
+
+function! ale_linters#eruby#ruumba#Handle(buffer, lines) abort
+    try
+        let l:errors = json_decode(a:lines[0])
+    catch
+        return []
+    endtry
+
+    if !has_key(l:errors, 'summary')
+    \|| l:errors['summary']['offense_count'] == 0
+    \|| empty(l:errors['files'])
+        return []
+    endif
+
+    let l:output = []
+
+    for l:error in l:errors['files'][0]['offenses']
+        let l:start_col = l:error['location']['column'] + 0
+        call add(l:output, {
+        \   'lnum': l:error['location']['line'] + 0,
+        \   'col': l:start_col,
+        \   'end_col': l:start_col + l:error['location']['length'] - 1,
+        \   'code': l:error['cop_name'],
+        \   'text': l:error['message'],
+        \   'type': ale_linters#eruby#ruumba#GetType(l:error['severity']),
+        \})
+    endfor
+
+    return l:output
+endfunction
+
+function! ale_linters#eruby#ruumba#GetType(severity) abort
+    if a:severity is? 'convention'
+    \|| a:severity is? 'warning'
+    \|| a:severity is? 'refactor'
+        return 'W'
+    endif
+
+    return 'E'
+endfunction
+
+call ale#linter#Define('eruby', {
+\   'name': 'ruumba',
+\   'executable_callback': ale#VarFunc('eruby_ruumba_executable'),
+\   'command_callback': 'ale_linters#eruby#ruumba#GetCommand',
+\   'callback': 'ale_linters#eruby#ruumba#Handle',
+\})

--- a/doc/ale-eruby.txt
+++ b/doc/ale-eruby.txt
@@ -1,15 +1,37 @@
 ===============================================================================
 ALE Eruby Integration                                       *ale-eruby-options*
 
-There are three linters for `eruby` files:
+There are four linters for `eruby` files:
 
 - `erb`
 - `erubis`
 - `erubi`
+- `ruumba`
 
 `erb` is in the Ruby standard library and is mostly universal. `erubis` is the
 default parser in Rails between 3.0 and 5.1. `erubi` is the default in Rails
-5.1 and later. To selectively enable a subset, see |g:ale_linters|.
+5.1 and later. `ruumba` can extract Ruby from eruby files and run rubocop on
+the result. To selectively enable a subset, see |g:ale_linters|.
+
+===============================================================================
+ruumba                                                       *ale-eruby-ruumba*
+
+g:ale_eruby_ruumba_executable                   *g:ale_eruby_ruumba_executable*
+                                                *b:ale_eruby_ruumba_executable*
+  Type: String
+  Default: `'ruumba`
+
+  Override the invoked ruumba binary. This is useful for running ruumba
+  from binstubs or a bundle.
+
+
+g:ale_eruby_ruumba_options                          *g:ale_ruby_ruumba_options*
+                                                    *b:ale_ruby_ruumba_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be change to modify flags given to ruumba.
+
 
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -92,6 +92,7 @@ CONTENTS                                                         *ale-contents*
       erlc................................|ale-erlang-erlc|
       syntaxerl...........................|ale-erlang-syntaxerl|
     eruby.................................|ale-eruby-options|
+      ruumba..............................|ale-eruby-ruumba|
     fish..................................|ale-fish-options|
     fortran...............................|ale-fortran-options|
       gcc.................................|ale-fortran-gcc|
@@ -414,7 +415,7 @@ Notes:
 * Dockerfile: `dockerfile_lint`, `hadolint`
 * Elixir: `credo`, `dialyxir`, `dogma`, `mix`!!, `elixir-ls`
 * Elm: `elm-format, elm-make`
-* Erb: `erb`, `erubi`, `erubis`
+* Erb: `erb`, `erubi`, `erubis`, `ruumba`
 * Erlang: `erlc`, `SyntaxErl`
 * Fish: `fish` (-n flag)
 * Fortran: `gcc`, `language_server`

--- a/test/command_callback/test_ruumba_command_callback.vader
+++ b/test/command_callback/test_ruumba_command_callback.vader
@@ -1,0 +1,29 @@
+Before:
+  call ale#assert#SetUpLinterTest('eruby', 'ruumba')
+  call ale#test#SetFilename('dummy.html.erb')
+
+  let g:ale_eruby_ruumba_executable = 'ruumba'
+  let g:ale_eruby_ruumba_options = ''
+
+After:
+  call ale#assert#TearDownLinterTest()
+
+Execute(Executable should default to ruumba):
+  AssertLinter 'ruumba', ale#Escape('ruumba')
+  \   . ' --format json --force-exclusion  --stdin '
+  \   . ale#Escape(ale#path#Simplify(g:dir . '/dummy.html.erb'))
+
+Execute(Should be able to set a custom executable):
+  let g:ale_eruby_ruumba_executable = 'bin/ruumba'
+
+  AssertLinter 'bin/ruumba' , ale#Escape('bin/ruumba')
+  \   . ' --format json --force-exclusion  --stdin '
+  \   . ale#Escape(ale#path#Simplify(g:dir . '/dummy.html.erb'))
+
+Execute(Setting bundle appends 'exec ruumba'):
+  let g:ale_eruby_ruumba_executable = 'path to/bundle'
+
+  AssertLinter 'path to/bundle', ale#Escape('path to/bundle')
+  \   . ' exec ruumba'
+  \   . ' --format json --force-exclusion  --stdin '
+  \   . ale#Escape(ale#path#Simplify(g:dir . '/dummy.html.erb'))


### PR DESCRIPTION
Ruumba provides RuboCop linting for ERB templates.

https://github.com/ericqweinstein/ruumba
