### PR TITLE
Decouple completion engine internals

### DIFF
--- a/autoload/ale/completion.vim
+++ b/autoload/ale/completion.vim
@@ -233,10 +233,10 @@ function! ALEAfterCompletionResults() abort
         return
     endif
 
-    " If the autocompletion events are not managed by ALE, don't mess with
+    " If the completion events are not managed by ALE, don't mess with
     " the omnifunc option. Otherwise, replace completion options shortly
     " before opening the menu.
-    if g:ale_autocompletion_enabled
+    if g:ale_completion_enabled
         call s:ReplaceCompletionOptions()
         call timer_start(0, {-> ale#util#FeedKeys("\<Plug>(ale_show_completion_menu)")})
     endif
@@ -625,11 +625,11 @@ function! s:Setup(enabled) abort
 endfunction
 
 function! ale#completion#Enable() abort
-    let g:ale_autocompletion_enabled = 1
-    call s:Setup(g:ale_autocompletion_enabled)
+    let g:ale_completion_enabled = 1
+    call s:Setup(g:ale_completion_enabled)
 endfunction
 
 function! ale#completion#Disable() abort
-    let g:ale_autocompletion_enabled = 0
-    call s:Setup(g:ale_autocompletion_enabled)
+    let g:ale_completion_enabled = 0
+    call s:Setup(g:ale_completion_enabled)
 endfunction

--- a/plugin/ale.vim
+++ b/plugin/ale.vim
@@ -133,11 +133,8 @@ let g:ale_history_enabled = get(g:, 'ale_history_enabled', 1)
 " A flag for storing the full output of commands in the history.
 let g:ale_history_log_output = get(g:, 'ale_history_log_output', 1)
 
-" Enable completion with LSP servers and tsserver
+" Enable automatic completion events with LSP servers and tsserver
 let g:ale_completion_enabled = get(g:, 'ale_completion_enabled', 0)
-
-" Enable automatic events for triggering completion
-let g:ale_autocompletion_enabled = get(g:, 'ale_autocompletion_enabled', g:ale_completion_enabled)
 
 " Enable automatic detection of pipenv for Python linters.
 let g:ale_python_auto_pipenv = get(g:, 'ale_python_auto_pipenv', 0)
@@ -146,7 +143,7 @@ if g:ale_set_balloons
     call ale#balloon#Enable()
 endif
 
-if g:ale_autocompletion_enabled
+if g:ale_completion_enabled
     call ale#completion#Enable()
 endif
 

--- a/plugin/ale.vim
+++ b/plugin/ale.vim
@@ -133,8 +133,11 @@ let g:ale_history_enabled = get(g:, 'ale_history_enabled', 1)
 " A flag for storing the full output of commands in the history.
 let g:ale_history_log_output = get(g:, 'ale_history_log_output', 1)
 
-" Enable automatic completion with LSP servers and tsserver
+" Enable completion with LSP servers and tsserver
 let g:ale_completion_enabled = get(g:, 'ale_completion_enabled', 0)
+
+" Enable automatic completion with LSP servers and tsserver
+let g:ale_autocompletion_enabled = get(g:, 'ale_autocompletion_enabled', g:ale_completion_enabled)
 
 " Enable automatic detection of pipenv for Python linters.
 let g:ale_python_auto_pipenv = get(g:, 'ale_python_auto_pipenv', 0)
@@ -143,7 +146,7 @@ if g:ale_set_balloons
     call ale#balloon#Enable()
 endif
 
-if g:ale_completion_enabled
+if g:ale_autocompletion_enabled
     call ale#completion#Enable()
 endif
 

--- a/plugin/ale.vim
+++ b/plugin/ale.vim
@@ -136,7 +136,7 @@ let g:ale_history_log_output = get(g:, 'ale_history_log_output', 1)
 " Enable completion with LSP servers and tsserver
 let g:ale_completion_enabled = get(g:, 'ale_completion_enabled', 0)
 
-" Enable automatic completion with LSP servers and tsserver
+" Enable automatic events for triggering completion
 let g:ale_autocompletion_enabled = get(g:, 'ale_autocompletion_enabled', g:ale_completion_enabled)
 
 " Enable automatic detection of pipenv for Python linters.

--- a/rplugin/python3/deoplete/sources/deoplete_ale.py
+++ b/rplugin/python3/deoplete/sources/deoplete_ale.py
@@ -1,0 +1,73 @@
+# ============================================================================
+# FILE: omni.py
+# AUTHOR: Shougo Matsushita <Shougo.Matsu at gmail.com>
+# License: MIT license
+# ============================================================================
+
+from deoplete.source.base import (
+    Base
+)
+from deoplete.util import (
+    convert2candidates
+)
+
+
+class Source(Base):
+
+    def __init__(self, vim):
+        super().__init__(vim)
+
+        self.name = 'ale'
+        self.mark = '[L]'
+        self.rank = 100
+        self.is_bytepos = True
+        self.min_pattern_length = 0
+        self.events = ['CompleteDone']
+
+        self.poll_func = 'ale#completion#PollCompletionResults'
+        self.position_func = 'ale#completion#FindCompletionStart'
+        self.reset_func = 'ale#completion#ClearBufferResults'
+
+    def on_event(self, context):
+        if context['event'] == 'CompleteDone':
+            context['completion_done'] = True
+
+    def get_completion_position(self):
+        return self.vim.call(self.position_func)
+
+    def patch_candidates(self, candidates):
+        if isinstance(candidates, dict):
+            candidates = candidates['words']
+        elif not isinstance(candidates, list):
+            candidates = convert2candidates(candidates)
+
+        for c in candidates:
+            c['dup'] = 1
+
+        return candidates
+
+    def gather_candidates(self, context):
+        candidates = []
+
+        try:
+            if 'initial_position' not in context:
+                self.vim.call(self.reset_func)
+                context['initial_position'] = self.get_completion_position()
+
+                if context['initial_position'] < 0:
+                    return []
+                else:
+                    context['is_async'] = True
+
+            candidates = self.vim.call(self.poll_func)
+
+            if 'completion_done' in context or candidates:
+                context['is_async'] = False
+                self.vim.call(self.reset_func)
+                candidates = self.patch_candidates(candidates)
+
+            # self.vim.command('echo localtime()')
+            return candidates
+        except Exception:
+            self.print_error('Error occurred calling ALE')
+            return None

--- a/test/completion/vimrc/minimal_autocompletion_vimrc
+++ b/test/completion/vimrc/minimal_autocompletion_vimrc
@@ -1,0 +1,17 @@
+" For testing ALE autocompletion with TSServer.
+" You need to include ALE at $VIMRUNTIME/pack/completion/opt/ale
+
+" Launch with VIMRUNTIME=[dummy directory] vim -u [path to this file] --noplugin new.js
+
+" Example: VIMRUNTIME=~/vim/mock vim -u ~/vim/mock/pack/completion/opt/ale/test/completion/vimrc/minimal_autocompletion_vimrc --noplugin new.js
+
+set nocompatible
+filetype on
+set filetype=javascript
+
+" Should enable autocompletion automatically
+let g:ale_completion_enabled = 1
+" Set up TSServer to enable completion
+let g:ale_linters = { 'javascript': ['tsserver'] }
+
+packadd ale


### PR DESCRIPTION
#### I will fix documentation and tests after the API changes are discussed and reviewed

# Notions
- The completion engine and the Autocmd events should be decoupled.
- Users can override the behavior of what happens to the results.
- Allow for interaction with other plugins, like deoplete (mentioned on https://github.com/w0rp/ale/issues/1753).

# Changes
- The process for polling/queuing activation has been separated from the Omnifunc itself.
- The old `ale#completion#Show` method called at the end of the completion parsing chain has been repurposed as `ale#completion#QueryDone`, which calls
     - Overridable **ALEProcessCompletionResults** for processing the parsed candidates for completion.
     - Overridable **ALEAfterCompletionResults** for adding flexibility to what happens after the processing is finished.

# How to test
Follow the instructions inside of [minimal_autocompletion_vimrc](test/completion/vimrc/minimal_autocompletion_vimrc).