### PR TITLE
Add additional options setting for clang-tidy linter

### DIFF
--- a/ale_linters/c/clangtidy.vim
+++ b/ale_linters/c/clangtidy.vim
@@ -11,9 +11,12 @@ call ale#Set('c_clangtidy_executable', 'clang-tidy')
 " http://clang.llvm.org/extra/clang-tidy/checks/list.html
 
 call ale#Set('c_clangtidy_checks', [])
-" Set this option to manually set some options for clang-tidy.
+" Set this option to manually set some options for clang-tidy to use as compile
+" flags.
 " This will disable compile_commands.json detection.
 call ale#Set('c_clangtidy_options', '')
+" Set this option to manually set options for clang-tidy directly.
+call ale#Set('c_clangtidy_extra_options', '')
 call ale#Set('c_build_dir', '')
 
 function! ale_linters#c#clangtidy#GetCommand(buffer) abort
@@ -25,8 +28,12 @@ function! ale_linters#c#clangtidy#GetCommand(buffer) abort
     \   ? ale#Var(a:buffer, 'c_clangtidy_options')
     \   : ''
 
+    " Get the options to pass directly to clang-tidy
+    let l:extra_options = ale#Var(a:buffer, 'c_clangtidy_extra_options')
+
     return '%e'
     \   . (!empty(l:checks) ? ' -checks=' . ale#Escape(l:checks) : '')
+    \   . (!empty(l:extra_options) ? ' ' . ale#Escape(l:extra_options) : '')
     \   . ' %s'
     \   . (!empty(l:build_dir) ? ' -p ' . ale#Escape(l:build_dir) : '')
     \   . (!empty(l:options) ? ' -- ' . l:options : '')

--- a/ale_linters/cpp/clangtidy.vim
+++ b/ale_linters/cpp/clangtidy.vim
@@ -5,9 +5,12 @@
 call ale#Set('cpp_clangtidy_executable', 'clang-tidy')
 " Set this option to check the checks clang-tidy will apply.
 call ale#Set('cpp_clangtidy_checks', [])
-" Set this option to manually set some options for clang-tidy.
+" Set this option to manually set some options for clang-tidy to use as compile
+" flags.
 " This will disable compile_commands.json detection.
 call ale#Set('cpp_clangtidy_options', '')
+" Set this option to manually set options for clang-tidy directly.
+call ale#Set('cpp_clangtidy_extra_options', '')
 call ale#Set('c_build_dir', '')
 
 function! ale_linters#cpp#clangtidy#GetCommand(buffer) abort
@@ -19,8 +22,12 @@ function! ale_linters#cpp#clangtidy#GetCommand(buffer) abort
     \   ? ale#Var(a:buffer, 'cpp_clangtidy_options')
     \   : ''
 
+    " Get the options to pass directly to clang-tidy
+    let l:extra_options = ale#Var(a:buffer, 'cpp_clangtidy_extra_options')
+
     return '%e'
     \   . (!empty(l:checks) ? ' -checks=' . ale#Escape(l:checks) : '')
+    \   . (!empty(l:extra_options) ? ' ' . ale#Escape(l:extra_options) : '')
     \   . ' %s'
     \   . (!empty(l:build_dir) ? ' -p ' . ale#Escape(l:build_dir) : '')
     \   . (!empty(l:options) ? ' -- ' . l:options : '')

--- a/doc/ale-c.txt
+++ b/doc/ale-c.txt
@@ -156,7 +156,7 @@ g:ale_c_clangtidy_options                           *g:ale_c_clangtidy_options*
   Type: |String|
   Default: `''`
 
-  This variable can be changed to modify flags given to clang-tidy.
+  This variable can be changed to modify compiler flags given to clang-tidy.
 
   - Setting this variable to a non-empty string,
   - and working in a buffer where no compilation database is found using
@@ -167,6 +167,14 @@ g:ale_c_clangtidy_options                           *g:ale_c_clangtidy_options*
   Only set this option if you want to control compiler flags
   entirely manually, and no `compile_commands.json` file is in one
   of the |g:ale_c_build_dir_names| directories of the project tree.
+
+
+g:ale_c_clangtidy_extra_options               *g:ale_c_clangtidy_extra_options*
+                                              *b:ale_c_clangtidy_extra_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be changed to modify flags given to clang-tidy.
 
 
 ===============================================================================

--- a/doc/ale-cpp.txt
+++ b/doc/ale-cpp.txt
@@ -125,7 +125,7 @@ g:ale_cpp_clangtidy_options                       *g:ale_cpp_clangtidy_options*
   Type: |String|
   Default: `''`
 
-  This variable can be changed to modify flags given to clang-tidy.
+  This variable can be changed to modify compiler flags given to clang-tidy.
 
   - Setting this variable to a non-empty string,
   - and working in a buffer where no compilation database is found using
@@ -136,6 +136,14 @@ g:ale_cpp_clangtidy_options                       *g:ale_cpp_clangtidy_options*
   Only set this option if you want to control compiler flags
   entirely manually, and no `compile_commands.json` file is in one
   of the |g:ale_c_build_dir_names| directories of the project tree.
+
+
+g:ale_cpp_clangtidy_extra_options           *g:ale_cpp_clangtidy_extra_options*
+                                            *b:ale_cpp_clangtidy_extra_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be changed to modify flags given to clang-tidy.
 
 
 ===============================================================================

--- a/test/command_callback/test_c_clang_tidy_command_callback.vader
+++ b/test/command_callback/test_c_clang_tidy_command_callback.vader
@@ -29,6 +29,12 @@ Execute(You should be able to manually set compiler flags for clang-tidy):
   AssertLinter 'clang-tidy',
   \ ale#Escape('clang-tidy') . ' -checks=' . ale#Escape('*') . ' %s -- -Wall'
 
+Execute(You should be able to manually set flags for clang-tidy):
+  let b:ale_c_clangtidy_extra_options = '-config='
+
+  AssertLinter 'clang-tidy',
+  \ ale#Escape('clang-tidy') . ' ' . ale#Escape('-config=') . ' %s'
+
 Execute(The build directory should be configurable):
   let b:ale_c_clangtidy_checks = ['*']
   let b:ale_c_build_dir = '/foo/bar'

--- a/test/command_callback/test_clang_tidy_command_callback.vader
+++ b/test/command_callback/test_clang_tidy_command_callback.vader
@@ -29,6 +29,12 @@ Execute(You should be able to manually set compiler flags for clang-tidy):
   AssertLinter 'clang-tidy',
   \ ale#Escape('clang-tidy') . ' -checks=' . ale#Escape('*') . ' %s -- -Wall'
 
+Execute(You should be able to manually set flags for clang-tidy):
+  let b:ale_cpp_clangtidy_extra_options = '-config='
+
+  AssertLinter 'clang-tidy',
+  \ ale#Escape('clang-tidy') . ' ' . ale#Escape('-config=') . ' %s'
+
 Execute(The build directory should be configurable):
   let b:ale_cpp_clangtidy_checks = ['*']
   let b:ale_c_build_dir = '/foo/bar'


### PR DESCRIPTION
Fixes #2324

Looking for some feedback on what to name the new option I've added for the clang-tidy linter. I've just used `g:ale_c(pp)_clangtidy_extra_options` as a temporary placeholder for now. This new setting can be used to configure clang-tidy specific settings unlike the existing options which can only configure compiler flags.

Ideally (IMO), the existing `g:ale_c(pp)_clangtidy_options` name would be repurposed for the new setting and the existing setting would be renamed to `g:ale_c(pp)_clangtidy_compiler_options` or something similar. This would more accurately reflect what each setting is actually used for. That would be a breaking change for existing users though so finding a better name for the new setting is probably the better option.