### PR TITLE
Fix javalsp command callback.

### DIFF
--- a/ale_linters/java/javalsp.vim
+++ b/ale_linters/java/javalsp.vim
@@ -1,7 +1,7 @@
 " Author: Horacio Sanson <https://github.com/hsanson>
 " Description: Support for the Java language server https://github.com/georgewfraser/vscode-javac
 
-call ale#Set('java_javalsp_executable', 'java')
+call ale#Set('java_javalsp_executable', 'launcher')
 
 function! ale_linters#java#javalsp#Executable(buffer) abort
     return ale#Var(a:buffer, 'java_javalsp_executable')
@@ -10,7 +10,25 @@ endfunction
 function! ale_linters#java#javalsp#Command(buffer) abort
     let l:executable = ale_linters#java#javalsp#Executable(a:buffer)
 
-    return ale#Escape(l:executable) . ' -Xverify:none -m javacs/org.javacs.Main'
+    if fnamemodify(l:executable, ':t') is# 'java'
+        " For backward compatibility.
+        let l:cmd = [
+        \ ale#Escape(l:executable),
+        \ '--add-exports jdk.compiler/com.sun.tools.javac.api=javacs',
+        \ '--add-exports jdk.compiler/com.sun.tools.javac.code=javacs',
+        \ '--add-exports jdk.compiler/com.sun.tools.javac.comp=javacs',
+        \ '--add-exports jdk.compiler/com.sun.tools.javac.main=javacs',
+        \ '--add-exports jdk.compiler/com.sun.tools.javac.tree=javacs',
+        \ '--add-exports jdk.compiler/com.sun.tools.javac.model=javacs',
+        \ '--add-exports jdk.compiler/com.sun.tools.javac.util=javacs',
+        \ '--add-opens jdk.compiler/com.sun.tools.javac.api=javacs',
+        \ '-m javacs/org.javacs.Main',
+        \]
+
+        return join(l:cmd, ' ')
+    else
+        return ale#Escape(l:executable)
+    endif
 endfunction
 
 call ale#linter#Define('java', {

--- a/ale_linters/java/javalsp.vim
+++ b/ale_linters/java/javalsp.vim
@@ -1,7 +1,7 @@
 " Author: Horacio Sanson <https://github.com/hsanson>
 " Description: Support for the Java language server https://github.com/georgewfraser/vscode-javac
 
-call ale#Set('java_javalsp_executable', 'launcher')
+call ale#Set('java_javalsp_executable', '')
 
 function! ale_linters#java#javalsp#Executable(buffer) abort
     return ale#Var(a:buffer, 'java_javalsp_executable')

--- a/doc/ale-java.txt
+++ b/doc/ale-java.txt
@@ -117,16 +117,19 @@ or
 
 This generates a dist/mac or dist/windows directory that contains the
 language server. To let ALE use this language server you need to set the
-g:ale_java_javalsp_executable variable to the absolute path of the java
+g:ale_java_javalsp_executable variable to the absolute path of the launcher
 executable in this directory.
 
 g:ale_java_javalsp_executable                   *g:ale_java_javalsp_executable*
                                                 *b:ale_java_javalsp_executable*
   Type: |String|
-  Default: `'java'`
+  Default: `'launcher'`
 
-This variable can be changed to use a different executable for java.
-
+This variable must be set to the absolute path of the language server launcher
+executable. For example:
+>
+  let g:ale_java_javalsp_executable=/java-language-server/dist/mac/bin/launcher
+<
 
 ===============================================================================
 eclipselsp                                                *ale-java-eclipselsp*

--- a/test/command_callback/test_javalsp_command_callback.vader
+++ b/test/command_callback/test_javalsp_command_callback.vader
@@ -6,7 +6,7 @@ After:
   call ale#assert#TearDownLinterTest()
 
 Execute(The javalsp callback should return the correct default value):
-  AssertLinter 'launcher', ale#Escape('launcher')
+  AssertLinter '', ale#Escape('')
 
 Execute(The javalsp java executable should be configurable):
   let b:ale_java_javalsp_executable = '/bin/foobar'

--- a/test/command_callback/test_javalsp_command_callback.vader
+++ b/test/command_callback/test_javalsp_command_callback.vader
@@ -6,9 +6,26 @@ After:
   call ale#assert#TearDownLinterTest()
 
 Execute(The javalsp callback should return the correct default value):
-  AssertLinter 'java', ale#Escape('java') . ' -Xverify:none -m javacs/org.javacs.Main'
+  AssertLinter 'launcher', ale#Escape('launcher')
 
 Execute(The javalsp java executable should be configurable):
   let b:ale_java_javalsp_executable = '/bin/foobar'
 
-  AssertLinter '/bin/foobar', ale#Escape('/bin/foobar') . ' -Xverify:none -m javacs/org.javacs.Main'
+  AssertLinter '/bin/foobar', ale#Escape('/bin/foobar')
+
+Execute(The javalsp callback should return backward compatible value):
+  let b:ale_java_javalsp_executable = '/bin/java'
+  let cmd = [
+  \ ale#Escape('/bin/java'),
+  \ '--add-exports jdk.compiler/com.sun.tools.javac.api=javacs',
+  \ '--add-exports jdk.compiler/com.sun.tools.javac.code=javacs',
+  \ '--add-exports jdk.compiler/com.sun.tools.javac.comp=javacs',
+  \ '--add-exports jdk.compiler/com.sun.tools.javac.main=javacs',
+  \ '--add-exports jdk.compiler/com.sun.tools.javac.tree=javacs',
+  \ '--add-exports jdk.compiler/com.sun.tools.javac.model=javacs',
+  \ '--add-exports jdk.compiler/com.sun.tools.javac.util=javacs',
+  \ '--add-opens jdk.compiler/com.sun.tools.javac.api=javacs',
+  \ '-m javacs/org.javacs.Main',
+  \]
+  AssertLinter '/bin/java', join(cmd, ' ')
+


### PR DESCRIPTION
The command used to invoke the language server is missing some options
to include additional java modules. Without these modules the server
was not working properly.

The correct command can be found in a `launcher` script on the same
directory the `java` executable for the language server is found.

This commit changes the docs to prefer the launcher script over the java
executable. For backward compatibility it also fixes the command
invocation in case the java executable is configured.
