### PR TITLE
Add support for javalsp configuration options.

### DIFF
--- a/ale_linters/java/javalsp.vim
+++ b/ale_linters/java/javalsp.vim
@@ -2,9 +2,22 @@
 " Description: Support for the Java language server https://github.com/georgewfraser/vscode-javac
 
 call ale#Set('java_javalsp_executable', '')
+call ale#Set('java_javalsp_config', {})
 
 function! ale_linters#java#javalsp#Executable(buffer) abort
     return ale#Var(a:buffer, 'java_javalsp_executable')
+endfunction
+
+function! ale_linters#java#javalsp#Config(buffer) abort
+    let l:defaults = { 'java': { 'classPath': [], 'externalDependencies': [] } }
+    let l:config = ale#Var(a:buffer, 'java_javalsp_config')
+
+    " Ensure the config dictionary contains both classPath and
+    " externalDependencies keys to avoid a NPE crash on Java Language Server.
+    call extend(l:config, l:defaults, 'keep')
+    call extend(l:config['java'], l:defaults['java'], 'keep')
+
+    return l:config
 endfunction
 
 function! ale_linters#java#javalsp#Command(buffer) abort
@@ -38,4 +51,5 @@ call ale#linter#Define('java', {
 \   'command': function('ale_linters#java#javalsp#Command'),
 \   'language': 'java',
 \   'project_root': function('ale#java#FindProjectRoot'),
+\   'lsp_config': function('ale_linters#java#javalsp#Config')
 \})

--- a/doc/ale-java.txt
+++ b/doc/ale-java.txt
@@ -131,6 +131,33 @@ executable. For example:
   let g:ale_java_javalsp_executable=/java-language-server/dist/mac/bin/launcher
 <
 
+g:ale_java_javalsp_config                           *g:ale_java_javalsp_config*
+                                                    *b:ale_java_javalsp_config*
+  Type: |Dictionary|
+  Default: `{}`
+
+The javalsp linter automatically detects external depenencies for Maven and
+Gradle projects. In case the javalsp fails to detect some of them, you can
+specify them setting a dictionary to |g:ale_java_javalsp_config| variable.
+>
+  let g:ale_java_javalsp_executable =
+  \ {
+  \   'java': {
+  \     'externalDependencies': [
+  \       'junit:junit:jar:4.12:test',   " Maven format
+  \       'junit:junit:4.1'              " Gradle format
+  \     ],
+  \     'classPath': [
+  \       'lib/some-dependency.jar',
+  \       '/android-sdk/platforms/android-28.jar'
+  \     ]
+  \   }
+  \ }
+
+The Java language server will look for the dependencies you specify in
+`externalDependencies` array in your Maven and Gradle caches ~/.m2 and
+~/.gradle.
+
 ===============================================================================
 eclipselsp                                                *ale-java-eclipselsp*
 

--- a/test/command_callback/test_javalsp_command_callback.vader
+++ b/test/command_callback/test_javalsp_command_callback.vader
@@ -29,3 +29,52 @@ Execute(The javalsp callback should return backward compatible value):
   \]
   AssertLinter '/bin/java', join(cmd, ' ')
 
+Execute(The javalsp should have default config):
+  AssertEqual
+  \ {
+  \   'java': {
+  \     'classPath': [],
+  \     'externalDependencies': []
+  \   }
+  \ },
+  \ ale_linters#java#javalsp#Config(bufnr(''))
+
+Execute(The javalsp should have default config if user sets empty hash):
+  let b:ale_java_javalsp_config = {}
+
+  AssertEqual
+  \ {
+  \   'java': {
+  \     'classPath': [],
+  \     'externalDependencies': []
+  \   }
+  \ },
+  \ ale_linters#java#javalsp#Config(bufnr(''))
+
+Execute(The javalsp should have add missing config):
+  let b:ale_java_javalsp_config = { 'java': { 'classPath': ['aaa.jar'] } }
+
+  AssertEqual
+  \ {
+  \   'java': {
+  \     'classPath': ['aaa.jar'],
+  \     'externalDependencies': []
+  \   }
+  \ },
+  \ ale_linters#java#javalsp#Config(bufnr(''))
+
+  let b:ale_java_javalsp_config =
+  \ {
+  \   'java': {
+  \     'externalDependencies': ['unit-test:2.0.0']
+  \   }
+  \ }
+
+  AssertEqual
+  \ {
+  \   'java': {
+  \     'classPath': [],
+  \     'externalDependencies': ['unit-test:2.0.0']
+  \   }
+  \ },
+  \ ale_linters#java#javalsp#Config(bufnr(''))


### PR DESCRIPTION
This MR adds a new configuration variable `g:ale_java_javalsp_config`
that allows to configure external dependencies and class paths to the
language server.

The variable accepts a dictionary similar to the one supported by the
[vscode/settings.json](https://github.com/georgewfraser/java-language-server#settings)
file.

Deprecates: #2561