### PR TITLE
Adjust column to be 0-based for LSP messages

### DIFF
--- a/autoload/ale/completion.vim
+++ b/autoload/ale/completion.vim
@@ -480,7 +480,7 @@ function! s:OnReady(linter, lsp_details, ...) abort
         \   b:ale_completion_info.line,
         \   min([
         \       b:ale_completion_info.line_length,
-        \       b:ale_completion_info.column,
+        \       b:ale_completion_info.column + 1,
         \   ]),
         \   ale#completion#GetTriggerCharacter(&filetype, b:ale_completion_info.prefix),
         \)

--- a/autoload/ale/lsp/message.vim
+++ b/autoload/ale/lsp/message.vim
@@ -3,6 +3,10 @@
 "
 " Messages in this movie will be returned in the format
 " [is_notification, method_name, params?]
+"
+" All functions which accept line and column arguments expect them to be 1-based
+" (the same format as being returned by getcurpos() and friends), those then
+" will be converted to 0-based as specified by LSP.
 let g:ale_lsp_next_version_id = 1
 
 " The LSP protocols demands that we send every change to a document, including
@@ -98,7 +102,7 @@ function! ale#lsp#message#Completion(buffer, line, column, trigger_character) ab
     \   'textDocument': {
     \       'uri': ale#path#ToURI(expand('#' . a:buffer . ':p')),
     \   },
-    \   'position': {'line': a:line - 1, 'character': a:column},
+    \   'position': {'line': a:line - 1, 'character': a:column - 1},
     \}]
 
     if !empty(a:trigger_character)
@@ -116,7 +120,7 @@ function! ale#lsp#message#Definition(buffer, line, column) abort
     \   'textDocument': {
     \       'uri': ale#path#ToURI(expand('#' . a:buffer . ':p')),
     \   },
-    \   'position': {'line': a:line - 1, 'character': a:column},
+    \   'position': {'line': a:line - 1, 'character': a:column - 1},
     \}]
 endfunction
 
@@ -125,7 +129,7 @@ function! ale#lsp#message#References(buffer, line, column) abort
     \   'textDocument': {
     \       'uri': ale#path#ToURI(expand('#' . a:buffer . ':p')),
     \   },
-    \   'position': {'line': a:line - 1, 'character': a:column},
+    \   'position': {'line': a:line - 1, 'character': a:column - 1},
     \   'context': {'includeDeclaration': v:false},
     \}]
 endfunction
@@ -141,7 +145,7 @@ function! ale#lsp#message#Hover(buffer, line, column) abort
     \   'textDocument': {
     \       'uri': ale#path#ToURI(expand('#' . a:buffer . ':p')),
     \   },
-    \   'position': {'line': a:line - 1, 'character': a:column},
+    \   'position': {'line': a:line - 1, 'character': a:column - 1},
     \}]
 endfunction
 

--- a/test/completion/test_lsp_completion_messages.vader
+++ b/test/completion/test_lsp_completion_messages.vader
@@ -215,7 +215,7 @@ Execute(The right message should be sent for the initial LSP request):
   \   }],
   \   [0, 'textDocument/completion', {
   \   'textDocument': {'uri': ale#path#ToURI(expand('%:p'))},
-  \   'position': {'line': 0, 'character': 3},
+  \   'position': {'line': 0, 'character': 2},
   \   }],
   \ ],
   \ g:message_list
@@ -274,7 +274,7 @@ Execute(Two completion requests shouldn't be sent in a row):
   \   }],
   \   [0, 'textDocument/completion', {
   \   'textDocument': {'uri': ale#path#ToURI(expand('%:p'))},
-  \   'position': {'line': 0, 'character': 3},
+  \   'position': {'line': 0, 'character': 2},
   \   }],
   \ ],
   \ g:message_list

--- a/test/lsp/test_lsp_client_messages.vader
+++ b/test/lsp/test_lsp_client_messages.vader
@@ -112,7 +112,7 @@ Execute(ale#lsp#message#Completion() should return correct messages):
   \     'textDocument': {
   \         'uri': ale#path#ToURI(g:dir . '/foo/bar.ts'),
   \     },
-  \     'position': {'line': 11, 'character': 34},
+  \     'position': {'line': 11, 'character': 33},
   \   }
   \ ],
   \ ale#lsp#message#Completion(bufnr(''), 12, 34, '')
@@ -126,7 +126,7 @@ Execute(ale#lsp#message#Completion() should return correct messages with a trigg
   \     'textDocument': {
   \         'uri': ale#path#ToURI(g:dir . '/foo/bar.ts'),
   \     },
-  \     'position': {'line': 11, 'character': 34},
+  \     'position': {'line': 11, 'character': 33},
   \     'context': {'triggerKind': 2, 'triggerCharacter': '.'},
   \   }
   \ ],
@@ -141,7 +141,7 @@ Execute(ale#lsp#message#Definition() should return correct messages):
   \     'textDocument': {
   \         'uri': ale#path#ToURI(g:dir . '/foo/bar.ts'),
   \     },
-  \     'position': {'line': 11, 'character': 34},
+  \     'position': {'line': 11, 'character': 33},
   \   }
   \ ],
   \ ale#lsp#message#Definition(bufnr(''), 12, 34)
@@ -155,7 +155,7 @@ Execute(ale#lsp#message#References() should return correct messages):
   \     'textDocument': {
   \         'uri': ale#path#ToURI(g:dir . '/foo/bar.ts'),
   \     },
-  \     'position': {'line': 11, 'character': 34},
+  \     'position': {'line': 11, 'character': 33},
   \     'context': {'includeDeclaration': v:false},
   \   }
   \ ],
@@ -181,7 +181,7 @@ Execute(ale#lsp#message#Hover() should return correct messages):
   \     'textDocument': {
   \         'uri': ale#path#ToURI(g:dir . '/foo/bar.ts'),
   \     },
-  \     'position': {'line': 11, 'character': 34},
+  \     'position': {'line': 11, 'character': 33},
   \   }
   \ ],
   \ ale#lsp#message#Hover(bufnr(''), 12, 34)

--- a/test/test_find_references.vader
+++ b/test/test_find_references.vader
@@ -270,7 +270,7 @@ Execute(LSP reference requests should be sent):
   \   }],
   \   [0, 'textDocument/references', {
   \   'textDocument': {'uri': ale#path#ToURI(expand('%:p'))},
-  \   'position': {'line': 0, 'character': 3},
+  \   'position': {'line': 0, 'character': 2},
   \   'context': {'includeDeclaration': v:false},
   \   }],
   \ ],

--- a/test/test_go_to_definition.vader
+++ b/test/test_go_to_definition.vader
@@ -377,7 +377,7 @@ Execute(LSP completion requests should be sent):
   \   }],
   \   [0, 'textDocument/definition', {
   \   'textDocument': {'uri': ale#path#ToURI(expand('%:p'))},
-  \   'position': {'line': 0, 'character': 3},
+  \   'position': {'line': 0, 'character': 2},
   \   }],
   \ ],
   \ g:message_list
@@ -413,7 +413,7 @@ Execute(LSP tab completion requests should be sent):
   \   }],
   \   [0, 'textDocument/definition', {
   \   'textDocument': {'uri': ale#path#ToURI(expand('%:p'))},
-  \   'position': {'line': 0, 'character': 3},
+  \   'position': {'line': 0, 'character': 2},
   \   }],
   \ ],
   \ g:message_list


### PR DESCRIPTION
Per LSP spec column is zero based while vim's `getcurpos()` returns
1-based columns. This fixes it by making an LSP request with 0-based
column instead.


<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!
-->

Where are the tests? Have you added tests? Have you updated the tests? Read the
comment above and the documentation referenced in it first. Write tests!

Seriously, read `:help ale-dev` and write tests.