### PR TITLE
Default executable for javalsp is empthy string.

### DIFF
--- a/doc/ale-java.txt
+++ b/doc/ale-java.txt
@@ -123,7 +123,7 @@ executable in this directory.
 g:ale_java_javalsp_executable                   *g:ale_java_javalsp_executable*
                                                 *b:ale_java_javalsp_executable*
   Type: |String|
-  Default: `'launcher'`
+  Default: `''`
 
 This variable must be set to the absolute path of the language server launcher
 executable. For example:


### PR DESCRIPTION
This fixes documentation for javalsp to match actual implementation.

