### PR TITLE
show rendered cargo error in detail for clippy errors

### DIFF
--- a/autoload/ale/handlers/rust.vim
+++ b/autoload/ale/handlers/rust.vim
@@ -56,14 +56,20 @@ function! ale#handlers#rust#HandleRustErrors(buffer, lines) abort
             endif
 
             if !empty(l:span)
-                call add(l:output, {
+                let l:output_line = {
                 \   'lnum': l:span.line_start,
                 \   'end_lnum': l:span.line_end,
                 \   'col': l:span.column_start,
                 \   'end_col': l:span.column_end-1,
                 \   'text': empty(l:span.label) ? l:error.message : printf('%s: %s', l:error.message, l:span.label),
                 \   'type': toupper(l:error.level[0]),
-                \})
+                \}
+
+                if has_key(l:error, 'rendered') && !empty(l:error.rendered)
+                    let l:output_line.detail = l:error.rendered
+                endif
+
+                call add(l:output, l:output_line)
             endif
         endfor
     endfor

--- a/test/handler/test_rust_handler.vader
+++ b/test/handler/test_rust_handler.vader
@@ -247,6 +247,57 @@ Execute(The Rust handler should show detailed errors):
   \   }),
   \ ])
 
+Execute(The Rust handler should show detailed clippy errors with rendered field if it's available):
+  call ale#test#SetFilename('src/playpen.rs')
+
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 4,
+  \     'end_lnum': 4,
+  \     'type': 'E',
+  \     'col': 21,
+  \     'end_col': 22,
+  \     'text': 'mismatched types: expected bool, found integral variable',
+  \     'detail': 'this is a detailed description',
+  \   },
+  \ ],
+  \ ale#handlers#rust#HandleRustErrors(bufnr(''), [
+  \   '',
+  \   'ignore this',
+  \   json_encode({
+  \     'message': {
+  \       'code': v:null,
+  \       'level': 'error',
+  \       'message': 'mismatched types',
+  \       'rendered': 'this is a detailed description',
+  \       'spans': [
+  \         {
+  \           'byte_end': 54,
+  \           'byte_start': 52,
+  \           'column_end': 23,
+  \           'column_start': 21,
+  \           'expansion': v:null,
+  \           'file_name': ale#path#Simplify('src/playpen.rs'),
+  \           'is_primary': v:true,
+  \           'label': 'expected bool, found integral variable',
+  \           'line_end': 4,
+  \           'line_start': 4,
+  \         }
+  \       ]
+  \     },
+  \   }),
+  \   json_encode({
+  \     'message': {
+  \       'code': v:null,
+  \       'level': 'error',
+  \       'message': 'aborting due to previous error(s)',
+  \       'spans': [
+  \       ]
+  \     },
+  \   }),
+  \ ])
+
 Execute(The Rust handler should find correct files):
   call ale#test#SetFilename('src/noerrors/mod.rs')
 


### PR DESCRIPTION
Sample clippy output:

```json
{
    "reason": "compiler-message",
    "package_id": "snow_white 0.1.0 (path+file:///Users/lazarus/dev/grim/snow_white)",
    "target": {
        "kind": [
            "lib"
        ],
        "crate_types": [
            "lib"
        ],
        "name": "snow_white",
        "src_path": "/Users/lazarus/dev/grim/snow_white/src/lib.rs",
        "edition": "2018",
        "doctest": true
    },
    "message": {
        "rendered": "warning: You are using an explicit closure for copying elements\n   --> snow_white/src/save.rs:289:21\n    |\n289 |                     pending_seqs.seqs.iter().map(|seq| *seq).collect::<Vec<Seq>>()\n    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: Consider calling the dedicated `copied` method: `pending_seqs.seqs.iter().copied()`\n    |\n    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#map_clone\n\n",
        "children": [
            {
                "children": [

                ],
                "code": null,
                "level": "help",
                "message": "for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#map_clone",
                "rendered": null,
                "spans": [

                ]
            },
            {
                "children": [

                ],
                "code": null,
                "level": "help",
                "message": "Consider calling the dedicated `copied` method",
                "rendered": null,
                "spans": [
                    {
                        "byte_end": 11764,
                        "byte_start": 11724,
                        "column_end": 61,
                        "column_start": 21,
                        "expansion": null,
                        "file_name": "snow_white/src/save.rs",
                        "is_primary": true,
                        "label": null,
                        "line_end": 289,
                        "line_start": 289,
                        "suggested_replacement": "pending_seqs.seqs.iter().copied()",
                        "suggestion_applicability": "MachineApplicable",
                        "text": [
                            {
                                "highlight_end": 61,
                                "highlight_start": 21,
                                "text": "                    pending_seqs.seqs.iter().map(|seq| *seq).collect::<Vec<Seq>>()"
                            }
                        ]
                    }
                ]
            }
        ],
        "code": {
            "code": "clippy::map_clone",
            "explanation": null
        },
        "level": "warning",
        "message": "You are using an explicit closure for copying elements",
        "spans": [
            {
                "byte_end": 11764,
                "byte_start": 11724,
                "column_end": 61,
                "column_start": 21,
                "expansion": null,
                "file_name": "snow_white/src/save.rs",
                "is_primary": true,
                "label": null,
                "line_end": 289,
                "line_start": 289,
                "suggested_replacement": null,
                "suggestion_applicability": null,
                "text": [
                    {
                        "highlight_end": 61,
                        "highlight_start": 21,
                        "text": "                    pending_seqs.seqs.iter().map(|seq| *seq).collect::<Vec<Seq>>()"
                    }
                ]
            }
        ]
    }
}

```

The current detail is:
```
You are using an explicit closure for copying elements
```

The new detail is:
```
warning: You are using an explicit closure for copying elements
   --> snow_white/src/save.rs:278:27
    |
278 |         let all_log_ids = logs.keys().map(|log_id| *log_id).collect::<Vec<LogId>>();
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: Consider calling the dedicated `copied` method: `logs.keys().copied()`
    |
    = note: #[warn(clippy::map_clone)] on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#map_clone
```