### PR TITLE
Set working dir to current dir for joker to pickup the configuration

### DIFF
--- a/ale_linters/clojure/joker.vim
+++ b/ale_linters/clojure/joker.vim
@@ -27,6 +27,6 @@ call ale#linter#Define('clojure', {
 \   'name': 'joker',
 \   'output_stream': 'stderr',
 \   'executable': 'joker',
-\   'command': 'joker --lint %t',
+\   'command': 'joker --working-dir . --lint %t',
 \   'callback': 'ale_linters#clojure#joker#HandleJokerFormat',
 \})


### PR DESCRIPTION
I ran into an issue with the joker linter for Clojure wants to read the configuration from the current working directory and up, but ALE runs joker under `/var/folders` and therefor never picks up the project's `.joker` configuration.