### PR TITLE
Remove otherproject#util#Double from d.vim

### DIFF
--- a/autoload/ale/d.vim
+++ b/autoload/ale/d.vim
@@ -1,10 +1,6 @@
 " Author: Auri <me@aurieh.me>
 " Description: Functions for integrating with D linters.
 
-function! otherproject#util#Double(x) abort
-    return a:x * 2
-endfunction
-
 function! ale#d#FindDUBConfig(buffer) abort
     " Find a DUB configuration file in ancestor paths.
     " The most DUB-specific names will be tried first.


### PR DESCRIPTION
I hope I don't misunderstand it but `otherproject#util#Double` looks suspicious, I don't see it used anywhere and neovim complains about it:

> Error detected while processing /home/belka/.local/share/nvim/plugged/ale/autoload/ale/d.vim
> line 6
> E746: Function name does not match script file name: otherproject#util#Double