### PR TITLE
 support older flake8 output, still used by hacking module from openstack style guide

### DIFF
--- a/ale_linters/python/flake8.vim
+++ b/ale_linters/python/flake8.vim
@@ -89,7 +89,7 @@ function! ale_linters#python#flake8#Handle(buffer, lines) abort
     " Matches patterns line the following:
     "
     " stdin:6:6: E111 indentation is not a multiple of four
-    let l:pattern = '\v^[a-zA-Z]?:?[^:]+:(\d+):?(\d+)?: ([[:alnum:]]+) (.*)$'
+    let l:pattern = '\v^[a-zA-Z]?:?[^:]+:(\d+):?(\d+)?: ([[:alnum:]]+):? (.*)$'
     let l:output = []
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)

--- a/test/handler/test_flake8_handler.vader
+++ b/test/handler/test_flake8_handler.vader
@@ -258,3 +258,19 @@ Execute(E112 should be a syntax error):
   \ ale_linters#python#flake8#Handle(bufnr(''), [
   \   'foo.py:6:1: E112 expected an indented block',
   \ ])
+
+Execute(Compatibility with hacking which uses older style flake8):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 6,
+  \     'col': 1,
+  \     'vcol': 1,
+  \     'code': 'H306',
+  \     'type': 'W',
+  \     'text': 'imports not in alphabetical order (smtplib, io)',
+  \   },
+  \ ],
+  \ ale_linters#python#flake8#Handle(bufnr(''), [
+  \   'foo.py:6:1: H306: imports not in alphabetical order (smtplib, io)',
+  \ ])


### PR DESCRIPTION
hacking module link: https://github.com/openstack-dev/hacking
They install specific version of flake8 with some other plugins.

Our internal style guide uses hacking, which is based on older flake8. The output changed slightly, and the difference is whether there is a ':' after the error code. So I merely add ':?' to the pattern here to make it work with new flake8 or older version.

I added the test for it, and here's the vader output. As you can see, my new test (the last one on the list) works and I haven't screwed the other ones. So yay!

Starting Vader: 1 suite(s), 11 case(s)
  Starting Vader: D:\github\ale\test\handler\test_flake8_handler.vader
    ( 1/11) [EXECUTE] The flake8 handler should handle basic warnings and syntax errors
    ( 2/11) [EXECUTE] The flake8 handler should set end column indexes for certain errors
    ( 3/11) [EXECUTE] The flake8 handler should handle stack traces
    ( 4/11) [EXECUTE] The flake8 handler should handle names with spaces
    ( 5/11) [EXECUTE] Warnings about trailing whitespace should be reported by default
    ( 6/11) [EXECUTE] Disabling trailing whitespace warnings should work
    ( 7/11) [EXECUTE] Warnings about trailing blank lines should be reported by default
    ( 8/11) [EXECUTE] Disabling trailing blank line warnings should work
    ( 9/11) [EXECUTE] F401 should be a warning
    (10/11) [EXECUTE] E112 should be a syntax error
    (11/11) [EXECUTE] Compatibility with hacking which uses older style flake8
  Success/Total: 11/11
Success/Total: 11/11 (assertions: 11/11)
Elapsed time: 0.407332 sec.


Thanks for this plugin! It's been boosting my productivity!