### PR TITLE
Fix java checkstyle handler.

### DIFF
--- a/ale_linters/java/checkstyle.vim
+++ b/ale_linters/java/checkstyle.vim
@@ -17,6 +17,10 @@ function! ale_linters#java#checkstyle#Handle(buffer, lines) abort
         \})
     endfor
 
+    if !empty(l:output)
+        return l:output
+    endif
+
     " old checkstyle versions
     let l:pattern = '\v(.+):(\d+): ([^:]+): (.+)$'
 

--- a/test/handler/test_checkstyle_handler.vader
+++ b/test/handler/test_checkstyle_handler.vader
@@ -21,10 +21,18 @@ Execute(The checkstyle handler should parse lines correctly):
   \     'code': 'JavadocMethod',
   \     'type': 'W',
   \   },
+  \   {
+  \     'lnum': 11,
+  \     'col': 7,
+  \     'text': 'WhitespaceAround: ''if'' is not followed by whitespace.',
+  \     'code': 'WhitespaceAround',
+  \     'type': 'W',
+  \   },
   \ ],
   \ ale_linters#java#checkstyle#Handle(666, [
   \   '[WARN] whatever:101: ''method def rcurly'' has incorrect indentation level 4, expected level should be 2. [Indentation]',
   \   '[WARN] whatever:63:3: Missing a Javadoc comment. [JavadocMethod]',
+  \   '[WARN] whatever:11:7: WhitespaceAround: ''if'' is not followed by whitespace. [WhitespaceAround]',
   \ ])
 
 Execute(The checkstyle handler should parse lines from older checkstyle versions correctly):


### PR DESCRIPTION
The checkstyle handler is capable of parsing the new and old output
formats. Unfortunately there are some particular output messages that
matched both the new and old regular expressions:

   [WARN] whatever:11:7: WhitespaceAround: ''if'' is not followed by whitespace. [WhitespaceAround]

This caused ALE to report extra errors since the message was being
matched twice, once as a warning and another (incorrect) old formatted
error.

This MR fixes this by stopping any parsing using the old format regexp
is any errors of the new format are correcly parsed. There is no reason
to expect checkstyle to output both styles in the same report.
