### PR TITLE
Clear the virtualtext on disable

### DIFF
--- a/autoload/ale/toggle.vim
+++ b/autoload/ale/toggle.vim
@@ -13,6 +13,10 @@ function! s:DisablePostamble() abort
     if g:ale_set_highlights
         call ale#highlight#UpdateHighlights()
     endif
+
+    if g:ale_virtualtext_cursor
+        call ale#virtualtext#Clear()
+    endif
 endfunction
 
 function! ale#toggle#Toggle() abort


### PR DESCRIPTION
Currently if virtualtext is displayed when ale gets disabled with `ALEDisable` or `ALEDisableBuffer` it does not get cleared.

This PR clears the text.

I didn't write tests, because I don't know how I can test that `nvim_buf_clear_highlight` was called.