### PR TITLE
prettier: Support experimental languages (Handlebars)

### DIFF
--- a/autoload/ale/fixers/prettier.vim
+++ b/autoload/ale/fixers/prettier.vim
@@ -39,51 +39,44 @@ function! ale#fixers#prettier#ApplyFixForVersion(buffer, version) abort
     let l:options = ale#Var(a:buffer, 'javascript_prettier_options')
     let l:parser = ''
 
+    let l:filetypes = split(getbufvar(a:buffer, '&filetype'), '\.')
+
+    if index(l:filetypes, 'handlebars') > -1
+        let l:parser = 'glimmer'
+    endif
+
     " Append the --parser flag depending on the current filetype (unless it's
     " already set in g:javascript_prettier_options).
-    if match(l:options, '--parser') == -1
-        if empty(expand('#' . a:buffer . ':e'))
-            " Mimic Prettier's defaults. In cases without a file extension or
-            " filetype (scratch buffer), Prettier needs `parser` set to know how
-            " to process the buffer.
-            if ale#semver#GTE(a:version, [1, 16, 0])
-                let l:parser = 'babel'
-            else
-                let l:parser = 'babylon'
-            endif
-
-            let l:prettier_parsers = {
-            \    'typescript': 'typescript',
-            \    'css': 'css',
-            \    'less': 'less',
-            \    'scss': 'scss',
-            \    'json': 'json',
-            \    'json5': 'json5',
-            \    'graphql': 'graphql',
-            \    'markdown': 'markdown',
-            \    'vue': 'vue',
-            \    'yaml': 'yaml',
-            \    'html': 'html',
-            \}
-
-            for l:filetype in split(getbufvar(a:buffer, '&filetype'), '\.')
-                if has_key(l:prettier_parsers, l:filetype)
-                    let l:parser = l:prettier_parsers[l:filetype]
-                    break
-                endif
-            endfor
+    if empty(expand('#' . a:buffer . ':e')) && l:parser is# ''  && match(l:options, '--parser') == -1
+        " Mimic Prettier's defaults. In cases without a file extension or
+        " filetype (scratch buffer), Prettier needs `parser` set to know how
+        " to process the buffer.
+        if ale#semver#GTE(a:version, [1, 16, 0])
+            let l:parser = 'babel'
         else
-            " Append a --parser flag. In cases the filetype has an exprimental
-            " support in Prettier and has to be appended manually.
-            let l:prettier_experimental_parsers = {
-            \    'html.handlebars': 'glimmer',
-            \}
-            let l:filetype = getbufvar(a:buffer, '&filetype')
-
-            if has_key(l:prettier_experimental_parsers, l:filetype)
-                let l:parser = l:prettier_experimental_parsers[l:filetype]
-            endif
+            let l:parser = 'babylon'
         endif
+
+        let l:prettier_parsers = {
+        \    'typescript': 'typescript',
+        \    'css': 'css',
+        \    'less': 'less',
+        \    'scss': 'scss',
+        \    'json': 'json',
+        \    'json5': 'json5',
+        \    'graphql': 'graphql',
+        \    'markdown': 'markdown',
+        \    'vue': 'vue',
+        \    'yaml': 'yaml',
+        \    'html': 'html',
+        \}
+
+        for l:filetype in l:filetypes
+            if has_key(l:prettier_parsers, l:filetype)
+                let l:parser = l:prettier_parsers[l:filetype]
+                break
+            endif
+        endfor
     endif
 
     if !empty(l:parser)

--- a/doc/ale-handlebars.txt
+++ b/doc/ale-handlebars.txt
@@ -3,6 +3,13 @@ ALE Handlebars Integration                             *ale-handlebars-options*
 
 
 ===============================================================================
+prettier                                              *ale-handlebars-prettier*
+
+See |ale-javascript-prettier| for information about the available options.
+Uses glimmer parser by default.
+
+
+===============================================================================
 ember-template-lint                          *ale-handlebars-embertemplatelint*
 
 g:ale_handlebars_embertemplatelint_executable

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2034,6 +2034,7 @@ documented in additional help files.
     hackfmt...............................|ale-hack-hackfmt|
     hhast.................................|ale-hack-hhast|
   handlebars..............................|ale-handlebars-options|
+    prettier..............................|ale-handlebars-prettier|
     ember-template-lint...................|ale-handlebars-embertemplatelint|
   haskell.................................|ale-haskell-options|
     brittany..............................|ale-haskell-brittany|

--- a/test/fixers/test_prettier_fixer_callback.vader
+++ b/test/fixers/test_prettier_fixer_callback.vader
@@ -280,6 +280,20 @@ Execute(Should set --parser based on first filetype of multiple filetypes):
   \     . ' --stdin-filepath %s --stdin',
   \ }
 
+Execute(Should set --parser for experimental language, Handlebars):
+  call ale#test#SetFilename('../prettier-test-files/testfile.hbs')
+
+  set filetype=html.handlebars
+
+  GivenCommandOutput ['1.6.0']
+  AssertFixer
+  \ {
+  \   'command': ale#path#CdString(expand('%:p:h'))
+  \     . ale#Escape(g:ale_javascript_prettier_executable)
+  \     . ' --parser glimmer'
+  \     . ' --stdin-filepath %s --stdin',
+  \ }
+
 Execute(The prettier_d post-processor should permit regular JavaScript content):
   AssertEqual
   \ [


### PR DESCRIPTION
In case the filetype has an exprimental support in Prettier, the --parser flag has to be set manually.

I'm not 100% sure if it's relevant or not to tie ale to an experimental flag in Prettier. But the patch is done, so I leave it to your judgement @w0rp 🙂.

For the time being, I'm using this workaround: https://github.com/w0rp/ale/issues/2247#issuecomment-457660222

Would close https://github.com/w0rp/ale/issues/2247

<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!
-->