### PR TITLE
Add g:ale_echo_command variable

### DIFF
--- a/autoload/ale/cursor.vim
+++ b/autoload/ale/cursor.vim
@@ -7,6 +7,8 @@ scriptencoding utf-8
 let g:ale_echo_delay = get(g:, 'ale_echo_delay', 10)
 " A string format for the echoed message.
 let g:ale_echo_msg_format = get(g:, 'ale_echo_msg_format', '%code: %%s')
+" Use this Ex command to output message when a cursor is near a warning or error.
+let g:ale_echo_command = get(g:, 'ale_echo_command', 'echomsg')
 
 let s:cursor_timer = -1
 let s:last_pos = [0, 0, 0]
@@ -27,8 +29,10 @@ function! ale#cursor#TruncatedEcho(original_message) abort
         " The message is truncated and saved to the history.
         setlocal shortmess+=T
 
+        let l:buffer = bufnr('')
+        let l:echo = ale#Var(l:buffer, 'echo_command')
         try
-            exec "norm! :echomsg l:message\n"
+            exec l:echo string(l:message)
         catch /^Vim\%((\a\+)\)\=:E523/
             " Fallback into manual truncate (#1987)
             let l:winwidth = winwidth(0)
@@ -38,7 +42,7 @@ function! ale#cursor#TruncatedEcho(original_message) abort
                 let l:message = l:message[:l:winwidth - 4] . '...'
             endif
 
-            exec 'echomsg l:message'
+            exec l:echo string(l:message)
         endtry
 
         " Reset the cursor position if we moved off the end of the line.

--- a/autoload/ale/cursor.vim
+++ b/autoload/ale/cursor.vim
@@ -29,8 +29,10 @@ function! ale#cursor#TruncatedEcho(original_message) abort
         " The message is truncated and saved to the history.
         setlocal shortmess+=T
 
+        " The message is truncated and saved to the history.
         let l:buffer = bufnr('')
         let l:echo = ale#Var(l:buffer, 'echo_command')
+
         try
             exec l:echo string(l:message)
         catch /^Vim\%((\a\+)\)\=:E523/

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -1131,6 +1131,17 @@ g:ale_echo_msg_warning_str                         *g:ale_echo_msg_warning_str*
   The string used for `%severity%` for warnings. See |g:ale_echo_msg_format|
 
 
+g:ale_echo_command                                 *g:ale_echo_command*
+
+  Type: |String|
+  Default: `'echomsg'`
+
+  The string used for echoing messages to command-line.
+  For example, you can specify `'echo'` not to record messages in |message-history|: >
+
+  let g:ale_echo_command = 'echo'
+<
+
 g:ale_enabled                                                   *g:ale_enabled*
                                                                 *b:ale_enabled*
 

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -1131,7 +1131,7 @@ g:ale_echo_msg_warning_str                         *g:ale_echo_msg_warning_str*
   The string used for `%severity%` for warnings. See |g:ale_echo_msg_format|
 
 
-g:ale_echo_command                                 *g:ale_echo_command*
+g:ale_echo_command                                         *g:ale_echo_command*
 
   Type: |String|
   Default: `'echomsg'`

--- a/test/test_cursor_warnings.vader
+++ b/test/test_cursor_warnings.vader
@@ -91,6 +91,8 @@ Before:
     return empty(l:lines) ? '' : l:lines[-1]
   endfunction
 
+  command -nargs=+ TestEchoCommand let g:test_echo_command_is_called = 1
+
 After:
   Restore
 
@@ -116,6 +118,9 @@ After:
   if &filetype is# 'ale-preview'
     noautocmd :q!
   endif
+
+  silent! delcommand TestEchoCommand
+  unlet! g:test_echo_command_is_called
 
 Given javascript(A Javscript file with warnings/errors):
   var x = 3 + 12345678
@@ -245,3 +250,13 @@ Execute(The cursor message shouldn't be echoed if the option is off):
   call ale#cursor#EchoCursorWarning()
 
   AssertEqual 'foo', GetLastMessage()
+
+Execute(The cursor message is passed to echo command):
+  let g:ale_echo_command = 'TestEchoCommand'
+  echom 'foo'
+
+  call cursor(1, 1)
+  call ale#cursor#EchoCursorWarning()
+
+  AssertEqual 'foo', GetLastMessage()
+  AssertEqual 1, exists('g:test_echo_command_is_called')

--- a/test/test_cursor_warnings.vader
+++ b/test/test_cursor_warnings.vader
@@ -1,6 +1,7 @@
 Before:
   Save g:ale_echo_msg_format
   Save g:ale_echo_cursor
+  Save g:ale_echo_command
 
   " We should prefer the error message at column 10 instead of the warning.
   let g:ale_buffer_info = {


### PR DESCRIPTION
<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-development`.

Have fun!
-->

<!--
Where are the tests? Have you added tests? Have you updated the tests? Read the
comment above and the documentation referenced in it first. Write tests!

Seriously, read `:help ale-development` and write tests.
-->

I added g:ale_echo_command variable which is used for echoing message string to command-line.
I don't want ale to record echoed messages in history (:h message-history), so I want to use `:echo` command to echo.

```vim
let g:ale_echo_command = 'echo'
```

What do you think about this?