### PR TITLE
Use relative paths when previewing file locations

### DIFF
--- a/autoload/ale/preview.vim
+++ b/autoload/ale/preview.vim
@@ -43,6 +43,7 @@ endfunction
 " Each item should have 'filename', 'line', and 'column' keys.
 function! ale#preview#ShowSelection(item_list) abort
     let l:lines = []
+    let l:sep = has('win32') ? '\' : '/'
 
     " Create lines to display to users.
     for l:item in a:item_list
@@ -50,7 +51,7 @@ function! ale#preview#ShowSelection(item_list) abort
 
         call add(
         \   l:lines,
-        \   l:item.filename
+        \   substitute(l:item.filename, '^' . getcwd() . l:sep, '', '')
         \       . ':' . l:item.line
         \       . ':' . l:item.column
         \       . (!empty(l:match) ? ' ' . l:match : ''),

--- a/autoload/ale/preview.vim
+++ b/autoload/ale/preview.vim
@@ -51,7 +51,7 @@ function! ale#preview#ShowSelection(item_list) abort
 
         call add(
         \   l:lines,
-        \   substitute(l:item.filename, '^' . getcwd() . l:sep, '', '')
+        \   substitute(l:item.filename, '^' . getcwd() . l:sep, '', '') " no-custom-checks
         \       . ':' . l:item.line
         \       . ':' . l:item.column
         \       . (!empty(l:match) ? ' ' . l:match : ''),

--- a/autoload/ale/preview.vim
+++ b/autoload/ale/preview.vim
@@ -41,17 +41,21 @@ endfunction
 
 " Show a location selection preview window, given some items.
 " Each item should have 'filename', 'line', and 'column' keys.
-function! ale#preview#ShowSelection(item_list) abort
-    let l:lines = []
+function! ale#preview#ShowSelection(item_list, ...) abort
+    let l:options = get(a:000, 0, {})
     let l:sep = has('win32') ? '\' : '/'
+    let l:lines = []
 
     " Create lines to display to users.
     for l:item in a:item_list
         let l:match = get(l:item, 'match', '')
+        let l:filename = get(l:options, 'use_relative_paths')
+        \   ? substitute(l:item.filename, '^' . getcwd() . l:sep, '', '')
+        \   : l:item.filename " no-custom-checks
 
         call add(
         \   l:lines,
-        \   substitute(l:item.filename, '^' . getcwd() . l:sep, '', '') " no-custom-checks
+        \   l:filename
         \       . ':' . l:item.line
         \       . ':' . l:item.column
         \       . (!empty(l:match) ? ' ' . l:match : ''),

--- a/autoload/ale/preview.vim
+++ b/autoload/ale/preview.vim
@@ -49,9 +49,11 @@ function! ale#preview#ShowSelection(item_list, ...) abort
     " Create lines to display to users.
     for l:item in a:item_list
         let l:match = get(l:item, 'match', '')
-        let l:filename = get(l:options, 'use_relative_paths')
-        \   ? substitute(l:item.filename, '^' . getcwd() . l:sep, '', '')
-        \   : l:item.filename " no-custom-checks
+        let l:filename = l:item.filename
+
+        if get(l:options, 'use_relative_paths')
+          let l:filename = substitute(l:item.filename, '^' . getcwd() . l:sep, '', '') " no-custom-checks
+        endif
 
         call add(
         \   l:lines,

--- a/autoload/ale/references.vim
+++ b/autoload/ale/references.vim
@@ -122,7 +122,7 @@ function! ale#references#Find(...) abort
 
     if len(a:000) > 0
         for l:option in a:000
-            if l:option ==? '-relative'
+            if l:option is? '-relative'
                 let l:options.use_relative_paths = 1
             endif
         endfor

--- a/autoload/ale/references.vim
+++ b/autoload/ale/references.vim
@@ -122,7 +122,7 @@ function! ale#references#Find(...) abort
 
     if len(a:000) > 0
         for l:option in a:000
-            if l:option == '-relative'
+            if l:option ==? '-relative'
                 let l:options.use_relative_paths = 1
             endif
         endfor

--- a/plugin/ale.vim
+++ b/plugin/ale.vim
@@ -199,7 +199,7 @@ command! -bar ALEGoToTypeDefinitionInSplit :call ale#definition#GoToType({'open_
 command! -bar ALEGoToTypeDefinitionInVSplit :call ale#definition#GoToType({'open_in': 'vertical-split'})
 
 " Find references for tsserver and LSP
-command! -bar ALEFindReferences :call ale#references#Find()
+command! -bar -nargs=* ALEFindReferences :call ale#references#Find(<f-args>)
 
 " Show summary information for the cursor.
 command! -bar ALEHover :call ale#hover#ShowAtCursor()

--- a/test/test_find_references.vader
+++ b/test/test_find_references.vader
@@ -8,6 +8,7 @@ Before:
   let g:message_list = []
   let g:preview_called = 0
   let g:item_list = []
+  let g:options = {}
   let g:capability_checked = ''
   let g:conn_id = v:null
   let g:WaitCallback = v:null
@@ -48,9 +49,10 @@ Before:
     call add(g:expr_list, a:expr)
   endfunction
 
-  function! ale#preview#ShowSelection(item_list) abort
+  function! ale#preview#ShowSelection(item_list, options) abort
     let g:preview_called = 1
     let g:item_list = a:item_list
+    let g:options = a:options
   endfunction
 
 After:
@@ -70,6 +72,7 @@ After:
   unlet! g:message_list
   unlet! g:expr_list
   unlet! b:ale_linters
+  unlet! g:options
   unlet! g:item_list
   unlet! g:preview_called
 

--- a/test/test_find_references.vader
+++ b/test/test_find_references.vader
@@ -8,6 +8,7 @@ Before:
   let g:message_list = []
   let g:preview_called = 0
   let g:item_list = []
+  let g:options = {}
   let g:capability_checked = ''
   let g:conn_id = v:null
   let g:WaitCallback = v:null
@@ -48,9 +49,10 @@ Before:
     call add(g:expr_list, a:expr)
   endfunction
 
-  function! ale#preview#ShowSelection(item_list) abort
+  function! ale#preview#ShowSelection(item_list, options) abort
     let g:preview_called = 1
     let g:item_list = a:item_list
+    let g:options = a:options
   endfunction
 
 After:
@@ -70,6 +72,7 @@ After:
   unlet! g:message_list
   unlet! g:expr_list
   unlet! b:ale_linters
+  unlet! g:options
   unlet! g:item_list
   unlet! g:preview_called
 
@@ -277,3 +280,21 @@ Execute(LSP reference requests should be sent):
   \ g:message_list
 
   AssertEqual {'42': {}}, ale#references#GetMap()
+
+Execute(Show absolute paths by default):
+  ALEFindReferences
+
+  AssertEqual
+  \ {
+  \   'use_relative_paths': 0,
+  \ },
+  \ g:options
+
+Execute(Show relative paths with -relative):
+  ALEFindReferences -relative
+
+  AssertEqual
+  \ {
+  \   'use_relative_paths': 1,
+  \ },
+  \ g:options

--- a/test/test_find_references.vader
+++ b/test/test_find_references.vader
@@ -183,7 +183,17 @@ Execute(tsserver reference requests should be sent):
   AssertEqual
   \ [[0, 'ts@references', {'file': expand('%:p'), 'line': 2, 'offset': 5}]],
   \ g:message_list
-  AssertEqual {'42': {}}, ale#references#GetMap()
+  AssertEqual {'42': {'use_relative_paths': 0}}, ale#references#GetMap()
+
+Execute('-relative' argument should enable 'use_relative_paths' in HandleTSServerResponse):
+  runtime ale_linters/typescript/tsserver.vim
+  call setpos('.', [bufnr(''), 2, 5, 0])
+
+  ALEFindReferences -relative
+
+  call call(g:WaitCallback, [g:conn_id, '/foo/bar'])
+
+  AssertEqual {'42': {'use_relative_paths': 1}}, ale#references#GetMap()
 
 Given python(Some Python file):
   foo
@@ -279,4 +289,15 @@ Execute(LSP reference requests should be sent):
   \ ],
   \ g:message_list
 
-  AssertEqual {'42': {}}, ale#references#GetMap()
+  AssertEqual {'42': {'use_relative_paths': 0}}, ale#references#GetMap()
+
+Execute('-relative' argument should enable 'use_relative_paths' in HandleLSPResponse):
+  runtime ale_linters/python/pyls.vim
+  let b:ale_linters = ['pyls']
+  call setpos('.', [bufnr(''), 1, 5, 0])
+
+  ALEFindReferences -relative
+
+  call call(g:WaitCallback, [g:conn_id, '/foo/bar'])
+
+  AssertEqual {'42': {'use_relative_paths': 1}}, ale#references#GetMap()

--- a/test/test_find_references.vader
+++ b/test/test_find_references.vader
@@ -282,6 +282,9 @@ Execute(LSP reference requests should be sent):
   AssertEqual {'42': {}}, ale#references#GetMap()
 
 Execute(Show absolute paths by default):
+  runtime ale_linters/typescript/tsserver.vim
+  call setpos('.', [bufnr(''), 2, 5, 0])
+
   ALEFindReferences
 
   AssertEqual
@@ -291,6 +294,9 @@ Execute(Show absolute paths by default):
   \ g:options
 
 Execute(Show relative paths with -relative):
+  runtime ale_linters/typescript/tsserver.vim
+  call setpos('.', [bufnr(''), 2, 5, 0])
+
   ALEFindReferences -relative
 
   AssertEqual

--- a/test/test_find_references.vader
+++ b/test/test_find_references.vader
@@ -8,7 +8,6 @@ Before:
   let g:message_list = []
   let g:preview_called = 0
   let g:item_list = []
-  let g:options = {}
   let g:capability_checked = ''
   let g:conn_id = v:null
   let g:WaitCallback = v:null
@@ -49,10 +48,9 @@ Before:
     call add(g:expr_list, a:expr)
   endfunction
 
-  function! ale#preview#ShowSelection(item_list, options) abort
+  function! ale#preview#ShowSelection(item_list) abort
     let g:preview_called = 1
     let g:item_list = a:item_list
-    let g:options = a:options
   endfunction
 
 After:
@@ -72,7 +70,6 @@ After:
   unlet! g:message_list
   unlet! g:expr_list
   unlet! b:ale_linters
-  unlet! g:options
   unlet! g:item_list
   unlet! g:preview_called
 
@@ -280,27 +277,3 @@ Execute(LSP reference requests should be sent):
   \ g:message_list
 
   AssertEqual {'42': {}}, ale#references#GetMap()
-
-Execute(Show absolute paths by default):
-  runtime ale_linters/typescript/tsserver.vim
-  call setpos('.', [bufnr(''), 2, 5, 0])
-
-  ALEFindReferences
-
-  AssertEqual
-  \ {
-  \   'use_relative_paths': 0,
-  \ },
-  \ g:options
-
-Execute(Show relative paths with -relative):
-  runtime ale_linters/typescript/tsserver.vim
-  call setpos('.', [bufnr(''), 2, 5, 0])
-
-  ALEFindReferences -relative
-
-  AssertEqual
-  \ {
-  \   'use_relative_paths': 1,
-  \ },
-  \ g:options


### PR DESCRIPTION
Absolute paths can be long and repetitive, and cause the more interesting details (in a file location preview) to be truncated. Instead, display file locations relative to the current working directory.