### PR TITLE
Fix #2368 - Open vertical list to the right

### DIFF
--- a/autoload/ale/list.vim
+++ b/autoload/ale/list.vim
@@ -115,7 +115,7 @@ function! s:SetListsImpl(timer_id, buffer, loclist) abort
         let l:open_type = ''
 
         if ale#Var(a:buffer, 'list_vertical') == 1
-            let l:open_type = 'vert '
+            let l:open_type = 'vert rightbelow '
         endif
 
         if g:ale_set_quickfix


### PR DESCRIPTION
This was normal behavior before, and it also stops ale from stealing focus.

This will work properly even if the default behavior is to open to the right.