### PR TITLE
Show more candidates for Deoplete completion

### DIFF
--- a/autoload/ale/completion.vim
+++ b/autoload/ale/completion.vim
@@ -215,6 +215,10 @@ function! ale#completion#GetCompletionPosition() abort
     return l:column - len(l:match) - 1
 endfunction
 
+function! ale#completion#GetCompletionPositionForDeoplete(input) abort
+    return match(a:input, '\k*$')
+endfunction
+
 function! ale#completion#GetCompletionResult() abort
     if exists('b:ale_completion_result')
         return b:ale_completion_result

--- a/autoload/ale/completion.vim
+++ b/autoload/ale/completion.vim
@@ -59,7 +59,8 @@ let s:omni_start_map = {
 \   '<default>': '\v[a-zA-Z$_][a-zA-Z$_0-9]*$',
 \}
 
-" A map of exact characters for triggering LSP completions.
+" A map of exact characters for triggering LSP completions. Do not forget to
+" update self.input_patterns in ale.py in updating entries in this map.
 let s:trigger_character_map = {
 \   '<default>': ['.'],
 \   'typescript': ['.', '''', '"'],

--- a/rplugin/python3/deoplete/sources/ale.py
+++ b/rplugin/python3/deoplete/sources/ale.py
@@ -24,6 +24,7 @@ class Source(Base):
         self.rank = 1000
         self.is_bytepos = True
         self.min_pattern_length = 1
+        self.input_pattern = r'(\.|::|->)\w*$'
 
     # Returns an integer for the start position, as with omnifunc.
     def get_completion_position(self):

--- a/rplugin/python3/deoplete/sources/ale.py
+++ b/rplugin/python3/deoplete/sources/ale.py
@@ -24,7 +24,13 @@ class Source(Base):
         self.rank = 1000
         self.is_bytepos = True
         self.min_pattern_length = 1
-        self.input_pattern = r'(\.|::|->)\w*$'
+        # Do not forget to update s:trigger_character_map in completion.vim in
+        # updating entries in this map.
+        self.input_patterns = {
+            '_': r'\.\w*$',
+            'rust': r'(\.|::)\w*$',
+            'typescript': r'(\.|\'|")\w*$',
+        }
 
     # Returns an integer for the start position, as with omnifunc.
     def get_complete_position(self, context):

--- a/rplugin/python3/deoplete/sources/ale.py
+++ b/rplugin/python3/deoplete/sources/ale.py
@@ -27,8 +27,10 @@ class Source(Base):
         self.input_pattern = r'(\.|::|->)\w*$'
 
     # Returns an integer for the start position, as with omnifunc.
-    def get_completion_position(self):
-        return self.vim.call('ale#completion#GetCompletionPosition')
+    def get_complete_position(self, context):
+        return self.vim.call(
+            'ale#completion#GetCompletionPositionForDeoplete', context['input']
+        )
 
     def gather_candidates(self, context):
         # Stop early if ALE can't provide completion data for this buffer.

--- a/test/completion/test_public_completion_api.vader
+++ b/test/completion/test_public_completion_api.vader
@@ -32,6 +32,10 @@ Execute(ale#completion#GetCompletionPosition() should return the position in the
   " This is the first character of 'bar'
   AssertEqual 4, ale#completion#GetCompletionPosition()
 
+Execute(ale#completion#GetCompletionPositionForDeoplete() should return the position on the given input string):
+  " This is the first character of 'bar'
+  AssertEqual 4, ale#completion#GetCompletionPositionForDeoplete('foo bar')
+
 Execute(ale#completion#CanProvideCompletions should return 0 when no completion sources are available):
   AssertEqual 0, ale#completion#CanProvideCompletions()
 

--- a/test/python/test_deoplete_source.py
+++ b/test/python/test_deoplete_source.py
@@ -41,6 +41,7 @@ class DeopleteSourceTest(unittest.TestCase):
         )
 
         self.assertEqual(attributes, {
+            'input_pattern': r'(\.|::|->)\w*$',
             'is_bytepos': True,
             'mark': '[L]',
             'min_pattern_length': 1,
@@ -48,12 +49,13 @@ class DeopleteSourceTest(unittest.TestCase):
             'rank': 1000,
         })
 
-    def test_completion_position(self):
-        self.call_results['ale#completion#GetCompletionPosition'] = 2
+    def test_complete_position(self):
+        self.call_results['ale#completion#GetCompletionPositionForDeoplete'] = 2
+        context = {'input': 'foo'}
 
-        self.assertEqual(self.source.get_completion_position(), 2)
+        self.assertEqual(self.source.get_complete_position(context), 2)
         self.assertEqual(self.call_list, [
-            ('ale#completion#GetCompletionPosition', ()),
+            ('ale#completion#GetCompletionPositionForDeoplete', ('foo',)),
         ])
 
     def test_request_completion_results(self):

--- a/test/python/test_deoplete_source.py
+++ b/test/python/test_deoplete_source.py
@@ -41,7 +41,11 @@ class DeopleteSourceTest(unittest.TestCase):
         )
 
         self.assertEqual(attributes, {
-            'input_pattern': r'(\.|::|->)\w*$',
+            'input_patterns': {
+                '_': r'\.\w*$',
+                'rust': r'(\.|::)\w*$',
+                'typescript': r'(\.|\'|")\w*$',
+            },
             'is_bytepos': True,
             'mark': '[L]',
             'min_pattern_length': 1,


### PR DESCRIPTION
Fix #2579 

This PR introduces more comfortable completion for Deoplete.

### e0f8304 Add separated func for deoplete

Deoplete needs `get_complete_position` method and it has a different signature. It already fetches the input string and attempts to detect the position with `\k*` regexp patterns.

### f5a908b Add input_pattern setting for deoplete

This option is used to determine if `min_pattern_length` is ignored. In usual, it does not start completion when the matched input string is shorter than `min_pattern_length`. But when the string matches `input_pattern`, it starts completion even when ths string is `''`.

----

By this, it shows candidates when the input string is `console.` only (see below and #2579 for detail).

| before | after |
|---|---|
| <img width="391" alt="スクリーンショット 0001-06-19 14 06 19" src="https://user-images.githubusercontent.com/1239245/59738295-b5d91600-929b-11e9-85b0-e309e728385b.png"> | <img width="392" alt="スクリーンショット 0001-06-19 14 07 58" src="https://user-images.githubusercontent.com/1239245/59738434-31d35e00-929c-11e9-835e-37203960d59d.png"> |

