### PR TITLE
make `gotype` return all errors

### DIFF
--- a/ale_linters/go/gotype.vim
+++ b/ale_linters/go/gotype.vim
@@ -6,7 +6,7 @@ function! ale_linters#go#gotype#GetCommand(buffer) abort
         return ''
     endif
 
-    return ale#path#BufferCdString(a:buffer) . ' gotype .'
+    return ale#path#BufferCdString(a:buffer) . ' gotype -e .'
 endfunction
 
 call ale#linter#Define('go', {

--- a/test/command_callback/test_gotype_command_callback.vader
+++ b/test/command_callback/test_gotype_command_callback.vader
@@ -7,7 +7,7 @@ After:
 
 Execute(The default gotype command should be correct):
   AssertLinter 'gotype',
-  \ ale#path#CdString(expand('%:p:h')) . ' gotype .'
+  \ ale#path#CdString(expand('%:p:h')) . ' gotype -e .'
 
 Execute(The gotype callback should ignore test files):
   call ale#test#SetFilename('bla_test.go')


### PR DESCRIPTION
When using `gotype` without the `-e` option, it will only output the first 10 errors. When working on a larger package that often means that those 10 errors are in other files then the one that you are currently working on which then seems to indicate that there are no errors.

By adding the `-e` flag, all errors will be returned and shown properly in the file that you are working on.