### PR TITLE
bugfix: c.vim: Pull build directory from compilation database

### DIFF
--- a/autoload/ale/c.vim
+++ b/autoload/ale/c.vim
@@ -200,14 +200,14 @@ function! s:GetLookupFromCompileCommandsFile(compile_commands_file) abort
     return l:empty
 endfunction
 
-function! ale#c#ParseCompileCommandsFlags(buffer, dir, file_lookup, dir_lookup) abort
+function! ale#c#ParseCompileCommandsFlags(buffer, file_lookup, dir_lookup) abort
     " Search for an exact file match first.
     let l:basename = tolower(expand('#' . a:buffer . ':t'))
     let l:file_list = get(a:file_lookup, l:basename, [])
 
     for l:item in l:file_list
         if bufnr(l:item.file) is a:buffer
-            return ale#c#ParseCFlags(a:dir, l:item.command)
+            return ale#c#ParseCFlags(l:item.directory, l:item.command)
         endif
     endfor
 
@@ -219,7 +219,7 @@ function! ale#c#ParseCompileCommandsFlags(buffer, dir, file_lookup, dir_lookup) 
 
     for l:item in l:dir_list
         if ale#path#Simplify(fnamemodify(l:item.file, ':h')) is? l:dir
-            return ale#c#ParseCFlags(a:dir, l:item.command)
+            return ale#c#ParseCFlags(l:item.directory, l:item.command)
         endif
     endfor
 
@@ -227,12 +227,11 @@ function! ale#c#ParseCompileCommandsFlags(buffer, dir, file_lookup, dir_lookup) 
 endfunction
 
 function! ale#c#FlagsFromCompileCommands(buffer, compile_commands_file) abort
-    let l:dir = ale#path#Dirname(a:compile_commands_file)
     let l:lookups = s:GetLookupFromCompileCommandsFile(a:compile_commands_file)
     let l:file_lookup = l:lookups[0]
     let l:dir_lookup = l:lookups[1]
 
-    return ale#c#ParseCompileCommandsFlags(a:buffer, l:dir, l:file_lookup, l:dir_lookup)
+    return ale#c#ParseCompileCommandsFlags(a:buffer, l:file_lookup, l:dir_lookup)
 endfunction
 
 function! ale#c#GetCFlags(buffer, output) abort

--- a/test/test_c_flag_parsing.vader
+++ b/test/test_c_flag_parsing.vader
@@ -161,14 +161,14 @@ Execute(FlagsFromCompileCommands should tolerate empty values):
   AssertEqual '', ale#c#FlagsFromCompileCommands(bufnr(''), '')
 
 Execute(ParseCompileCommandsFlags should tolerate empty values):
-  AssertEqual '', ale#c#ParseCompileCommandsFlags(bufnr(''), '', {}, {})
+  AssertEqual '', ale#c#ParseCompileCommandsFlags(bufnr(''), {}, {})
 
 Execute(ParseCompileCommandsFlags should parse some basic flags):
   noautocmd execute 'file! ' . fnameescape(ale#path#Simplify('/foo/bar/xmms2-mpris/src/xmms2-mpris.c'))
 
   AssertEqual
   \ '-I' . ale#path#Simplify('/usr/include/xmms2'),
-  \ ale#c#ParseCompileCommandsFlags(bufnr(''), ale#path#Simplify('/foo/bar/xmms2-mpris'), { "xmms2-mpris.c": [
+  \ ale#c#ParseCompileCommandsFlags(bufnr(''), { "xmms2-mpris.c": [
   \   {
   \     'directory': ale#path#Simplify('/foo/bar/xmms2-mpris'),
   \     'command': '/usr/bin/cc  -I' . ale#path#Simplify('/usr/include/xmms2')
@@ -183,7 +183,7 @@ Execute(ParseCompileCommandsFlags should fall back to files in the same director
 
   AssertEqual
   \ '-I' . ale#path#Simplify('/usr/include/xmms2'),
-  \ ale#c#ParseCompileCommandsFlags(bufnr(''), ale#path#Simplify('/foo/bar/xmms2-mpris'), {}, { "src": [
+  \ ale#c#ParseCompileCommandsFlags(bufnr(''), {}, { "src": [
   \   {
   \     'directory': ale#path#Simplify('/foo/bar/xmms2-mpris'),
   \     'command': '/usr/bin/cc  -I' . ale#path#Simplify('/usr/include/xmms2')


### PR DESCRIPTION
The LLVM compiler database JSON already includes a directory where the
build was performed:
https://clang.llvm.org/docs/JSONCompilationDatabase.html

Prefer this directory for fixing relative paths in compiler include
arguments in ale#c#ParseCFlags.

Without this change, users cannot create a symlink to their compilation
database as suggested in the LLVM tooling setup instructions:
https://clang.llvm.org/docs/HowToSetupToolingForLLVM.html

<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!
-->

Where are the tests? Have you added tests? Have you updated the tests? Read the
comment above and the documentation referenced in it first. Write tests!

Seriously, read `:help ale-dev` and write tests.
