### PR TITLE
Add `-relative` option to ALESymbolSearch

### DIFF
--- a/autoload/ale/symbol.vim
+++ b/autoload/ale/symbol.vim
@@ -97,7 +97,7 @@ function! ale#symbol#ParseArgs(args) abort
     let l:opts = []
 
     for l:arg in l:args
-        if l:arg =~ '^-'
+        if l:arg =~? '^-'
             call add(l:opts, l:arg)
         else
             break

--- a/autoload/ale/symbol.vim
+++ b/autoload/ale/symbol.vim
@@ -52,12 +52,12 @@ function! ale#symbol#HandleLSPResponse(conn_id, response) abort
         if empty(l:item_list)
             call ale#util#Execute('echom ''No symbols found.''')
         else
-            call ale#preview#ShowSelection(l:item_list)
+            call ale#preview#ShowSelection(l:item_list, l:options)
         endif
     endif
 endfunction
 
-function! s:OnReady(linter, lsp_details, query, ...) abort
+function! s:OnReady(linter, lsp_details, query, options, ...) abort
     let l:buffer = a:lsp_details.buffer
 
     " If we already made a request, stop here.
@@ -76,34 +76,46 @@ function! s:OnReady(linter, lsp_details, query, ...) abort
     call setbufvar(l:buffer, 'ale_symbol_request_made', 1)
     let s:symbol_map[l:request_id] = {
     \   'buffer': l:buffer,
+    \   'use_relative_paths': has_key(a:options, 'use_relative_paths') ? a:options.use_relative_paths : 0
     \}
 endfunction
 
-function! s:Search(linter, buffer, query) abort
+function! s:Search(linter, buffer, query, options) abort
     let l:lsp_details = ale#lsp_linter#StartLSP(a:buffer, a:linter)
 
     if !empty(l:lsp_details)
         call ale#lsp#WaitForCapability(
         \   l:lsp_details.connection_id,
         \   'symbol_search',
-        \   function('s:OnReady', [a:linter, l:lsp_details, a:query]),
+        \   function('s:OnReady', [a:linter, l:lsp_details, a:query, a:options]),
         \)
     endif
 endfunction
 
-function! ale#symbol#Search(query) abort
-    if type(a:query) isnot v:t_string || empty(a:query)
+function! ale#symbol#Search(args) abort
+    if type(a:args) isnot v:t_string || empty(a:args)
         throw 'A non-empty string must be provided!'
     endif
 
     let l:buffer = bufnr('')
+    let l:query = []
+    let l:options = {}
+
+    " Separate arguments from flags
+    for l:arg in split(a:args)
+        if l:arg is? '-relative'
+            let l:options.use_relative_paths = 1
+        else
+            call add(l:query, l:arg)
+        endif
+    endfor
 
     " Set a flag so we only make one request.
     call setbufvar(l:buffer, 'ale_symbol_request_made', 0)
 
     for l:linter in ale#linter#Get(getbufvar(l:buffer, '&filetype'))
         if !empty(l:linter.lsp) && l:linter.lsp isnot# 'tsserver'
-            call s:Search(l:linter, l:buffer, a:query)
+            call s:Search(l:linter, l:buffer, join(l:query), l:options)
         endif
     endfor
 endfunction

--- a/autoload/ale/symbol.vim
+++ b/autoload/ale/symbol.vim
@@ -92,25 +92,8 @@ function! s:Search(linter, buffer, query, options) abort
     endif
 endfunction
 
-function! ale#symbol#ParseArgs(args) abort
-    let l:args = split(a:args)
-    let l:opts = []
-
-    for l:arg in l:args
-        if l:arg =~? '^-'
-            call add(l:opts, l:arg)
-        else
-            break
-        endif
-    endfor
-
-    let l:query = join(l:args[len(l:opts):-1])
-
-    return [l:opts, l:query]
-endfunction
-
 function! ale#symbol#Search(args) abort
-    let [l:opts, l:query] = ale#symbol#ParseArgs(a:args)
+    let [l:opts, l:query] = ale#args#Parse(['relative'], a:args)
 
     if empty(l:query)
         throw 'A non-empty string must be provided!'
@@ -119,7 +102,7 @@ function! ale#symbol#Search(args) abort
     let l:buffer = bufnr('')
     let l:options = {}
 
-    if index(l:opts, '-relative') > -1
+    if has_key(l:opts, 'relative')
         let l:options.use_relative_paths = 1
     endif
 

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -891,6 +891,8 @@ supported:
 
 |ALEFindReferences| - Find references for the word under the cursor.
 
+Options:
+  `-relative`       Show file paths in the results relative to the working dir
 
 -------------------------------------------------------------------------------
 5.5 Hovering                                                        *ale-hover*
@@ -931,6 +933,8 @@ commands are supported:
 
 |ALESymbolSearch| - Search for symbols in the workspace.
 
+Options:
+  `-relative`     Show file paths in the results relative to the working dir
 
 ===============================================================================
 6. Global Options                                                 *ale-options*

--- a/test/test_symbol_search.vader
+++ b/test/test_symbol_search.vader
@@ -7,6 +7,7 @@ Before:
   let g:message_list = []
   let g:preview_called = 0
   let g:item_list = []
+  let g:options = {}
   let g:capability_checked = ''
   let g:conn_id = v:null
   let g:WaitCallback = v:null
@@ -47,9 +48,10 @@ Before:
     call add(g:expr_list, a:expr)
   endfunction
 
-  function! ale#preview#ShowSelection(item_list) abort
+  function! ale#preview#ShowSelection(item_list, options) abort
     let g:preview_called = 1
     let g:item_list = a:item_list
+    let g:options = a:options
   endfunction
 
 After:
@@ -63,6 +65,7 @@ After:
   unlet! g:message_list
   unlet! g:expr_list
   unlet! b:ale_linters
+  unlet! g:options
   unlet! g:item_list
   unlet! g:preview_called
 
@@ -170,4 +173,15 @@ Execute(LSP symbol requests should be sent):
   \ ],
   \ g:message_list
 
-  AssertEqual {'42': {'buffer': bufnr('')}}, ale#symbol#GetMap()
+  AssertEqual {'42': {'buffer': bufnr(''), 'use_relative_paths': 0}}, ale#symbol#GetMap()
+
+Execute('-relative' argument should enable 'use_relative_paths' in HandleLSPResponse):
+  runtime ale_linters/python/pyls.vim
+  let b:ale_linters = ['pyls']
+  call setpos('.', [bufnr(''), 1, 5, 0])
+
+  ALESymbolSearch -relative foo bar
+
+  call call(g:WaitCallback, [g:conn_id, '/foo/bar'])
+
+  AssertEqual {'42': {'buffer': bufnr(''), 'use_relative_paths': 1}}, ale#symbol#GetMap()


### PR DESCRIPTION
I added the `-relative` option to ALESymbolSearch, and the associated test.

However, I only use TSServer, which doesn't seem to be implemented for **ALESymbolSearch**, so I'm unable to actually test the `-relative` option IRL. I kept changes minimal, and the existing tests pass. But I would certainly prefer a quick real-world test to confirm.