### PR TITLE
Supporting filtered jump

### DIFF
--- a/autoload/ale/loclist_jumping.vim
+++ b/autoload/ale/loclist_jumping.vim
@@ -111,26 +111,31 @@ function! ale#loclist_jumping#Jump(direction, ...) abort
     endif
 endfunction
 
-function! ale#loclist_jumping#WrapJump(direction, ...) abort
+function! ale#loclist_jumping#WrapJump(direction, sargs) abort
+    let [l:args, l:rest] = ale#args#Parse(['error', 'warning', 'info', 'wrap',
+    \                                      'style', 'nostyle'], a:sargs)
+
     let l:wrap = 0
     let l:type_filter = 'any'
     let l:subtype_filter = 'any'
 
-    for l:flag in a:000
-        if l:flag is# '-wrap'
-            let l:wrap = 1
-        elseif l:flag is# '-error'
-            let l:type_filter = 'E'
-        elseif l:flag is# '-warning'
-            let l:type_filter = 'W'
-        elseif l:flag is# '-info'
-            let l:type_filter = 'I'
-        elseif l:flag is# '-style'
-            let l:subtype_filter = 'style'
-        elseif l:flag is# '-nostyle'
-            let l:subtype_filter = ''
-        endif
-    endfor
+    if get(l:args, 'wrap', 'nil') is# ''
+        let l:wrap = 1
+    endif
+
+    if get(l:args, 'error', 'nil') is# ''
+        let l:type_filter = 'E'
+    elseif get(l:args, 'warning', 'nil') is# ''
+        let l:type_filter = 'W'
+    elseif get(l:args, 'info', 'nil') is# ''
+        let l:type_filter = 'I'
+    endif
+
+    if get(l:args, 'nostyle', 'nil') is# ''
+        let l:subtype_filter = 'style'
+    elseif get(l:args, 'style', 'nil') is# ''
+        let l:subtype_filter = ''
+    endif
 
     call ale#loclist_jumping#Jump(a:direction, l:wrap, l:type_filter,
     \                             l:subtype_filter)

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2471,11 +2471,11 @@ ALELast                                                               *ALELast*
   behaviour :
   `-wrap` enable wrapping around the file
   `-error`, `-warning` and `-info` enable jumping to errors, warnings or infos
-    respectively, ignoring anything else. They are mutually exclusive and only
-    the last one will have effect.
+    respectively, ignoring anything else. They are mutually exclusive and if
+    several are provided the priority is the following: error > warning > info.
   `-style` and `-nostyle` allow you to jump respectively to style error or
     warning and to not style error or warning. They also are mutually
-    exclusive.
+    exclusive and nostyle has priority over style.
   
   Flags can be combined to create create custom jumping. Thus you can use
   ":ALENext -wrap -error -nosyle" to jump to the next error which is not a

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2462,14 +2462,36 @@ ALELast                                                               *ALELast*
   `ALEPreviousWrap` and `ALENextWrap` will wrap around the file to find
   the last or first warning or error in the file, respectively.
 
+  `ALEPrevious` and `ALENext` take optional flags arguments to custom their
+  behaviour :
+  `-wrap` enable wrapping around the file
+  `-error`, `-warning` and `-info` enable jumping to errors, warnings or infos
+    respectively, ignoring anything else. They are mutually exclusive and only
+    the last one will have effect.
+  `-style` and `-nostyle` allow you to jump respectively to style error or
+    warning and to not style error or warning. They also are mutually
+    exclusive.
+  
+  Flags can be combined to create create custom jumping. Thus you can use
+  ":ALENext -wrap -error -nosyle" to jump to the next error which is not a
+  style error while going back to the begining of the file if needed.
+
   `ALEFirst` goes to the first error or warning in the buffer, while `ALELast`
   goes to the last one.
 
   The following |<Plug>| mappings are defined for the commands: >
   <Plug>(ale_previous) - ALEPrevious
   <Plug>(ale_previous_wrap) - ALEPreviousWrap
+  <Plug>(ale_previous_error) - ALEPrevious -error
+  <Plug>(ale_previous_wrap_error) - ALEPrevious -wrap -error
+  <Plug>(ale_previous_warning) - ALEPrevious -warning
+  <Plug>(ale_previous_wrap_warning) - ALEPrevious -wrap -warning
   <Plug>(ale_next) - ALENext
   <Plug>(ale_next_wrap) - ALENextWrap
+  <Plug>(ale_next_error) - ALENext -error
+  <Plug>(ale_next_wrap_error) - ALENext -wrap -error
+  <Plug>(ale_next_warning) - ALENext -warning
+  <Plug>(ale_next_wrap_warning) - ALENext -wrap -warning
   <Plug>(ale_first) - ALEFirst
   <Plug>(ale_last) - ALELast
 <

--- a/plugin/ale.vim
+++ b/plugin/ale.vim
@@ -152,9 +152,9 @@ endif
 
 " Define commands for moving through warnings and errors.
 command! -bar -nargs=* ALEPrevious
-\    :call ale#loclist_jumping#Jump('before', <f-args>)
+\    :call ale#loclist_jumping#WrapJump('before', <f-args>)
 command! -bar -nargs=* ALENext
-\    :call ale#loclist_jumping#Jump('after', <f-args>)
+\    :call ale#loclist_jumping#WrapJump('after', <f-args>)
 
 command! -bar ALEPreviousWrap :call ale#loclist_jumping#Jump('before', 1)
 command! -bar ALENextWrap :call ale#loclist_jumping#Jump('after', 1)
@@ -223,10 +223,10 @@ nnoremap <silent> <Plug>(ale_previous) :ALEPrevious<Return>
 nnoremap <silent> <Plug>(ale_previous_wrap) :ALEPreviousWrap<Return>
 nnoremap <silent> <Plug>(ale_next) :ALENext<Return>
 nnoremap <silent> <Plug>(ale_next_wrap) :ALENextWrap<Return>
-nnoremap <silent> <Plug>(ale_next_error) :ALENext 0 E<Return>
-nnoremap <silent> <Plug>(ale_next_wrap_error) :ALENext 1 E<Return>
-nnoremap <silent> <Plug>(ale_next_warning) :ALENext 0 W<Return>
-nnoremap <silent> <Plug>(ale_next_wrap_warning) :ALENext 1 W<Return>
+nnoremap <silent> <Plug>(ale_next_error) :ALENext -error<Return>
+nnoremap <silent> <Plug>(ale_next_wrap_error) :ALENext -wrap -error<Return>
+nnoremap <silent> <Plug>(ale_next_warning) :ALENext -warning<Return>
+nnoremap <silent> <Plug>(ale_next_wrap_warning) :ALENext -wrap -warning<Return>
 nnoremap <silent> <Plug>(ale_first) :ALEFirst<Return>
 nnoremap <silent> <Plug>(ale_last) :ALELast<Return>
 nnoremap <silent> <Plug>(ale_toggle) :ALEToggle<Return>

--- a/plugin/ale.vim
+++ b/plugin/ale.vim
@@ -221,6 +221,10 @@ command! -bar ALEComplete :call ale#completion#AlwaysGetCompletions(0)
 " <Plug> mappings for commands
 nnoremap <silent> <Plug>(ale_previous) :ALEPrevious<Return>
 nnoremap <silent> <Plug>(ale_previous_wrap) :ALEPreviousWrap<Return>
+nnoremap <silent> <Plug>(ale_previous_error) :ALEPrevious -error<Return>
+nnoremap <silent> <Plug>(ale_previous_wrap_error) :ALEPrevious -wrap -error<Return>
+nnoremap <silent> <Plug>(ale_previous_warning) :ALEPrevious -warning<Return>
+nnoremap <silent> <Plug>(ale_previous_wrap_warning) :ALEPrevious -wrap -warning<Return>
 nnoremap <silent> <Plug>(ale_next) :ALENext<Return>
 nnoremap <silent> <Plug>(ale_next_wrap) :ALENextWrap<Return>
 nnoremap <silent> <Plug>(ale_next_error) :ALENext -error<Return>

--- a/plugin/ale.vim
+++ b/plugin/ale.vim
@@ -151,9 +151,12 @@ if g:ale_completion_enabled
 endif
 
 " Define commands for moving through warnings and errors.
-command! -bar ALEPrevious :call ale#loclist_jumping#Jump('before', 0)
+command! -bar -nargs=* ALEPrevious
+\    :call ale#loclist_jumping#Jump('before', <f-args>)
+command! -bar -nargs=* ALENext
+\    :call ale#loclist_jumping#Jump('after', <f-args>)
+
 command! -bar ALEPreviousWrap :call ale#loclist_jumping#Jump('before', 1)
-command! -bar ALENext :call ale#loclist_jumping#Jump('after', 0)
 command! -bar ALENextWrap :call ale#loclist_jumping#Jump('after', 1)
 command! -bar ALEFirst :call ale#loclist_jumping#JumpToIndex(0)
 command! -bar ALELast :call ale#loclist_jumping#JumpToIndex(-1)
@@ -220,6 +223,10 @@ nnoremap <silent> <Plug>(ale_previous) :ALEPrevious<Return>
 nnoremap <silent> <Plug>(ale_previous_wrap) :ALEPreviousWrap<Return>
 nnoremap <silent> <Plug>(ale_next) :ALENext<Return>
 nnoremap <silent> <Plug>(ale_next_wrap) :ALENextWrap<Return>
+nnoremap <silent> <Plug>(ale_next_error) :ALENext 0 E<Return>
+nnoremap <silent> <Plug>(ale_next_wrap_error) :ALENext 1 E<Return>
+nnoremap <silent> <Plug>(ale_next_warning) :ALENext 0 W<Return>
+nnoremap <silent> <Plug>(ale_next_wrap_warning) :ALENext 1 W<Return>
 nnoremap <silent> <Plug>(ale_first) :ALEFirst<Return>
 nnoremap <silent> <Plug>(ale_last) :ALELast<Return>
 nnoremap <silent> <Plug>(ale_toggle) :ALEToggle<Return>

--- a/plugin/ale.vim
+++ b/plugin/ale.vim
@@ -152,9 +152,9 @@ endif
 
 " Define commands for moving through warnings and errors.
 command! -bar -nargs=* ALEPrevious
-\    :call ale#loclist_jumping#WrapJump('before', <f-args>)
+\    :call ale#loclist_jumping#WrapJump('before', <q-args>)
 command! -bar -nargs=* ALENext
-\    :call ale#loclist_jumping#WrapJump('after', <f-args>)
+\    :call ale#loclist_jumping#WrapJump('after', <q-args>)
 
 command! -bar ALEPreviousWrap :call ale#loclist_jumping#Jump('before', 1)
 command! -bar ALENextWrap :call ale#loclist_jumping#Jump('after', 1)

--- a/test/test_loclist_jumping.vader
+++ b/test/test_loclist_jumping.vader
@@ -5,23 +5,23 @@ Before:
   \     {'type': 'E', 'bufnr': bufnr('') - 1, 'lnum': 3, 'col': 2},
   \     {'type': 'E', 'bufnr': bufnr(''), 'lnum': 1, 'col': 2},
   \     {'type': 'E', 'bufnr': bufnr(''), 'lnum': 1, 'col': 3},
-  \     {'type': 'E', 'bufnr': bufnr(''), 'lnum': 2, 'col': 1},
+  \     {'type': 'W', 'bufnr': bufnr(''), 'lnum': 2, 'col': 1},
   \     {'type': 'E', 'bufnr': bufnr(''), 'lnum': 2, 'col': 2},
-  \     {'type': 'E', 'bufnr': bufnr(''), 'lnum': 2, 'col': 3},
-  \     {'type': 'E', 'bufnr': bufnr(''), 'lnum': 2, 'col': 6},
+  \     {'type': 'W', 'bufnr': bufnr(''), 'lnum': 2, 'col': 3},
+  \     {'type': 'W', 'bufnr': bufnr(''), 'lnum': 2, 'col': 6},
   \     {'type': 'E', 'bufnr': bufnr(''), 'lnum': 2, 'col': 700},
   \     {'type': 'E', 'bufnr': bufnr('') + 1, 'lnum': 3, 'col': 2},
   \   ],
   \ },
   \}
 
-  function! TestJump(position, wrap, pos)
+  function! TestJump(position, wrap, filter, pos)
     call cursor(a:pos)
 
     if type(a:position) == type(0)
       call ale#loclist_jumping#JumpToIndex(a:position)
     else
-      call ale#loclist_jumping#Jump(a:position, a:wrap)
+      call ale#loclist_jumping#Jump(a:position, a:wrap, a:filter)
     endif
 
     return getcurpos()[1:2]
@@ -36,46 +36,56 @@ Given foobar (Some imaginary filetype):
   12345678
 
 Execute(loclist jumping should jump correctly when not wrapping):
-  AssertEqual [2, 1], TestJump('before', 0, [2, 2])
-  AssertEqual [1, 3], TestJump('before', 0, [2, 1])
-  AssertEqual [2, 3], TestJump('after', 0, [2, 2])
-  AssertEqual [2, 1], TestJump('after', 0, [1, 3])
-  AssertEqual [2, 6], TestJump('after', 0, [2, 4])
-  AssertEqual [2, 8], TestJump('after', 0, [2, 6])
+  AssertEqual [2, 1], TestJump('before', 0, 'A', [2, 2])
+  AssertEqual [1, 3], TestJump('before', 0, 'A', [2, 1])
+  AssertEqual [2, 3], TestJump('after', 0, 'A', [2, 2])
+  AssertEqual [2, 1], TestJump('after', 0, 'A', [1, 3])
+  AssertEqual [2, 6], TestJump('after', 0, 'A', [2, 4])
+  AssertEqual [2, 8], TestJump('after', 0, 'A', [2, 6])
 
 Execute(loclist jumping should jump correctly when wrapping):
-  AssertEqual [2, 1], TestJump('before', 1, [2, 2])
-  AssertEqual [1, 3], TestJump('before', 1, [2, 1])
-  AssertEqual [2, 3], TestJump('after', 1, [2, 2])
-  AssertEqual [2, 1], TestJump('after', 1, [1, 3])
-  AssertEqual [2, 6], TestJump('after', 1, [2, 4])
+  AssertEqual [2, 1], TestJump('before', 1, 'A', [2, 2])
+  AssertEqual [1, 3], TestJump('before', 1, 'A', [2, 1])
+  AssertEqual [2, 3], TestJump('after', 1, 'A', [2, 2])
+  AssertEqual [2, 1], TestJump('after', 1, 'A', [1, 3])
+  AssertEqual [2, 6], TestJump('after', 1, 'A', [2, 4])
 
-  AssertEqual [1, 2], TestJump('after', 1, [2, 8])
-  AssertEqual [2, 8], TestJump('before', 1, [1, 2])
+  AssertEqual [1, 2], TestJump('after', 1, 'A', [2, 8])
+  AssertEqual [2, 8], TestJump('before', 1, 'A', [1, 2])
+
+Execute(loclist jumping should jump correctly with warning filters):
+  AssertEqual [2, 1], TestJump('after', 0, 'W', [1, 2])
+  AssertEqual [2, 6], TestJump('after', 0, 'W', [2, 3])
+  AssertEqual [2, 1], TestJump('after', 1, 'W', [2, 6])
+
+Execute(loclist jumping should jump correctly with error filters):
+  AssertEqual [1, 2], TestJump('after', 1, 'E', [2, 700])
+  AssertEqual [2, 2], TestJump('before', 0, 'E', [2, 700])
+  AssertEqual [2, 2], TestJump('after', 1, 'E', [1, 3])
 
 Execute(loclist jumping not jump when the loclist is empty):
   let g:ale_buffer_info[bufnr('%')].loclist = []
 
-  AssertEqual [1, 6], TestJump('before', 0, [1, 6])
-  AssertEqual [1, 6], TestJump('before', 1, [1, 6])
-  AssertEqual [1, 6], TestJump('after', 0, [1, 6])
-  AssertEqual [1, 6], TestJump('after', 1, [1, 6])
+  AssertEqual [1, 6], TestJump('before', 0, 'A', [1, 6])
+  AssertEqual [1, 6], TestJump('before', 1, 'A', [1, 6])
+  AssertEqual [1, 6], TestJump('after', 0, 'A', [1, 6])
+  AssertEqual [1, 6], TestJump('after', 1, 'A', [1, 6])
 
 Execute(We should be able to jump to the last item):
-  AssertEqual [2, 8], TestJump(-1, 0, [1, 6])
+  AssertEqual [2, 8], TestJump(-1, 0, 'A', [1, 6])
 
 Execute(We shouldn't move when jumping to the last item where there are none):
   let g:ale_buffer_info[bufnr('%')].loclist = []
 
-  AssertEqual [1, 6], TestJump(-1, 0, [1, 6])
+  AssertEqual [1, 6], TestJump(-1, 0, 'A', [1, 6])
 
 Execute(We should be able to jump to the first item):
-  AssertEqual [1, 2], TestJump(0, 0, [1, 6])
+  AssertEqual [1, 2], TestJump(0, 0, 'A', [1, 6])
 
 Execute(We shouldn't move when jumping to the first item where there are none):
   let g:ale_buffer_info[bufnr('%')].loclist = []
 
-  AssertEqual [1, 6], TestJump(0, 0, [1, 6])
+  AssertEqual [1, 6], TestJump(0, 0, 'A', [1, 6])
 
 Execute(We should be able to jump when the error line is blank):
   " Add a blank line at the end.
@@ -84,7 +94,7 @@ Execute(We should be able to jump when the error line is blank):
   call add(g:ale_buffer_info[bufnr('%')].loclist, {'type': 'E', 'bufnr': bufnr(''), 'lnum': 3, 'col': 1})
 
   AssertEqual 0, len(getline(3))
-  AssertEqual [2, 8], TestJump('before', 0, [3, 1])
-  AssertEqual [2, 8], TestJump('before', 1, [3, 1])
-  AssertEqual [3, 1], TestJump('after', 0, [3, 1])
-  AssertEqual [1, 2], TestJump('after', 1, [3, 1])
+  AssertEqual [2, 8], TestJump('before', 0, 'A', [3, 1])
+  AssertEqual [2, 8], TestJump('before', 1, 'A', [3, 1])
+  AssertEqual [3, 1], TestJump('after', 0, 'A', [3, 1])
+  AssertEqual [1, 2], TestJump('after', 1, 'A', [3, 1])

--- a/test/test_loclist_jumping.vader
+++ b/test/test_loclist_jumping.vader
@@ -2,15 +2,15 @@ Before:
   let g:ale_buffer_info = {
   \ bufnr(''): {
   \   'loclist': [
-  \     {'type': 'E', 'bufnr': bufnr('') - 1, 'lnum': 3, 'col': 2},
-  \     {'type': 'E', 'bufnr': bufnr(''), 'lnum': 1, 'col': 2},
-  \     {'type': 'E', 'bufnr': bufnr(''), 'lnum': 1, 'col': 3},
-  \     {'type': 'W', 'bufnr': bufnr(''), 'lnum': 2, 'col': 1},
-  \     {'type': 'E', 'bufnr': bufnr(''), 'lnum': 2, 'col': 2},
-  \     {'type': 'W', 'bufnr': bufnr(''), 'lnum': 2, 'col': 3},
-  \     {'type': 'W', 'bufnr': bufnr(''), 'lnum': 2, 'col': 6},
-  \     {'type': 'E', 'bufnr': bufnr(''), 'lnum': 2, 'col': 700},
-  \     {'type': 'E', 'bufnr': bufnr('') + 1, 'lnum': 3, 'col': 2},
+  \     {'type': 'E', 'any', 'bufnr': bufnr('') - 1, 'lnum': 3, 'col': 2},
+  \     {'type': 'E', 'any', 'bufnr': bufnr(''), 'lnum': 1, 'col': 2},
+  \     {'type': 'E', 'any', 'bufnr': bufnr(''), 'lnum': 1, 'col': 3},
+  \     {'type': 'W', 'any', 'bufnr': bufnr(''), 'lnum': 2, 'col': 1},
+  \     {'type': 'E', 'any', 'subtype': 'style', 'bufnr': bufnr(''), 'lnum': 2, 'col': 2},
+  \     {'type': 'W', 'any', 'subtype': 'style', 'bufnr': bufnr(''), 'lnum': 2, 'col': 3},
+  \     {'type': 'W', 'any', 'bufnr': bufnr(''), 'lnum': 2, 'col': 6},
+  \     {'type': 'E', 'any', 'bufnr': bufnr(''), 'lnum': 2, 'col': 700},
+  \     {'type': 'E', 'any', 'bufnr': bufnr('') + 1, 'lnum': 3, 'col': 2},
   \   ],
   \ },
   \}
@@ -36,65 +36,70 @@ Given foobar (Some imaginary filetype):
   12345678
 
 Execute(loclist jumping should jump correctly when not wrapping):
-  AssertEqual [2, 1], TestJump('before', 0, 'A', [2, 2])
-  AssertEqual [1, 3], TestJump('before', 0, 'A', [2, 1])
-  AssertEqual [2, 3], TestJump('after', 0, 'A', [2, 2])
-  AssertEqual [2, 1], TestJump('after', 0, 'A', [1, 3])
-  AssertEqual [2, 6], TestJump('after', 0, 'A', [2, 4])
-  AssertEqual [2, 8], TestJump('after', 0, 'A', [2, 6])
+  AssertEqual [2, 1], TestJump('before', 0, 'any', 'any', [2, 2])
+  AssertEqual [1, 3], TestJump('before', 0, 'any', 'any', [2, 1])
+  AssertEqual [2, 3], TestJump('after', 0, 'any', 'any', [2, 2])
+  AssertEqual [2, 1], TestJump('after', 0, 'any', 'any', [1, 3])
+  AssertEqual [2, 6], TestJump('after', 0, 'any', 'any', [2, 4])
+  AssertEqual [2, 8], TestJump('after', 0, 'any', 'any', [2, 6])
 
 Execute(loclist jumping should jump correctly when wrapping):
-  AssertEqual [2, 1], TestJump('before', 1, 'A', [2, 2])
-  AssertEqual [1, 3], TestJump('before', 1, 'A', [2, 1])
-  AssertEqual [2, 3], TestJump('after', 1, 'A', [2, 2])
-  AssertEqual [2, 1], TestJump('after', 1, 'A', [1, 3])
-  AssertEqual [2, 6], TestJump('after', 1, 'A', [2, 4])
+  AssertEqual [2, 1], TestJump('before', 1, 'any', 'any', [2, 2])
+  AssertEqual [1, 3], TestJump('before', 1, 'any', 'any', [2, 1])
+  AssertEqual [2, 3], TestJump('after', 1, 'any', 'any', [2, 2])
+  AssertEqual [2, 1], TestJump('after', 1, 'any', 'any', [1, 3])
+  AssertEqual [2, 6], TestJump('after', 1, 'any', 'any', [2, 4])
 
-  AssertEqual [1, 2], TestJump('after', 1, 'A', [2, 8])
-  AssertEqual [2, 8], TestJump('before', 1, 'A', [1, 2])
+  AssertEqual [1, 2], TestJump('after', 1, 'any', 'any', [2, 8])
+  AssertEqual [2, 8], TestJump('before', 1, 'any', 'any', [1, 2])
 
 Execute(loclist jumping should jump correctly with warning filters):
-  AssertEqual [2, 1], TestJump('after', 0, 'W', [1, 2])
-  AssertEqual [2, 6], TestJump('after', 0, 'W', [2, 3])
-  AssertEqual [2, 1], TestJump('after', 1, 'W', [2, 6])
+  AssertEqual [2, 1], TestJump('after', 0, 'W', 'any', [1, 2])
+  AssertEqual [2, 6], TestJump('after', 0, 'W', 'any', [2, 3])
+  AssertEqual [2, 1], TestJump('after', 1, 'W', 'any', [2, 6])
 
 Execute(loclist jumping should jump correctly with error filters):
-  AssertEqual [1, 2], TestJump('after', 1, 'E', [2, 700])
-  AssertEqual [2, 2], TestJump('before', 0, 'E', [2, 700])
-  AssertEqual [2, 2], TestJump('after', 1, 'E', [1, 3])
+  AssertEqual [1, 2], TestJump('after', 1, 'E', 'any', [2, 700])
+  AssertEqual [2, 2], TestJump('before', 0, 'E', 'any', [2, 700])
+  AssertEqual [2, 2], TestJump('after', 1, 'E', 'any', [1, 3])
+
+Execute(loclist jumping should jump correctly with sub type filters):
+  AssertEqual [2, 6], TestJump('after', 0, 'any', 'style', [2, 1])
+  AssertEqual [2, 2], TestJump('after', 0, 'any', '', [1, 2])
+  AssertEqual [2, 1], TestJump('after', 1, 'any', 'style', [2, 6])
 
 Execute(loclist jumping not jump when the loclist is empty):
   let g:ale_buffer_info[bufnr('%')].loclist = []
 
-  AssertEqual [1, 6], TestJump('before', 0, 'A', [1, 6])
-  AssertEqual [1, 6], TestJump('before', 1, 'A', [1, 6])
-  AssertEqual [1, 6], TestJump('after', 0, 'A', [1, 6])
-  AssertEqual [1, 6], TestJump('after', 1, 'A', [1, 6])
+  AssertEqual [1, 6], TestJump('before', 0, 'any', 'any', [1, 6])
+  AssertEqual [1, 6], TestJump('before', 1, 'any', 'any', [1, 6])
+  AssertEqual [1, 6], TestJump('after', 0, 'any', 'any', [1, 6])
+  AssertEqual [1, 6], TestJump('after', 1, 'any', 'any', [1, 6])
 
 Execute(We should be able to jump to the last item):
-  AssertEqual [2, 8], TestJump(-1, 0, 'A', [1, 6])
+  AssertEqual [2, 8], TestJump(-1, 0, 'any', 'any', [1, 6])
 
 Execute(We shouldn't move when jumping to the last item where there are none):
   let g:ale_buffer_info[bufnr('%')].loclist = []
 
-  AssertEqual [1, 6], TestJump(-1, 0, 'A', [1, 6])
+  AssertEqual [1, 6], TestJump(-1, 0, 'any', 'any', [1, 6])
 
 Execute(We should be able to jump to the first item):
-  AssertEqual [1, 2], TestJump(0, 0, 'A', [1, 6])
+  AssertEqual [1, 2], TestJump(0, 0, 'any', 'any', [1, 6])
 
 Execute(We shouldn't move when jumping to the first item where there are none):
   let g:ale_buffer_info[bufnr('%')].loclist = []
 
-  AssertEqual [1, 6], TestJump(0, 0, 'A', [1, 6])
+  AssertEqual [1, 6], TestJump(0, 0, 'any', 'any', [1, 6])
 
 Execute(We should be able to jump when the error line is blank):
   " Add a blank line at the end.
   call setline(1, getline('.', '$') + [''])
   " Add a problem on the blank line.
-  call add(g:ale_buffer_info[bufnr('%')].loclist, {'type': 'E', 'bufnr': bufnr(''), 'lnum': 3, 'col': 1})
+  call add(g:ale_buffer_info[bufnr('%')].loclist, {'type': 'E', 'any', 'bufnr': bufnr(''), 'lnum': 3, 'col': 1})
 
   AssertEqual 0, len(getline(3))
-  AssertEqual [2, 8], TestJump('before', 0, 'A', [3, 1])
-  AssertEqual [2, 8], TestJump('before', 1, 'A', [3, 1])
-  AssertEqual [3, 1], TestJump('after', 0, 'A', [3, 1])
-  AssertEqual [1, 2], TestJump('after', 1, 'A', [3, 1])
+  AssertEqual [2, 8], TestJump('before', 0, 'any', 'any', [3, 1])
+  AssertEqual [2, 8], TestJump('before', 1, 'any', 'any', [3, 1])
+  AssertEqual [3, 1], TestJump('after', 0, 'any', 'any', [3, 1])
+  AssertEqual [1, 2], TestJump('after', 1, 'any', 'any', [3, 1])

--- a/test/test_loclist_jumping.vader
+++ b/test/test_loclist_jumping.vader
@@ -2,26 +2,27 @@ Before:
   let g:ale_buffer_info = {
   \ bufnr(''): {
   \   'loclist': [
-  \     {'type': 'E', 'any', 'bufnr': bufnr('') - 1, 'lnum': 3, 'col': 2},
-  \     {'type': 'E', 'any', 'bufnr': bufnr(''), 'lnum': 1, 'col': 2},
-  \     {'type': 'E', 'any', 'bufnr': bufnr(''), 'lnum': 1, 'col': 3},
-  \     {'type': 'W', 'any', 'bufnr': bufnr(''), 'lnum': 2, 'col': 1},
-  \     {'type': 'E', 'any', 'subtype': 'style', 'bufnr': bufnr(''), 'lnum': 2, 'col': 2},
-  \     {'type': 'W', 'any', 'subtype': 'style', 'bufnr': bufnr(''), 'lnum': 2, 'col': 3},
-  \     {'type': 'W', 'any', 'bufnr': bufnr(''), 'lnum': 2, 'col': 6},
-  \     {'type': 'E', 'any', 'bufnr': bufnr(''), 'lnum': 2, 'col': 700},
-  \     {'type': 'E', 'any', 'bufnr': bufnr('') + 1, 'lnum': 3, 'col': 2},
+  \     {'type': 'E', 'bufnr': bufnr('') - 1, 'lnum': 3, 'col': 2},
+  \     {'type': 'E', 'bufnr': bufnr(''), 'lnum': 1, 'col': 2},
+  \     {'type': 'E', 'bufnr': bufnr(''), 'lnum': 1, 'col': 3},
+  \     {'type': 'W', 'sub_type': 'style', 'bufnr': bufnr(''), 'lnum': 2, 'col': 1},
+  \     {'type': 'E', 'bufnr': bufnr(''), 'lnum': 2, 'col': 2},
+  \     {'type': 'W', 'sub_type': 'style', 'bufnr': bufnr(''), 'lnum': 2, 'col': 3},
+  \     {'type': 'W', 'bufnr': bufnr(''), 'lnum': 2, 'col': 6},
+  \     {'type': 'E', 'bufnr': bufnr(''), 'lnum': 2, 'col': 700},
+  \     {'type': 'E', 'bufnr': bufnr('') + 1, 'lnum': 3, 'col': 2},
   \   ],
   \ },
   \}
 
-  function! TestJump(position, wrap, filter, pos)
+  function! TestJump(position, wrap, filter, subtype_filter, pos)
     call cursor(a:pos)
 
     if type(a:position) == type(0)
       call ale#loclist_jumping#JumpToIndex(a:position)
     else
-      call ale#loclist_jumping#Jump(a:position, a:wrap, a:filter)
+      call ale#loclist_jumping#Jump(a:position, a:wrap, a:filter, 
+      \                             a:subtype_filter)
     endif
 
     return getcurpos()[1:2]
@@ -64,8 +65,8 @@ Execute(loclist jumping should jump correctly with error filters):
   AssertEqual [2, 2], TestJump('after', 1, 'E', 'any', [1, 3])
 
 Execute(loclist jumping should jump correctly with sub type filters):
-  AssertEqual [2, 6], TestJump('after', 0, 'any', 'style', [2, 1])
-  AssertEqual [2, 2], TestJump('after', 0, 'any', '', [1, 2])
+  AssertEqual [2, 3], TestJump('after', 0, 'any', 'style', [2, 1])
+  AssertEqual [2, 2], TestJump('after', 0, 'any', '', [1, 3])
   AssertEqual [2, 1], TestJump('after', 1, 'any', 'style', [2, 6])
 
 Execute(loclist jumping not jump when the loclist is empty):
@@ -96,7 +97,7 @@ Execute(We should be able to jump when the error line is blank):
   " Add a blank line at the end.
   call setline(1, getline('.', '$') + [''])
   " Add a problem on the blank line.
-  call add(g:ale_buffer_info[bufnr('%')].loclist, {'type': 'E', 'any', 'bufnr': bufnr(''), 'lnum': 3, 'col': 1})
+  call add(g:ale_buffer_info[bufnr('%')].loclist, {'type': 'E', 'bufnr': bufnr(''), 'lnum': 3, 'col': 1})
 
   AssertEqual 0, len(getline(3))
   AssertEqual [2, 8], TestJump('before', 0, 'any', 'any', [3, 1])


### PR DESCRIPTION
This pull request address #2198.
I used extra argument to generalized `ale#loclist_jumping#Jump` and `ale#loclist_jumping#FindNearest` to the use of a filter on the type of error. You can now use `:ALENext 1 E` to jump to the next error ignoring warnings with wrapping. I added the corresponding <plug> binding to ease creating of custom shortcut.

PS: This is my first attempt at coding in a Vim plugin and at making a pull request, so I may have forgotten something but I would be glad to fix anything not orthodox.