### PR TITLE
Force sort locale in check-supported-tools-tables

### DIFF
--- a/test/script/check-supported-tools-tables
+++ b/test/script/check-supported-tools-tables
@@ -42,7 +42,7 @@ done < <(
 exit_code=0
 
 # Sort the tools ignoring case, and complain when things are out of order.
-sort -f -k1,2 "$doc_file" -o "$doc_sorted_file"
+LC_ALL=en_US.UTF-8 sort -f -k1,2 "$doc_file" -o "$doc_sorted_file"
 
 diff -U0 "$doc_sorted_file" "$doc_file" || exit_code=$?
 


### PR DESCRIPTION
Otherwise it reports that the list isn't sorted properly if user's LANG
is different.