### PR TITLE
javac: Don't assume src/main/java always exists

### DIFF
--- a/ale_linters/java/javac.vim
+++ b/ale_linters/java/javac.vim
@@ -55,15 +55,14 @@ function! ale_linters#java#javac#GetCommand(buffer, import_paths) abort
         if isdirectory(l:jaxb_dir)
             call add(l:sp_dirs, l:jaxb_dir)
         endif
+    endif
 
-        " Automatically include the test directory, but only for test code.
-        if expand('#' . a:buffer . ':p') =~? '\vsrc[/\\]test[/\\]java'
-            let l:test_dir = fnamemodify(l:src_dir, ':h:h:h')
-            \   . (has('win32') ? '\test\java\' : '/test/java/')
+    " Automatically include the test directory, but only for test code.
+    if expand('#' . a:buffer . ':p') =~? '\vsrc[/\\]test[/\\]java'
+        let l:test_dir = ale#path#FindNearestDirectory(a:buffer, 'src/test/java')
 
-            if isdirectory(l:test_dir)
-                call add(l:sp_dirs, l:test_dir)
-            endif
+        if isdirectory(l:test_dir)
+            call add(l:sp_dirs, l:test_dir)
         endif
     endif
 

--- a/test/command_callback/test_javac_command_callback.vader
+++ b/test/command_callback/test_javac_command_callback.vader
@@ -166,3 +166,15 @@ Execute(The javac callback should include src/main/jaxb when available):
   \     ale#path#Simplify(g:dir . '/java_paths_with_jaxb/src/main/jaxb/'),
   \   ], g:cp_sep))
   \   . ' -d ' . ale#Escape('TEMP_DIR') . ' %t'
+
+Execute(The javac callback should add -sourcepath even if src/java/main doesn't exist):
+  call ale#engine#Cleanup(bufnr(''))
+  call ale#test#SetFilename('java_paths_no_main/src/test/java/com/something/dummy.java')
+  call ale#engine#InitBufferInfo(bufnr(''))
+
+  AssertLinter 'javac',
+  \ ale#path#CdString(expand('%:p:h')) . ale#Escape('javac') . ' -Xlint'
+  \   . ' -sourcepath ' . ale#Escape(join([
+  \     ale#path#Simplify(g:dir . '/java_paths_no_main/src/test/java/'),
+  \   ], g:cp_sep))
+  \   . ' -d ' . ale#Escape('TEMP_DIR') . ' %t'


### PR DESCRIPTION
Some projects I have only have src/test/java (no /src/main/java), which
seemed to break some incorrect assumptions the linter had.
