### PR TITLE
Add phpstan autoload option

### DIFF
--- a/ale_linters/php/phpstan.vim
+++ b/ale_linters/php/phpstan.vim
@@ -5,11 +5,17 @@
 let g:ale_php_phpstan_executable = get(g:, 'ale_php_phpstan_executable', 'phpstan')
 let g:ale_php_phpstan_level = get(g:, 'ale_php_phpstan_level', '')
 let g:ale_php_phpstan_configuration = get(g:, 'ale_php_phpstan_configuration', '')
+let g:ale_php_phpstan_autoload = get(g:, 'ale_php_phpstan_autoload', '')
 
 function! ale_linters#php#phpstan#GetCommand(buffer, version) abort
     let l:configuration = ale#Var(a:buffer, 'php_phpstan_configuration')
     let l:configuration_option = !empty(l:configuration)
     \   ? ' -c ' . ale#Escape(l:configuration)
+    \   : ''
+
+    let l:autoload = ale#Var(a:buffer, 'php_phpstan_autoload')
+    let l:autoload_option = !empty(l:autoload)
+    \   ? ' -a ' . ale#Escape(l:autoload)
     \   : ''
 
     let l:level =  ale#Var(a:buffer, 'php_phpstan_level')
@@ -31,6 +37,7 @@ function! ale_linters#php#phpstan#GetCommand(buffer, version) abort
     return '%e analyze --no-progress'
     \   . l:error_format
     \   . l:configuration_option
+    \   . l:autoload_option
     \   . l:level_option
     \   . ' %s'
 endfunction

--- a/doc/ale-php.txt
+++ b/doc/ale-php.txt
@@ -171,6 +171,14 @@ g:ale_php_phpstan_configuration               *g:ale_php_phpstan_configuration*
   This variable sets path to phpstan configuration file.
 
 
+g:ale_php_phpstan_autoload                         *g:ale_php_phpstan_autoload*
+                                                   *b:ale_php_phpstan_autoload*
+  Type: |String|
+  Default: `''`
+
+  This variable sets path to phpstan autoload file.
+
+
 ===============================================================================
 psalm                                                           *ale-php-psalm*
 

--- a/test/command_callback/test_phpstan_command_callbacks.vader
+++ b/test/command_callback/test_phpstan_command_callbacks.vader
@@ -64,3 +64,9 @@ Execute(Configuration file exists in current directory, but force phpstan config
   \ ale#Escape('phpstan') . ' --version',
   \ ale#Escape('phpstan') . ' analyze --no-progress --errorFormat raw -c ' . ale#Escape('phpstan.custom.neon') . ' %s'
   \ ]
+
+Execute(Autoload parameter is added to the command):
+  let g:ale_php_phpstan_autoload = 'autoload.php'
+
+  AssertLinter 'phpstan',
+  \ ale#Escape('phpstan') . ' analyze --no-progress --errorFormat raw -a ' . ale#Escape('autoload.php') . ' -l ' . ale#Escape('4') . ' %s'


### PR DESCRIPTION
This PR adds the `-a` option to ale's phpstan call. I used to `let g:ale_php_phpstan_configuration = 'phpstan.neon -a autoload.php'`, but that was broken recently in commit 5f64f8dc5799d9ad93544d24fb780428cd07dbbe due to option escaping. So I just added this option and it works for me.

I could probably write a simple test to verify that the option is used, but not sure if it's necessary. What do you think?