### PR TITLE
Make ocamlformat work without temporary files

### DIFF
--- a/autoload/ale/fixers/ocamlformat.vim
+++ b/autoload/ale/fixers/ocamlformat.vim
@@ -5,14 +5,14 @@ call ale#Set('ocaml_ocamlformat_executable', 'ocamlformat')
 call ale#Set('ocaml_ocamlformat_options', '')
 
 function! ale#fixers#ocamlformat#Fix(buffer) abort
+    let l:filename = expand('#' . a:buffer . ':p')
     let l:executable = ale#Var(a:buffer, 'ocaml_ocamlformat_executable')
     let l:options = ale#Var(a:buffer, 'ocaml_ocamlformat_options')
 
     return {
     \   'command': ale#Escape(l:executable)
     \       . (empty(l:options) ? '' : ' ' . l:options)
-    \       . ' --inplace'
-    \       . ' %t',
-    \   'read_temporary_file': 1,
+    \       . ' --name=' . ale#Escape(l:filename)
+    \       . ' -'
     \}
 endfunction

--- a/test/fixers/test_ocamlformat_fixer_callback.vader
+++ b/test/fixers/test_ocamlformat_fixer_callback.vader
@@ -18,10 +18,9 @@ Execute(The ocamlformat callback should return the correct default values):
 
   AssertEqual
   \ {
-  \   'read_temporary_file': 1,
   \   'command': ale#Escape('xxxinvalid')
-  \     . ' --inplace'
-  \     . ' %t',
+  \     . ' --name=' . ale#Escape(bufname(bufnr('')))
+  \     . ' -',
   \ },
   \ ale#fixers#ocamlformat#Fix(bufnr(''))
 
@@ -31,10 +30,9 @@ Execute(The ocamlformat callback should include custom ocamlformat options):
 
   AssertEqual
   \ {
-  \   'read_temporary_file': 1,
   \   'command': ale#Escape('xxxinvalid')
   \     . ' ' . g:ale_ocaml_ocamlformat_options
-  \     . ' --inplace'
-  \     . ' %t',
+  \     . ' --name=' . ale#Escape(bufname(bufnr('')))
+  \     . ' -',
   \ },
   \ ale#fixers#ocamlformat#Fix(bufnr(''))


### PR DESCRIPTION
Problem: ocamlformat is configured to format files in-place and thus go via creating a temporary file for that. Because the temporary file resides in a different directory ocamlformat can't find `.ocamlformat` configuration files in an original location of source files.

Solution: ocamlformat since version 0.8 can read sources of stdin and spur result on stdout. We reconfigure ocamlformat fixer to use this simpler interface.

cc @sbl 