### PR TITLE
change default action when can't find the root path for go's bingo linter

### DIFF
--- a/ale_linters/go/bingo.vim
+++ b/ale_linters/go/bingo.vim
@@ -17,7 +17,24 @@ function! ale_linters#go#bingo#FindProjectRoot(buffer) abort
         let l:mods = ':h:h'
     endif
 
-    return !empty(l:project_root) ? fnamemodify(l:project_root, l:mods) : ''
+    if empty(l:project_root)
+	let l:project_root = ale#path#FindNearestFile(a:buffer,'main.go')
+	let l:mods = ':h'
+    endif
+
+    if empty(l:project_root)
+	let l:project_root = fnamemodify(bufname(a:buffer),':p')
+	let l:project_root = fnameescape(l:project_root)
+	let l:mods = ':h'
+    else
+        if empty($GOPATH) || stridx(l:project_root,$GOPATH)==-1
+	    let l:project_root = fnamemodify(bufname(a:buffer),':p')
+	    let l:project_root = fnameescape(l:project_root)
+	    let l:mods = ':h'
+        endif
+    endif
+
+    return fnamemodify(l:project_root, l:mods) 
 endfunction
 
 call ale#linter#Define('go', {


### PR DESCRIPTION
The bingo linter has a bug.
In default,when the FindProjectRoot function can't find the root path in ale_linters/go/bingo.vim,it will return empty,and this will make bingo stop.
This pull request change the default action.When can't find the root path like before,it will not return empty but use current buffer's dir as root path.Then,the bingo can start at anytime.
There is still another problem with bingo linter.
The hint message show's "Token file does not exist..."
I don't known how to do with this.