### PR TITLE
Better phpstan default configuration

### DIFF
--- a/ale_linters/php/phpstan.vim
+++ b/ale_linters/php/phpstan.vim
@@ -13,8 +13,9 @@ function! ale_linters#php#phpstan#GetCommand(buffer, version) abort
     \   : ''
 
     let l:level =  ale#Var(a:buffer, 'php_phpstan_level')
+    let l:config_file_exists = ale#path#FindNearestFile(a:buffer, 'phpstan.neon')
 
-    if empty(l:level) && !filereadable('phpstan.neon')
+    if empty(l:level) && empty(l:config_file_exists)
         " if no configuration file is found, then use 4 as a default level
         let l:level = '4'
     endif

--- a/ale_linters/php/phpstan.vim
+++ b/ale_linters/php/phpstan.vim
@@ -13,10 +13,12 @@ function! ale_linters#php#phpstan#GetCommand(buffer, version) abort
     \   : ''
 
     let l:level =  ale#Var(a:buffer, 'php_phpstan_level')
+
     if empty(l:level) && !filereadable('phpstan.neon')
         " if no configuration file is found, then use 4 as a default level
         let l:level = '4'
     endif
+
     let l:level_option = !empty(l:level)
     \   ? ' -l ' . l:level
     \   : ''

--- a/test/command_callback/test_phpstan_command_callbacks.vader
+++ b/test/command_callback/test_phpstan_command_callbacks.vader
@@ -1,34 +1,66 @@
 Before:
+  call delete('./phpstan.neon')
   call ale#assert#SetUpLinterTest('php', 'phpstan')
 
   GivenCommandOutput ['0.10.2']
 
 After:
+  call delete('./phpstan.neon')
   call ale#assert#TearDownLinterTest()
 
 Execute(Custom executables should be used for the executable and command):
   let g:ale_php_phpstan_executable = 'phpstan_test'
 
   AssertLinter 'phpstan_test',
-  \ ale#Escape('phpstan_test') . ' analyze -l4 --errorFormat raw %s'
+  \ ale#Escape('phpstan_test') . ' analyze --no-progress --errorFormat raw -l 4 %s'
 
 Execute(project with level set to 3):
   call ale#test#SetFilename('phpstan-test-files/foo/test.php')
   let g:ale_php_phpstan_level = 3
 
   AssertLinter 'phpstan',
-  \ ale#Escape('phpstan') . ' analyze -l3 --errorFormat raw %s'
+  \ ale#Escape('phpstan') . ' analyze --no-progress --errorFormat raw -l 3 %s'
 
 Execute(Custom phpstan configuration file):
   let g:ale_php_phpstan_configuration = 'phpstan_config'
 
   AssertLinter 'phpstan',
-  \ ale#Escape('phpstan') . ' analyze -l4 --errorFormat raw -c phpstan_config %s'
+  \ ale#Escape('phpstan') . ' analyze --no-progress --errorFormat raw -c phpstan_config -l 4 %s'
 
 Execute(Choose the right format for error format param):
   GivenCommandOutput ['0.10.3']
 
   AssertLinter 'phpstan', [
   \ ale#Escape('phpstan') . ' --version',
-  \ ale#Escape('phpstan') . ' analyze -l4 --error-format raw %s'
+  \ ale#Escape('phpstan') . ' analyze --no-progress --error-format raw -l 4 %s'
+  \ ]
+
+Execute(Configuration file exists in current directory):
+  call writefile(['parameters:', '  level: 7'], './phpstan.neon')
+  let g:ale_php_phpstan_level = ''
+  let g:ale_php_phpstan_configuration = ''
+
+  AssertLinter 'phpstan', [
+  \ ale#Escape('phpstan') . ' --version',
+  \ ale#Escape('phpstan') . ' analyze --no-progress --errorFormat raw %s'
+  \ ]
+
+Execute(Configuration file exists in current directory, but force phpstan level):
+  call writefile(['parameters:', '  level: 7'], './phpstan.neon')
+  let g:ale_php_phpstan_configuration = ''
+  let g:ale_php_phpstan_level = '7'
+
+  AssertLinter 'phpstan', [
+  \ ale#Escape('phpstan') . ' --version',
+  \ ale#Escape('phpstan') . ' analyze --no-progress --errorFormat raw -l 7 %s'
+  \ ]
+
+Execute(Configuration file exists in current directory, but force phpstan configuration):
+  call writefile(['parameters:', '  level: 7'], './phpstan.neon')
+  let g:ale_php_phpstan_level = ''
+  let g:ale_php_phpstan_configuration = 'phpstan.custom.neon'
+
+  AssertLinter 'phpstan', [
+  \ ale#Escape('phpstan') . ' --version',
+  \ ale#Escape('phpstan') . ' analyze --no-progress --errorFormat raw -c phpstan.custom.neon %s'
   \ ]

--- a/test/handler/test_phpstan_handler.vader
+++ b/test/handler/test_phpstan_handler.vader
@@ -14,7 +14,7 @@ Execute(Output without errors should be parsed correctly):
 
   AssertEqual
   \ [],
-  \ ale_linters#php#phpstan#Handle(bufnr(''), [" 1/1 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%"])
+  \ ale_linters#php#phpstan#Handle(bufnr(''), [])
 
 Execute(Output with some errors should be parsed correctly):
   call ale#test#SetFilename('phpstan-test-files/foo/test.php')
@@ -24,21 +24,20 @@ Execute(Output with some errors should be parsed correctly):
   \   {
   \     'lnum': 9,
   \     'text': 'Call to method format() on an unknown class DateTimeImutable.',
-  \     'type': 'W'
+  \     'type': 'E'
   \   },
   \   {
   \     'lnum': 16,
   \     'text': 'Sample message.',
-  \     'type': 'W'
+  \     'type': 'E'
   \   },
   \   {
   \     'lnum': 192,
   \     'text': 'Invalid command testCommand.',
-  \     'type': 'W'
+  \     'type': 'E'
   \   }
   \ ],
   \ ale_linters#php#phpstan#Handle(bufnr(''), [
-  \   ' 1/1 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%',
   \   'phpstan-test-files/foo/test.php:9:Call to method format() on an unknown class DateTimeImutable.',
   \   'phpstan-test-files/foo/test.php:16:Sample message.',
   \   'phpstan-test-files/foo/test.php:192:Invalid command testCommand.',
@@ -52,11 +51,10 @@ Execute(Output should be parsed correctly with Windows paths):
   \   {
   \     'lnum': 9,
   \     'text': 'Access to an undefined property Test::$var.',
-  \     'type': 'W'
+  \     'type': 'E'
   \   }
   \ ],
   \ ale_linters#php#phpstan#Handle(bufnr(''), [
-  \   ' 1/1 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%',
   \   'D:\phpstan-test-files\foo\test.php:9:Access to an undefined property Test::$var.',
   \])
 
@@ -68,10 +66,9 @@ Execute(Output for .inc files should be parsed correctly):
   \   {
   \     'lnum': 9,
   \     'text': 'Access to an undefined property Test::$var.',
-  \     'type': 'W'
+  \     'type': 'E'
   \   }
   \ ],
   \ ale_linters#php#phpstan#Handle(bufnr(''), [
-  \   ' 1/1 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%',
   \   '/phpstan-test-files/foo/test.inc:9:Access to an undefined property Test::$var.',
   \])


### PR DESCRIPTION
- If a config file is found, then do not set the default level to `4`, the level should be in the configuration file (except if you force it of course).
- Mark phpstan error as error, not warning, as phpstan does not have warning, only errors.
- Use the `--no-progress` parameter

Thank you !