### PR TITLE
Fall back to detecting LSP project roots based on Git repositories

### DIFF
--- a/autoload/ale/assert.vim
+++ b/autoload/ale/assert.vim
@@ -109,6 +109,14 @@ function! ale#assert#LSPProject(expected_root) abort
     AssertEqual a:expected_root, l:root
 endfunction
 
+function! ale#assert#LSPProjectFull(expected_root) abort
+    let l:buffer = bufnr('')
+    let l:linter = s:GetLinter()
+    let l:root = ale#lsp_linter#FindProjectRoot(l:buffer, l:linter)
+
+    AssertEqual a:expected_root, l:root
+endfunction
+
 function! ale#assert#LSPAddress(expected_address) abort
     let l:buffer = bufnr('')
     let l:linter = s:GetLinter()
@@ -158,6 +166,7 @@ function! ale#assert#SetUpLinterTest(filetype, name) abort
     command! -nargs=+ AssertLSPConfig :call ale#assert#LSPConfig(<args>)
     command! -nargs=+ AssertLSPLanguage :call ale#assert#LSPLanguage(<args>)
     command! -nargs=+ AssertLSPProject :call ale#assert#LSPProject(<args>)
+    command! -nargs=+ AssertLSPProjectFull :call ale#assert#LSPProjectFull(<args>)
     command! -nargs=+ AssertLSPAddress :call ale#assert#LSPAddress(<args>)
 endfunction
 

--- a/test/lsp/test_lsp_root_detection.vader
+++ b/test/lsp/test_lsp_root_detection.vader
@@ -1,0 +1,41 @@
+Before:
+  call ale#assert#SetUpLinterTest('c', 'clangd')
+
+After:
+  if isdirectory(g:dir . '/.git')
+    call delete(g:dir . '/.git', 'd')
+  endif
+
+  if filereadable(g:dir . '/.git')
+    call delete(g:dir . '/.git')
+  endif
+
+  if filereadable(g:dir . '/example/.git')
+    call delete(g:dir . '/example/.git')
+  endif
+
+  if isdirectory(g:dir . '/example')
+    call delete(g:dir . '/example', 'd')
+  endif
+
+  call ale#assert#TearDownLinterTest()
+
+Execute(The project path should be correct for .git directories):
+  call ale#test#SetFilename('other-file.c')
+  call mkdir(g:dir . '/.git')
+
+  AssertLSPProjectFull g:dir
+
+Execute(The project path should be correct for .git files):
+  call ale#test#SetFilename('other-file.c')
+  call writefile([], g:dir . '/.git')
+
+  AssertLSPProjectFull g:dir
+
+Execute(The project path should be correct for .git submodules):
+  call ale#test#SetFilename('example/other-file.c')
+  call mkdir(g:dir . '/.git')
+  call mkdir(g:dir . '/example')
+  call writefile([], g:dir . '/example/.git')
+
+  AssertLSPProjectFull has('win32') ? g:dir . '\example' : g:dir . '/example'


### PR DESCRIPTION
Currently, we detect the linter root based on a variety of techniques. However, these techniques are not foolproof. For example, clangd works fine for many things without a compile_commands.json file, and Go projects may be build outside of the GOPATH to take advantage of Go 1.11's automatic module support.

If the language-specific technique does not produce a root, then the LSP linter is not enabled, which is suboptimal. As a fallback, detect whether we are in a Git repository, and if so, use that as the project root. Handle both regular repositories and submodules.