### PR TITLE
clang-format supported with nvcc (cuda files)

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -142,8 +142,8 @@ let s:default_registry = {
 \   },
 \   'clang-format': {
 \       'function': 'ale#fixers#clangformat#Fix',
-\       'suggested_filetypes': ['c', 'cpp'],
-\       'description': 'Fix C/C++ files with clang-format.',
+\       'suggested_filetypes': ['c', 'cpp', 'cuda'],
+\       'description': 'Fix C/C++ and cuda files with clang-format.',
 \   },
 \   'cmakeformat': {
 \       'function': 'ale#fixers#cmakeformat#Fix',

--- a/doc/ale-cuda.txt
+++ b/doc/ale-cuda.txt
@@ -22,4 +22,11 @@ g:ale_cuda_nvcc_options                               *g:ale_cuda_nvcc_options*
   This variable can be changed to modify flags given to nvcc.
 
 ===============================================================================
+clang-format                                              *ale-cuda-clangformat*
+
+See |ale-c-clangformat| for information about the available options.
+Note that the C options are also used for cuda.
+
+
+===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2251,6 +2251,7 @@ documented in additional help files.
     stylelint.............................|ale-css-stylelint|
   cuda....................................|ale-cuda-options|
     nvcc..................................|ale-cuda-nvcc|
+    clang-format..........................|ale-cuda-clangformat|
   d.......................................|ale-d-options|
     dls...................................|ale-d-dls|
     uncrustify............................|ale-d-uncrustify|

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -103,6 +103,7 @@ ALE supports the following key features for linting:
       stylelint...........................|ale-css-stylelint|
     cuda..................................|ale-cuda-options|
       nvcc................................|ale-cuda-nvcc|
+      clang-format........................|ale-cuda-clangformat|
     d.....................................|ale-d-options|
       dls.................................|ale-d-dls|
       uncrustify..........................|ale-d-uncrustify|


### PR DESCRIPTION
<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!
-->

Added support for clang-format to be used with nvcc (cuda files). Issue #2318 

Just as ale-cpp-clangformat uses ale-c-clangformat for options. Similarly the ale-cuda-clangformat uses ale-c-clangformat for options.

