### PR TITLE
Support ale_sh_shellcheck_dialect to set shellcheck dialect

### DIFF
--- a/ale_linters/sh/shellcheck.vim
+++ b/ale_linters/sh/shellcheck.vim
@@ -8,6 +8,7 @@
 " let g:ale_sh_shellcheck_exclusions = 'SC2002,SC2004'
 call ale#Set('sh_shellcheck_exclusions', get(g:, 'ale_linters_sh_shellcheck_exclusions', ''))
 call ale#Set('sh_shellcheck_executable', 'shellcheck')
+call ale#Set('sh_shellcheck_dialect', 'auto')
 call ale#Set('sh_shellcheck_options', '')
 
 function! ale_linters#sh#shellcheck#GetExecutable(buffer) abort
@@ -53,8 +54,12 @@ function! ale_linters#sh#shellcheck#GetCommand(buffer, version_output) abort
 
     let l:options = ale#Var(a:buffer, 'sh_shellcheck_options')
     let l:exclude_option = ale#Var(a:buffer, 'sh_shellcheck_exclusions')
-    let l:dialect = ale_linters#sh#shellcheck#GetDialectArgument(a:buffer)
+    let l:dialect = ale#Var(a:buffer, 'sh_shellcheck_dialect')
     let l:external_option = ale#semver#GTE(l:version, [0, 4, 0]) ? ' -x' : ''
+
+    if l:dialect is# 'auto'
+        let l:dialect = ale_linters#sh#shellcheck#GetDialectArgument(a:buffer)
+    endif
 
     return ale#path#BufferCdString(a:buffer)
     \   . ale#Escape(l:executable)

--- a/doc/ale-sh.txt
+++ b/doc/ale-sh.txt
@@ -61,6 +61,18 @@ g:ale_sh_shellcheck_options                       *g:ale_sh_shellcheck_options*
   let g:ale_sh_shellcheck_options = '-x'
 <
 
+
+g:ale_sh_shellcheck_dialect                       *g:ale_sh_shellcheck_dialect*
+                                                  *b:ale_sh_shellcheck_dialect*
+  Type: |String|
+  Default: `'auto'`
+
+  This variable specifies the shellcheck dialect (`-s` option).  The value
+  `'auto'` causes ALE to detect the dialect automatically, based on the shebang
+  line (if present) or the value of `b:is_bash`, `b:is_sh`, or `b:is_kornshell`
+  (set and used by |sh.vim|).
+
+
 g:ale_sh_shellcheck_exclusions                 *g:ale_sh_shellcheck_exclusions*
                                                *b:ale_sh_shellcheck_exclusions*
   Type: |String|

--- a/test/command_callback/test_shellcheck_command_callback.vader
+++ b/test/command_callback/test_shellcheck_command_callback.vader
@@ -33,6 +33,18 @@ Execute(The shellcheck command should include the dialect):
   AssertLinter 'shellcheck',
   \ b:prefix . ale#Escape('shellcheck') . ' -s bash' . b:suffix
 
+Execute(The shellcheck command should use ale_sh_shellcheck_dialect):
+  let b:ale_sh_shellcheck_dialect = 'ksh93'
+
+  AssertLinter 'shellcheck',
+  \ b:prefix . ale#Escape('shellcheck') . ' -s ksh93' . b:suffix
+
+Execute(The shellcheck command should allow unspecified dialect):
+  let b:ale_sh_shellcheck_dialect = ''
+
+  AssertLinter 'shellcheck',
+  \ b:prefix . ale#Escape('shellcheck') . b:suffix
+
 Execute(The shellcheck command should include the dialect before options and exclusions):
   let b:is_bash = 1
   let b:ale_sh_shellcheck_options = '--foobar'


### PR DESCRIPTION
As discussed in w0rp/ale#1051, there are cases (including my own) where it would be useful to be able to specify the dialect explicitly or allow `shellcheck` to determine the dialect using its own logic and considering [`# shellcheck shell=` directives](https://github.com/koalaman/shellcheck/wiki/Directive#shell) in the file.  This commit allows users to do so using the `ale_sh_shellcheck_dialect` variable, which can be set empty to disable auto-detection or set to a particular dialect to use it unconditionally.

Fixes: w0rp/ale#1051

Thanks for considering,
Kevin