### PR TITLE
Add g:ale_sh_shellcheck_change_directory

### DIFF
--- a/ale_linters/sh/shellcheck.vim
+++ b/ale_linters/sh/shellcheck.vim
@@ -10,6 +10,7 @@ call ale#Set('sh_shellcheck_exclusions', get(g:, 'ale_linters_sh_shellcheck_excl
 call ale#Set('sh_shellcheck_executable', 'shellcheck')
 call ale#Set('sh_shellcheck_dialect', 'auto')
 call ale#Set('sh_shellcheck_options', '')
+call ale#Set('sh_shellcheck_change_directory', 1)
 
 function! ale_linters#sh#shellcheck#GetDialectArgument(buffer) abort
     let l:shell_type = ale#handlers#sh#GetShellType(a:buffer)
@@ -40,12 +41,15 @@ function! ale_linters#sh#shellcheck#GetCommand(buffer, version) abort
     let l:exclude_option = ale#Var(a:buffer, 'sh_shellcheck_exclusions')
     let l:dialect = ale#Var(a:buffer, 'sh_shellcheck_dialect')
     let l:external_option = ale#semver#GTE(a:version, [0, 4, 0]) ? ' -x' : ''
+    let l:cd_string = ale#Var(a:buffer, 'sh_shellcheck_change_directory')
+    \   ? ale#path#BufferCdString(a:buffer)
+    \   : ''
 
     if l:dialect is# 'auto'
         let l:dialect = ale_linters#sh#shellcheck#GetDialectArgument(a:buffer)
     endif
 
-    return ale#path#BufferCdString(a:buffer)
+    return l:cd_string
     \   . '%e'
     \   . (!empty(l:dialect) ? ' -s ' . l:dialect : '')
     \   . (!empty(l:options) ? ' ' . l:options : '')

--- a/doc/ale-sh.txt
+++ b/doc/ale-sh.txt
@@ -62,6 +62,18 @@ g:ale_sh_shellcheck_options                       *g:ale_sh_shellcheck_options*
 <
 
 
+g:ale_sh_shellcheck_change_directory     *g:ale_sh_shellcheck_change_directory*
+                                         *b:ale_sh_shellcheck_change_directory*
+  Type: |Number|
+  Default: `1`
+
+  If set to `1`, ALE will switch to the directory the shell file being
+  checked with `shellcheck` is in before checking it. This helps `shellcheck`
+  determine the path to sourced files more easily. This option can be turned
+  off if you want to control the directory `shellcheck` is executed from
+  yourself.
+
+
 g:ale_sh_shellcheck_dialect                       *g:ale_sh_shellcheck_dialect*
                                                   *b:ale_sh_shellcheck_dialect*
   Type: |String|

--- a/test/command_callback/test_shellcheck_command_callback.vader
+++ b/test/command_callback/test_shellcheck_command_callback.vader
@@ -14,6 +14,11 @@ After:
 Execute(The default shellcheck command should be correct):
   AssertLinter 'shellcheck', b:prefix . ale#Escape('shellcheck') . b:suffix
 
+Execute(The option disabling changing directories should work):
+  let g:ale_sh_shellcheck_change_directory = 0
+
+  AssertLinter 'shellcheck', ale#Escape('shellcheck') . b:suffix
+
 Execute(The shellcheck command should accept options):
   let b:ale_sh_shellcheck_options = '--foobar'
 


### PR DESCRIPTION
This change adds a new `g:ale_sh_shellcheck_change_directory` option to control whether or not to change directory to where the source is located before running `shellcheck`. It defaults to `1`, identical to the other linter directory-related options (I took heavy direction from the Python linters here) and so preserves the current behavior of ALE.

This is to help ShellCheck users that have a larger source base with sub-directories and CI that prefers to run from the root of a repository. As ShellCheck determines the relative directory in the `shellcheck source=path/to/src.sh` to be relative to the current working directory, it's hard to to have a value that satisfies both a *vim/ALE and a Makefile/TravisCI setup. The option here can be used as a first step to harmonize these two cases while any future features/changes in ShellCheck develop (see koalaman/shellcheck#769 and koalaman/shellcheck#539 for more context).

---

Thanks so much for your hard work on ALE. I know I'm not alone, and I know maintainers don't hear this nearly often enough, but tools like this really make a huge difference in daily developer life. ALE has made a massive difference for me and how I work, so thank you! 🍺 