### PR TITLE
Update docs on default after recent changes

### DIFF
--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -981,7 +981,7 @@ g:ale_lint_on_insert_leave                         *g:ale_lint_on_insert_leave*
                                                    *b:ale_lint_on_insert_leave*
 
   Type: |Number|
-  Default: `0`
+  Default: `1`
 
   When set to `1` in your vimrc file, this option will cause ALE to run
   linters when you leave insert mode.


### PR DESCRIPTION
`g:ale_lint_on_insert_leave` default has been changed from 0 to 1 in 168768b32667b244e0afdc8da851d91ab95d6e2f