### PR TITLE
Fix eclipselsp workspace config

### DIFF
--- a/ale_linters/java/eclipselsp.vim
+++ b/ale_linters/java/eclipselsp.vim
@@ -5,6 +5,7 @@ let s:version_cache = {}
 
 call ale#Set('java_eclipselsp_path', ale#path#Simplify($HOME . '/eclipse.jdt.ls'))
 call ale#Set('java_eclipselsp_config_path', '')
+call ale#Set('java_eclipselsp_workspace_path', '')
 call ale#Set('java_eclipselsp_executable', 'java')
 
 function! ale_linters#java#eclipselsp#Executable(buffer) abort
@@ -89,6 +90,16 @@ function! ale_linters#java#eclipselsp#CommandWithVersion(buffer, version_lines, 
     return ale_linters#java#eclipselsp#Command(a:buffer, l:version)
 endfunction
 
+function! ale_linters#java#eclipselsp#WorkspacePath(buffer) abort
+    let l:wspath = ale#Var(a:buffer, 'java_eclipselsp_workspace_path')
+
+    if !empty(l:wspath)
+        return l:wspath
+    endif
+
+    return ale#path#Dirname(ale#java#FindProjectRoot(a:buffer))
+endfunction
+
 function! ale_linters#java#eclipselsp#Command(buffer, version) abort
     let l:path = ale#Var(a:buffer, 'java_eclipselsp_path')
 
@@ -102,11 +113,11 @@ function! ale_linters#java#eclipselsp#Command(buffer, version) abort
     \ '-noverify',
     \ '-Xmx1G',
     \ '-jar',
-    \ ale_linters#java#eclipselsp#JarPath(a:buffer),
+    \ ale#Escape(ale_linters#java#eclipselsp#JarPath(a:buffer)),
     \ '-configuration',
-    \ ale_linters#java#eclipselsp#ConfigurationPath(a:buffer),
+    \ ale#Escape(ale_linters#java#eclipselsp#ConfigurationPath(a:buffer)),
     \ '-data',
-    \ ale#java#FindProjectRoot(a:buffer)
+    \ ale#Escape(ale_linters#java#eclipselsp#WorkspacePath(a:buffer))
     \ ]
 
     if ale#semver#GTE(a:version, [1, 9])

--- a/doc/ale-java.txt
+++ b/doc/ale-java.txt
@@ -130,7 +130,7 @@ g:ale_java_eclipselsp_path                         *g:ale_java_eclipselsp_path*
 
   Absolute path to the location of the eclipse.jdt.ls repository folder. Or if
   you have VSCode extension installed the absolute path to the VSCode extensions
-  folder (e.g. $HOME/.vscode/extensions in Linux).
+  folder (e.g. $HOME/.vscode/extensions/redhat.java-0.4x.0 in Linux).
 
 
 g:ale_java_eclipselsp_executable                *g:ale_java_eclipse_executable*
@@ -153,6 +153,18 @@ g:ale_java_eclipselsp_config_path                *g:ale_java_eclipse_config_path
   This setting is particularly useful when eclipselsp is installed in a
   non-writable directory like `/usr/share/java/jdtls`, as is the case when
   installed via system package.
+
+
+g:ale_java_eclipselsp_workspace_path       *g:ale_java_eclipselsp_workspace_path*
+                                           *b:ale_java_eclipselsp_workspace_path*
+
+  Type: |String|
+  Default: `''`
+
+  If you have Eclipse installed is good idea to set this variable to the
+  absolute path of the Eclipse workspace. If not set this value will be set to
+  the parent folder of the project root.
+
 
 ===============================================================================
 uncrustify                                                *ale-java-uncrustify*

--- a/test/command_callback/test_eclipselsp_command_callback.vader
+++ b/test/command_callback/test_eclipselsp_command_callback.vader
@@ -61,11 +61,11 @@ Execute(The eclipselsp callback should return the correct default value):
     \ '-noverify',
     \ '-Xmx1G',
     \ '-jar',
-    \ '',
+    \ ale#Escape(''),
     \ '-configuration',
-    \ b:cfg,
+    \ ale#Escape(b:cfg),
     \ '-data',
-    \ ''
+    \ ale#Escape(ale#path#Simplify(''))
     \]
   AssertLinter 'java', join(cmd, ' ')
 
@@ -79,11 +79,11 @@ Execute(The eclipselsp callback should allow custom executable):
     \ '-noverify',
     \ '-Xmx1G',
     \ '-jar',
-    \ '',
+    \ ale#Escape(''),
     \ '-configuration',
-    \ b:cfg,
+    \ ale#Escape(b:cfg),
     \ '-data',
-    \ ''
+    \ ale#Escape(ale#path#Simplify(''))
     \]
   AssertLinter '/bin/foobar', join(cmd, ' ')
 
@@ -97,10 +97,10 @@ Execute(The eclipselsp callback should allow custom configuration path):
     \ '-noverify',
     \ '-Xmx1G',
     \ '-jar',
-    \ '',
+    \ ale#Escape(''),
     \ '-configuration',
-    \ ale#path#Simplify('/home/config'),
+    \ ale#Escape(ale#path#Simplify('/home/config')),
     \ '-data',
-    \ ''
+    \ ale#Escape(ale#path#Simplify(''))
     \]
   AssertLinter 'java', join(cmd, ' ')


### PR DESCRIPTION
Fixes command line used to start eclipselsp to set workspace correctly. Also adds a conf variable to set a specific eclipse workspace path.

Fixes #2519