### PR TITLE
Run xml linters on xsd and xslt files

### DIFF
--- a/autoload/ale/linter.vim
+++ b/autoload/ale/linter.vim
@@ -17,6 +17,8 @@ let s:default_ale_linter_aliases = {
 \   'verilog_systemverilog': ['verilog_systemverilog', 'verilog'],
 \   'vimwiki': 'markdown',
 \   'vue': ['vue', 'javascript'],
+\   'xsd': ['xsd', 'xml'],
+\   'xslt': ['xslt', 'xml'],
 \   'zsh': 'sh',
 \}
 

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -1016,6 +1016,8 @@ g:ale_linter_aliases                                     *g:ale_linter_aliases*
   \   'verilog_systemverilog': ['verilog_systemverilog', 'verilog'],
   \   'vimwiki': 'markdown',
   \   'vue': ['vue', 'javascript'],
+  \   'xsd': ['xsd', 'xml'],
+  \   'xslt': ['xslt', 'xml'],
   \   'zsh': 'sh',
   \}
 <


### PR DESCRIPTION
Both xsd and xslt are by definition written in XML, and thus the same
linter(s) can be run to check them for well-formedness.