### PR TITLE
Center the result after `ale#util#Open` jumps

### DIFF
--- a/autoload/ale/util.vim
+++ b/autoload/ale/util.vim
@@ -111,6 +111,7 @@ function! ale#util#Open(filename, line, column, options) abort
     endif
 
     call cursor(a:line, a:column)
+    redraw!
 endfunction
 
 let g:ale#util#error_priority = 5

--- a/autoload/ale/util.vim
+++ b/autoload/ale/util.vim
@@ -112,6 +112,7 @@ function! ale#util#Open(filename, line, column, options) abort
 
     call cursor(a:line, a:column)
     redraw!
+    normal zz
 endfunction
 
 let g:ale#util#error_priority = 5

--- a/autoload/ale/util.vim
+++ b/autoload/ale/util.vim
@@ -111,7 +111,7 @@ function! ale#util#Open(filename, line, column, options) abort
     endif
 
     call cursor(a:line, a:column)
-    normal zz
+    normal! zz
 endfunction
 
 let g:ale#util#error_priority = 5

--- a/autoload/ale/util.vim
+++ b/autoload/ale/util.vim
@@ -111,7 +111,6 @@ function! ale#util#Open(filename, line, column, options) abort
     endif
 
     call cursor(a:line, a:column)
-    redraw!
     normal zz
 endfunction
 


### PR DESCRIPTION
In certain cases, when I use `:ALEGoToDefinition` (or other jumping call) and it leads to a location in the same file, the cursor moves, but the screen does not redraw.  Then, when I use a motion movement or wait a few seconds, the screen will finally update. This may be due to Vim's `lazyredraw` setting.

This PR forces a redraw after the cursor moves.