### PR TITLE
Fix javalsp command.

### DIFF
--- a/ale_linters/java/javalsp.vim
+++ b/ale_linters/java/javalsp.vim
@@ -2,15 +2,17 @@
 " Description: Support for the Java language server https://github.com/georgewfraser/vscode-javac
 
 call ale#Set('java_javalsp_jar', 'javacs.jar')
+call ale#Set('java_javalsp_executable', 'java')
 
 function! ale_linters#java#javalsp#Executable(buffer) abort
-    return 'java'
+    return ale#Var(a:buffer, 'java_javalsp_executable')
 endfunction
 
 function! ale_linters#java#javalsp#Command(buffer) abort
     let l:jar = ale#Var(a:buffer, 'java_javalsp_jar')
+    let l:executable = ale_linters#java#javalsp#Executable(a:buffer)
 
-    return ale#Escape('java -cp ' . l:jar . ' -Xverify:none org.javacs.Main')
+    return ale#Escape(l:executable) . ' -cp ' . l:jar . ' -Xverify:none org.javacs.Main'
 endfunction
 
 call ale#linter#Define('java', {

--- a/doc/ale-java.txt
+++ b/doc/ale-java.txt
@@ -88,14 +88,20 @@ This generates a out/fat-jar.jar file that contains the language server. To
 let ALE use this language server you need to set the g:ale_java_javalsp_jar
 variable to the absolute path of this jar file.
 
+g:ale_java_javalsp_executable                   *g:ale_java_javalsp_executable*
+                                                *b:ale_java_javalsp_executable*
+  Type: |String|
+  Default: `'java'`
+
+This variable can be changed to use a different executable for java.
+
 g:ale_java_javalsp_jar                                 *g:ale_java_javalsp_jar*
                                                        *b:ale_java_javalsp_jar*
 
-  Type: String
-  Default: 'fat-jar.jar
+  Type: |String|
+  Default: `'fat-jar.jar'`
 
   Path to the location of the vscode-javac language server plugin.
-  and -d. They are added automatically.
 
 
 ===============================================================================

--- a/test/command_callback/test_javalsp_command_callback.vader
+++ b/test/command_callback/test_javalsp_command_callback.vader
@@ -6,5 +6,9 @@ After:
   call ale#assert#TearDownLinterTest()
 
 Execute(The javalsp callback should return the correct default value):
-  AssertLinter 'java', ale#Escape('java -cp javacs.jar -Xverify:none org.javacs.Main')
+  AssertLinter 'java', ale#Escape('java') . ' -cp javacs.jar -Xverify:none org.javacs.Main'
 
+Execute(The javalsp java executable should be configurable):
+  let b:ale_java_javalsp_executable = '/bin/foobar'
+
+  AssertLinter '/bin/foobar', ale#Escape('/bin/foobar') . ' -cp javacs.jar -Xverify:none org.javacs.Main'


### PR DESCRIPTION
The command used to invoke the LSP process was being escaped wrong.

Also added a new option to set a different java executable and fixed the
documentation.

Closes #1994 