### PR TITLE
Add Vale linter for AsciiDoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ formatting.
 | ASM | [gcc](https://gcc.gnu.org) |
 | Ansible | [ansible-lint](https://github.com/willthames/ansible-lint) |
 | API Blueprint | [drafter](https://github.com/apiaryio/drafter) |
-| AsciiDoc | [alex](https://github.com/wooorm/alex) !!, [proselint](http://proselint.com/), [redpen](http://redpen.cc/), [write-good](https://github.com/btford/write-good) |
+| AsciiDoc | [alex](https://github.com/wooorm/alex) !!, [proselint](http://proselint.com/), [redpen](http://redpen.cc/), [write-good](https://github.com/btford/write-good), [vale](https://github.com/ValeLint/vale) |
 | Awk | [gawk](https://www.gnu.org/software/gawk/)|
 | Bash | [language-server](https://github.com/mads-hartmann/bash-language-server), shell [-n flag](https://www.gnu.org/software/bash/manual/bash.html#index-set), [shellcheck](https://www.shellcheck.net/), [shfmt](https://github.com/mvdan/sh) |
 | Bourne Shell | shell [-n flag](http://linux.die.net/man/1/sh), [shellcheck](https://www.shellcheck.net/), [shfmt](https://github.com/mvdan/sh) |

--- a/ale_linters/asciidoc/vale.vim
+++ b/ale_linters/asciidoc/vale.vim
@@ -1,0 +1,9 @@
+" Author: Jeff Kreeftmeijer https://github.com/jeffkreeftmeijer
+" Description: vale for AsciiDoc files
+
+call ale#linter#Define('asciidoc', {
+\   'name': 'vale',
+\   'executable': 'vale',
+\   'command': 'vale --output=line %t',
+\   'callback': 'ale#handlers#unix#HandleAsWarning',
+\})

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -395,7 +395,7 @@ Notes:
 * ASM: `gcc`
 * Ansible: `ansible-lint`
 * API Blueprint: `drafter`
-* AsciiDoc: `alex`!!, `proselint`, `redpen`, `write-good`
+* AsciiDoc: `alex`!!, `proselint`, `redpen`, `write-good`, `vale`
 * Awk: `gawk`
 * Bash: `language-server`, `shell` (-n flag), `shellcheck`, `shfmt`
 * Bourne Shell: `shell` (-n flag), `shellcheck`, `shfmt`


### PR DESCRIPTION
Vale supports AsciiDoc. This patch adds a Vale linter for AsciiDoc files, which is based on the existing Markdown linter.

This is a patch I made in October of last year, and have been using ever since in AsciiDoc documents. I found it while cleaning up my dotfiles and I have no idea why I never submitted it as a patch, but here it is (freshly rebased!). 