### PR TITLE
Raise deoplete source rank to 1000

### DIFF
--- a/rplugin/python3/deoplete/sources/ale.py
+++ b/rplugin/python3/deoplete/sources/ale.py
@@ -21,7 +21,7 @@ class Source(Base):
 
         self.name = 'ale'
         self.mark = '[L]'
-        self.rank = 100
+        self.rank = 1000
         self.is_bytepos = True
         self.min_pattern_length = 1
 

--- a/test/python/test_deoplete_source.py
+++ b/test/python/test_deoplete_source.py
@@ -45,7 +45,7 @@ class DeopleteSourceTest(unittest.TestCase):
             'mark': '[L]',
             'min_pattern_length': 1,
             'name': 'ale',
-            'rank': 100,
+            'rank': 1000,
         })
 
     def test_completion_position(self):


### PR DESCRIPTION
The deoplete source rank of 100 is far too low for a language specific completion source. The builtin "around" completion source which "collects candidates around the cursor" even have a higher rank of 300. [LanguageClient-neovim](https://github.com/autozimu/LanguageClient-neovim/blob/next/rplugin/python3/deoplete/sources/LanguageClientSource.py#L13) also set this to 1000. 