### PR TITLE
Let rust rls linter find the default rust toolchain automatically

### DIFF
--- a/ale_linters/rust/rls.vim
+++ b/ale_linters/rust/rls.vim
@@ -2,7 +2,7 @@
 " Description: A language server for Rust
 
 call ale#Set('rust_rls_executable', 'rls')
-call ale#Set('rust_rls_toolchain', 'nightly')
+call ale#Set('rust_rls_toolchain', '')
 call ale#Set('rust_rls_config', {})
 
 function! ale_linters#rust#rls#GetCommand(buffer) abort

--- a/doc/ale-rust.txt
+++ b/doc/ale-rust.txt
@@ -164,10 +164,14 @@ g:ale_rust_rls_executable                           *g:ale_rust_rls_executable*
 g:ale_rust_rls_toolchain                             *g:ale_rust_rls_toolchain*
                                                      *b:ale_rust_rls_toolchain*
   Type: |String|
-  Default: `'nightly'`
+  Default: `''`
 
   This option can be set to change the toolchain used for `rls`. Possible
-  values include `'nightly'`, `'beta'`, and `'stable'`.
+  values include `'nightly'`, `'beta'`, `'stable'`, and `''`. When using
+  option `''`, rls will automatically find the default toolchain set by
+  rustup. If you want to use `rls` from a specific toolchain version, you may
+  also use values like `'channel-yyyy-mm-dd-arch-target'` as long as
+  `'rls +{toolchain_name} -V'` runs correctly in your command line.
 
   The `rls` server will only be started once per executable.
 

--- a/test/command_callback/test_rust_rls_callbacks.vader
+++ b/test/command_callback/test_rust_rls_callbacks.vader
@@ -5,7 +5,7 @@ After:
   call ale#assert#TearDownLinterTest()
 
 Execute(The default executable path should be correct):
-  AssertLinter 'rls', ale#Escape('rls') . ' +' . ale#Escape('nightly')
+  AssertLinter 'rls', ale#Escape('rls')
 
 Execute(The toolchain should be configurable):
   let g:ale_rust_rls_toolchain = 'stable'


### PR DESCRIPTION
This patch comes from this [comment](https://github.com/w0rp/ale/issues/1877#issuecomment-482096001).

As `rls` and `clippy` are [not always available](https://rust-lang.github.io/rustup-components-history/index.html) for the latest nightly rust build, nightly rust users typically needs to specify another version of nightly rust in order to get `rls` working. The version string looks somewhat like `nightly-2019-03-05` instead of just `nightly`. Therefore, the default value of `g:ale_rust_rls_toolchain` `nightly` usually just doesn't work and the documentation also did not point out the use of customizable toolchain names.  In fact, `rls` actually allows users to omit the toolchain name so that it will automatically find the default toolchain set by `rustup`, and the linter actually supports this behavior but it was not reflected in the documentation. Therefore, setting the default value as `''` is more suitable for most cases. In addition, stable rust users also won't need to change this variable by hand, and rls linter can work out-of-the-box.

I have read `:help ale-dev`. This patch does not seem to need additional tests.