### PR TITLE
Update the perl-linter's l:pattern to catch missing errors

### DIFF
--- a/ale_linters/perl/perl.vim
+++ b/ale_linters/perl/perl.vim
@@ -18,7 +18,7 @@ function! ale_linters#perl#perl#Handle(buffer, lines) abort
         return []
     endif
 
-    let l:pattern = '\(.\+\) at \(.\+\) line \(\d\+\)'
+    let l:pattern = '\(.\+\) at \(.\+\) line \(\d\+\),'
     let l:output = []
     let l:basename = expand('#' . a:buffer . ':t')
 

--- a/ale_linters/perl/perl.vim
+++ b/ale_linters/perl/perl.vim
@@ -18,7 +18,7 @@ function! ale_linters#perl#perl#Handle(buffer, lines) abort
         return []
     endif
 
-    let l:pattern = '\(.\+\) at \(.\+\) line \(\d\+\),'
+    let l:pattern = '\(..\{-}\) at \(..\{-}\) line \(\d\+\)'
     let l:output = []
     let l:basename = expand('#' . a:buffer . ':t')
 

--- a/test/handler/test_perl_handler.vader
+++ b/test/handler/test_perl_handler.vader
@@ -91,3 +91,19 @@ Execute(The Perl linter reports errors even when mixed with warnings):
   \ 'syntax error at - line 8, at EOF',
   \ 'Execution of t.pl aborted due to compilation errors.',
   \ ])
+
+Execute(The Perl linter reports errors even when an additional file location is included):
+  AssertEqual
+  \ [
+  \ {'lnum': '5', 'type': 'E', 'text': '"my" variable $foo masks earlier declaration in same scope'},
+  \ {'lnum': '6', 'type': 'E', 'text': '"my" variable $foo masks earlier declaration in same scope'},
+  \ {'lnum': '11', 'type': 'E', 'text': 'Global symbol "$asdf" requires explicit package name (did you forget to declare "my $asdf"?)'},
+  \ {'lnum': '12', 'type': 'E', 'text': 'Global symbol "$asdf" requires explicit package name (did you forget to declare "my $asdf"?)'},
+  \ ],
+  \ ale_linters#perl#perl#Handle(bufnr(''), [
+  \ '"my" variable $foo masks earlier declaration in same scope at - line 5.',
+  \ '"my" variable $foo masks earlier declaration in same scope at - line 6, at <DATA> line 1.',
+  \ 'Global symbol "$asdf" requires explicit package name (did you forget to declare "my $asdf"?) at - line 11.',
+  \ 'Global symbol "$asdf" requires explicit package name (did you forget to declare "my $asdf"?) at - line 12, <DATA> line 1.',
+  \ 'Execution of t.pl aborted due to compilation errors.',
+  \ ])


### PR DESCRIPTION
In some situations, errors reported by `perl -c` can have multiple
listings of "at <file> line <number>". If the l:pattern is changed to
use non-greedy matching it will also match these.

For example:
```
use strict;
use DateTime;
$asdf=1;
```

Results in:
```
Global symbol "$asdf" requires explicit package name (did you forget to declare "my $asdf"?) at /Users/mgrimes/t.pl line 3, <DATA> line 1.
/Users/mgrimes/t.pl had compilation errors.
```

I am not 100% sure why `perl -c` generates errors with the extra "file
line <num>". It only happens in some versions of perl when certain
modules are used.


<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-development`.

Have fun!
-->

Where are the tests? Have you added tests? Have you updated the tests? Read the
comment above and the documentation referenced in it first. Write tests!

Seriously, read `:help ale-development` and write tests.