### PR TITLE
Add floskell for Haskell formatting

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -190,6 +190,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['hack'],
 \       'description': 'Fix Hack files with hackfmt.',
 \   },
+\   'floskell': {
+\       'function': 'ale#fixers#floskell#Fix',
+\       'suggested_filetypes': ['haskell'],
+\       'description': 'Fix Haskell files with floskell.',
+\   },
 \   'hfmt': {
 \       'function': 'ale#fixers#hfmt#Fix',
 \       'suggested_filetypes': ['haskell'],

--- a/autoload/ale/fixers/floskell.vim
+++ b/autoload/ale/fixers/floskell.vim
@@ -1,0 +1,20 @@
+" Author: robertjlooby <robertjlooby@gmail.com>
+" Description: Integration of floskell with ALE.
+
+call ale#Set('haskell_floskell_executable', 'floskell')
+
+function! ale#fixers#floskell#GetExecutable(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'haskell_floskell_executable')
+
+    return ale#handlers#haskell_stack#EscapeExecutable(l:executable, 'floskell')
+endfunction
+
+function! ale#fixers#floskell#Fix(buffer) abort
+    let l:executable = ale#fixers#floskell#GetExecutable(a:buffer)
+
+    return {
+    \   'command': l:executable
+    \       . ' %t',
+    \   'read_temporary_file': 1,
+    \}
+endfunction

--- a/doc/ale-haskell.txt
+++ b/doc/ale-haskell.txt
@@ -13,6 +13,16 @@ g:ale_haskell_brittany_executable           *g:ale_haskell_brittany_executable*
   This variable can be changed to use a different executable for brittany.
 
 ===============================================================================
+floskell                                                 *ale-haskell-floskell*
+
+g:ale_haskell_floskell_executable           *g:ale_haskell_floskell_executable*
+                                            *b:ale_haskell_floskell_executable*
+  Type: |String|
+  Default: `'floskell'`
+
+  This variable can be changed to use a different executable for floskell.
+
+===============================================================================
 ghc                                                           *ale-haskell-ghc*
 
 g:ale_haskell_ghc_options                           *g:ale_haskell_ghc_options*

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -175,6 +175,7 @@ Notes:
 * Haskell
   * `brittany`
   * `cabal-ghc`
+  * `floskell`
   * `ghc`
   * `ghc-mod`
   * `hdevtools`

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -1958,6 +1958,7 @@ documented in additional help files.
     ember-template-lint...................|ale-handlebars-embertemplatelint|
   haskell.................................|ale-haskell-options|
     brittany..............................|ale-haskell-brittany|
+    floskell..............................|ale-haskell-floskell|
     ghc...................................|ale-haskell-ghc|
     ghc-mod...............................|ale-haskell-ghc-mod|
     cabal-ghc.............................|ale-haskell-cabal-ghc|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -184,6 +184,7 @@ formatting.
 * Haskell
   * [brittany](https://github.com/lspitzner/brittany)
   * [cabal-ghc](https://www.haskell.org/cabal/)
+  * [floskell](https://github.com/ennocramer/floskell)
   * [ghc](https://www.haskell.org/ghc/)
   * [ghc-mod](https://github.com/DanielG/ghc-mod)
   * [hdevtools](https://hackage.haskell.org/package/hdevtools)

--- a/test/fixers/test_floskell_fixer_callback.vader
+++ b/test/fixers/test_floskell_fixer_callback.vader
@@ -1,0 +1,23 @@
+Before:
+  Save g:ale_haskell_floskell_executable
+
+  " Use an invalid global executable, so we don't match it.
+  let g:ale_haskell_floskell_executable = 'xxxinvalid'
+
+  call ale#test#SetDirectory('/testplugin/test/fixers')
+
+After:
+  Restore
+
+  call ale#test#RestoreDirectory()
+
+Execute(The floskell callback should return the correct default values):
+  call ale#test#SetFilename('../haskell_files/testfile.hs')
+
+  AssertEqual
+  \ {
+  \   'read_temporary_file': 1,
+  \   'command': ale#Escape('xxxinvalid')
+  \     . ' %t',
+  \ },
+  \ ale#fixers#floskell#Fix(bufnr(''))


### PR DESCRIPTION
This adds a fixer for formatting Haskell files with [floskell](https://github.com/ennocramer/floskell).