### PR TITLE
Elm: Support for elm-lsp

### DIFF
--- a/ale_linters/elm/elm_lsp.vim
+++ b/ale_linters/elm/elm_lsp.vim
@@ -1,0 +1,22 @@
+" Author: antew - https://github.com/antew
+" Description: LSP integration for elm, currently supports diagnostics (linting)
+
+call ale#Set('elm_lsp_executable', 'elm-lsp')
+call ale#Set('elm_lsp_use_global', get(g:, 'ale_use_global_executables', 0))
+
+function! elm_lsp#GetRootDir(buffer) abort
+    let l:elm_json = ale#path#FindNearestFile(a:buffer, 'elm.json')
+
+    return !empty(l:elm_json) ? fnamemodify(l:elm_json, ':p:h') : ''
+endfunction
+
+call ale#linter#Define('elm', {
+\   'name': 'elm_lsp',
+\   'lsp': 'stdio',
+\   'executable': {b -> ale#node#FindExecutable(b, 'elm_lsp', [
+\       'node_modules/.bin/elm-lsp',
+\   ])},
+\   'command': '%e --stdio',
+\   'project_root': function('elm_lsp#GetRootDir'),
+\   'language': 'elm'
+\})

--- a/doc/ale-elm.txt
+++ b/doc/ale-elm.txt
@@ -29,6 +29,24 @@ g:ale_elm_format_options                             *g:ale_elm_format_options*
   This variable can be set to pass additional options to elm-format.
 
 ===============================================================================
+elm-lsp                                                       *ale-elm-elm-lsp*
+
+g:ale_elm_lsp_executable                             *g:ale_elm_lsp_executable*
+                                                     *b:ale_elm_lsp_executable*
+  Type: |String|
+  Default: `'elm-lsp'`
+
+  See |ale-integrations-local-executables|
+
+
+g:ale_elm_lsp_use_global                             *g:ale_elm_lsp_use_global*
+                                                     *b:ale_elm_lsp_use_global*
+  Type: |Number|
+  Default: `get(g:, 'ale_use_global_executables', 0)`
+
+  See |ale-integrations-local-executables|
+
+===============================================================================
 elm-make                                                     *ale-elm-elm-make*
 
 g:ale_elm_make_executable                           *g:ale_elm_make_executable*

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -118,6 +118,7 @@ Notes:
   * `mix`!!
 * Elm
   * `elm-format`
+  * `elm-lsp`
   * `elm-make`
 * Erb
   * `erb`

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -122,6 +122,7 @@ ALE supports the following key features for linting:
       credo...............................|ale-elixir-credo|
     elm...................................|ale-elm-options|
       elm-format..........................|ale-elm-elm-format|
+      elm-lsp.............................|ale-elm-elm-lsp|
       elm-make............................|ale-elm-elm-make|
     erlang................................|ale-erlang-options|
       erlc................................|ale-erlang-erlc|
@@ -2260,6 +2261,7 @@ documented in additional help files.
     credo.................................|ale-elixir-credo|
   elm.....................................|ale-elm-options|
     elm-format............................|ale-elm-elm-format|
+    elm-lsp...............................|ale-elm-elm-lsp|
     elm-make..............................|ale-elm-elm-make|
   erlang..................................|ale-erlang-options|
     erlc..................................|ale-erlang-erlc|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -127,6 +127,7 @@ formatting.
   * [mix](https://hexdocs.pm/mix/Mix.html) :warning: :floppy_disk:
 * Elm
   * [elm-format](https://github.com/avh4/elm-format)
+  * [elm-lsp](https://github.com/antew/elm-lsp)
   * [elm-make](https://github.com/elm-lang/elm-make)
 * Erb
   * [erb](https://apidock.com/ruby/ERB)

--- a/test/command_callback/test_elm_lsp_command_callbacks.vader
+++ b/test/command_callback/test_elm_lsp_command_callbacks.vader
@@ -1,0 +1,29 @@
+Before:
+  call ale#assert#SetUpLinterTest('elm', 'elm_lsp')
+
+After:
+  call ale#assert#TearDownLinterTest()
+
+Execute(The default executable path should be correct):
+  call ale#test#SetFilename('../elm-test-files/newapp/src/Main.elm')
+
+  AssertLinter 'elm-lsp', ale#Escape('elm-lsp') . ' --stdio'
+
+Execute(The project root should be detected correctly):
+  AssertLSPProject ''
+
+  call ale#test#SetFilename('../elm-test-files/newapp/src/Main.elm')
+
+  AssertLSPProject ale#path#Simplify(g:dir . '/../elm-test-files/newapp')
+
+Execute(Should let users configure a global executable and override local paths):
+  call ale#test#SetFilename('../elm-test-files/newapp/src/Main.elm')
+
+  let g:ale_elm_lsp_executable = '/path/to/custom/elm-lsp'
+  let g:ale_elm_lsp_use_global = 1
+
+  AssertLinter '/path/to/custom/elm-lsp',
+  \ ale#Escape('/path/to/custom/elm-lsp') . ' --stdio'
+
+Execute(The language should be correct):
+  AssertLSPLanguage 'elm'


### PR DESCRIPTION
This adds support for [elm-lsp](https://www.npmjs.com/package/elm-lsp), making good on https://github.com/antew/vim-elm-analyse/issues/1 :)

The language server only supports diagnostics so far, but I'll be adding more soon.

Please let me know if anything looks odd, I am currently terrible at vimscript!