### PR TITLE
Add support for pyls configuration options

### DIFF
--- a/ale_linters/python/pyls.vim
+++ b/ale_linters/python/pyls.vim
@@ -4,6 +4,7 @@
 call ale#Set('python_pyls_executable', 'pyls')
 call ale#Set('python_pyls_use_global', get(g:, 'ale_use_global_executables', 0))
 call ale#Set('python_pyls_auto_pipenv', 0)
+call ale#Set('python_pyls_config', {})
 
 function! ale_linters#python#pyls#GetExecutable(buffer) abort
     if (ale#Var(a:buffer, 'python_auto_pipenv') || ale#Var(a:buffer, 'python_pyls_auto_pipenv'))
@@ -31,4 +32,5 @@ call ale#linter#Define('python', {
 \   'command_callback': 'ale_linters#python#pyls#GetCommand',
 \   'project_root_callback': 'ale#python#FindProjectRoot',
 \   'completion_filter': 'ale#completion#python#CompletionItemFilter',
+\   'lsp_config_callback': ale#VarFunc('python_pyls_config'),
 \})

--- a/doc/ale-python.txt
+++ b/doc/ale-python.txt
@@ -494,6 +494,24 @@ g:ale_python_pyls_auto_pipenv                   *g:ale_python_pyls_auto_pipenv*
   if true. This is overridden by a manually-set executable.
 
 
+g:ale_python_pyls_config                             *g:ale_python_pyls_config*
+                                                     *b:ale_python_pyls_config*
+  Type: |Dictionary|
+  Default: `{}`
+
+  Dictionary with configuration settings for pyls. For example, to disable
+  the pycodestyle linter: >
+        {
+      \   'pyls': {
+      \     'plugins': {
+      \       'pycodestyle': {
+      \         'enabled': v:false
+      \       }
+      \     }
+      \   },
+      \ }
+<
+
 ===============================================================================
 pyre                                                          *ale-python-pyre*
 

--- a/test/command_callback/test_pyls_command_callback.vader
+++ b/test/command_callback/test_pyls_command_callback.vader
@@ -45,3 +45,8 @@ Execute(Pipenv is detected when python_pyls_auto_pipenv is set):
 
   AssertLinter 'pipenv',
   \ ale#Escape('pipenv') . ' run pyls'
+
+Execute(Should accept configuration settings):
+  AssertLSPConfig {}
+  let b:ale_python_pyls_config = {'pyls': {'plugins': {'preload': {'enabled': v:false}}}}
+  AssertLSPConfig {'pyls': {'plugins': {'preload': {'enabled': v:false}}}}


### PR DESCRIPTION
Resolves #1443.
Tests and documentation are included.
Heavily inspired by the analogous support added for elixir-ls.