### PR TITLE
Change ALE integration with Deoplete in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,9 @@ the source of completion information, or mix it with other sources.
 
 ```vim
 " Use ALE and also some plugin 'foobar' as completion sources for all code.
-let g:deoplete#sources = {'_': ['ale', 'foobar']}
+call deoplete#custom#option('sources', {
+\ '_': ['ale', 'foobar'],
+\})
 ```
 
 ALE also offers its own automatic completion support, which does not require any


### PR DESCRIPTION
`g:deoplete#sources` variable was removed according to:

https://github.com/Shougo/deoplete.nvim/commit/f1b571a306c6565790d7b7a45408c1564e872088