### PR TITLE
Pass --compiler flag to elm-test when linting 0.19 tests

### DIFF
--- a/ale_linters/elm/make.vim
+++ b/ale_linters/elm/make.vim
@@ -189,7 +189,10 @@ endfunction
 " Return the command to execute the linter in the projects directory.
 " If it doesn't, then this will fail when imports are needed.
 function! ale_linters#elm#make#GetCommand(buffer) abort
+    let l:executable = ale_linters#elm#make#GetExecutable(a:buffer)
     let l:root_dir = ale_linters#elm#make#GetRootDir(a:buffer)
+    let l:is_v19 = ale_linters#elm#make#IsVersionGte19(a:buffer)
+    let l:is_using_elm_test = l:executable =~# 'elm-test$'
 
     if empty(l:root_dir)
         let l:dir_set_cmd = ''
@@ -197,11 +200,20 @@ function! ale_linters#elm#make#GetCommand(buffer) abort
         let l:dir_set_cmd = 'cd ' . ale#Escape(l:root_dir) . ' && '
     endif
 
+    " elm-test needs to know the path of elm-make if elm isn't installed globally.
+    " https://github.com/rtfeldman/node-test-runner/blob/57728f10668f2d2ab3179e7e3208bcfa9a1f19aa/README.md#--compiler
+    if l:is_v19 && l:is_using_elm_test
+        let l:elm_make_executable = ale#node#FindExecutable(a:buffer, 'elm_make', ['node_modules/.bin/elm'])
+        let l:elm_test_compiler_flag = ' --compiler ' . l:elm_make_executable . ' '
+    else
+        let l:elm_test_compiler_flag = ' '
+    endif
+
     " The elm compiler, at the time of this writing, uses '/dev/null' as
     " a sort of flag to tell the compiler not to generate an output file,
     " which is why this is hard coded here.
     " Source: https://github.com/elm-lang/elm-compiler/blob/19d5a769b30ec0b2fc4475985abb4cd94cd1d6c3/builder/src/Generate/Output.hs#L253
-    return l:dir_set_cmd . '%e make --report=json --output=/dev/null %t'
+    return l:dir_set_cmd . '%e make --report=json --output=/dev/null' . l:elm_test_compiler_flag . '%t'
 endfunction
 
 function! ale_linters#elm#make#GetExecutable(buffer) abort

--- a/test/command_callback/test_elm_make_command_callback.vader
+++ b/test/command_callback/test_elm_make_command_callback.vader
@@ -22,7 +22,8 @@ Execute(should get elm-test executable for test code with elm >= 0.19):
 
   AssertLinter g:executable,
   \ 'cd ' . ale#Escape(ale#path#Simplify(g:dir . '/../elm-test-files/newapp')) . ' && '
-  \ . ale#Escape(g:executable) . ' make --report=json --output=/dev/null %t'
+  \ . ale#Escape(g:executable) . ' make --report=json --output=/dev/null --compiler '
+  \ . ale#path#Simplify(g:dir . '/../elm-test-files/newapp/node_modules/.bin/elm') . ' %t'
 
 Execute(should fallback to elm executable with elm >= 0.19):
   call ale#test#SetFilename('../elm-test-files/newapp-notests/tests/TestMain.elm')


### PR DESCRIPTION
This makes elm make linter work when elm is not installed globally.