### PR TITLE
Don't hardcode the namespace id for virtual text

### DIFF
--- a/autoload/ale/virtualtext.vim
+++ b/autoload/ale/virtualtext.vim
@@ -7,6 +7,9 @@ scriptencoding utf-8
 let g:ale_virtualtext_delay = get(g:, 'ale_virtualtext_delay', 10)
 let s:cursor_timer = -1
 let s:last_pos = [0, 0, 0]
+if has('nvim-0.3.2')
+  let s:ns_id = nvim_create_namespace('ale')
+endif
 
 if !hlexists('ALEVirtualTextError')
     highlight link ALEVirtualTextError ALEError
@@ -35,7 +38,7 @@ function! ale#virtualtext#Clear() abort
 
     let l:buffer = bufnr('')
 
-    call nvim_buf_clear_highlight(l:buffer, 1000, 0, -1)
+    call nvim_buf_clear_highlight(l:buffer, s:ns_id, 0, -1)
 endfunction
 
 function! ale#virtualtext#ShowMessage(message, hl_group) abort
@@ -48,7 +51,7 @@ function! ale#virtualtext#ShowMessage(message, hl_group) abort
     let l:buffer = bufnr('')
     let l:prefix = get(g:, 'ale_virtualtext_prefix', '> ')
 
-    call nvim_buf_set_virtual_text(l:buffer, 1000, l:line-1, [[l:prefix.a:message, a:hl_group]], {})
+    call nvim_buf_set_virtual_text(l:buffer, s:ns_id, l:line-1, [[l:prefix.a:message, a:hl_group]], {})
 endfunction
 
 function! s:StopCursorTimer() abort

--- a/autoload/ale/virtualtext.vim
+++ b/autoload/ale/virtualtext.vim
@@ -7,8 +7,9 @@ scriptencoding utf-8
 let g:ale_virtualtext_delay = get(g:, 'ale_virtualtext_delay', 10)
 let s:cursor_timer = -1
 let s:last_pos = [0, 0, 0]
+
 if has('nvim-0.3.2')
-  let s:ns_id = nvim_create_namespace('ale')
+    let s:ns_id = nvim_create_namespace('ale')
 endif
 
 if !hlexists('ALEVirtualTextError')


### PR DESCRIPTION
This makes collisions with other plugins less likely.

Note: this function was merged just yesterday to Nvim master. A variant that works since earlier is to initialize `s:ns_id` to zero, and use `let s:ns_id = nvim_buf_set_virtual_text(l:buffer, s:ns_id, ...)`