### PR TITLE
Use new cabal exec command

### DIFF
--- a/ale_linters/haskell/cabal_ghc.vim
+++ b/ale_linters/haskell/cabal_ghc.vim
@@ -4,7 +4,7 @@
 call ale#Set('haskell_cabal_ghc_options', '-fno-code -v0')
 
 function! ale_linters#haskell#cabal_ghc#GetCommand(buffer) abort
-    return 'cabal exec -- ghc '
+    return 'cabal v1-exec -- ghc '
     \   . ale#Var(a:buffer, 'haskell_cabal_ghc_options')
     \   . ' %t'
 endfunction

--- a/ale_linters/haskell/cabal_ghc.vim
+++ b/ale_linters/haskell/cabal_ghc.vim
@@ -1,10 +1,32 @@
-" Author: Eric Wolf <ericwolf42@gmail.com>
+" Author: Eric Wolf <ericwolf42@gmail.com>, Daniel T. <daniel.t.dt@gmail.com>
 " Description: ghc for Haskell files called with cabal exec
 
+call ale#Set('haskell_cabal_ghc_executable', 'cabal')
 call ale#Set('haskell_cabal_ghc_options', '-fno-code -v0')
 
-function! ale_linters#haskell#cabal_ghc#GetCommand(buffer) abort
-    return 'cabal v1-exec -- ghc '
+function! ale_linters#haskell#cabal_ghc#GetExecutable(buffer) abort
+    return ale#Var(a:buffer, 'haskell_cabal_ghc_executable')
+endfunction
+
+function! ale_linters#haskell#cabal_ghc#VersionCheck(buffer) abort
+    let l:executable = ale_linters#haskell#cabal_ghc#GetExecutable(a:buffer)
+
+    " Check the Vint version if we haven't checked it already.
+    return !ale#semver#HasVersion(l:executable)
+    \   ? ale#Escape(l:executable) . ' --numeric-version'
+    \   : ''
+endfunction
+
+function! ale_linters#haskell#cabal_ghc#GetCommand(buffer, version_output) abort
+    let l:executable = ale_linters#haskell#cabal_ghc#GetExecutable(a:buffer)
+    let l:version = ale#semver#GetVersion(l:executable, a:version_output)
+
+    let l:exec_cmd = ale#semver#GTE(l:version, [2, 0, 0])
+    \   ? ' v1-exec'
+    \   : ' exec'
+
+    return ale#Escape(l:executable)
+    \   . l:exec_cmd . ' -- ghc '
     \   . ale#Var(a:buffer, 'haskell_cabal_ghc_options')
     \   . ' %t'
 endfunction
@@ -13,7 +35,10 @@ call ale#linter#Define('haskell', {
 \   'name': 'cabal_ghc',
 \   'aliases': ['cabal-ghc'],
 \   'output_stream': 'stderr',
-\   'executable': 'cabal',
-\   'command': function('ale_linters#haskell#cabal_ghc#GetCommand'),
+\   'executable': function('ale_linters#haskell#cabal_ghc#GetExecutable'),
+\   'command_chain': [
+\       {'callback': 'ale_linters#haskell#cabal_ghc#VersionCheck'},
+\       {'callback': 'ale_linters#haskell#cabal_ghc#GetCommand'},
+\   ],
 \   'callback': 'ale#handlers#haskell#HandleGHCFormat',
 \})

--- a/test/command_callback/test_haskell_cabal_ghc_command_callbacks.vader
+++ b/test/command_callback/test_haskell_cabal_ghc_command_callbacks.vader
@@ -1,15 +1,8 @@
 Before:
-  Save g:ale_haskell_cabal_ghc_options
-
-  unlet! g:ale_haskell_cabal_ghc_options
-  unlet! b:ale_haskell_cabal_ghc_options
-
-  runtime ale_linters/haskell/cabal_ghc.vim
+  call ale#assert#SetUpLinterTest('haskell', 'cabal_ghc')
 
 After:
-  Restore
-  unlet! b:ale_haskell_cabal_ghc_options
-  call ale#linter#Reset()
+  call ale#assert#TearDownLinterTest()
 
 Execute(The options should be used in the command):
   AssertEqual
@@ -19,5 +12,5 @@ Execute(The options should be used in the command):
   let b:ale_haskell_cabal_ghc_options = 'foobar'
 
   AssertEqual
-  \ 'cabal exec -- ghc foobar %t',
+  \ 'cabal v1-exec -- ghc foobar %t',
   \ ale_linters#haskell#cabal_ghc#GetCommand(bufnr(''))

--- a/test/command_callback/test_haskell_cabal_ghc_command_callbacks.vader
+++ b/test/command_callback/test_haskell_cabal_ghc_command_callbacks.vader
@@ -13,7 +13,7 @@ After:
 
 Execute(The options should be used in the command):
   AssertEqual
-  \ 'cabal exec -- ghc -fno-code -v0 %t',
+  \ 'cabal v1-exec -- ghc -fno-code -v0 %t',
   \ ale_linters#haskell#cabal_ghc#GetCommand(bufnr(''))
 
   let b:ale_haskell_cabal_ghc_options = 'foobar'


### PR DESCRIPTION
Cabal [build has changed](https://cabal.readthedocs.io/en/latest/nix-local-build-overview.html).
Using cabal v2.4.0.0, the current command `cabal exec` prints a deprecation warning like this:

```
Warning: The exec command is a part of the legacy v1 style of cabal usage.

Please switch to using either the new project style and the new-exec command
or the legacy v1-exec alias as new-style projects will become the default in
the next version of cabal-install. Please file a bug if you cannot replicate a
working v1- use case with the new-style commands.

For more information, see: https://wiki.haskell.org/Cabal/NewBuild
```

This PR just apply the suggestions from that warning but I think we
should consider expose this command as a configurable variable.