### PR TITLE
Add `babylon` parser for `javascript` filetypes

### DIFF
--- a/autoload/ale/fixers/prettier.vim
+++ b/autoload/ale/fixers/prettier.vim
@@ -48,6 +48,7 @@ function! ale#fixers#prettier#ApplyFixForVersion(buffer, version_output) abort
     " already set in g:javascript_prettier_options).
     if empty(expand('#' . a:buffer . ':e')) && match(l:options, '--parser') == -1
         let l:prettier_parsers = {
+        \    'javascript': 'babylon',
         \    'typescript': 'typescript',
         \    'css': 'css',
         \    'less': 'less',


### PR DESCRIPTION
I'm not sure why the default `let l:parser = 'babylon'` [was removed](https://github.com/w0rp/ale/commit/cb8ad9fbd82df92993e526a8e48d4400ba08936b#diff-3c6cea148687a701cb21dbf2e3e4b5ddL40). `babylon` is the default parser for **prettier**.

But since it was removed, this fixer doesn't work for regular Javascript files. This PR will connect `javascript` file-types to the `babylon` parser, while keeping the current `let l:parser = ''`.