### PR TITLE
Fall back to vim's tags in ALEGoToDefinition

### DIFF
--- a/autoload/ale/definition.vim
+++ b/autoload/ale/definition.vim
@@ -137,8 +137,13 @@ function! ale#definition#GoTo(options) abort
     for l:linter in ale#linter#Get(&filetype)
         if !empty(l:linter.lsp)
             call s:GoToLSPDefinition(l:linter, a:options, 'definition')
+
+            return
         endif
     endfor
+
+    " Fall back to vim's tags
+    call ale#util#Tag(a:options)
 endfunction
 
 function! ale#definition#GoToType(options) abort

--- a/autoload/ale/util.vim
+++ b/autoload/ale/util.vim
@@ -114,6 +114,30 @@ function! ale#util#Open(filename, line, column, options) abort
     normal! zz
 endfunction
 
+" Jump to tag under cursor (using CTRL-]) respecting options['open_in']
+" (see above).
+function! ale#util#Tag(options) abort
+    let l:open_in = get(a:options, 'open_in', 'current-buffer')
+
+    if l:open_in is# 'tab'
+        call ale#util#Execute('tab split')
+    elseif l:open_in is# 'horizontal-split'
+        call ale#util#Execute('split')
+    elseif l:open_in is# 'vertical-split'
+        call ale#util#Execute('vsplit')
+    endif
+
+    try
+        call ale#util#Execute("normal! \<c-]>")
+    catch
+        if l:open_in isnot# 'current-buffer'
+            call ale#util#Execute('close')
+        endif
+
+        execute 'echohl ErrorMsg | echomsg v:exception | echohl None'
+    endtry
+endfunction
+
 let g:ale#util#error_priority = 5
 let g:ale#util#warning_priority = 4
 let g:ale#util#info_priority = 3

--- a/test/script/check-supported-tools-tables
+++ b/test/script/check-supported-tools-tables
@@ -42,7 +42,7 @@ done < <(
 exit_code=0
 
 # Sort the tools ignoring case, and complain when things are out of order.
-sort -f -k1,2 "$doc_file" -o "$doc_sorted_file"
+LC_ALL=en_US.UTF-8 sort -f -k1,2 "$doc_file" -o "$doc_sorted_file"
 
 diff -U0 "$doc_sorted_file" "$doc_file" || exit_code=$?
 


### PR DESCRIPTION
This makes it practical to globally map `<C-]>` and `<C-W><C-]>` to
`ALEGoToDefinition` and have it automatically choose between ale's LSP and
vim's `:tag`.

> Where are the tests? Have you added tests? Have you updated the tests? Read the
> comment above and the documentation referenced in it first. Write tests!
> 
> Seriously, read `:help ale-dev` and write tests.

I'm not sure if this change is useful for other people and I'm not sure
I implemented it at the correct place, so I'm presenting it as a Work in
Progress. If you think this is a useful addition, I'll add tests and
update documentation. Hope it's okay this way. :-)