### PR TITLE
Add javalsp lsp options

### DIFF
--- a/ale_linters/java/javalsp.vim
+++ b/ale_linters/java/javalsp.vim
@@ -2,9 +2,36 @@
 " Description: Support for the Java language server https://github.com/georgewfraser/vscode-javac
 
 call ale#Set('java_javalsp_executable', '')
+call ale#Set('java_javalsp_external_deps', [])
+call ale#Set('java_javalsp_classpaths', [])
 
 function! ale_linters#java#javalsp#Executable(buffer) abort
     return ale#Var(a:buffer, 'java_javalsp_executable')
+endfunction
+
+function! ale_linters#java#javalsp#Deps(buffer) abort
+    let l:deps = ale#Var(a:buffer, 'java_javalsp_external_deps')
+
+    return type(l:deps) is v:t_list
+    \ ? l:deps
+    \ : function(l:deps)(a:buffer)
+endfunction
+
+function! ale_linters#java#javalsp#Paths(buffer) abort
+    let l:paths = ale#Var(a:buffer, 'java_javalsp_classpaths')
+
+    return type(l:paths) is v:t_list
+    \ ? l:paths
+    \ : function(l:paths)(a:buffer)
+endfunction
+
+function! ale_linters#java#javalsp#Options(buffer) abort
+    return {
+    \ 'java': {
+    \    'externalDependencies': ale_linters#java#javalsp#Deps(a:buffer),
+    \    'classPath': ale_linters#java#javalsp#Paths(a:buffer)
+    \ }
+    \}
 endfunction
 
 function! ale_linters#java#javalsp#Command(buffer) abort
@@ -38,4 +65,5 @@ call ale#linter#Define('java', {
 \   'command': function('ale_linters#java#javalsp#Command'),
 \   'language': 'java',
 \   'project_root': function('ale#java#FindProjectRoot'),
+\   'lsp_config': function('ale_linters#java#javalsp#Options')
 \})


### PR DESCRIPTION
This MR adds two new configuration options `g:ale_java_javalsp_external_deps` and `g:ale_java_javalsp_classpaths` that are analog to the `java.externalDependencies` and `java.classPath` configurations available in the [vscode/settings.json](https://github.com/georgewfraser/java-language-server#settings) file.

With these is possible to add Android deps to the configuration and get auto-completion for Android classes.
 
Moreover these options can be set to a vim function that provides means  to dynamically update the dependencies. The only concern here is if the function is executed in background by ALE or not. Retrieving dependencies using gradle/mnv can take a long time on large projects.

FYI: @DonnieWest @GrimKriegor this may be of interest for you.
