### PR TITLE
javac linter: fix handling of error messages containing ':' character

### DIFF
--- a/ale_linters/java/javac.vim
+++ b/ale_linters/java/javac.vim
@@ -92,7 +92,7 @@ function! ale_linters#java#javac#Handle(buffer, lines) abort
     " Main.java:13: warning: [deprecation] donaught() in Testclass has been deprecated
     " Main.java:16: error: ';' expected
     let l:directory = expand('#' . a:buffer . ':p:h')
-    let l:pattern = '\v^(.*):(\d+): (.+):(.+)$'
+    let l:pattern = '\v^(.*):(\d+): (.{-1,}):(.+)$'
     let l:col_pattern = '\v^(\s*\^)$'
     let l:symbol_pattern = '\v^ +symbol: *(class|method) +([^ ]+)'
     let l:output = []

--- a/test/handler/test_javac_handler.vader
+++ b/test/handler/test_javac_handler.vader
@@ -44,6 +44,13 @@ Execute(The javac handler should handle cannot find symbol errors):
   \     'text': 'error: cannot find symbol: bar()',
   \     'type': 'E',
   \   },
+  \   {
+  \     'filename': ale#path#Simplify('/tmp/vLPr4Q5/33/foo.java'),
+  \     'lnum': 58,
+  \     'col': 19,
+  \     'text': 'error: incompatible types: Bar cannot be converted to Foo',
+  \     'type': 'E',
+  \   },
   \ ],
   \ ale_linters#java#javac#Handle(bufnr(''), [
   \   '/tmp/vLPr4Q5/33/foo.java:1: error: some error',
@@ -62,7 +69,10 @@ Execute(The javac handler should handle cannot find symbol errors):
   \   '      this.bar();',
   \   '          ^',
   \   '  symbol: method bar()',
-  \   '5 errors',
+  \   '/tmp/vLPr4Q5/33/foo.java:58: error: incompatible types: Bar cannot be converted to Foo',
+  \   '      this.setFoo(bar);',
+  \   '                  ^',
+  \   '6 errors',
   \ ])
 
 Execute(The javac handler should resolve files from different directories):


### PR DESCRIPTION
Javac error messages containing a ':' character were reported as error by the javac linter.