### PR TITLE
[lsp] Add Texlab support

### DIFF
--- a/ale_linters/tex/texlab.vim
+++ b/ale_linters/tex/texlab.vim
@@ -1,0 +1,21 @@
+" Author: Ricardo Liang <ricardoliang@gmail.com>
+" Description: Texlab language server (Rust rewrite)
+
+call ale#Set('tex_texlab_executable', 'texlab')
+call ale#Set('tex_texlab_options', '')
+
+function! ale_linters#tex#texlab#GetProjectRoot(buffer) abort
+    return ''
+endfunction
+
+function! ale_linters#tex#texlab#GetCommand(buffer) abort
+    return '%e' . ale#Pad(ale#Var(a:buffer, 'tex_texlab_options'))
+endfunction
+
+call ale#linter#Define('tex', {
+\   'name': 'texlab',
+\   'lsp': 'stdio',
+\   'executable': {b -> ale#Var(b, 'tex_texlab_executable')},
+\   'command': function('ale_linters#tex#texlab#GetCommand'),
+\   'project_root': function('ale_linters#tex#texlab#GetProjectRoot'),
+\})

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -236,6 +236,7 @@ Notes:
   * `lacheck`
   * `proselint`
   * `redpen`
+  * `texlab`
   * `textlint`
   * `vale`
   * `write-good`

--- a/doc/ale-tex.txt
+++ b/doc/ale-tex.txt
@@ -54,4 +54,24 @@ g:ale_tex_latexindent_options                   *g:ale_tex_latexindent_options*
 
 
 ===============================================================================
+texlab                                                          *ale-tex-texlab*
+
+g:ale_tex_texlab_executable                        *g:ale_tex_texlab_executable*
+                                                   *b:ale_tex_texlab_executable*
+  Type: |String|
+  Default: `'texlab'`
+
+  This variable can be changed to change the path to texlab.
+
+
+g:ale_tex_texlab_options                              *g:ale_tex_texlab_options*
+                                                      *b:ale_tex_texlab_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be changed to modify flags given to texlab.
+
+
+
+===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2245,6 +2245,7 @@ documented in additional help files.
     chktex................................|ale-tex-chktex|
     lacheck...............................|ale-tex-lacheck|
     latexindent...........................|ale-tex-latexindent|
+    texlab................................|ale-tex-texlab|
   texinfo.................................|ale-texinfo-options|
     write-good............................|ale-texinfo-write-good|
   text....................................|ale-text-options|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -245,6 +245,7 @@ formatting.
   * [lacheck](https://www.ctan.org/pkg/lacheck)
   * [proselint](http://proselint.com/)
   * [redpen](http://redpen.cc/)
+  * [texlab](https://texlab.netlify.com) ([Rust rewrite](https://github.com/latex-lsp/texlab/tree/rust))
   * [textlint](https://textlint.github.io/)
   * [vale](https://github.com/ValeLint/vale)
   * [write-good](https://github.com/btford/write-good)

--- a/test/command_callback/test_texlab_command_callbacks.vader
+++ b/test/command_callback/test_texlab_command_callbacks.vader
@@ -1,0 +1,27 @@
+Before:
+  call ale#assert#SetUpLinterTest('tex', 'texlab')
+  
+  Save &filetype
+  let &filetype = 'tex'
+
+After:
+  call ale#assert#TearDownLinterTest()
+
+Execute(The language string should be correct):
+  AssertLSPLanguage 'tex'
+
+Execute(The default executable path should be correct):
+  AssertLinter 'texlab', ale#Escape('texlab')
+
+Execute(The project root should be detected correctly):
+  AssertLSPProject ''
+
+Execute(The executable should be configurable):
+  let b:ale_tex_texlab_executable = 'foobar'
+
+  AssertLinter 'foobar', ale#Escape('foobar')
+
+Execute(The options should be configurable):
+  let b:ale_tex_texlab_options = '-v'
+
+  AssertLinter 'texlab', ale#Escape('texlab') . ' ' . b:ale_tex_texlab_options


### PR DESCRIPTION
Adds LSP support for LaTeX via the open-source [Texlab](https://github.com/latex-lsp/texlab/tree/rust), maintained by [Netlify](https://texlab.netlify.com/).