### PR TITLE
Fix checkstyle default configuration.

### DIFF
--- a/ale_linters/java/checkstyle.vim
+++ b/ale_linters/java/checkstyle.vim
@@ -2,7 +2,7 @@
 " Description: checkstyle for Java files
 
 call ale#Set('java_checkstyle_executable', 'checkstyle')
-call ale#Set('java_checkstyle_config', 'google_checks.xml')
+call ale#Set('java_checkstyle_config', '/google_checks.xml')
 call ale#Set('java_checkstyle_options', '')
 
 function! ale_linters#java#checkstyle#Handle(buffer, lines) abort
@@ -39,11 +39,21 @@ function! ale_linters#java#checkstyle#Handle(buffer, lines) abort
     return l:output
 endfunction
 
+function! s:GetConfig(buffer, config) abort
+    if ale#path#IsAbsolute(a:config)
+        return a:config
+    endif
+
+    let s:file = ale#path#FindNearestFile(a:buffer, a:config)
+
+    return !empty(s:file) ? s:file : a:config
+endfunction
+
 function! ale_linters#java#checkstyle#GetCommand(buffer) abort
     let l:options = ale#Var(a:buffer, 'java_checkstyle_options')
     let l:config_option = ale#Var(a:buffer, 'java_checkstyle_config')
     let l:config = l:options !~# '\v(^| )-c' && !empty(l:config_option)
-    \   ? ale#path#FindNearestFile(a:buffer, l:config_option)
+    \   ? s:GetConfig(a:buffer, l:config_option)
     \   : ''
 
     return '%e'

--- a/doc/ale-java.txt
+++ b/doc/ale-java.txt
@@ -9,7 +9,7 @@ g:ale_java_checkstyle_config                     *g:ale_java_checkstyle_config*
                                                  *b:ale_java_checkstyle_config*
 
   Type: |String|
-  Default: `'google_checks.xml'`
+  Default: `'/google_checks.xml'`
 
   A path to a checkstyle configuration file.
 

--- a/test/command_callback/test_checkstyle_command_callback.vader
+++ b/test/command_callback/test_checkstyle_command_callback.vader
@@ -6,17 +6,27 @@ After:
   call ale#assert#TearDownLinterTest()
 
 Execute(The checkstyle callback should return the correct default value):
-  AssertLinter 'checkstyle', ale#Escape('checkstyle') . ' %s'
+  AssertLinter 'checkstyle',
+  \ ale#Escape('checkstyle')
+  \ . ' -c ' . ale#Escape('/google_checks.xml')
+  \ . ' %s'
 
 Execute(The checkstyle executable should be configurable):
   let b:ale_java_checkstyle_executable = 'foobar'
 
-  AssertLinter 'foobar', ale#Escape('foobar') . ' %s'
+  AssertLinter 'foobar',
+  \ ale#Escape('foobar')
+  \ . ' -c ' . ale#Escape('/google_checks.xml')
+  \ . ' %s'
 
 Execute(Custom options should be supported):
   let b:ale_java_checkstyle_options = '--foobar'
 
-  AssertLinter 'checkstyle', ale#Escape('checkstyle') . ' --foobar %s'
+  AssertLinter 'checkstyle',
+  \ ale#Escape('checkstyle')
+  \ . ' --foobar'
+  \ . ' -c ' . ale#Escape('/google_checks.xml')
+  \ . ' %s'
 
 Execute(configuration files set in _config should be supported):
   let b:ale_java_checkstyle_config = ale#path#Simplify(g:dir . '/checkstyle_paths/other_config.xml')
@@ -36,12 +46,12 @@ Execute(configuration files set in _options should be preferred over _config):
 
   AssertLinter 'checkstyle', ale#Escape('checkstyle') . ' -x -c /bar.xml %s'
 
-Execute(google_checks.xml should be detected automatically):
+Execute(google_checks.xml should be used by default):
   call ale#test#SetFilename('checkstyle_paths/test.java')
 
   AssertLinter 'checkstyle',
   \ ale#Escape('checkstyle')
-  \ . ' -c ' . ale#Escape(ale#path#Simplify(g:dir . '/checkstyle_paths/google_checks.xml'))
+  \ . ' -c ' . ale#Escape('/google_checks.xml')
   \ . ' %s'
 
 Execute(Other relative paths should be supported):


### PR DESCRIPTION
Checkstyle xml configuration is mandatory and not providing one causes
the tool to fail with the following error:

    Must specify a config XML file.

Checkstyle itself contains a default configuration as part of its
assests named `/google_checks.xml`. Invoking checkstyle with this config
works even if such file does not exists in the file system:

    checkstyle -c /google_checks.xml

This should be the default invocation to allow ALE to use checkstyle
with zero configuration.

Also when a user sets `g:ale_java_checkstyle_config` option, ALE should
use it to invoke checkstyle even if such file does not exists in the
filesystem. This is because checkstyle is able to use configuration files
within JAR files defined in the CLASSPATH. The default `/google_checks.xml`
is an example of such configuration available within a JAR resource.