### PR TITLE
Remove test/command_callback/mix_paths/

### DIFF
--- a/test/command_callback/mix_paths/wrapped_project/mix.exs
+++ b/test/command_callback/mix_paths/wrapped_project/mix.exs
@@ -1,1 +1,0 @@
-use Mix.Config

--- a/test/command_callback/test_elixir_mix_command_callbacks.vader
+++ b/test/command_callback/test_elixir_mix_command_callbacks.vader
@@ -11,10 +11,10 @@ After:
   call ale#assert#TearDownLinterTest()
 
 Execute(The default mix command should be correct):
-  call ale#test#SetFilename('mix_paths/wrapped_project/lib/app.ex')
+  call ale#test#SetFilename('elixir_paths/mix_project/lib/app.ex')
 
   AssertLinter 'mix',
-  \ ale#path#CdString(ale#path#Simplify(g:dir . '/mix_paths/wrapped_project'))
+  \ ale#path#CdString(ale#path#Simplify(g:dir . '/elixir_paths/mix_project'))
   \ . g:env_prefix
   \ . 'mix compile %s'
 


### PR DESCRIPTION
All of the other tests were already using equivalent fixtures under
`test/command_callback/elixir_paths/`, so let's use that path everywhere.