### PR TITLE
Elm: Update link to compiler repository

### DIFF
--- a/supported-tools.md
+++ b/supported-tools.md
@@ -131,7 +131,7 @@ formatting.
 * Elm
   * [elm-format](https://github.com/avh4/elm-format)
   * [elm-lsp](https://github.com/antew/elm-lsp)
-  * [elm-make](https://github.com/elm-lang/elm-make)
+  * [elm-make](https://github.com/elm/compiler)
 * Erb
   * [erb](https://apidock.com/ruby/ERB)
   * [erubi](https://github.com/jeremyevans/erubi)


### PR DESCRIPTION
Updating the docs because the link was referring to the previous archived repository. It should be `elm/compiler`.