### PR TITLE
Add ability to manually trigger completion menu

### DIFF
--- a/autoload/ale/completion.vim
+++ b/autoload/ale/completion.vim
@@ -509,6 +509,12 @@ function! ale#completion#GetCompletions() abort
         return
     endif
 
+    call ale#completion#AlwaysGetCompletions()
+endfunction
+
+" This function can be used to manually trigger autocomplete, even when
+" g:ale_completion_enabled is set to false
+function! ale#completion#AlwaysGetCompletions() abort
     let [l:line, l:column] = getcurpos()[1:2]
 
     let l:prefix = ale#completion#GetPrefix(&filetype, l:line, l:column)

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -820,6 +820,9 @@ with |g:ale_completion_max_suggestions|.
 If you don't like some of the suggestions you see, you can filter them out
 with |g:ale_completion_excluded_words| or |b:ale_completion_excluded_words|.
 
+The |ALEComplete| command can be used to show completion suggestions manually,
+even when |g:ale_completion_enabled| is set to `0`.
+
                                                 *ale-completion-completopt-bug*
 
 ALE implements completion as you type by temporarily adjusting |completeopt|

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2235,6 +2235,17 @@ ALE will use to search for Python executables.
 ===============================================================================
 8. Commands/Keybinds                                             *ale-commands*
 
+ALEComplete                                                       *ALEComplete*
+
+  Manually trigger LSP autocomplete and show the menu. Works only when called
+  from insert mode. >
+
+    inoremap <silent> <C-Space> <C-\><C-O>:GetCompletions<CR>
+<
+  A plug mapping `<Plug>(ale_complete)` is defined for this command. >
+
+    imap <C-Space> <Plug>(ale_complete)
+<
 ALEDocumentation                                             *ALEDocumentation*
 
   Similar to the |ALEHover| command, retrieve documentation information for

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2240,7 +2240,7 @@ ALEComplete                                                       *ALEComplete*
   Manually trigger LSP autocomplete and show the menu. Works only when called
   from insert mode. >
 
-    inoremap <silent> <C-Space> <C-\><C-O>:GetCompletions<CR>
+    inoremap <silent> <C-Space> <C-\><C-O>:AleComplete<CR>
 <
   A plug mapping `<Plug>(ale_complete)` is defined for this command. >
 

--- a/plugin/ale.vim
+++ b/plugin/ale.vim
@@ -204,6 +204,8 @@ command! -bar ALEDocumentation :call ale#hover#ShowDocumentationAtCursor()
 " Search for appearances of a symbol, such as a type name or function name.
 command! -nargs=1 ALESymbolSearch :call ale#symbol#Search(<q-args>)
 
+command! -bar ALEComplete :call ale#completion#AlwaysGetCompletions()
+
 " <Plug> mappings for commands
 nnoremap <silent> <Plug>(ale_previous) :ALEPrevious<Return>
 nnoremap <silent> <Plug>(ale_previous_wrap) :ALEPreviousWrap<Return>
@@ -229,6 +231,7 @@ nnoremap <silent> <Plug>(ale_go_to_definition_in_vsplit) :ALEGoToDefinitionInVSp
 nnoremap <silent> <Plug>(ale_find_references) :ALEFindReferences<Return>
 nnoremap <silent> <Plug>(ale_hover) :ALEHover<Return>
 nnoremap <silent> <Plug>(ale_documentation) :ALEDocumentation<Return>
+inoremap <silent> <Plug>(ale_complete) <C-\><C-O>:ALEComplete<Return>
 
 " Set up autocmd groups now.
 call ale#events#Init()

--- a/test/test_ale_complete_command.vader
+++ b/test/test_ale_complete_command.vader
@@ -1,13 +1,20 @@
 Before:
-  call ale#completion#AlwaysGetCompletions()
+  function! MockAlwaysGetCompletions() abort
+    let g:get_completions_called = 0
 
-  let g:get_completions_called = 0
-  function! ale#completion#AlwaysGetCompletions() abort
-    let g:get_completions_called = 1
+    function! ale#completion#AlwaysGetCompletions() abort
+      let g:get_completions_called = 1
+    endfunction
   endfunction
 
+  call MockAlwaysGetCompletions()
+
 After:
+  unlet! g:get_completions_called
+  delfunction MockAlwaysGetCompletions
   delfunction ale#completion#AlwaysGetCompletions
+
+  runtime autoload/ale/completion.vim
 
 Execute(ale#completion#AlwaysGetCompletions should be called when ALEComplete is executed):
   AssertEqual 0, g:get_completions_called

--- a/test/test_ale_complete_command.vader
+++ b/test/test_ale_complete_command.vader
@@ -1,0 +1,15 @@
+Before:
+  call ale#completion#AlwaysGetCompletions()
+
+  let g:get_completions_called = 0
+  function! ale#completion#AlwaysGetCompletions() abort
+    let g:get_completions_called = 1
+  endfunction
+
+After:
+  delfunction ale#completion#AlwaysGetCompletions
+
+Execute(ale#completion#AlwaysGetCompletions should be called when ALEComplete is executed):
+  AssertEqual 0, g:get_completions_called
+  ALEComplete
+  AssertEqual 1, g:get_completions_called


### PR DESCRIPTION
Following the discussion in #1830, a part of `ale#completion#GetCompletions` was extracted into a new function: `ale#completion#AlwaysGetCompletions`. A new `:ALEComplete` command was added, along with a plug mapping: `<Plug>(ale_complete)`. Auto-completion can be triggered manually whether or not `g:ale_completion_enabled` is set.

Sample bindings:

```vim
inoremap <silent> <C-Space> <C-\><C-O>:GetCompletions<CR>
" or
imap <C-Space> <Plug>(ale_complete) 
```