### PR TITLE
improve the lsp diagnostic message format

### DIFF
--- a/autoload/ale/lsp/response.vim
+++ b/autoload/ale/lsp/response.vim
@@ -27,14 +27,8 @@ function! ale#lsp#response#ReadDiagnostics(response) abort
 
     for l:diagnostic in a:response.params.diagnostics
         let l:severity = get(l:diagnostic, 'severity', 0)
-        " we want to preserve the line breaks for `detail` but replace with
-        " spaces for text
-        let l:diagnostic.detail = l:diagnostic.message
-        let l:diagnostic.text = substitute(l:diagnostic.message, "\n", ' ', 'g')
-        let l:diagnostic.text= l:diagnostic.message
-
         let l:loclist_item = {
-        \   'text': l:diagnostic.text,
+        \   'text': substitute(l:diagnostic.message, "\n", ' ', 'g'),
         \   'type': 'E',
         \   'lnum': l:diagnostic.range.start.line + 1,
         \   'col': l:diagnostic.range.start.character + 1,
@@ -69,14 +63,14 @@ function! ale#lsp#response#ReadDiagnostics(response) abort
             \   ':' . (val.location.range.start.character + 1) .
             \   ":\n\t" . val.message
             \})
-            let l:loclist_item.detail = l:diagnostic.detail . "\n" . join(l:related, "\n")
+            let l:loclist_item.detail = l:diagnostic.message . "\n" . join(l:related, "\n")
         endif
 
         if has_key(l:diagnostic, 'source')
             let l:loclist_item.detail = printf(
             \   '[%s] %s',
             \   l:diagnostic.source,
-            \   l:diagnostic.text
+            \   l:diagnostic.message
             \)
         endif
 

--- a/autoload/ale/lsp/response.vim
+++ b/autoload/ale/lsp/response.vim
@@ -28,7 +28,7 @@ function! ale#lsp#response#ReadDiagnostics(response) abort
     for l:diagnostic in a:response.params.diagnostics
         let l:severity = get(l:diagnostic, 'severity', 0)
         let l:loclist_item = {
-        \   'text': substitute(l:diagnostic.message, "\n", ' ', 'g'),
+        \   'text': substitute(l:diagnostic.message, '\(\r\n\|\n\|\r\)', ' ', 'g'),
         \   'type': 'E',
         \   'lnum': l:diagnostic.range.start.line + 1,
         \   'col': l:diagnostic.range.start.character + 1,

--- a/autoload/ale/lsp/response.vim
+++ b/autoload/ale/lsp/response.vim
@@ -31,6 +31,7 @@ function! ale#lsp#response#ReadDiagnostics(response) abort
         " spaces for text
         let l:diagnostic.detail = l:diagnostic.message
         let l:diagnostic.text = substitute(l:diagnostic.message, "\n", ' ', 'g')
+        let l:diagnostic.text= l:diagnostic.message
 
         let l:loclist_item = {
         \   'text': l:diagnostic.text,

--- a/autoload/ale/lsp/response.vim
+++ b/autoload/ale/lsp/response.vim
@@ -27,9 +27,13 @@ function! ale#lsp#response#ReadDiagnostics(response) abort
 
     for l:diagnostic in a:response.params.diagnostics
         let l:severity = get(l:diagnostic, 'severity', 0)
-        let l:diagnostic.message = substitute(l:diagnostic.message, "\n", ' ', 'g')
+        " we want to preserve the line breaks for `detail` but replace with
+        " spaces for text
+        let l:diagnostic.detail = l:diagnostic.message
+        let l:diagnostic.text = substitute(l:diagnostic.message, "\n", ' ', 'g')
+
         let l:loclist_item = {
-        \   'text': l:diagnostic.message,
+        \   'text': l:diagnostic.text,
         \   'type': 'E',
         \   'lnum': l:diagnostic.range.start.line + 1,
         \   'col': l:diagnostic.range.start.character + 1,
@@ -62,16 +66,16 @@ function! ale#lsp#response#ReadDiagnostics(response) abort
             \   ale#path#FromURI(val.location.uri) .
             \   ':' . (val.location.range.start.line + 1) .
             \   ':' . (val.location.range.start.character + 1) .
-            \   ":\n\t" . val.message
+            \   ":\n\t" . val.text
             \})
-            let l:loclist_item.detail = l:diagnostic.message . "\n" . join(l:related, "\n")
+            let l:loclist_item.detail = l:diagnostic.detail . "\n" . join(l:related, "\n")
         endif
 
         if has_key(l:diagnostic, 'source')
             let l:loclist_item.detail = printf(
             \   '[%s] %s',
             \   l:diagnostic.source,
-            \   l:diagnostic.message
+            \   l:diagnostic.text
             \)
         endif
 

--- a/autoload/ale/lsp/response.vim
+++ b/autoload/ale/lsp/response.vim
@@ -27,6 +27,7 @@ function! ale#lsp#response#ReadDiagnostics(response) abort
 
     for l:diagnostic in a:response.params.diagnostics
         let l:severity = get(l:diagnostic, 'severity', 0)
+        let l:diagnostic.message = substitute(l:diagnostic.message, "\n", ' ', 'g')
         let l:loclist_item = {
         \   'text': l:diagnostic.message,
         \   'type': 'E',

--- a/autoload/ale/lsp/response.vim
+++ b/autoload/ale/lsp/response.vim
@@ -66,7 +66,7 @@ function! ale#lsp#response#ReadDiagnostics(response) abort
             \   ale#path#FromURI(val.location.uri) .
             \   ':' . (val.location.range.start.line + 1) .
             \   ':' . (val.location.range.start.character + 1) .
-            \   ":\n\t" . val.text
+            \   ":\n\t" . val.message
             \})
             let l:loclist_item.detail = l:diagnostic.detail . "\n" . join(l:related, "\n")
         endif

--- a/test/lsp/test_read_lsp_diagnostics.vader
+++ b/test/lsp/test_read_lsp_diagnostics.vader
@@ -114,7 +114,7 @@ Execute(ale#lsp#response#ReadDiagnostics() should keep detail with line breaks b
   \   {
   \     'type': 'E',
   \     'text': 'cannot borrow `cap` as mutable more than once at a time  mutable borrow starts here in previous iteration of loop',
-  \     'detail': '[rustc] cannot borrow `cap` as mutable more than once at a time\n\nmutable borrow starts here in previous iteration of loop',
+  \     'detail': "[rustc] cannot borrow `cap` as mutable\r\nmore than once at a time\n\nmutable borrow starts here\rin previous iteration of loop",
   \     'lnum': 10,
   \     'col': 15,
   \     'end_lnum': 12,
@@ -124,7 +124,7 @@ Execute(ale#lsp#response#ReadDiagnostics() should keep detail with line breaks b
   \ ale#lsp#response#ReadDiagnostics({'params': {'uri': 'filename.ts', 'diagnostics': [
   \   {
   \     'range': Range(9, 14, 11, 22),
-  \     'message': 'cannot borrow `cap` as mutable more than once at a time\n\nmutable borrow starts here in previous iteration of loop',
+  \     'message': "cannot borrow `cap` as mutable\r\nmore than once at a time\n\nmutable borrow starts here\rin previous iteration of loop",
   \     'source': 'rustc',
   \   }
   \ ]}})

--- a/test/lsp/test_read_lsp_diagnostics.vader
+++ b/test/lsp/test_read_lsp_diagnostics.vader
@@ -109,6 +109,26 @@ Execute(ale#lsp#response#ReadDiagnostics() should include sources in detail):
   \   }
   \ ]}})
 
+Execute(ale#lsp#response#ReadDiagnostics() should keep detail with line breaks but replace with spaces in text):
+  AssertEqual [
+  \   {
+  \     'type': 'E',
+  \     'text': 'cannot borrow `cap` as mutable more than once at a time  mutable borrow starts here in previous iteration of loop',
+  \     'detail': '[rustc] cannot borrow `cap` as mutable more than once at a time\n\nmutable borrow starts here in previous iteration of loop',
+  \     'lnum': 10,
+  \     'col': 15,
+  \     'end_lnum': 12,
+  \     'end_col': 22,
+  \   }
+  \ ],
+  \ ale#lsp#response#ReadDiagnostics({'params': {'uri': 'filename.ts', 'diagnostics': [
+  \   {
+  \     'range': Range(9, 14, 11, 22),
+  \     'message': 'cannot borrow `cap` as mutable more than once at a time\n\nmutable borrow starts here in previous iteration of loop',
+  \     'source': 'rustc',
+  \   }
+  \ ]}})
+
 Execute(ale#lsp#response#ReadDiagnostics() should consider -1 to be a meaningless code):
   AssertEqual [
   \   {


### PR DESCRIPTION
Here I am trying to improve the LSP diagnostic message format via replacing the line breaks with spaces (see #2301). This fix will affect the message in the status line, virtual text and the `ALEDetail`. 

However, I don't think this is what we desire: now the `ALEDetail` no longer has the line breaks. I assume the virtual text region is somehow binded with the `ALEDetail`? Any input on it? 

Regards,