### PR TITLE
Allow running eclipselsp as installed by system package on GNU/Linux

### DIFF
--- a/ale_linters/java/eclipselsp.vim
+++ b/ale_linters/java/eclipselsp.vim
@@ -4,6 +4,7 @@
 let s:version_cache = {}
 
 call ale#Set('java_eclipselsp_path', ale#path#Simplify($HOME . '/eclipse.jdt.ls'))
+call ale#Set('java_eclipselsp_config_path', '')
 call ale#Set('java_eclipselsp_executable', 'java')
 
 function! ale_linters#java#eclipselsp#Executable(buffer) abort
@@ -44,24 +45,18 @@ endfunction
 
 function! ale_linters#java#eclipselsp#ConfigurationPath(buffer) abort
     let l:path = fnamemodify(ale_linters#java#eclipselsp#JarPath(a:buffer), ':p:h:h')
+    let l:config_path = ale#Var(a:buffer, 'java_eclipselsp_config_path')
 
-    if l:path =~# '^/usr/share'
-        let l:home_path = $HOME . '/.jdtls'
+    if !empty(l:config_path)
+        return ale#path#Simplify(l:config_path)
+    endif
 
-        if !isdirectory(l:home_path)
-            call mkdir(l:home_path)
-            execute '!ln -s ' . l:path . '/config_linux/config.ini ' . l:home_path . '/config.ini'
-        endif
-        let l:path = l:home_path
-
+    if has('win32')
+        let l:path = l:path . '/config_win'
+    elseif has('macunix')
+        let l:path = l:path . '/config_mac'
     else
-        if has('win32')
-            let l:path = l:path . '/config_win'
-        elseif has('macunix')
-            let l:path = l:path . '/config_mac'
-        else
-            let l:path = l:path . '/config_linux'
-        endif
+        let l:path = l:path . '/config_linux'
     endif
 
     return ale#path#Simplify(l:path)

--- a/doc/ale-java.txt
+++ b/doc/ale-java.txt
@@ -141,6 +141,19 @@ g:ale_java_eclipselsp_executable                *g:ale_java_eclipse_executable*
   This variable can be set to change the executable path used for java.
 
 
+g:ale_java_eclipselsp_config_path                *g:ale_java_eclipse_config_path*
+                                                 *b:ale_java_eclipse_config_path*
+  Type: |String|
+  Default: `''`
+
+  Set this variable to change the configuration directory path used by
+  eclipselsp (e.g. `$HOME/.jdtls` in Linux).
+  By default ALE will attempt to use the configuration within the installation
+  directory.
+  This setting is particularly useful when eclipselsp is installed in a
+  non-writable directory like `/usr/share/java/jdtls`, as is the case when
+  installed via system package.
+
 ===============================================================================
 uncrustify                                                *ale-java-uncrustify*
 

--- a/test/command_callback/test_eclipselsp_command_callback.vader
+++ b/test/command_callback/test_eclipselsp_command_callback.vader
@@ -85,3 +85,20 @@ Execute(The eclipselsp callback should allow custom executable):
     \]
   AssertLinter '/bin/foobar', join(cmd, ' ')
 
+Execute(The eclipselsp callback should allow custom configuration path):
+  let b:ale_java_eclipselsp_config_path='/home/config'
+  let cmd = [ ale#Escape('java'),
+    \ '-Declipse.application=org.eclipse.jdt.ls.core.id1',
+    \ '-Dosgi.bundles.defaultStartLevel=4',
+    \ '-Declipse.product=org.eclipse.jdt.ls.core.product',
+    \ '-Dlog.level=ALL',
+    \ '-noverify',
+    \ '-Xmx1G',
+    \ '-jar',
+    \ '',
+    \ '-configuration',
+    \ b:ale_java_eclipselsp_config_path,
+    \ '-data',
+    \ ''
+    \]
+  AssertLinter 'java', join(cmd, ' ')


### PR DESCRIPTION
This is a continuation of https://github.com/w0rp/ale/pull/2514

Thanks for the feedback on the last PR and please allow me to suggest a different approach based on the suggestions presented there.

I removed the code that creates the `~/.jdtls` config directory and replaced it with an optional parameter that takes a path to the config directory. If this parameter is not present then ALE keeps the previous behavior of looking for the config directory within eclipselsp installation directory.
I've also added a mention to this in the documentation.
This way ALE has no side-effects and does no configuration for eclipselsp but still allows the users to have the configuration directory wherever they wish.

Is it acceptable like this?

Please note that the main goal of this PR is to have ALE working with eclipselsp when it is installed by a distro package. As is, ALE assumes that the config dir is within the installation dir. That can't be the case with a distro package because eclipselsp is installed to a non-writable dir like `/usr/share/java/jdtls/`.

Should I attempt adding any particular tests to cover these additions?

This implementation was inspired by https://github.com/w0rp/ale/pull/2520.

Thank you for your time.