### PR TITLE
Add support for Vim's tagstack to ALEGoToDefinition

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM tweekmonster/vim-testbed:latest
 
 RUN install_vim -tag v8.0.0027 -build \
-                -tag v8.1.0204 -build \
+                -tag v8.1.0519 -build \
                 -tag neovim:v0.2.0 -build \
                 -tag neovim:v0.3.0 -build
 

--- a/autoload/ale/definition.vim
+++ b/autoload/ale/definition.vim
@@ -3,6 +3,9 @@
 
 let s:go_to_definition_map = {}
 
+" Enable automatic updates of the tagstack
+let g:ale_update_tagstack = get(g:, 'ale_update_tagstack', 1)
+
 " Used to get the definition map in tests.
 function! ale#definition#GetMap() abort
     return deepcopy(s:go_to_definition_map)
@@ -17,6 +20,18 @@ function! ale#definition#ClearLSPData() abort
     let s:go_to_definition_map = {}
 endfunction
 
+function! ale#definition#UpdateTagStack() abort
+    let l:should_update_tagstack = exists('*gettagstack') && exists('*settagstack') && g:ale_update_tagstack
+
+    if l:should_update_tagstack
+        let l:from = [bufnr('%'), line('.'), col('.'), 0]
+        let l:tagname = expand('<cword>')
+        let l:winid = win_getid()
+        call settagstack(l:winid, {'items': [{'from': l:from, 'tagname': l:tagname}]}, 'a')
+        call settagstack(l:winid, {'curidx': len(gettagstack(l:winid)['items']) + 1})
+    endif
+endfunction
+
 function! ale#definition#HandleTSServerResponse(conn_id, response) abort
     if get(a:response, 'command', '') is# 'definition'
     \&& has_key(s:go_to_definition_map, a:response.request_seq)
@@ -27,6 +42,7 @@ function! ale#definition#HandleTSServerResponse(conn_id, response) abort
             let l:line = a:response.body[0].start.line
             let l:column = a:response.body[0].start.offset
 
+            call ale#definition#UpdateTagStack()
             call ale#util#Open(l:filename, l:line, l:column, l:options)
         endif
     endif
@@ -51,6 +67,7 @@ function! ale#definition#HandleLSPResponse(conn_id, response) abort
             let l:line = l:item.range.start.line + 1
             let l:column = l:item.range.start.character + 1
 
+            call ale#definition#UpdateTagStack()
             call ale#util#Open(l:filename, l:line, l:column, l:options)
             break
         endfor

--- a/autoload/ale/definition.vim
+++ b/autoload/ale/definition.vim
@@ -24,10 +24,12 @@ function! ale#definition#UpdateTagStack() abort
     let l:should_update_tagstack = exists('*gettagstack') && exists('*settagstack') && g:ale_update_tagstack
 
     if l:should_update_tagstack
-        let l:from = [bufnr('%'), line('.'), col('.'), 0]
+        " Grab the old location (to jump back to) and the word under the
+        " cursor (as a label for the tagstack)
+        let l:old_location = [bufnr('%'), line('.'), col('.'), 0]
         let l:tagname = expand('<cword>')
         let l:winid = win_getid()
-        call settagstack(l:winid, {'items': [{'from': l:from, 'tagname': l:tagname}]}, 'a')
+        call settagstack(l:winid, {'items': [{'from': l:old_location, 'tagname': l:tagname}]}, 'a')
         call settagstack(l:winid, {'curidx': len(gettagstack(l:winid)['items']) + 1})
     endif
 endfunction

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -371,6 +371,9 @@ information returned by LSP servers. The following commands are supported:
 |ALEGoToDefinitionInSplit| - The same, but in a new split.
 |ALEGoToDefinitionInVSplit| - The same, but in a new vertical split.
 
+ALE will update Vim's |tagstack| automatically unless |g:ale_update_tagstack| is
+set to `0`.
+
 -------------------------------------------------------------------------------
 5.3 Go To Type Definition                           *ale-go-to-type-definition*
 
@@ -1492,6 +1495,14 @@ g:ale_sign_warning                                         *g:ale_sign_warning*
   Default: `'--'`
 
   The sign for warnings in the sign gutter.
+
+
+g:ale_update_tagstack                                   *g:ale_update_tagstack*
+                                                        *b:ale_update_tagstack*
+ Type: |Number|
+ Default: `1`
+
+ This option can be set to disable updating Vim's |tagstack| automatically.
 
 
 g:ale_type_map                                                 *g:ale_type_map*

--- a/test/test_go_to_definition.vader
+++ b/test/test_go_to_definition.vader
@@ -78,6 +78,15 @@ After:
 Execute(Other messages for the tsserver handler should be ignored):
   call ale#definition#HandleTSServerResponse(1, {'command': 'foo'})
 
+Execute(Tagstack should be incremented if supported):
+  if exists('*gettagstack') && exists('*settagstack')
+    let original_stack_depth = gettagstack().length
+  endif
+  call ale#definition#UpdateTagStack()
+  if exists('*gettagstack') && exists('*settagstack')
+    AssertEqual original_stack_depth + 1, gettagstack().length
+  endif
+
 Execute(Failed definition responses should be handled correctly):
   call ale#definition#SetMap({3: {'open_in': 'current-buffer'}})
   call ale#definition#HandleTSServerResponse(


### PR DESCRIPTION
Fixes #1236.

I added tests - but to be fair, this feature won't work on versions of Vim earlier than [8.1.0519](https://github.com/vim/vim/commit/f49cc60aa802862c595ff619dccc11271633a94b) and the test automation script doesn't test on anything that recent.

The feature is designed to degrade gracefully; and I'm open to suggestions on how to best clarify the version requirement in the docs.