### PR TITLE
Add XO as a linter/fixer for TypeScript files

### DIFF
--- a/ale_linters/typescript/xo.vim
+++ b/ale_linters/typescript/xo.vim
@@ -11,7 +11,7 @@ endfunction
 function! ale_linters#typescript#xo#GetCommand(buffer) abort
     return ale#Escape(ale_linters#typescript#xo#GetExecutable(a:buffer))
     \   . ale#Pad(ale#Var(a:buffer, 'typescript_xo_options'))
-    \   . ale#Pad('--reporter unix --stdin --stdin-filename %s')
+    \   . ' --reporter unix --stdin --stdin-filename %s'
 endfunction
 
 " xo uses eslint and the output format is the same

--- a/ale_linters/typescript/xo.vim
+++ b/ale_linters/typescript/xo.vim
@@ -1,0 +1,23 @@
+call ale#Set('typescript_xo_executable', 'xo')
+call ale#Set('typescript_xo_use_global', get(g:, 'ale_use_global_executables', 0))
+call ale#Set('typescript_xo_options', '')
+
+function! ale_linters#typescript#xo#GetExecutable(buffer) abort
+    return ale#node#FindExecutable(a:buffer, 'typescript_xo', [
+    \   'node_modules/.bin/xo',
+    \])
+endfunction
+
+function! ale_linters#typescript#xo#GetCommand(buffer) abort
+    return ale#Escape(ale_linters#typescript#xo#GetExecutable(a:buffer))
+    \   . ' ' . ale#Var(a:buffer, 'typescript_xo_options')
+    \   . ' --reporter unix --stdin --stdin-filename %s'
+endfunction
+
+" xo uses eslint and the output format is the same
+call ale#linter#Define('typescript', {
+\   'name': 'xo',
+\   'executable': function('ale_linters#typescript#xo#GetExecutable'),
+\   'command': function('ale_linters#typescript#xo#GetCommand'),
+\   'callback': 'ale#handlers#eslint#Handle',
+\})

--- a/ale_linters/typescript/xo.vim
+++ b/ale_linters/typescript/xo.vim
@@ -10,8 +10,8 @@ endfunction
 
 function! ale_linters#typescript#xo#GetCommand(buffer) abort
     return ale#Escape(ale_linters#typescript#xo#GetExecutable(a:buffer))
-    \   . ' ' . ale#Var(a:buffer, 'typescript_xo_options')
-    \   . ' --reporter unix --stdin --stdin-filename %s'
+    \   . ale#Pad(ale#Var(a:buffer, 'typescript_xo_options'))
+    \   . ale#Pad('--reporter unix --stdin --stdin-filename %s')
 endfunction
 
 " xo uses eslint and the output format is the same

--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -252,8 +252,8 @@ let s:default_registry = {
 \   },
 \   'xo': {
 \       'function': 'ale#fixers#xo#Fix',
-\       'suggested_filetypes': ['javascript'],
-\       'description': 'Fix JavaScript files using xo --fix.',
+\       'suggested_filetypes': ['javascript', 'typescript'],
+\       'description': 'Fix JavaScript/TypeScript files using xo --fix.',
 \   },
 \   'qmlfmt': {
 \       'function': 'ale#fixers#qmlfmt#Fix',

--- a/test/command_callback/test_xo_command_callback.vader
+++ b/test/command_callback/test_xo_command_callback.vader
@@ -1,0 +1,20 @@
+Before:
+  call ale#assert#SetUpLinterTest('typescript', 'xo')
+  call ale#test#SetFilename('testfile.ts')
+  unlet! b:executable
+
+After:
+  call ale#assert#TearDownLinterTest()
+
+Execute(The XO executable should be called):
+  AssertLinter 'xo', ale#Escape('xo') . ' --reporter unix --stdin --stdin-filename %s'
+
+Execute(The XO executable should be configurable):
+  let b:ale_typescript_xo_executable = 'foobar'
+
+  AssertLinter 'foobar', ale#Escape('foobar') . ' --reporter unix --stdin --stdin-filename %s'
+
+Execute(The XO options should be configurable):
+  let b:ale_typescript_xo_options = '--wat'
+
+  AssertLinter 'xo', ale#Escape('xo') . ' --wat --reporter unix --stdin --stdin-filename %s'


### PR DESCRIPTION
Replicated from [ale_linters/javascript/xo.vim](https://github.com/w0rp/ale/blob/master/ale_linters/javascript/xo.vim)