### PR TITLE
Add better ksh support

### DIFF
--- a/autoload/ale/handlers/sh.vim
+++ b/autoload/ale/handlers/sh.vim
@@ -9,7 +9,7 @@ function! ale#handlers#sh#GetShellType(buffer) abort
         " Remove options like -e, etc.
         let l:command = substitute(l:bang_line, ' --\?[a-zA-Z0-9]\+', '', 'g')
 
-        for l:possible_shell in ['bash', 'dash', 'ash', 'tcsh', 'csh', 'zsh', 'sh']
+        for l:possible_shell in ['bash', 'dash', 'ash', 'tcsh', 'csh', 'zsh', 'ksh', 'sh']
             if l:command =~# l:possible_shell . '\s*$'
                 return l:possible_shell
             endif

--- a/test/test_shell_detection.vader
+++ b/test/test_shell_detection.vader
@@ -57,6 +57,22 @@ Execute(csh should be detected appropriately):
   AssertEqual 'csh', ale_linters#sh#shell#GetExecutable(bufnr(''))
   AssertEqual 'csh', ale_linters#sh#shellcheck#GetDialectArgument(bufnr(''))
 
+Given(A file with a ksh hashbang):
+  #!/bin/ksh
+
+Execute(/bin/ksh should be detected appropriately):
+  AssertEqual 'ksh', ale#handlers#sh#GetShellType(bufnr(''))
+  AssertEqual 'ksh', ale_linters#sh#shell#GetExecutable(bufnr(''))
+  AssertEqual 'ksh', ale_linters#sh#shellcheck#GetDialectArgument(bufnr(''))
+
+Given(A file with a ksh as an argument to env):
+  #!/usr/bin/env ksh
+
+Execute(ksh should be detected appropriately):
+  AssertEqual 'ksh', ale#handlers#sh#GetShellType(bufnr(''))
+  AssertEqual 'ksh', ale_linters#sh#shell#GetExecutable(bufnr(''))
+  AssertEqual 'ksh', ale_linters#sh#shellcheck#GetDialectArgument(bufnr(''))
+
 Given(A file with a sh hash bang and arguments):
   #!/usr/bin/env sh -eu --foobar
 

--- a/test/test_shell_detection.vader
+++ b/test/test_shell_detection.vader
@@ -52,7 +52,7 @@ Execute(zsh should be detected appropriately):
 Given(A file with a csh hash bang and arguments):
   #!/usr/bin/env csh -eu --foobar
 
-Execute(zsh should be detected appropriately):
+Execute(csh should be detected appropriately):
   AssertEqual 'csh', ale#handlers#sh#GetShellType(bufnr(''))
   AssertEqual 'csh', ale_linters#sh#shell#GetExecutable(bufnr(''))
   AssertEqual 'csh', ale_linters#sh#shellcheck#GetDialectArgument(bufnr(''))


### PR DESCRIPTION
Ksh was not being detected properly for me by ALE

A file with this code would be run by ALE through `/bin/sh -n` and by shellcheck with `-s sh`, leading to it incorrectly complaining about process substitution being undefined in POSIX sh.

```ksh
#!/bin/ksh

diff -w <(find expected_logs/ -maxdepth 1 | sed 's/.expected//' | sort) <(find logs/ -maxdepth 1 | sed -E 's/\.[^.]+\.log$//' | sort)
```

I tested it locally and it fixes my issue.