### PR TITLE
Improve java checkstyle command configuration.

### DIFF
--- a/ale_linters/java/checkstyle.vim
+++ b/ale_linters/java/checkstyle.vim
@@ -1,6 +1,9 @@
 " Author: Devon Meunier <devon.meunier@gmail.com>
 " Description: checkstyle for Java files
 
+call ale#Set('java_checkstyle_executable', 'checkstyle')
+call ale#Set('java_checkstyle_config', 'google_checks.xml')
+
 function! ale_linters#java#checkstyle#Handle(buffer, lines) abort
     let l:output = []
 
@@ -35,15 +38,22 @@ function! ale_linters#java#checkstyle#Handle(buffer, lines) abort
     return l:output
 endfunction
 
-function! ale_linters#java#checkstyle#GetCommand(buffer) abort
-    return 'checkstyle '
-    \ . ale#Var(a:buffer, 'java_checkstyle_options')
-    \ . ' %s'
+function! ale_linters#java#checkstyle#GetConfig(buffer) abort
+    let l:cfg = ale#Var(a:buffer, 'java_checkstyle_config')
+
+    if filereadable(l:cfg)
+        return l:cfg
+    endif
+
+    return ale#path#ResolveLocalPath(a:buffer, l:cfg, '/google_checks.xml')
 endfunction
 
-if !exists('g:ale_java_checkstyle_options')
-    let g:ale_java_checkstyle_options = '-c /google_checks.xml'
-endif
+function! ale_linters#java#checkstyle#GetCommand(buffer) abort
+    return ale#Escape(ale#Var(a:buffer, 'java_checkstyle_executable'))
+    \ . ' -c '
+    \ . ale_linters#java#checkstyle#GetConfig(a:buffer)
+    \ . ' %s'
+endfunction
 
 call ale#linter#Define('java', {
 \   'name': 'checkstyle',

--- a/ale_linters/java/checkstyle.vim
+++ b/ale_linters/java/checkstyle.vim
@@ -3,6 +3,7 @@
 
 call ale#Set('java_checkstyle_executable', 'checkstyle')
 call ale#Set('java_checkstyle_config', 'google_checks.xml')
+call ale#Set('java_checkstyle_options', '')
 
 function! ale_linters#java#checkstyle#Handle(buffer, lines) abort
     let l:output = []
@@ -38,8 +39,19 @@ function! ale_linters#java#checkstyle#Handle(buffer, lines) abort
     return l:output
 endfunction
 
+function! ale_linters#java#checkstyle#GetOptions(buffer) abort
+    " Check _options setting and use it if defined for backward compatibility.
+    let l:cfg = ale#Var(a:buffer, 'java_checkstyle_options')
+
+    if !empty(l:cfg)
+        return l:cfg
+    endif
+
+    return '-c ' . ale_linters#java#checkstyle#GetConfig(a:buffer)
+endfunction
+
 function! ale_linters#java#checkstyle#GetConfig(buffer) abort
-    let l:cfg = ale#Var(a:buffer, 'java_checkstyle_config')
+    let l:cfg = ale#Var(a:buffer, 'java_checkstyle_options')
 
     if filereadable(l:cfg)
         return l:cfg
@@ -50,8 +62,8 @@ endfunction
 
 function! ale_linters#java#checkstyle#GetCommand(buffer) abort
     return ale#Escape(ale#Var(a:buffer, 'java_checkstyle_executable'))
-    \ . ' -c '
-    \ . ale_linters#java#checkstyle#GetConfig(a:buffer)
+    \ . ' '
+    \ . ale_linters#java#checkstyle#GetOptions(a:buffer)
     \ . ' %s'
 endfunction
 

--- a/doc/ale-java.txt
+++ b/doc/ale-java.txt
@@ -26,7 +26,18 @@ g:ale_java_checkstyle_executable             *g:ale_java_checkstyle_executable*
   Type: String
   Default: 'checkstyle'
 
-  Path to the checkstyle executable.
+  Path to the checkstyle executable or launch script.
+
+g:ale_java_checkstyle_options                   *g:ale_java_checkstyle_options*
+                                                *b:ale_java_checkstyle_options*
+
+  Type: String
+  Default: ''
+
+  This configuration exists only for backward compatibility. Is recommended to
+  use |g:ale_java_checkstyle_executable| and |g:ale_java_checkstyle_config|
+  instead. If defined, this variable will take precedence over the other two.
+
 
 ===============================================================================
 javac                                                          *ale-java-javac*

--- a/doc/ale-java.txt
+++ b/doc/ale-java.txt
@@ -5,14 +5,28 @@ ALE Java Integration                                         *ale-java-options*
 ===============================================================================
 checkstyle                                                *ale-java-checkstyle*
 
-g:ale_java_checkstyle_options                   *g:ale_java_checkstyle_options*
-                                                *b:ale_java_checkstyle_options*
+g:ale_java_checkstyle_config                     *g:ale_java_checkstyle_config*
+                                                 *b:ale_java_checkstyle_config*
 
   Type: String
-  Default: '-c /google_checks.xml'
+  Default: '/google_checks.xml'
 
-  This variable can be changed to modify flags given to checkstyle.
+  Name of the checkstyle configuration file. This can be set either to an
+  absolute path or a filename. When set to an absolute path and the path
+  exists then it will be used directly as configuration file. If a name is set
+  then ALE will look for the closest file that matches that name in the
+  current buffer directory and its parents.
 
+  In case the absolute path does not exists or if no config file is found with
+  the name, then the default '/google_checks.xml' configuration will be used.
+
+g:ale_java_checkstyle_executable             *g:ale_java_checkstyle_executable*
+                                             *b:ale_java_checkstyle_executable*
+
+  Type: String
+  Default: 'checkstyle'
+
+  Path to the checkstyle executable.
 
 ===============================================================================
 javac                                                          *ale-java-javac*

--- a/test/command_callback/test_checkstyle_command_callback.vader
+++ b/test/command_callback/test_checkstyle_command_callback.vader
@@ -1,0 +1,22 @@
+Before:
+  call ale#assert#SetUpLinterTest('java', 'checkstyle')
+  call ale#test#SetFilename('dummy.java')
+
+After:
+  call ale#assert#TearDownLinterTest()
+
+Execute(The checkstyle callback should return the correct default value):
+  let cmd = [ ale#Escape('checkstyle'),
+    \ '-c /google_checks.xml',
+    \ '%s'
+    \]
+  AssertLinter 'checkstyle', join(cmd, ' ')
+
+Execute(The checkstyle callback should override executable):
+  let g:ale_java_checkstyle_executable = 'bin/checkstyle'
+  let cmd = [ ale#Escape('bin/checkstyle'),
+    \ '-c /google_checks.xml',
+    \ '%s'
+    \]
+  AssertLinter 'checkstyle', join(cmd, ' ')
+

--- a/test/command_callback/test_checkstyle_command_callback.vader
+++ b/test/command_callback/test_checkstyle_command_callback.vader
@@ -13,9 +13,17 @@ Execute(The checkstyle callback should return the correct default value):
   AssertLinter 'checkstyle', join(cmd, ' ')
 
 Execute(The checkstyle callback should override executable):
-  let g:ale_java_checkstyle_executable = 'bin/checkstyle'
+  let b:ale_java_checkstyle_executable = 'bin/checkstyle'
   let cmd = [ ale#Escape('bin/checkstyle'),
     \ '-c /google_checks.xml',
+    \ '%s'
+    \]
+  AssertLinter 'checkstyle', join(cmd, ' ')
+
+Execute(The checkstyle callback should use deprecated _options if defined):
+  let b:ale_java_checkstyle_options = '-c /tmp/checks.xml'
+  let cmd = [ ale#Escape('checkstyle'),
+    \ '-c /tmp/checks.xml',
     \ '%s'
     \]
   AssertLinter 'checkstyle', join(cmd, ' ')


### PR DESCRIPTION
The g:ale_java_checkstyle_options only worked with absolute paths making
it difficult to have a per project configuration. This MR introduces a
new g:ale_java_checkstyle_config configuration. This option can be an
absolute path or a filename. When a filename is set then the nearest
file that matches it in the current buffer folder or any of its parents
will be used.

Note: The above is a breaking change since it replaces the
g:ale_java_checkstyle_options variable with a different one.

Also a new configuration g:ale_java_checkstyle_executable is added. This
allows users to create more specialized launch scripts (#1305) to invoke
checkstyle.