### PR TITLE
Add API for custom LSP requests

### DIFF
--- a/autoload/ale/lsp.vim
+++ b/autoload/ale/lsp.vim
@@ -5,9 +5,6 @@
 let s:connections = get(s:, 'connections', {})
 let g:ale_lsp_next_message_id = 1
 
-" A Dictionary to track one-shot callbacks for custom LSP requests
-let s:custom_callbacks = get(s:, 'custom_callbacks', {})
-
 " Given an id, which can be an executable or address, and a project path,
 " create a new connection if needed. Return a unique ID for the connection.
 function! ale#lsp#Register(executable_or_address, project, init_options) abort
@@ -299,19 +296,10 @@ function! ale#lsp#HandleMessage(conn_id, message) abort
     " responses.
     if l:conn.initialized
         for l:response in l:response_list
-            if has_key(l:response, 'id') && has_key(s:custom_callbacks, l:response.id)
-                " Response to a custom request, call the registered one-shot handler.
-                try
-                    call s:custom_callbacks[l:response.id](l:response)
-                finally
-                    call remove(s:custom_callbacks, l:response.id)
-                endtry
-            else
-                " Call all of the registered handlers with the response.
-                for l:Callback in l:conn.callback_list
-                    call ale#util#GetFunction(l:Callback)(a:conn_id, l:response)
-                endfor
-            endif
+            " Call all of the registered handlers with the response.
+            for l:Callback in l:conn.callback_list
+                call ale#util#GetFunction(l:Callback)(a:conn_id, l:response)
+            endfor
         endfor
     endif
 endfunction
@@ -535,18 +523,6 @@ function! ale#lsp#Send(conn_id, message) abort
     call s:SendMessageData(l:conn, l:data)
 
     return l:id == 0 ? -1 : l:id
-endfunction
-
-" Send a custom request to an LSP server.
-" The given callback is called on response.
-function! ale#lsp#SendCustomRequest(conn_id, message, Callback) abort
-    let l:id = ale#lsp#Send(a:conn_id, a:message)
-
-    if l:id > 0
-        let s:custom_callbacks[l:id] = a:Callback
-    endif
-
-    return l:id
 endfunction
 
 " Notify LSP servers or tsserver if a document is opened, if needed.

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -3205,9 +3205,6 @@ ale#lsp_linter#SendRequest(buffer, linter_name, method, parameters, Callback)
   request is received, and takes as unique argument a dictionary representing
   the response to the request obtained from the server.
 
-  The function returns zero if the request is succesfully sent, non-zero
-  otherwise.
-
 
 ale#other_source#ShowResults(buffer, linter_name, loclist)
                                                *ale#other_source#ShowResults()*

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -3191,6 +3191,24 @@ ale#linter#PreventLoading(filetype)               *ale#linter#PreventLoading()*
   |runtimepath| for that filetype. This function can be called from vimrc or
   similar to prevent ALE from loading linters.
 
+
+ale#lsp_linter#SendRequest(buffer, linter_name, method, parameters, Callback)
+                                                 *ale#lsp_linter#SendRequest()*
+
+  Send a custom request to an LSP linter.
+
+  `buffer` must be a valid buffer number, and `linter_name` is a |String|
+  identifying an LSP linter that is available and enabled for the |filetype|
+  of `buffer`. `method` is a |String| identifying an LSP method supported by
+  `linter`, while `parameters` is a |dictionary| of LSP parameters applicable
+  to `method`. `Callback` is a |Funcref| that is called when a response to the
+  request is received, and takes as unique argument a dictionary representing
+  the response to the request obtained from the server.
+
+  The function returns zero if the request is succesfully sent, non-zero
+  otherwise.
+
+
 ale#other_source#ShowResults(buffer, linter_name, loclist)
                                                *ale#other_source#ShowResults()*
 

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -3192,18 +3192,30 @@ ale#linter#PreventLoading(filetype)               *ale#linter#PreventLoading()*
   similar to prevent ALE from loading linters.
 
 
-ale#lsp_linter#SendRequest(buffer, linter_name, method, parameters, Callback)
+ale#lsp_linter#SendRequest(buffer, linter_name, message, [Handler])
                                                  *ale#lsp_linter#SendRequest()*
 
-  Send a custom request to an LSP linter.
+  Send a custom request to an LSP linter. The arguments are defined as
+  follows:
 
-  `buffer` must be a valid buffer number, and `linter_name` is a |String|
-  identifying an LSP linter that is available and enabled for the |filetype|
-  of `buffer`. `method` is a |String| identifying an LSP method supported by
-  `linter`, while `parameters` is a |dictionary| of LSP parameters applicable
-  to `method`. `Callback` is a |Funcref| that is called when a response to the
-  request is received, and takes as unique argument a dictionary representing
-  the response to the request obtained from the server.
+  `buffer`       A valid buffer number.
+
+  `linter_name`  A |String| identifying an LSP linter that is available and
+                 enabled for the |filetype| of `buffer`.
+
+  `message`      A |List| in the form `[is_notification, method, parameters]`,
+                 containing three elements:
+                 `is_notification` - an |Integer| that has value 1 if the
+                   request is a notification, 0 otherwise;
+                 `methdod` - a |String|, identifying an LSP method supported
+                   by `linter`;
+                 `parameters` - a |dictionary| of LSP parameters that are
+                   applicable to `method`.
+
+  `Handler`      Optional argument, meaningful only when `message[0]` is 0.
+                 A |Funcref| that is called when a response to the request is
+                 received, and takes as unique argument a dictionary
+                 representing the response obtained from the server.
 
 
 ale#other_source#ShowResults(buffer, linter_name, loclist)

--- a/test/lsp/test_lsp_custom_request.vader
+++ b/test/lsp/test_lsp_custom_request.vader
@@ -4,12 +4,12 @@ Before:
   runtime autoload/ale/lsp_linter.vim
 
   let g:address = 'ccls_address'
-  let g:callback_result = 0
   let g:conn_id = -1
   let g:executable = 'ccls'
   let g:executable_or_address = ''
   let g:linter_name = 'ccls'
   let g:magic_number = 42
+  let g:no_result = 0
   let g:message_list = []
   let g:message_id = 1
   let g:method = '$ccls/call'
@@ -29,6 +29,8 @@ Before:
   \   'read_buffer': 1,
   \   'command': '%e'
   \ }]
+
+  let g:callback_result = g:no_result
 
   " Encode dictionary to jsonrpc
   function! Encode(obj) abort
@@ -69,16 +71,15 @@ Before:
   endfunction
 
   " Code for a test case
-  function! TestCase() abort
+  function! TestCase(is_notification) abort
     " Test sending a custom request
     let g:return_value = ale#lsp_linter#SendRequest(
     \  bufnr('%'),
     \  g:linter_name,
-    \  g:method,
-    \  g:parameters,
+    \  [a:is_notification, g:method, g:parameters],
     \  function('Callback'))
 
-    Assert index(g:message_list, [0, g:method, g:parameters]) >= 0
+    Assert index(g:message_list, [a:is_notification, g:method, g:parameters]) >= 0
 
     " Mock an incoming response to the request
     let g:response = Encode({
@@ -89,7 +90,7 @@ Before:
     call ale#lsp#HandleMessage(g:conn_id, g:response)
 
     AssertEqual
-    \ g:magic_number,
+    \ a:is_notification ? g:no_result : g:magic_number,
     \ g:callback_result
   endfunction
 
@@ -101,11 +102,13 @@ After:
   unlet! g:callback_result
   unlet! g:conn_id
   unlet! g:executable
+  unlet! g:is_notification
   unlet! g:linter_name
   unlet! g:magic_number
   unlet! g:message_list
   unlet! g:message_id
   unlet! g:method
+  unlet! g:no_result
   unlet! g:parameters
   unlet! g:project_root
   unlet! g:response
@@ -124,13 +127,33 @@ Execute(Test custom request to server identified by executable):
   let g:executable_or_address = g:executable
   let g:linter_list[0].executable = {b -> g:executable}
   let g:linter_list[0].lsp = 'stdio'
+  let g:is_notification = 0
 
-  call TestCase()
+  call TestCase(g:is_notification)
+
+Given cpp(Empty cpp file):
+Execute(Test custom notification to server identified by executable):
+  let g:executable_or_address = g:executable
+  let g:linter_list[0].executable = {b -> g:executable}
+  let g:linter_list[0].lsp = 'stdio'
+  let g:is_notification = 1
+
+  call TestCase(g:is_notification)
 
 Given cpp(Empty cpp file):
 Execute(Test custom request to server identified by address):
   let g:executable_or_address = g:address
   let g:linter_list[0].address = {b -> g:address}
   let g:linter_list[0].lsp = 'socket'
+  let g:is_notification = 0
 
-  call TestCase()
+  call TestCase(g:is_notification)
+
+Given cpp(Empty cpp file):
+Execute(Test custom notification to server identified by address):
+  let g:executable_or_address = g:address
+  let g:linter_list[0].address = {b -> g:address}
+  let g:linter_list[0].lsp = 'socket'
+  let g:is_notification = 1
+
+  call TestCase(g:is_notification)

--- a/test/lsp/test_lsp_custom_request.vader
+++ b/test/lsp/test_lsp_custom_request.vader
@@ -1,0 +1,120 @@
+Before:
+  runtime autoload/ale/linter.vim
+  runtime autoload/ale/lsp.vim
+  runtime autoload/ale/lsp_linter.vim
+
+  let g:address = 'ccls_address'
+  let g:callback_result = 0
+  let g:conn_id = -1
+  let g:executable = 'ccls'
+  let g:linter_name = 'ccls'
+  let g:magic_number = 42
+  let g:message = -1
+  let g:message_id = 1
+  let g:method = '$ccls/call'
+  let g:parameters = {}
+  let g:project = '/project/root'
+  let g:return_value = -1
+
+  let g:linter_list = [{
+  \   'output_stream': 'stdout',
+  \   'lint_file': 0,
+  \   'language': 'cpp',
+  \   'name': g:linter_name,
+  \   'project_root': {b -> g:project},
+  \   'aliases': [],
+  \   'language_callback': {b -> 'cpp'},
+  \   'read_buffer': 1,
+  \   'command': '%e'
+  \ }]
+
+  " Encode dictionary to jsonrpc
+  function! Encode(obj) abort
+    let l:body = json_encode(a:obj)
+    return 'Content-Length: ' . strlen(l:body) . "\r\n\r\n" . l:body
+  endfunction
+
+  " Register the server with given executable or address
+  function! InitServer(executable_or_address) abort
+    let g:conn_id = ale#lsp#Register(a:executable_or_address, g:project, {})
+    call ale#lsp#HandleMessage(g:conn_id, Encode({'method': 'initialize'}))
+  endfunction
+
+  " Dummy callback
+  function! Callback(response) abort
+    let g:callback_result = a:response.result.value
+  endfunction
+
+  " Replace the GetAll function to mock an LSP linter
+  function! ale#linter#GetAll(filetype) abort
+    return g:linter_list
+  endfunction
+
+  " Replace the Send function to mock an LSP linter
+  function! ale#lsp#Send(conn_id, message) abort
+    let g:message = a:message
+    return g:message_id
+  endfunction
+
+  " Code for a test case
+  function! TestCase() abort
+    " Test sending a custom request
+    let g:return_value = ale#lsp_linter#SendRequest(bufnr('%'), g:linter_name, g:method, g:parameters, function('Callback'))
+
+    AssertEqual
+    \ 0,
+    \ g:return_value
+
+    AssertEqual
+    \ [0, g:method, g:parameters],
+    \ g:message
+
+    " Mock an incoming response to the request
+    call ale#lsp#HandleMessage(g:conn_id, Encode({'id': g:message_id, 'jsonrpc': '2.0', 'result': {'value': g:magic_number}}))
+
+    AssertEqual
+    \ g:magic_number,
+    \ g:callback_result
+  endfunction
+
+After:
+  if g:conn_id isnot v:null
+    call ale#lsp#RemoveConnectionWithID(g:conn_id)
+  endif
+
+  unlet! g:callback_result
+  unlet! g:conn_id
+  unlet! g:executable
+  unlet! g:linter_name
+  unlet! g:magic_number
+  unlet! g:message
+  unlet! g:message_id
+  unlet! g:method
+  unlet! g:parameters
+  unlet! g:project
+  unlet! g:return_value
+
+  delfunction Encode
+  delfunction InitServer
+  delfunction Callback
+  delfunction TestCase
+
+  runtime autoload/ale/linter.vim
+  runtime autoload/ale/lsp.vim
+  runtime autoload/ale/lsp_linter.vim
+
+Given cpp(Empty cpp file):
+Execute(Test custom request to server identified by executable):
+  call InitServer(g:executable)
+  let g:linter_list[0].executable = {b -> g:executable}
+  let g:linter_list[0].lsp = 'stdio'
+
+  call TestCase()
+
+Given cpp(Empty cpp file):
+Execute(Test custom request to server identified by address):
+  call InitServer(g:address)
+  let g:linter_list[0].address = {b -> g:address}
+  let g:linter_list[0].lsp = 'socket'
+
+  call TestCase()

--- a/test/lsp/test_lsp_custom_request.vader
+++ b/test/lsp/test_lsp_custom_request.vader
@@ -7,13 +7,15 @@ Before:
   let g:callback_result = 0
   let g:conn_id = -1
   let g:executable = 'ccls'
+  let g:executable_or_address = ''
   let g:linter_name = 'ccls'
   let g:magic_number = 42
-  let g:message = -1
+  let g:message_list = []
   let g:message_id = 1
   let g:method = '$ccls/call'
   let g:parameters = {}
-  let g:project = '/project/root'
+  let g:project_root = '/project/root'
+  let g:response = ''
   let g:return_value = -1
 
   let g:linter_list = [{
@@ -21,7 +23,7 @@ Before:
   \   'lint_file': 0,
   \   'language': 'cpp',
   \   'name': g:linter_name,
-  \   'project_root': {b -> g:project},
+  \   'project_root': {b -> g:project_root},
   \   'aliases': [],
   \   'language_callback': {b -> 'cpp'},
   \   'read_buffer': 1,
@@ -34,10 +36,20 @@ Before:
     return 'Content-Length: ' . strlen(l:body) . "\r\n\r\n" . l:body
   endfunction
 
-  " Register the server with given executable or address
-  function! InitServer(executable_or_address) abort
-    let g:conn_id = ale#lsp#Register(a:executable_or_address, g:project, {})
+  " Replace the StartLSP function to mock an LSP linter
+  function! ale#lsp_linter#StartLSP(buffer, linter, Callback) abort
+    let g:conn_id = ale#lsp#Register(g:executable_or_address, g:project_root, {})
+    call ale#lsp#MarkDocumentAsOpen(g:conn_id, a:buffer)
     call ale#lsp#HandleMessage(g:conn_id, Encode({'method': 'initialize'}))
+
+    let l:details = {
+    \ 'command': g:executable,
+    \ 'buffer': a:buffer,
+    \ 'connection_id': g:conn_id,
+    \ 'project_root': g:project_root,
+    \}
+
+    call ale#lsp_linter#OnInit(a:linter, l:details, a:Callback)
   endfunction
 
   " Dummy callback
@@ -52,25 +64,29 @@ Before:
 
   " Replace the Send function to mock an LSP linter
   function! ale#lsp#Send(conn_id, message) abort
-    let g:message = a:message
+    call add(g:message_list, a:message)
     return g:message_id
   endfunction
 
   " Code for a test case
   function! TestCase() abort
     " Test sending a custom request
-    let g:return_value = ale#lsp_linter#SendRequest(bufnr('%'), g:linter_name, g:method, g:parameters, function('Callback'))
+    let g:return_value = ale#lsp_linter#SendRequest(
+    \  bufnr('%'),
+    \  g:linter_name,
+    \  g:method,
+    \  g:parameters,
+    \  function('Callback'))
 
-    AssertEqual
-    \ 0,
-    \ g:return_value
-
-    AssertEqual
-    \ [0, g:method, g:parameters],
-    \ g:message
+    Assert index(g:message_list, [0, g:method, g:parameters]) >= 0
 
     " Mock an incoming response to the request
-    call ale#lsp#HandleMessage(g:conn_id, Encode({'id': g:message_id, 'jsonrpc': '2.0', 'result': {'value': g:magic_number}}))
+    let g:response = Encode({
+    \  'id': g:message_id,
+    \  'jsonrpc': '2.0',
+    \  'result': {'value': g:magic_number}
+    \ })
+    call ale#lsp#HandleMessage(g:conn_id, g:response)
 
     AssertEqual
     \ g:magic_number,
@@ -87,15 +103,15 @@ After:
   unlet! g:executable
   unlet! g:linter_name
   unlet! g:magic_number
-  unlet! g:message
+  unlet! g:message_list
   unlet! g:message_id
   unlet! g:method
   unlet! g:parameters
-  unlet! g:project
+  unlet! g:project_root
+  unlet! g:response
   unlet! g:return_value
 
   delfunction Encode
-  delfunction InitServer
   delfunction Callback
   delfunction TestCase
 
@@ -105,7 +121,7 @@ After:
 
 Given cpp(Empty cpp file):
 Execute(Test custom request to server identified by executable):
-  call InitServer(g:executable)
+  let g:executable_or_address = g:executable
   let g:linter_list[0].executable = {b -> g:executable}
   let g:linter_list[0].lsp = 'stdio'
 
@@ -113,7 +129,7 @@ Execute(Test custom request to server identified by executable):
 
 Given cpp(Empty cpp file):
 Execute(Test custom request to server identified by address):
-  call InitServer(g:address)
+  let g:executable_or_address = g:address
   let g:linter_list[0].address = {b -> g:address}
   let g:linter_list[0].lsp = 'socket'
 


### PR DESCRIPTION
Implement a function `ale#lsp_linter#SendRequest` that allows to send
custom LSP requests to an enabled LSP linter.

Resolves #2474
