### PR TITLE
python/pylint: Change directory to project root

### DIFF
--- a/ale_linters/python/pylint.vim
+++ b/ale_linters/python/pylint.vim
@@ -17,9 +17,17 @@ function! ale_linters#python#pylint#GetExecutable(buffer) abort
 endfunction
 
 function! ale_linters#python#pylint#GetCommand(buffer) abort
-    let l:cd_string = ale#Var(a:buffer, 'python_pylint_change_directory')
-    \   ? ale#path#BufferCdString(a:buffer)
-    \   : ''
+    let l:cd_string = ''
+
+    if ale#Var(a:buffer, 'python_pylint_change_directory')
+        " pylint only checks for pylintrc in the packages above its current
+        " directory before falling back to user and global pylintrc.
+        " Run from project root, if found, otherwise buffer dir.
+        let l:project_root = ale#python#FindProjectRoot(a:buffer)
+        let l:cd_string = l:project_root isnot# ''
+        \   ? ale#path#CdString(l:project_root)
+        \   : ale#path#BufferCdString(a:buffer)
+    endif
 
     let l:executable = ale_linters#python#pylint#GetExecutable(a:buffer)
 

--- a/autoload/ale/python.vim
+++ b/autoload/ale/python.vim
@@ -28,6 +28,8 @@ function! ale#python#FindProjectRootIni(buffer) abort
         \|| filereadable(l:path . '/flake8.cfg')
         \|| filereadable(l:path . '/.flake8rc')
         \|| filereadable(l:path . '/pylama.ini')
+        \|| filereadable(l:path . '/pylintrc')
+        \|| filereadable(l:path . '/.pylintrc')
         \|| filereadable(l:path . '/Pipfile')
         \|| filereadable(l:path . '/Pipfile.lock')
             return l:path

--- a/doc/ale-python.txt
+++ b/doc/ale-python.txt
@@ -32,6 +32,8 @@ ALE will look for configuration files with the following filenames. >
   flake8.cfg
   .flake8rc
   pylama.ini
+  pylintrc
+  .pylintrc
   Pipfile
   Pipfile.lock
 <
@@ -512,10 +514,12 @@ g:ale_python_pylint_change_directory     *g:ale_python_pylint_change_directory*
   Type: |Number|
   Default: `1`
 
-  If set to `1`, ALE will switch to the directory the Python file being
-  checked with `pylint` is in before checking it. This helps `pylint` find
-  configuration files more easily. This option can be turned off if you want
-  to control the directory Python is executed from yourself.
+  If set to `1`, `pylint` will be run from a detected project root, per
+  |ale-python-root|.  Since `pylint` only checks for `pylintrc` in the packages
+  above its current directory before falling back to user and global `pylintrc`
+  files, this is necessary for `pylint` to use a project `pylintrc` file, if
+  present.  This option can be turned off if you want to control the directory
+  Python is executed from yourself.
 
 
 g:ale_python_pylint_executable                 *g:ale_python_pylint_executable*

--- a/test/command_callback/test_pylint_command_callback.vader
+++ b/test/command_callback/test_pylint_command_callback.vader
@@ -39,7 +39,7 @@ Execute(The pylint callbacks shouldn't detect virtualenv directories where they 
   silent execute 'file ' . fnameescape(g:dir . '/python_paths/no_virtualenv/subdir/foo/bar.py')
 
   AssertLinter 'pylint',
-  \ ale#path#BufferCdString(bufnr(''))
+  \ ale#path#CdString(ale#path#Simplify(g:dir . '/python_paths/no_virtualenv/subdir'))
   \   . ale#Escape('pylint') . ' ' . b:command_tail
 
 Execute(The pylint callbacks should detect virtualenv directories):
@@ -50,7 +50,7 @@ Execute(The pylint callbacks should detect virtualenv directories):
   \)
 
   AssertLinter b:executable,
-  \ ale#path#BufferCdString(bufnr(''))
+  \ ale#path#CdString(ale#path#Simplify(g:dir . '/python_paths/with_virtualenv/subdir'))
   \   . ale#Escape(b:executable) . ' ' . b:command_tail
 
 Execute(You should able able to use the global pylint instead):
@@ -58,7 +58,7 @@ Execute(You should able able to use the global pylint instead):
   let g:ale_python_pylint_use_global = 1
 
   AssertLinter 'pylint',
-  \ ale#path#BufferCdString(bufnr(''))
+  \ ale#path#CdString(ale#path#Simplify(g:dir . '/python_paths/with_virtualenv/subdir'))
   \   . ale#Escape('pylint') . ' ' . b:command_tail
 
 Execute(Setting executable to 'pipenv' appends 'run pylint'):


### PR DESCRIPTION
Pylint only [checks for `pylintrc` (and `.pylintrc`)](https://github.com/PyCQA/pylint/blob/pylint-2.2.2/pylint/config.py#L106) files in the packages above its current directory before falling back to user or global `pylintrc` files.  For projects with modules in a `src` dir, running `pylint` from the directory containing the module file will not use the project `pylintrc`.

This pull request solves the issue by adopting the convention used by many other Python linters of running from the project root.  It also adds `pylintrc` and `.pylintrc` to `FindProjectRoot` and updates the docs to match the new behavior.

Thanks for considering,
Kevin