### PR TITLE
Fix error when parsing compile_commands for c languages

### DIFF
--- a/autoload/ale/c.vim
+++ b/autoload/ale/c.vim
@@ -202,7 +202,7 @@ function! s:GetLookupFromCompileCommandsFile(compile_commands_file) abort
         let l:file_lookup[l:basename] = get(l:file_lookup, l:basename, []) + [l:entry]
 
         let l:dirbasename = tolower(fnamemodify(l:entry.directory, ':p:h:t'))
-        let l:dir_lookup[l:dirbasename] = get(l:dir_lookup, l:basename, []) + [l:entry]
+        let l:dir_lookup[l:dirbasename] = get(l:dir_lookup, l:dirbasename, []) + [l:entry]
     endfor
 
     if !empty(l:file_lookup) && !empty(l:dir_lookup)


### PR DESCRIPTION
This little error caused that when parsing compile_commands json, the
filename was used to fetch entries in dir_lookup dictionary (dirname is supposed to be used), hence, when
adding new json commands, it never found anything in dir_lookup and
instead rewrote the previous entry. Hence, the dir_lookup always
contained list of only **one** compile_command per directory **instead of all**
compile_commands for given directory.

Someone evidently didn't check his/her code when implementing the parse_compile_command code and this super minor code inaccuracy caused me quite a headache whenever my c++ project had multiple compile commands per one directory.

Just to be clear what is fixed here: before, in line 205 in `c.vim` the json entry for **filename** was fetched and then json entry for **directory** name was appended to that entry. However, since the dictionary used here was the one that used **directory** names as keys, the json entry for **filename** was always empty. What wasn't empty was entry with the same **directory** key, but that entry was overwritten with the new json entry for the same directory. Hence, in the line 205 the json entry for the given dirname was always overwriting the previous entry instead of appending it.