### PR TITLE
pylama: Use %s instead of %t

### DIFF
--- a/ale_linters/python/pylama.vim
+++ b/ale_linters/python/pylama.vim
@@ -34,10 +34,13 @@ function! ale_linters#python#pylama#GetCommand(buffer) abort
     \   ? ' run pylama'
     \   : ''
 
+    " Note: Using %t to lint changes would be preferable, but many pylama
+    " checks use surrounding paths (e.g. C0103 module name, E0402 relative
+    " import beyond top, etc.).  Neither is ideal.
     return l:cd_string
     \   . ale#Escape(l:executable) . l:exec_args
     \   . ale#Pad(ale#Var(a:buffer, 'python_pylama_options'))
-    \   . ' %t'
+    \   . ' %s'
 endfunction
 
 function! ale_linters#python#pylama#Handle(buffer, lines) abort
@@ -67,12 +70,6 @@ function! ale_linters#python#pylama#Handle(buffer, lines) abort
     \}
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)
-        " Ignore C0103 for module name from temporary path (%t) which may not
-        " comply with module-rgx.
-        if l:match[3] is# 'C0103' && l:match[4] =~# '^Module name '
-            continue
-        endif
-
         call add(l:output, {
         \   'lnum': str2nr(l:match[1]),
         \   'col': str2nr(l:match[2]),
@@ -91,4 +88,5 @@ call ale#linter#Define('python', {
 \   'executable_callback': 'ale_linters#python#pylama#GetExecutable',
 \   'command_callback': 'ale_linters#python#pylama#GetCommand',
 \   'callback': 'ale_linters#python#pylama#Handle',
+\   'lint_file': 1,
 \})

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -332,6 +332,7 @@ Notes:
   * `prospector`
   * `pycodestyle`
   * `pydocstyle`
+  * `pylama`!!
   * `pylint`!!
   * `pyls`
   * `pyre`

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -341,6 +341,7 @@ formatting.
   * [prospector](https://github.com/PyCQA/prospector) :warning:
   * [pycodestyle](https://github.com/PyCQA/pycodestyle) :warning:
   * [pydocstyle](https://www.pydocstyle.org/) :warning:
+  * [pylama](https://github.com/klen/pylama) :floppy_disk:
   * [pylint](https://www.pylint.org/) :floppy_disk:
   * [pyls](https://github.com/palantir/python-language-server) :warning:
   * [pyre](https://github.com/facebook/pyre-check) :warning:

--- a/test/command_callback/test_pylama_command_callback.vader
+++ b/test/command_callback/test_pylama_command_callback.vader
@@ -3,7 +3,7 @@ Before:
   call ale#test#SetFilename('test.py')
 
   let b:bin_dir = has('win32') ? 'Scripts' : 'bin'
-  let b:command_tail = ' %t'
+  let b:command_tail = ' %s'
 
 After:
   unlet! b:bin_dir

--- a/test/handler/test_pylama_handler.vader
+++ b/test/handler/test_pylama_handler.vader
@@ -191,22 +191,3 @@ Execute(The pylama handler should handle message codes followed by a colon):
   \ ale_linters#python#pylama#Handle(bufnr(''), [
   \   'index.py:31:1: E800: Found commented out code: # needs_sphinx = ''1.0'' [eradicate]',
   \ ])
-
-" The directory created for %t may not comply with pylint module name config.
-" This should not be reported to users.
-Execute(The pylama handler should ignore C0103 from temp dir, not others):
-  AssertEqual
-  \ [
-  \   {
-  \     'lnum': 29,
-  \     'col': 0,
-  \     'code': 'C0103',
-  \     'type': 'W',
-  \     'sub_type': 'style',
-  \     'text': 'Constant name "badname" doesn''t conform to UPPER_CASE naming style [pylint]',
-  \   },
-  \ ],
-  \ ale_linters#python#pylama#Handle(bufnr(''), [
-  \   '../../../../tmp/vmynR33/456/__init__.py:1:0: C0103 Module name "456" doesn''t conform to snake_case naming style [pylint]',
-  \   '../../../../tmp/vmynR33/456/__init__.py:29:0: C0103 Constant name "badname" doesn''t conform to UPPER_CASE naming style [pylint]',
-  \ ])


### PR DESCRIPTION
My apologies for yet another Pylama pull request.  After more testing, I think my decision to use `%t` (and suppressing C0103) was the wrong approach.  I am finding more errors which depend on the real path and surrounding files (e.g. `E0401 - Unable to import %s`, `E0402 - Attempted relative import beyond top-level package`).  I suspect there will be even more from Pylama plugins that I haven't used and that switching to `%s` is the better choice.  Thoughts?

Thanks for considering,
Kevin