### PR TITLE
Add associated line text on ALEFindReferences results for TypeScript

### DIFF
--- a/autoload/ale/references.vim
+++ b/autoload/ale/references.vim
@@ -27,6 +27,7 @@ function! ale#references#HandleTSServerResponse(conn_id, response) abort
                 \ 'filename': l:response_item.file,
                 \ 'line': l:response_item.start.line,
                 \ 'column': l:response_item.start.offset,
+                \ 'match': trim(l:response_item.lineText),
                 \})
             endfor
 

--- a/autoload/ale/references.vim
+++ b/autoload/ale/references.vim
@@ -27,7 +27,7 @@ function! ale#references#HandleTSServerResponse(conn_id, response) abort
                 \ 'filename': l:response_item.file,
                 \ 'line': l:response_item.start.line,
                 \ 'column': l:response_item.start.offset,
-                \ 'match': trim(l:response_item.lineText),
+                \ 'match': substitute(l:response_item.lineText, '^\s*\(.\{-}\)\s*$', '\1', ''),
                 \})
             endfor
 

--- a/test/test_find_references.vader
+++ b/test/test_find_references.vader
@@ -135,9 +135,9 @@ Execute(Results should be shown for tsserver responses):
 
   AssertEqual
   \ [
-  \   {'filename': '/foo/bar/app.ts', 'column': 9, 'line': 9},
-  \   {'filename': '/foo/bar/app.ts', 'column': 3, 'line': 804},
-  \   {'filename': '/foo/bar/other/app.ts', 'column': 3, 'line': 51},
+  \   {'filename': '/foo/bar/app.ts', 'column': 9, 'line': 9, 'match': 'import {doSomething} from ''./whatever'''},
+  \   {'filename': '/foo/bar/app.ts', 'column': 3, 'line': 804, 'match': 'doSomething()'},
+  \   {'filename': '/foo/bar/other/app.ts', 'column': 3, 'line': 51, 'match': 'doSomething()'},
   \ ],
   \ g:item_list
   AssertEqual {}, ale#references#GetMap()


### PR DESCRIPTION
Displays the line of code along with the referenced position, which resolves `#1` on [this comment](https://github.com/w0rp/ale/issues/1759#issuecomment-407866025).

I've only added it for TSServer (I'm not using any other LSP at the moment). But if you wanted to include it for generic LSPs, append the `match` [here](https://github.com/chaucerbao/ale/blob/24fda01a0e50fedba1b3f893142e3da49c36d31b/autoload/ale/references.vim#L56)