### PR TITLE
Add option to show msg id when pylint is used

### DIFF
--- a/ale_linters/python/pylint.vim
+++ b/ale_linters/python/pylint.vim
@@ -6,6 +6,7 @@ call ale#Set('python_pylint_options', '')
 call ale#Set('python_pylint_use_global', get(g:, 'ale_use_global_executables', 0))
 call ale#Set('python_pylint_change_directory', 1)
 call ale#Set('python_pylint_auto_pipenv', 0)
+call ale#Set('python_pylint_use_msg_id', 0)
 
 function! ale_linters#python#pylint#GetExecutable(buffer) abort
     if (ale#Var(a:buffer, 'python_auto_pipenv') || ale#Var(a:buffer, 'python_pylint_auto_pipenv'))
@@ -64,11 +65,17 @@ function! ale_linters#python#pylint#Handle(buffer, lines) abort
             continue
         endif
 
+        if ale#Var(a:buffer, 'python_pylint_use_msg_id') is# 1
+            let l:code_out = l:code
+        else
+            let l:code_out = l:match[4]
+        endif
+
         call add(l:output, {
         \   'lnum': l:match[1] + 0,
         \   'col': l:match[2] + 1,
         \   'text': l:match[5],
-        \   'code': l:match[4],
+        \   'code': l:code_out,
         \   'type': l:code[:0] is# 'E' ? 'E' : 'W',
         \})
     endfor

--- a/doc/ale-python.txt
+++ b/doc/ale-python.txt
@@ -580,6 +580,14 @@ g:ale_python_pylint_auto_pipenv               *g:ale_python_pylint_auto_pipenv*
   if true. This is overridden by a manually-set executable.
 
 
+g:ale_python_pylint_use_msg_id                 *g:ale_python_pylint_use_msg_id*
+                                               *b:ale_python_pylint_use_msg_id*
+  Type: |Number|
+  Default: `0`
+
+  Use message for output (e.g. I0011) instead of symbolic name of the message
+  (e.g. locally-disabled).
+
 ===============================================================================
 pyls                                                          *ale-python-pyls*
 

--- a/test/handler/test_pylint_handler.vader
+++ b/test/handler/test_pylint_handler.vader
@@ -113,3 +113,23 @@ Execute(The pylint handler should parse Windows filenames):
   \   '------------------------------------------------------------------',
   \   'Your code has been rated at 5.83/10 (previous run: 5.83/10, +0.00)',
   \ ])
+
+Execute(Use msg_id):
+  let g:ale_python_pylint_use_msg_id = 1
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 13,
+  \     'col': 6,
+  \     'text': 'Undefined variable ''x''',
+  \     'code': 'E0602',
+  \     'type': 'E',
+  \   },
+  \ ],
+  \ ale_linters#python#pylint#Handle(bufnr(''), [
+  \   '************* Module test',
+  \   'D:\acm\github\vim\tools\test.py:13:5: E0602 (undefined-variable) Undefined variable ''x''',
+  \   '',
+  \   '------------------------------------------------------------------',
+  \   'Your code has been rated at 5.83/10 (previous run: 5.83/10, +0.00)',
+  \ ])


### PR DESCRIPTION
With this change, `let g:ale_python_pylint_use_msg_id = 1` can be used to tweak the output of pylint.

This would allow you to show message id instead of human-friendly format (See #852 for discussion).

I've never written vimscript before and basically have no idea what I'm doing, so couldn't write test.
I'd appreciate it if someone can add a test for this.
