### PR TITLE
End position in LSP range is exclusive

### DIFF
--- a/autoload/ale/lsp/response.vim
+++ b/autoload/ale/lsp/response.vim
@@ -33,7 +33,7 @@ function! ale#lsp#response#ReadDiagnostics(response) abort
         \   'lnum': l:diagnostic.range.start.line + 1,
         \   'col': l:diagnostic.range.start.character + 1,
         \   'end_lnum': l:diagnostic.range.end.line + 1,
-        \   'end_col': l:diagnostic.range.end.character + 1,
+        \   'end_col': l:diagnostic.range.end.character,
         \}
 
         if l:severity == s:SEVERITY_WARNING

--- a/test/lsp/test_read_lsp_diagnostics.vader
+++ b/test/lsp/test_read_lsp_diagnostics.vader
@@ -17,7 +17,7 @@ Execute(ale#lsp#response#ReadDiagnostics() should handle errors):
   \     'lnum': 3,
   \     'col': 11,
   \     'end_lnum': 5,
-  \     'end_col': 16,
+  \     'end_col': 15,
   \     'code': 'some-error',
   \   }
   \ ],
@@ -38,7 +38,7 @@ Execute(ale#lsp#response#ReadDiagnostics() should handle warnings):
   \     'lnum': 2,
   \     'col': 4,
   \     'end_lnum': 2,
-  \     'end_col': 4,
+  \     'end_col': 3,
   \     'code': 'some-warning',
   \   }
   \ ],
@@ -59,7 +59,7 @@ Execute(ale#lsp#response#ReadDiagnostics() should treat messages with missing se
   \     'lnum': 3,
   \     'col': 11,
   \     'end_lnum': 5,
-  \     'end_col': 16,
+  \     'end_col': 15,
   \     'code': 'some-error',
   \   }
   \ ],
@@ -79,7 +79,7 @@ Execute(ale#lsp#response#ReadDiagnostics() should handle messages without codes)
   \     'lnum': 3,
   \     'col': 11,
   \     'end_lnum': 5,
-  \     'end_col': 16,
+  \     'end_col': 15,
   \   }
   \ ],
   \ ale#lsp#response#ReadDiagnostics({'params': {'uri': 'filename.ts', 'diagnostics': [
@@ -98,7 +98,7 @@ Execute(ale#lsp#response#ReadDiagnostics() should include sources in detail):
   \     'lnum': 10,
   \     'col': 15,
   \     'end_lnum': 12,
-  \     'end_col': 23,
+  \     'end_col': 22,
   \   }
   \ ],
   \ ale#lsp#response#ReadDiagnostics({'params': {'uri': 'filename.ts', 'diagnostics': [
@@ -117,7 +117,7 @@ Execute(ale#lsp#response#ReadDiagnostics() should consider -1 to be a meaningles
   \     'lnum': 3,
   \     'col': 11,
   \     'end_lnum': 5,
-  \     'end_col': 16,
+  \     'end_col': 15,
   \   }
   \ ],
   \ ale#lsp#response#ReadDiagnostics({'params': {'uri': 'filename.ts', 'diagnostics': [
@@ -136,7 +136,7 @@ Execute(ale#lsp#response#ReadDiagnostics() should handle multiple messages):
   \     'lnum': 1,
   \     'col': 3,
   \     'end_lnum': 1,
-  \     'end_col': 3,
+  \     'end_col': 2,
   \   },
   \   {
   \     'type': 'W',
@@ -144,7 +144,7 @@ Execute(ale#lsp#response#ReadDiagnostics() should handle multiple messages):
   \     'lnum': 2,
   \     'col': 5,
   \     'end_lnum': 2,
-  \     'end_col': 5,
+  \     'end_col': 4,
   \   },
   \ ],
   \ ale#lsp#response#ReadDiagnostics({'params': {'uri': 'filename.ts', 'diagnostics': [
@@ -167,7 +167,7 @@ Execute(ale#lsp#response#ReadDiagnostics() should use relatedInformation for det
   \     'lnum': 1,
   \     'col': 3,
   \     'end_lnum': 1,
-  \     'end_col': 3,
+  \     'end_col': 2,
   \     'detail': "Something went wrong!\n/tmp/someotherfile.txt:43:80:\n\tmight be this"
   \   }
   \ ],

--- a/test/test_ignoring_linters.vader
+++ b/test/test_ignoring_linters.vader
@@ -242,7 +242,7 @@ Execute(Buffer ignore lists should be applied for LSP linters):
   \     'lnum': 1,
   \     'col': 10,
   \     'type': 'E',
-  \     'end_col': 10,
+  \     'end_col': 9,
   \     'end_lnum': 1,
   \     'text': 'x',
   \   }


### PR DESCRIPTION
From LSP spec:

> A range in a text document expressed as (zero-based) start and end
> positions. A range is comparable to a selection in an editor. Therefore
> the end position is exclusive.

https://microsoft.github.io/language-server-protocol/specification

<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!
-->

Where are the tests? Have you added tests? Have you updated the tests? Read the
comment above and the documentation referenced in it first. Write tests!

Seriously, read `:help ale-dev` and write tests.