### PR TITLE
Add specific highlight group for virtual text

### DIFF
--- a/autoload/ale/virtualtext.vim
+++ b/autoload/ale/virtualtext.vim
@@ -63,11 +63,18 @@ function! ale#virtualtext#ShowCursorWarning(...) abort
         let l:type = get(l:loc, 'type', 'E')
 
         if l:type is# 'E'
-            let l:hl_group = 'ALEVirtualTextError'
+            if exists('g:ale_virtualtext_error_hi')
+              let l:hl_group = g:ale_virtualtext_error_hi
+            else
+              let l:hl_group = 'ALEError'
+            endif
         elseif l:type is# 'W'
-            let l:hl_group = 'ALEVirtualTextWarning'
+            if exists('g:ale_virtualtext_warning_hi')
+              let l:hl_group = g:ale_virtualtext_warning_hi
+            else
+              let l:hl_group = 'ALEWarning'
+            endif
         endif
-
         call ale#virtualtext#ShowMessage(l:msg, l:hl_group)
     endif
 endfunction

--- a/autoload/ale/virtualtext.vim
+++ b/autoload/ale/virtualtext.vim
@@ -8,6 +8,14 @@ let g:ale_virtualtext_delay = get(g:, 'ale_virtualtext_delay', 10)
 let s:cursor_timer = -1
 let s:last_pos = [0, 0, 0]
 
+if !hlexists('ALEVirtualTextWarning')
+  highlight link ALEVirtualTextWarning ALEWarning
+endif
+
+if !hlexists('ALEVirtualTextError')
+  highlight link ALEVirtualTextError ALEError
+endif
+
 function! ale#virtualtext#Clear() abort
     if !has('nvim-0.3.2')
         return
@@ -63,17 +71,10 @@ function! ale#virtualtext#ShowCursorWarning(...) abort
         let l:type = get(l:loc, 'type', 'E')
 
         if l:type is# 'E'
-            if exists('g:ale_virtualtext_error_hi')
-              let l:hl_group = g:ale_virtualtext_error_hi
-            else
-              let l:hl_group = 'ALEError'
-            endif
+          let l:hl_group = 'ALEVirtualTextError'
+        endif
         elseif l:type is# 'W'
-            if exists('g:ale_virtualtext_warning_hi')
-              let l:hl_group = g:ale_virtualtext_warning_hi
-            else
-              let l:hl_group = 'ALEWarning'
-            endif
+            let l:hl_group = 'ALEVirtualTextWarning'
         endif
         call ale#virtualtext#ShowMessage(l:msg, l:hl_group)
     endif

--- a/autoload/ale/virtualtext.vim
+++ b/autoload/ale/virtualtext.vim
@@ -9,11 +9,11 @@ let s:cursor_timer = -1
 let s:last_pos = [0, 0, 0]
 
 if !hlexists('ALEVirtualTextWarning')
-  highlight link ALEVirtualTextWarning ALEWarning
+    highlight link ALEVirtualTextWarning ALEWarning
 endif
 
 if !hlexists('ALEVirtualTextError')
-  highlight link ALEVirtualTextError ALEError
+    highlight link ALEVirtualTextError ALEError
 endif
 
 function! ale#virtualtext#Clear() abort

--- a/autoload/ale/virtualtext.vim
+++ b/autoload/ale/virtualtext.vim
@@ -63,9 +63,9 @@ function! ale#virtualtext#ShowCursorWarning(...) abort
         let l:type = get(l:loc, 'type', 'E')
 
         if l:type is# 'E'
-            let l:hl_group = 'ALEError'
+            let l:hl_group = 'ALEVirtualTextError'
         elseif l:type is# 'W'
-            let l:hl_group = 'ALEWarning'
+            let l:hl_group = 'ALEVirtualTextWarning'
         endif
 
         call ale#virtualtext#ShowMessage(l:msg, l:hl_group)

--- a/autoload/ale/virtualtext.vim
+++ b/autoload/ale/virtualtext.vim
@@ -72,7 +72,6 @@ function! ale#virtualtext#ShowCursorWarning(...) abort
 
         if l:type is# 'E'
           let l:hl_group = 'ALEVirtualTextError'
-        endif
         elseif l:type is# 'W'
             let l:hl_group = 'ALEVirtualTextWarning'
         endif

--- a/autoload/ale/virtualtext.vim
+++ b/autoload/ale/virtualtext.vim
@@ -71,7 +71,7 @@ function! ale#virtualtext#ShowCursorWarning(...) abort
         let l:type = get(l:loc, 'type', 'E')
 
         if l:type is# 'E'
-          let l:hl_group = 'ALEVirtualTextError'
+            let l:hl_group = 'ALEVirtualTextError'
         elseif l:type is# 'W'
             let l:hl_group = 'ALEVirtualTextWarning'
         endif

--- a/autoload/ale/virtualtext.vim
+++ b/autoload/ale/virtualtext.vim
@@ -75,6 +75,7 @@ function! ale#virtualtext#ShowCursorWarning(...) abort
         elseif l:type is# 'W'
             let l:hl_group = 'ALEVirtualTextWarning'
         endif
+
         call ale#virtualtext#ShowMessage(l:msg, l:hl_group)
     endif
 endfunction

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -1891,28 +1891,13 @@ g:ale_virtualtext_cursor                                           *g:ale_virtua
 
   Messages can be prefixed prefixed with a string. See |g:ale_virtualtext_prefix|.
 
-  Message appearance can be modified by assigning highlight groups to
-  |g:ale_virtualtext_error_hi| and |g:ale_virtualtext_warning_hi|
+  Message appearance can be changed by modifying these highlight groups:
+  |ALEVirtualTextError| |ALEVirtualTextWarning|
 
-g:ale_virtualtext_error_hi                                           *g:ale_virtualtext_error_hi*
-
-  Type: |String|
-  Default: `ALEError`
-
-  This is the highlight group for error messages displayed via
-  ale_virtualtext.
-
-g:ale_virtualtext_warning_hi                                           *g:ale_virtualtext_warning_hi*
-
-  Type: |String|
-  Default: `ALEWarning`
-
-  This is the highlight group for warning messages displayed via
-  ale_virtualtext.
 
 
 g:ale_virtualtext_delay                                             *g:ale_virtualtext_delay*
-                                                             *b:ale_virtualtext_delay*
+b:ale_virtualtext_delay                                             *b:ale_virtualtext_delay*
   Type: |Number|
   Default: `10`
 

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -1891,6 +1891,25 @@ g:ale_virtualtext_cursor                                           *g:ale_virtua
 
   Messages can be prefixed prefixed with a string. See |g:ale_virtualtext_prefix|.
 
+  Message appearance can be modified by assigning highlight groups to
+  |g:ale_virtualtext_error_hi| and |g:ale_virtualtext_warning_hi|
+
+g:ale_virtualtext_error_hi                                           *g:ale_virtualtext_error_hi*
+
+  Type: |String|
+  Default: `ALEError`
+
+  This is the highlight group for error messages displayed via
+  ale_virtualtext.
+
+g:ale_virtualtext_warning_hi                                           *g:ale_virtualtext_warning_hi*
+
+  Type: |String|
+  Default: `ALEWarning`
+
+  This is the highlight group for warning messages displayed via
+  ale_virtualtext.
+
 
 g:ale_virtualtext_delay                                             *g:ale_virtualtext_delay*
                                                              *b:ale_virtualtext_delay*


### PR DESCRIPTION
This changes the highlight group used in the `ale_virtualtext` function. It allows for the styling of virtual text to be different than the default `ALEError` or `ALEWarning` allowing vitualtext to stand out better.

Before:
![old_highlight](https://user-images.githubusercontent.com/19915504/48335471-7c399000-e666-11e8-9505-2b50a2e2dba7.png)

After:
![new_highlight](https://user-images.githubusercontent.com/19915504/48335479-80fe4400-e666-11e8-95c6-18237d80e214.png)

