### PR TITLE
Checkstyle improvements

### DIFF
--- a/ale_linters/java/checkstyle.vim
+++ b/ale_linters/java/checkstyle.vim
@@ -2,8 +2,10 @@
 " Description: checkstyle for Java files
 
 function! ale_linters#java#checkstyle#Handle(buffer, lines) abort
-    let l:pattern = '\v\[(WARN|ERROR)\] [a-zA-Z]?:?[^:]+:(\d+):(\d+)?:? (.*) \[(.+)\]$'
     let l:output = []
+
+    " modern checkstyle versions
+    let l:pattern = '\v\[(WARN|ERROR)\] [a-zA-Z]?:?[^:]+:(\d+):(\d+)?:? (.*) \[(.+)\]$'
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)
         call add(l:output, {
@@ -12,6 +14,17 @@ function! ale_linters#java#checkstyle#Handle(buffer, lines) abort
         \   'col': l:match[3] + 0,
         \   'text': l:match[4],
         \   'code': l:match[5],
+        \})
+    endfor
+
+    " old checkstyle versions
+    let l:pattern = '\v(.+):(\d+): ([^:]+): (.+)$'
+
+    for l:match in ale#util#GetMatches(a:lines, l:pattern)
+        call add(l:output, {
+        \   'type': l:match[3] is? 'warning' ? 'W' : 'E',
+        \   'lnum': l:match[2] + 0,
+        \   'text': l:match[4],
         \})
     endfor
 

--- a/ale_linters/java/checkstyle.vim
+++ b/ale_linters/java/checkstyle.vim
@@ -34,7 +34,7 @@ endfunction
 function! ale_linters#java#checkstyle#GetCommand(buffer) abort
     return 'checkstyle '
     \ . ale#Var(a:buffer, 'java_checkstyle_options')
-    \ . ' %t'
+    \ . ' %s'
 endfunction
 
 if !exists('g:ale_java_checkstyle_options')
@@ -46,4 +46,5 @@ call ale#linter#Define('java', {
 \   'executable': 'checkstyle',
 \   'command_callback': 'ale_linters#java#checkstyle#GetCommand',
 \   'callback': 'ale_linters#java#checkstyle#Handle',
+\   'lint_file': 1,
 \})

--- a/test/handler/test_checkstyle_handler.vader
+++ b/test/handler/test_checkstyle_handler.vader
@@ -26,3 +26,16 @@ Execute(The checkstyle handler should parse lines correctly):
   \   '[WARN] whatever:101: ''method def rcurly'' has incorrect indentation level 4, expected level should be 2. [Indentation]',
   \   '[WARN] whatever:63:3: Missing a Javadoc comment. [JavadocMethod]',
   \ ])
+
+Execute(The checkstyle handler should parse lines from older checkstyle versions correctly):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 289,
+  \     'text': '''method def modifier'' have incorrect indentation level 4, expected level should be 2.',
+  \     'type': 'W',
+  \   },
+  \ ],
+  \ ale_linters#java#checkstyle#Handle(666, [
+  \   '/home/languitar/src/rsb-java/rsb-java/src/main/java/rsb/Listener.java:289: warning: ''method def modifier'' have incorrect indentation level 4, expected level should be 2.',
+  \ ])


### PR DESCRIPTION
This PR adds support for an older output format of checkstyle and removes the support for linting temporary files, which causes problems for some checks as discussed in #1305.
