### PR TITLE
ruby: fix a typo in a comment

### DIFF
--- a/autoload/ale/ruby.vim
+++ b/autoload/ale/ruby.vim
@@ -1,7 +1,7 @@
 " Author: Eddie Lebow https://github.com/elebow
 " Description: Functions for integrating with Ruby tools
 
-" Find the nearest dir contining "app", "db", and "config", and assume it is
+" Find the nearest dir containing "app", "db", and "config", and assume it is
 " the root of a Rails app.
 function! ale#ruby#FindRailsRoot(buffer) abort
     for l:name in ['app', 'config', 'db']


### PR DESCRIPTION
I noticed this while working on something else
