### PR TITLE
Add g:haskell_stack_ghc_options like …_cabal_ghc_…

### DIFF
--- a/ale_linters/haskell/stack_ghc.vim
+++ b/ale_linters/haskell/stack_ghc.vim
@@ -1,11 +1,20 @@
 " Author: w0rp <devw0rp@gmail.com>
 " Description: ghc for Haskell files, using Stack
 
+call ale#Set('haskell_stack_ghc_options', '-fno-code -v0')
+
+function! ale_linters#haskell#stack_ghc#GetCommand(buffer) abort
+    return ale#handlers#haskell#GetStackExecutable(a:buffer)
+    \ . ' ghc -- '
+    \ . ale#Var(a:buffer, 'haskell_stack_ghc_options')
+    \ . ' %t'
+endfunction
+
 call ale#linter#Define('haskell', {
 \   'name': 'stack_ghc',
 \   'aliases': ['stack-ghc'],
 \   'output_stream': 'stderr',
 \   'executable_callback': 'ale#handlers#haskell#GetStackExecutable',
-\   'command': 'stack ghc -- -fno-code -v0 %t',
+\   'command_callback': 'ale_linters#haskell#stack_ghc#GetCommand',
 \   'callback': 'ale#handlers#haskell#HandleGHCFormat',
 \})

--- a/doc/ale-haskell.txt
+++ b/doc/ale-haskell.txt
@@ -108,6 +108,17 @@ g:ale_haskell_stack_build_options           *g:ale_haskell_stack_build_options*
   programs will be slower unless you separately rebuild them outside of ALE.
 
 ===============================================================================
+stack-ghc                                               *ale-haskell-stack-ghc*
+
+g:ale_haskell_stack_ghc_options               *g:ale_haskell_stack_ghc_options*
+                                              *b:ale_haskell_stack_ghc_options*
+  Type: |String|
+  Default: `'-fno-code -v0'`
+
+  This variable can be changed to modify flags given to ghc through `stack
+  ghc`
+
+===============================================================================
 stylish-haskell                                   *ale-haskell-stylish-haskell*
 
 g:ale_haskell_stylish_haskell_executable

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -140,6 +140,7 @@ CONTENTS                                                         *ale-contents*
       hfmt................................|ale-haskell-hfmt|
       hlint...............................|ale-haskell-hlint|
       stack-build.........................|ale-haskell-stack-build|
+      stack-ghc...........................|ale-haskell-stack-ghc|
       stylish-haskell.....................|ale-haskell-stylish-haskell|
       hie.................................|ale-haskell-hie|
     hcl...................................|ale-hcl-options|

--- a/test/command_callback/test_haskell_stack_ghc_command_callback.vader
+++ b/test/command_callback/test_haskell_stack_ghc_command_callback.vader
@@ -12,3 +12,6 @@ Execute(The linter should be executed when there is a stack.yaml file):
 
   AssertLinter 'stack', 'stack ghc -- -fno-code -v0 %t'
 
+  let b:ale_haskell_stack_ghc_options = 'foobar'
+
+  AssertLinter 'stack', 'stack ghc -- foobar %t'


### PR DESCRIPTION
Adds new option `g:haskell_stack_ghc_options` which passes options to `stack ghc`. Previously the options were hard-coded.
This implementation is based on [`g:haskell_cabal_ghc_options`](https://github.com/w0rp/ale/blob/c879cd4b5f58a6120951a086e819e1d5c498bf6e/ale_linters/haskell/cabal_ghc.vim).

  - [x] Docs
  - [x] Tests
  - [x] Coding standards (as far as I know; based on an existing implementation)