### PR TITLE
Add g:ale_disable_lsp and b:ale_disable_lsp to disable linters powered by LSP

### DIFF
--- a/autoload/ale.vim
+++ b/autoload/ale.vim
@@ -8,6 +8,7 @@ let g:ale_echo_msg_info_str = get(g:, 'ale_echo_msg_info_str', 'Info')
 let g:ale_echo_msg_warning_str = get(g:, 'ale_echo_msg_warning_str', 'Warning')
 " Ignoring linters, for disabling some, or ignoring LSP diagnostics.
 let g:ale_linters_ignore = get(g:, 'ale_linters_ignore', {})
+let g:ale_disable_lsp = get(g:, 'ale_disable_lsp', 0)
 
 let s:lint_timer = -1
 let s:getcmdwintype_exists = exists('*getcmdwintype')
@@ -90,8 +91,9 @@ function! s:Lint(buffer, should_lint_file, timer_id) abort
 
     " Apply ignore lists for linters only if needed.
     let l:ignore_config = ale#Var(a:buffer, 'linters_ignore')
+    let l:disable_lsp = ale#Var(a:buffer, 'disable_lsp')
     let l:linters = !empty(l:ignore_config)
-    \   ? ale#engine#ignore#Exclude(l:filetype, l:linters, l:ignore_config)
+    \   ? ale#engine#ignore#Exclude(l:filetype, l:linters, l:ignore_config, l:disable_lsp)
     \   : l:linters
 
     " Tell other sources that they can start checking the buffer now.

--- a/autoload/ale/engine/ignore.vim
+++ b/autoload/ale/engine/ignore.vim
@@ -22,7 +22,7 @@ function! ale#engine#ignore#GetList(filetype, config) abort
 endfunction
 
 " Given a List of linter descriptions, exclude the linters to be ignored.
-function! ale#engine#ignore#Exclude(filetype, all_linters, config) abort
+function! ale#engine#ignore#Exclude(filetype, all_linters, config, disable_lsp) abort
     let l:names_to_remove = ale#engine#ignore#GetList(a:filetype, a:config)
     let l:filtered_linters = []
 
@@ -36,6 +36,10 @@ function! ale#engine#ignore#Exclude(filetype, all_linters, config) abort
                 break
             endif
         endfor
+
+        if a:disable_lsp && has_key(l:linter, 'lsp') && l:linter.lsp isnot# ''
+            let l:should_include = 0
+        endif
 
         if l:should_include
             call add(l:filtered_linters, l:linter)

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -1587,6 +1587,15 @@ g:ale_windows_node_executable_path         *g:ale_windows_node_executable_path*
   setting.
 
 
+g:ale_disable_lsp                                            *g:ale_disable_lsp*
+                                                             *b:ale_disable_lsp*
+
+  Type: |Number|
+  Default: `0`
+
+  When this option is set to `1`, ALE ignores all linters powered by LSP.
+  Please see also |ale-lsp|.
+
 -------------------------------------------------------------------------------
 6.1. Highlights                                                *ale-highlights*
 

--- a/test/test_ignoring_linters.vader
+++ b/test/test_ignoring_linters.vader
@@ -30,6 +30,7 @@ Execute(Exclude should ignore some invalid values):
   \     {'name': 'linter3', 'aliases': []},
   \   ],
   \   'foo',
+  \   0,
   \ )
   AssertEqual
   \ [
@@ -44,6 +45,7 @@ Execute(Exclude should ignore some invalid values):
   \     {'name': 'linter2', 'aliases': ['alias1']},
   \     {'name': 'linter3', 'aliases': []},
   \   ],
+  \   0,
   \   0,
   \ )
   AssertEqual
@@ -60,6 +62,7 @@ Execute(Exclude should ignore some invalid values):
   \     {'name': 'linter3', 'aliases': []},
   \   ],
   \   v:null,
+  \   0,
   \ )
 
 Execute(Exclude should handle Lists):
@@ -75,6 +78,7 @@ Execute(Exclude should handle Lists):
   \     {'name': 'linter3', 'aliases': []},
   \   ],
   \   ['linter1', 'alias1'],
+  \   0,
   \ )
 
 Execute(Exclude should handle Dictionaries):
@@ -90,11 +94,51 @@ Execute(Exclude should handle Dictionaries):
   \     {'name': 'linter3', 'aliases': []},
   \   ],
   \   {'foo': ['linter1'], 'bar': ['alias1']},
+  \   0,
+  \ )
+
+Execute(Exclude should filter LSP linters when g:ale_disable_lsp is set to 1):
+  let g:ale_disable_lsp = 1
+  AssertEqual
+  \ [
+  \   {'name': 'linter1', 'aliases': [], 'lsp': ''},
+  \   {'name': 'linter2', 'aliases': []},
+  \ ],
+  \ ale#engine#ignore#Exclude(
+  \   'foo',
+  \   [
+  \       {'name': 'linter1', 'aliases': [], 'lsp': ''},
+  \       {'name': 'linter2', 'aliases': []},
+  \       {'name': 'linter3', 'aliases': [], 'lsp': 'stdio'},
+  \   ],
+  \   [],
+  \   1,
+  \ )
+
+Execute(Exclude should filter LSP linters when b:ale_disable_lsp is set to 1):
+  let b:ale_disable_lsp = 1
+  AssertEqual
+  \ [
+  \   {'name': 'linter1', 'aliases': [], 'lsp': ''},
+  \   {'name': 'linter2', 'aliases': []},
+  \ ],
+  \ ale#engine#ignore#Exclude(
+  \   'foo',
+  \   [
+  \       {'name': 'linter1', 'aliases': [], 'lsp': ''},
+  \       {'name': 'linter2', 'aliases': []},
+  \       {'name': 'linter3', 'aliases': [], 'lsp': 'stdio'},
+  \   ],
+  \   [],
+  \   1,
   \ )
 
 Before:
   Save g:ale_linters_ignore
   Save g:ale_buffer_info
+  Save g:ale_disable_lsp
+
+  let g:ale_disable_lsp = 0
 
   let g:linters = []
   let g:loclist = []
@@ -127,6 +171,7 @@ After:
   unlet! b:ale_linters_ignore
   unlet! b:ale_quitting
   unlet! b:ale_save_event_fired
+  unlet! b:ale_disable_lsp
   unlet! g:linters
   unlet! g:loclist
   unlet! g:lsp_message


### PR DESCRIPTION
<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!
-->

ALE provides some features using LSP. However, it makes conflicts when another LSP client is installed for better LSP integration. For example, two LSP server instances are spawned (one by ALE, and another by other LSP client).

So I added a new config variable `ale_disable_lsp` for avoiding the issue. When it is set to `1`, all LSP linters are ignored. The variable is set to `0` by default and it does not change default behavior. 