### PR TITLE
Respect python black fixer configuration file

### DIFF
--- a/autoload/ale/fixers/black.vim
+++ b/autoload/ale/fixers/black.vim
@@ -5,6 +5,7 @@ call ale#Set('python_black_executable', 'black')
 call ale#Set('python_black_use_global', get(g:, 'ale_use_global_executables', 0))
 call ale#Set('python_black_options', '')
 call ale#Set('python_black_auto_pipenv', 0)
+call ale#Set('python_black_change_directory', 1)
 
 function! ale#fixers#black#GetExecutable(buffer) abort
     if (ale#Var(a:buffer, 'python_auto_pipenv') || ale#Var(a:buffer, 'python_black_auto_pipenv'))
@@ -16,6 +17,10 @@ function! ale#fixers#black#GetExecutable(buffer) abort
 endfunction
 
 function! ale#fixers#black#Fix(buffer) abort
+    let l:cd_string = ale#Var(a:buffer, 'python_black_change_directory')
+    \   ? ale#path#BufferCdString(a:buffer)
+    \   : ''
+
     let l:executable = ale#fixers#black#GetExecutable(a:buffer)
 
     let l:exec_args = l:executable =~? 'pipenv$'
@@ -25,7 +30,7 @@ function! ale#fixers#black#Fix(buffer) abort
     let l:options = ale#Var(a:buffer, 'python_black_options')
 
     return {
-    \   'command': ale#Escape(l:executable) . l:exec_args
+    \   'command': l:cd_string . ale#Escape(l:executable) . l:exec_args
     \       . (!empty(l:options) ? ' ' . l:options : '')
     \       . ' -',
     \}

--- a/doc/ale-python.txt
+++ b/doc/ale-python.txt
@@ -139,6 +139,16 @@ g:ale_python_black_auto_pipenv                  *g:ale_python_black_auto_pipenv*
   Detect whether the file is inside a pipenv, and set the executable to `pipenv`
   if true. This is overridden by a manually-set executable.
 
+g:ale_python_black_change_directory       *g:ale_python_black_change_directory*
+                                          *b:ale_python_black_change_directory*
+  Type: |Number|
+  Default: `1`
+
+  If set to `1`, ALE will switch to the directory the Python file being
+  checked with `black` is in before checking it. This helps `black` find
+  configuration files more easily. This option can be turned off if you want
+  to control the directory Python is executed from yourself.
+
 
 ===============================================================================
 flake8                                                      *ale-python-flake8*

--- a/test/fixers/test_black_fixer_callback.vader
+++ b/test/fixers/test_black_fixer_callback.vader
@@ -24,11 +24,12 @@ After:
 Execute(The black callback should return the correct default values):
   silent execute 'file ' . fnameescape(g:dir . '/python_paths/with_virtualenv/subdir/foo/bar.py')
   AssertEqual
-  \ {'command': ale#Escape(ale#path#Simplify(g:dir . '/python_paths/with_virtualenv/env/' . b:bin_dir . '/black')) . ' -'},
+  \ {'command': ale#path#BufferCdString(bufnr('')) . ale#Escape(ale#path#Simplify(g:dir . '/python_paths/with_virtualenv/env/' . b:bin_dir . '/black')) . ' -'},
   \ ale#fixers#black#Fix(bufnr(''))
 
 Execute(The black callback should include options):
   let g:ale_python_black_options = '--some-option'
+  let g:ale_python_black_change_directory = 0
 
   silent execute 'file ' . fnameescape(g:dir . '/python_paths/with_virtualenv/subdir/foo/bar.py')
   AssertEqual
@@ -37,8 +38,10 @@ Execute(The black callback should include options):
 
 Execute(Pipenv is detected when python_black_auto_pipenv is set):
   let g:ale_python_black_auto_pipenv = 1
+  let g:ale_python_black_change_directory = 0
+
   call ale#test#SetFilename('/testplugin/test/python_fixtures/pipenv/whatever.py')
 
-  AssertEqual 
+  AssertEqual
   \ {'command': ale#Escape('pipenv') . ' run black -'},
   \ ale#fixers#black#Fix(bufnr(''))


### PR DESCRIPTION
Similar to other linters/fixers, by default change to the directory of
the file being fixed before invoking `black`, which allows the tool to
read project-specific configuration (pyproject.toml)

Fixes #2218
