### PR TITLE
Only set the unnamed register at the end of :ALEInfoToClipboard

### DIFF
--- a/autoload/ale/debugging.vim
+++ b/autoload/ale/debugging.vim
@@ -237,10 +237,11 @@ function! ale#debugging#Info() abort
 endfunction
 
 function! ale#debugging#InfoToClipboard() abort
-    redir @+>
+    redir => l:output
         silent call ale#debugging#Info()
     redir END
 
+    let @+ = l:output
     call s:Echo('ALEInfo copied to your clipboard')
 endfunction
 


### PR DESCRIPTION
This fixes performance problems in Neovim, where every character results
in spawning a new clipboard-tool process.

Behaviour is not similarly pathological in Vim, but it still results in
an unnecessary amount of register churn.