### PR TITLE
fix 2434: use text field instead of the detail field for virtualtext

### DIFF
--- a/autoload/ale/virtualtext.vim
+++ b/autoload/ale/virtualtext.vim
@@ -81,7 +81,7 @@ function! ale#virtualtext#ShowCursorWarning(...) abort
     call ale#virtualtext#Clear()
 
     if !empty(l:loc)
-        let l:msg = get(l:loc, 'detail', l:loc.text)
+        let l:msg = get(l:loc, 'text', l:loc.text)
         let l:hl_group = 'ALEVirtualTextInfo'
         let l:type = get(l:loc, 'type', 'E')
 

--- a/autoload/ale/virtualtext.vim
+++ b/autoload/ale/virtualtext.vim
@@ -81,7 +81,7 @@ function! ale#virtualtext#ShowCursorWarning(...) abort
     call ale#virtualtext#Clear()
 
     if !empty(l:loc)
-        let l:msg = get(l:loc, 'text', l:loc.text)
+        let l:msg = l:loc.text
         let l:hl_group = 'ALEVirtualTextInfo'
         let l:type = get(l:loc, 'type', 'E')
 


### PR DESCRIPTION
We actually want to use `text` instead of `detail` in virtualtext because the formal handles the line breaks nicely. For detail please see #2434 