### PR TITLE
Continue scalac compilation until just before bytecode generation

### DIFF
--- a/ale_linters/scala/scalac.vim
+++ b/ale_linters/scala/scalac.vim
@@ -9,7 +9,7 @@ endfunction
 call ale#linter#Define('scala', {
 \   'name': 'scalac',
 \   'executable_callback': {buf -> s:IsSbt(buf) ? '' : 'scalac'},
-\   'command': '%e -Ystop-after:parser %t',
+\   'command': '%e -Ystop-before:jvm %t',
 \   'callback': 'ale#handlers#scala#HandleScalacLintFormat',
 \   'output_stream': 'stderr',
 \})

--- a/test/command_callback/test_scalac_command_callback.vader
+++ b/test/command_callback/test_scalac_command_callback.vader
@@ -6,7 +6,7 @@ After:
 
 Given scala(An empty Scala file):
 Execute(The default executable and command should be correct):
-  AssertLinter 'scalac', ale#Escape('scalac') . ' -Ystop-after:parser %t'
+  AssertLinter 'scalac', ale#Escape('scalac') . ' -Ystop-before:jvm %t'
 
 Given scala.sbt(An empty SBT file):
 Execute(scalac should not be run for sbt files):


### PR DESCRIPTION
Previous behavior does not compile deep enough to surface errors.

See compiler phases:
https://docs.scala-lang.org/overviews/compiler-options/index.html#compilation-phases