### PR TITLE
Parse more C/C++ compiler options

### DIFF
--- a/autoload/ale/c.vim
+++ b/autoload/ale/c.vim
@@ -79,51 +79,43 @@ function! ale#c#AreSpecialCharsBalanced(option) abort
 endfunction
 
 function! ale#c#ParseCFlags(path_prefix, cflag_line) abort
-    let l:cflags_list = []
-    let l:previous_options = ''
-
-    let l:split_lines = split(a:cflag_line, ' ')
+    let l:split_lines = split(a:cflag_line)
     let l:option_index = 0
 
     while l:option_index < len(l:split_lines)
-        let l:option = l:previous_options . l:split_lines[l:option_index]
-        let l:option_index = l:option_index + 1
+        let l:next_option_index = l:option_index + 1
 
-        " Check if cflag contained an unmatched special character and should not have been splitted
-        if ale#c#AreSpecialCharsBalanced(l:option) == 0 && l:option_index < len(l:split_lines)
-            let l:previous_options = l:option . ' '
-            continue
-        endif
+        " Join space-separated option
+        while l:next_option_index < len(l:split_lines) &&
+            \ stridx(l:split_lines[l:next_option_index], '-') != 0
+            let l:next_option_index += 1
+        endwhile
 
-        " Check if there was spaces after -D/-I and the flag should not have been splitted
-        if l:option is# '-D' || l:option is# '-I'
-            let l:previous_options = l:option
-            continue
-        endif
+        let l:option = join(l:split_lines[l:option_index : l:next_option_index-1], ' ')
+        call remove(l:split_lines, l:option_index, l:next_option_index-1)
+        call insert(l:split_lines, l:option, l:option_index)
 
-        let l:previous_options = ''
-
-
-        " Fix relative paths if needed
-        if stridx(l:option, '-I') >= 0 &&
-           \ stridx(l:option, '-I' . s:sep) < 0
-            let l:rel_path = join(split(l:option, '\zs')[2:], '')
-            let l:rel_path = substitute(l:rel_path, '"', '', 'g')
-            let l:rel_path = substitute(l:rel_path, '''', '', 'g')
-            let l:option = ale#Escape('-I' . a:path_prefix .
-                                      \ s:sep . l:rel_path)
-        endif
-
-        " Parse the cflag
-        if stridx(l:option, '-I') >= 0 ||
-           \ stridx(l:option, '-D') >= 0
-            if index(l:cflags_list, l:option) < 0
-                call add(l:cflags_list, l:option)
+        " Ignore invalid or conflicting options
+        if stridx(l:option, '-') != 0 ||
+            \ stridx(l:option, '-o') == 0 ||
+            \ stridx(l:option, '-c') == 0
+            call remove(l:split_lines, l:option_index)
+            let l:option_index = l:option_index - 1
+        " Fix relative path
+        elseif stridx(l:option, '-I') == 0
+            if !(stridx(l:option, ':') == 2+1 || stridx(l:option, '/') == 2+0)
+                let l:option = '-I' . a:path_prefix . s:sep . l:option[2:]
+                call remove(l:split_lines, l:option_index)
+                call insert(l:split_lines, l:option, l:option_index)
             endif
         endif
+
+        let l:option_index = l:option_index + 1
     endwhile
 
-    return join(l:cflags_list, ' ')
+    call uniq(l:split_lines)
+
+    return join(l:split_lines, ' ')
 endfunction
 
 function! ale#c#ParseCFlagsFromMakeOutput(buffer, make_output) abort

--- a/test/test_c_flag_parsing.vader
+++ b/test/test_c_flag_parsing.vader
@@ -14,14 +14,25 @@ Execute(The CFlags parser should be able to parse include directives):
   call ale#test#SetFilename('test_c_projects/makefile_project/subdir/file.c')
 
   AssertEqual
-  \ ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir')),
+  \ '-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'),
   \ ale#c#ParseCFlagsFromMakeOutput(bufnr(''), ['gcc -Isubdir -c file.c'])
+
+  AssertEqual
+  \ '-isystem ' . '/usr/include/dir',
+  \ ale#c#ParseCFlagsFromMakeOutput(bufnr(''), ['gcc -isystem /usr/include/dir -c file.c'])
+
+Execute(ParseCFlags should ignore -c and -o):
+  call ale#test#SetFilename('test_c_projects/makefile_project/subdir/file.c')
+
+  AssertEqual
+  \ '-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'),
+  \ ale#c#ParseCFlagsFromMakeOutput(bufnr(''), ['gcc -Isubdir -c file.c -o a.out'])
 
 Execute(The CFlags parser should be able to parse macro directives):
   call ale#test#SetFilename('test_c_projects/makefile_project/subdir/file.c')
 
   AssertEqual
-  \ ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'))
+  \ '-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir')
   \   . ' -DTEST=1',
   \ ale#c#ParseCFlagsFromMakeOutput(bufnr(''), ['gcc -Isubdir -DTEST=1 -c file.c'])
 
@@ -29,7 +40,7 @@ Execute(The CFlags parser should be able to parse macro directives with spaces):
   call ale#test#SetFilename('test_c_projects/makefile_project/subdir/file.c')
 
   AssertEqual
-  \ ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'))
+  \ '-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir')
   \   . ' -DTEST=$(( 2 * 4 ))',
   \ ale#c#ParseCFlagsFromMakeOutput(bufnr(''), ['gcc -Isubdir -DTEST=$(( 2 * 4 )) -c file.c'])
 
@@ -37,14 +48,14 @@ Execute(The CFlags parser should be able to parse shell directives with spaces):
   call ale#test#SetFilename('test_c_projects/makefile_project/subdir/file.c')
 
   AssertEqual
-  \ ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'))
+  \ '-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir')
   \   .  ' -DTEST=`date +%s`',
   \ ale#c#ParseCFlagsFromMakeOutput(bufnr(''), ['gcc -Isubdir -DTEST=`date +%s` -c file.c'])
 
 Execute(ParseCFlags should be able to parse flags with relative paths):
   AssertEqual
-  \ ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'))
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include'))
+  \ '-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir')
+  \   . ' ' . '-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include')
   \   . ' -DTEST=`date +%s`',
   \ ale#c#ParseCFlags(
   \   ale#path#Simplify(g:dir. '/test_c_projects/makefile_project'),
@@ -56,8 +67,8 @@ Execute(ParseCFlags should be able to parse flags with relative paths):
 Execute(ParseCFlags should be able to parse -Dgoal):
   AssertEqual
   \ '-Dgoal=9'
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'))
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include'))
+  \   . ' ' . '-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir')
+  \   . ' ' . '-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include')
   \   . ' -DTEST=`date +%s`',
   \ ale#c#ParseCFlags(
   \   ale#path#Simplify(g:dir. '/test_c_projects/makefile_project'),
@@ -66,29 +77,16 @@ Execute(ParseCFlags should be able to parse -Dgoal):
   \     . ' -DTEST=`date +%s` -c file.c'
   \ )
 
-Execute(ParseCFlags should ignore -T and other arguments):
-  AssertEqual
-  \ '-Dgoal=9'
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'))
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include'))
-  \   . ' -DTEST=`date +%s`',
-  \ ale#c#ParseCFlags(
-  \   ale#path#Simplify(g:dir. '/test_c_projects/makefile_project'),
-  \   'gcc -Dgoal=9 -Tlinkerfile.ld blabla -Isubdir --sysroot=subdir '
-  \     .  '-I'. ale#path#Simplify('kernel/include')
-  \     .  ' -DTEST=`date +%s` -c file.c'
-  \ )
-
 Execute(ParseCFlags should handle paths with spaces in double quotes):
   AssertEqual
   \ '-Dgoal=9'
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'))
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/dir with spaces'))
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include'))
+  \   . ' ' . '-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir')
+  \   . ' ' . '-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/"dir with spaces"')
+  \   . ' ' . '-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include')
   \   . ' -DTEST=`date +%s`',
   \ ale#c#ParseCFlags(
   \   ale#path#Simplify(g:dir. '/test_c_projects/makefile_project'),
-  \   'gcc -Dgoal=9 -Tlinkerfile.ld blabla -Isubdir '
+  \   'gcc -Dgoal=9 -Isubdir '
   \     . '-I"dir with spaces"' . ' -I'. ale#path#Simplify('kernel/include')
   \     . ' -DTEST=`date +%s` -c file.c'
   \ )
@@ -96,29 +94,28 @@ Execute(ParseCFlags should handle paths with spaces in double quotes):
 Execute(ParseCFlags should handle paths with spaces in single quotes):
   AssertEqual
   \ '-Dgoal=9'
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'))
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/dir with spaces'))
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include'))
+  \   . ' ' . '-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir')
+  \   . ' ' . '-I' . ale#path#Simplify(g:dir. "/test_c_projects/makefile_project/'dir with spaces'")
+  \   . ' ' . '-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include')
   \   . ' -DTEST=`date +%s`',
   \ ale#c#ParseCFlags(
   \   ale#path#Simplify(g:dir. '/test_c_projects/makefile_project'),
-  \   'gcc -Dgoal=9 -Tlinkerfile.ld blabla -Isubdir '
-  \     . '-I''dir with spaces''' . ' -I'. ale#path#Simplify('kernel/include')
+  \   'gcc -Dgoal=9 -Isubdir '
+  \     . "-I'dir with spaces'" . ' -I'. ale#path#Simplify('kernel/include')
   \     . ' -DTEST=`date +%s` -c file.c'
   \ )
 
 Execute(ParseCFlags should handle paths with minuses):
   AssertEqual
   \ '-Dgoal=9'
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'))
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/dir with spaces'))
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/dir-with-dash'))
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include'))
+  \   . ' ' . '-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir')
+  \   . ' ' . '-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/dir-with-dash')
+  \   . ' ' . '-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include')
   \   . ' -DTEST=`date +%s`',
   \ ale#c#ParseCFlags(
   \   ale#path#Simplify(g:dir. '/test_c_projects/makefile_project'),
-  \   'gcc -Dgoal=9 -Tlinkerfile.ld blabla -Isubdir '
-  \     . '-I''dir with spaces''' . ' -Idir-with-dash'
+  \   'gcc -Dgoal=9 -Isubdir '
+  \     . ' -Idir-with-dash'
   \     . ' -I'. ale#path#Simplify('kernel/include')
   \     . ' -DTEST=`date +%s` -c file.c'
   \ )
@@ -126,17 +123,14 @@ Execute(ParseCFlags should handle paths with minuses):
 Execute(ParseCFlags should handle -D with minuses):
   AssertEqual
   \ '-Dgoal=9'
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'))
+  \   . ' ' . '-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir')
   \   . ' -Dmacro-with-dash'
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/dir with spaces'))
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/dir-with-dash'))
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include'))
+  \   . ' ' . '-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include')
   \   . ' -DTEST=`date +%s`',
   \ ale#c#ParseCFlags(
   \   ale#path#Simplify(g:dir. '/test_c_projects/makefile_project'),
-  \   'gcc -Dgoal=9 -Tlinkerfile.ld blabla -Isubdir '
+  \   'gcc -Dgoal=9 -Isubdir '
   \     . '-Dmacro-with-dash '
-  \     . '-I''dir with spaces''' . ' -Idir-with-dash'
   \     . ' -I'. ale#path#Simplify('kernel/include')
   \     . ' -DTEST=`date +%s` -c file.c'
   \ )
@@ -144,16 +138,11 @@ Execute(ParseCFlags should handle -D with minuses):
 Execute(ParseCFlags should handle flags at the end of the line):
   AssertEqual
   \ '-Dgoal=9'
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'))
-  \   . ' -Dmacro-with-dash'
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/dir with spaces'))
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/dir-with-dash'))
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include')),
+  \   . ' ' . '-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir')
+  \   . ' ' . '-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include'),
   \ ale#c#ParseCFlags(
   \   ale#path#Simplify(g:dir. '/test_c_projects/makefile_project'),
-  \   'gcc -Dgoal=9 -Tlinkerfile.ld blabla -Isubdir '
-  \     . '-Dmacro-with-dash '
-  \     . '-I''dir with spaces''' . ' -Idir-with-dash'
+  \   'gcc -Dgoal=9 -Isubdir '
   \     . ' -I'. ale#path#Simplify('kernel/include')
   \ )
 
@@ -167,14 +156,14 @@ Execute(ParseCompileCommandsFlags should parse some basic flags):
   noautocmd execute 'file! ' . fnameescape(ale#path#Simplify('/foo/bar/xmms2-mpris/src/xmms2-mpris.c'))
 
   AssertEqual
-  \ '-I' . ale#path#Simplify('/usr/include/xmms2'),
+  \ '-I' . '/usr/include/xmms2',
   \ ale#c#ParseCompileCommandsFlags(bufnr(''), { "xmms2-mpris.c": [
   \   {
-  \     'directory': ale#path#Simplify('/foo/bar/xmms2-mpris'),
-  \     'command': '/usr/bin/cc  -I' . ale#path#Simplify('/usr/include/xmms2')
+  \     'directory': '/foo/bar/xmms2-mpris',
+  \     'command': '/usr/bin/cc  -I' . '/usr/include/xmms2'
   \       . '    -o CMakeFiles/xmms2-mpris.dir/src/xmms2-mpris.c.o'
-  \       . '   -c ' . ale#path#Simplify('/foo/bar/xmms2-mpris/src/xmms2-mpris.c'),
-  \     'file': ale#path#Simplify('/foo/bar/xmms2-mpris/src/xmms2-mpris.c'),
+  \       . '   -c ' . '/foo/bar/xmms2-mpris/src/xmms2-mpris.c',
+  \     'file': '/foo/bar/xmms2-mpris/src/xmms2-mpris.c',
   \   },
   \ ] }, {})
 
@@ -182,40 +171,23 @@ Execute(ParseCompileCommandsFlags should fall back to files in the same director
   noautocmd execute 'file! ' . fnameescape(ale#path#Simplify('/foo/bar/xmms2-mpris/src/xmms2-mpris.c'))
 
   AssertEqual
-  \ '-I' . ale#path#Simplify('/usr/include/xmms2'),
+  \ '-I' . '/usr/include/xmms2',
   \ ale#c#ParseCompileCommandsFlags(bufnr(''), {}, { "src": [
   \   {
-  \     'directory': ale#path#Simplify('/foo/bar/xmms2-mpris'),
-  \     'command': '/usr/bin/cc  -I' . ale#path#Simplify('/usr/include/xmms2')
+  \     'directory': '/foo/bar/xmms2-mpris',
+  \     'command': '/usr/bin/cc  -I' . '/usr/include/xmms2'
   \       . '    -o CMakeFiles/xmms2-mpris.dir/src/xmms2-mpris.c.o'
-  \       . '   -c ' . ale#path#Simplify('/foo/bar/xmms2-mpris/src/xmms2-mpris.c'),
-  \     'file': ale#path#Simplify((has('win32') ? 'C:' : '') . '/foo/bar/xmms2-mpris/src/xmms2-other.c'),
+  \       . '   -c ' . '/foo/bar/xmms2-mpris/src/xmms2-mpris.c',
+  \     'file': (has('win32') ? 'C:' : '') . '/foo/bar/xmms2-mpris/src/xmms2-other.c',
   \   },
   \ ] })
 
-Execute(ParseCFlags should not merge flags):
-  AssertEqual
-  \ '-Dgoal=9'
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'))
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/dir with spaces'))
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/dir-with-dash'))
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include')),
-  \ ale#c#ParseCFlags(
-  \   ale#path#Simplify(g:dir. '/test_c_projects/makefile_project'),
-  \   'gcc -Dgoal=9 -Tlinkerfile.ld blabla -Isubdir '
-  \     . 'subdir/somedep1.o ' . 'subdir/somedep2.o '
-  \     . '-I''dir with spaces''' . ' -Idir-with-dash '
-  \     . 'subdir/somedep3.o ' . 'subdir/somedep4.o '
-  \     . ' -I'. ale#path#Simplify('kernel/include') . ' '
-  \     . 'subdir/somedep5.o ' . 'subdir/somedep6.o '
-  \ )
-
 Execute(ParseCFlags should handle parenthesis and quotes):
   AssertEqual
-  \ '-Dgoal=9 -Dtest1="('' '')" -Dtest2=''(` `)'' -Dtest3=`(" ")`',
+  \ '-Dgoal=9 -Dtest1="('' '')" file1.o -Dtest2=''(` `)'' file2.o -Dtest3=`(" ")` file3.o',
   \ ale#c#ParseCFlags(
   \   ale#path#Simplify(g:dir. '/test_c_projects/makefile_project'),
-  \   'gcc -Dgoal=9 -Tlinkerfile.ld blabla '
+  \   'gcc -Dgoal=9 '
   \     . '-Dtest1="('' '')" file1.o '
   \     . '-Dtest2=''(` `)'' file2.o '
   \     . '-Dtest3=`(" ")` file3.o '


### PR DESCRIPTION
According gcc manual, in addition to '-I/path/to/include', there are many other flags can be used to add header search directory. Qt with cmake use '-isystem' to include Qt headers, if not adding these flags to cflag_line, ale cannot find Qt headers. This PR adds these flags to cflag_line.