### PR TITLE
[tslint] Make sure `ruleName` is shown

### DIFF
--- a/ale_linters/typescript/tslint.vim
+++ b/ale_linters/typescript/tslint.vim
@@ -20,7 +20,7 @@ function! ale_linters#typescript#tslint#Handle(buffer, lines) abort
 
         let l:item = {
         \   'type': (get(l:error, 'ruleSeverity', '') is# 'WARNING' ? 'W' : 'E'),
-        \   'text': l:error.failure,
+        \   'text': l:error.failure . ' (' . l:error.ruleName . ')',
         \   'lnum': l:error.startPosition.line + 1,
         \   'col': l:error.startPosition.character + 1,
         \   'end_lnum': l:error.endPosition.line + 1,


### PR DESCRIPTION
This PR adds the violated rule name to displayed message.
This makes the error message more useful.

Before:

```
[tslint] variable name must be in lowerCamelCase, PascalCase or UPPER_CASE [Error]
```

After:

```
[tslint] variable name must be in lowerCamelCase, PascalCase or UPPER_CASE (variable-name) [Error]
```