### PR TITLE
Add lsp_config support for rls

### DIFF
--- a/ale_linters/rust/rls.vim
+++ b/ale_linters/rust/rls.vim
@@ -3,6 +3,7 @@
 
 call ale#Set('rust_rls_executable', 'rls')
 call ale#Set('rust_rls_toolchain', 'nightly')
+call ale#Set('rust_rls_config', '')
 
 function! ale_linters#rust#rls#GetCommand(buffer) abort
     let l:toolchain = ale#Var(a:buffer, 'rust_rls_toolchain')
@@ -19,6 +20,7 @@ endfunction
 call ale#linter#Define('rust', {
 \   'name': 'rls',
 \   'lsp': 'stdio',
+\   'lsp_config': {b -> ale#Var(b, 'rust_rls_config')},
 \   'executable': {b -> ale#Var(b, 'rust_rls_executable')},
 \   'command': function('ale_linters#rust#rls#GetCommand'),
 \   'project_root': function('ale_linters#rust#rls#GetProjectRoot'),

--- a/ale_linters/rust/rls.vim
+++ b/ale_linters/rust/rls.vim
@@ -3,7 +3,7 @@
 
 call ale#Set('rust_rls_executable', 'rls')
 call ale#Set('rust_rls_toolchain', 'nightly')
-call ale#Set('rust_rls_config', '')
+call ale#Set('rust_rls_config', {})
 
 function! ale_linters#rust#rls#GetCommand(buffer) abort
     let l:toolchain = ale#Var(a:buffer, 'rust_rls_toolchain')

--- a/doc/ale-rust.txt
+++ b/doc/ale-rust.txt
@@ -180,7 +180,7 @@ g:ale_rust_rls_config                                   *g:ale_rust_rls_config*
   Dictionary with configuration settings for rls. For example, to force
   using clippy as linter: >
         {
-      \   'rls': {
+      \   'rust': {
       \     'clippy_preference': 'on'
       \   }
       \ }

--- a/doc/ale-rust.txt
+++ b/doc/ale-rust.txt
@@ -172,6 +172,20 @@ g:ale_rust_rls_toolchain                             *g:ale_rust_rls_toolchain*
   The `rls` server will only be started once per executable.
 
 
+g:ale_rust_rls_config                                *g:ale_rust_rls_config*
+                                                     *b:ale_rust_rls_config*
+  Type: |Dictionary|
+  Default: `{}`
+
+  Dictionary with configuration settings for rls. For example, to force
+  using clippy as linter: >
+        {
+      \   'rls': {
+      \     'clippy_preference': 'on'
+      \   }
+      \ }
+
+
 ===============================================================================
 rustc                                                          *ale-rust-rustc*
 

--- a/doc/ale-rust.txt
+++ b/doc/ale-rust.txt
@@ -172,8 +172,8 @@ g:ale_rust_rls_toolchain                             *g:ale_rust_rls_toolchain*
   The `rls` server will only be started once per executable.
 
 
-g:ale_rust_rls_config                                *g:ale_rust_rls_config*
-                                                     *b:ale_rust_rls_config*
+g:ale_rust_rls_config                                   *g:ale_rust_rls_config*
+                                                        *b:ale_rust_rls_config*
   Type: |Dictionary|
   Default: `{}`
 

--- a/test/command_callback/test_rust_rls_callbacks.vader
+++ b/test/command_callback/test_rust_rls_callbacks.vader
@@ -28,4 +28,3 @@ Execute(Should accept configuration settings):
   AssertLSPConfig {}
   let b:ale_rust_rls_config = {'rust': {'clippy_preference': 'on'}}
   AssertLSPConfig {'rust': {'clippy_preference': 'on'}}
-

--- a/test/command_callback/test_rust_rls_callbacks.vader
+++ b/test/command_callback/test_rust_rls_callbacks.vader
@@ -23,3 +23,9 @@ Execute(The project root should be detected correctly):
   call ale#test#SetFilename('rust-rls-project/test.rs')
 
   AssertLSPProject ale#path#Simplify(g:dir . '/rust-rls-project')
+
+Execute(Should accept configuration settings):
+  AssertLSPConfig {}
+  let b:ale_rust_rls_config = {'rust': {'clippy_preference': 'on'}}
+  AssertLSPConfig {'rust': {'clippy_preference': 'on'}}
+


### PR DESCRIPTION
This is a first draft, based on how it was implemented for pyls. Still needs
tests. My first contribution to a vim project, so I'm still sorting things out.

Currently *not* working with `clippy_preference`, which is the main reason I'm interested in adding the feature.