### PR TITLE
Include plugin description in local help line

### DIFF
--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -1,4 +1,4 @@
-*ale.txt*  For Vim version 8.0.
+*ale.txt*	Plugin to lint and fix files asynchronously
 *ale*
 
 ALE - Asynchronous Lint Engine


### PR DESCRIPTION
The recommended format for _vim's internal help files_ is "&lt;tag&gt; &lt;for vim version&gt; &lt;last change&gt;", (see `:help help-writing` but this format is not parsed the same way for plugins. For plugins the recommended format includes a description of the plugin such as "&lt;tag&gt; &lt;description&gt;". See `:help write-local-help` for the different template.