### PR TITLE
Add Sorbet ruby linter and fixer

### DIFF
--- a/ale_linters/ruby/sorbet.vim
+++ b/ale_linters/ruby/sorbet.vim
@@ -1,0 +1,23 @@
+call ale#Set('ruby_sorbet_executable', 'srb')
+call ale#Set('ruby_sorbet_options', '')
+
+function! ale_linters#ruby#sorbet#GetCommand(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'ruby_sorbet_executable')
+    let l:options = ale#Var(a:buffer, 'ruby_sorbet_options')
+
+    return ale#handlers#ruby#EscapeExecutable(l:executable, 'srb')
+    \   . ' tc'
+    \   . (!empty(l:options) ? ' ' . l:options : '')
+    \   . ' --lsp --disable-watchman'
+endfunction
+
+call ale#linter#Define('ruby', {
+\   'name': 'sorbet',
+\   'aliases': ['srb'],
+\   'lsp': 'stdio',
+\   'language': 'ruby',
+\   'executable': {b -> ale#Var(b, 'ruby_sorbet_executable')},
+\   'command': function('ale_linters#ruby#sorbet#GetCommand'),
+\   'project_root': function('ale#ruby#FindProjectRoot')
+\})
+

--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -115,6 +115,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['scala'],
 \       'description': 'Fix Scala files using scalafmt',
 \   },
+\   'sorbet': {
+\       'function': 'ale#fixers#sorbet#Fix',
+\       'suggested_filetypes': ['ruby'],
+\       'description': 'Fix ruby files with srb tc --autocorrect.',
+\   },
 \   'standard': {
 \       'function': 'ale#fixers#standard#Fix',
 \       'suggested_filetypes': ['javascript'],

--- a/autoload/ale/fixers/sorbet.vim
+++ b/autoload/ale/fixers/sorbet.vim
@@ -1,0 +1,19 @@
+call ale#Set('ruby_sorbet_executable', 'srb')
+call ale#Set('ruby_sorbet_options', '')
+
+function! ale#fixers#sorbet#GetCommand(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'ruby_sorbet_executable')
+    let l:options = ale#Var(a:buffer, 'ruby_sorbet_options')
+
+    return ale#handlers#ruby#EscapeExecutable(l:executable, 'srb')
+    \   . ' tc'
+    \   . (!empty(l:options) ? ' ' . l:options : '')
+    \   . ' --autocorrect --file %t'
+endfunction
+
+function! ale#fixers#sorbet#Fix(buffer) abort
+    return {
+    \   'command': ale#fixers#sorbet#GetCommand(a:buffer),
+    \   'read_temporary_file': 1,
+    \}
+endfunction

--- a/doc/ale-ruby.txt
+++ b/doc/ale-ruby.txt
@@ -130,6 +130,26 @@ g:ale_ruby_solargraph_executable             *g:ale_ruby_solargraph_executable*
 
 
 ===============================================================================
+sorbet                                                       *ale-ruby-sorbet*
+
+g:ale_ruby_sorbet_executable                    *g:ale_ruby_sorbet_executable*
+                                                *b:ale_ruby_sorbet_executable*
+  Type: String
+  Default: `'srb'`
+
+  Override the invoked sorbet binary. Set this to `'bundle'` to invoke
+  `'bundle` `exec` srb'.
+
+
+g:ale_ruby_sorbet_options                         *g:ale_ruby_sorbet_options*
+                                                   *b:ale_ruby_sorbet_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be change to modify flags given to sorbet.
+
+
+===============================================================================
 standardrb                                                *ale-ruby-standardrb*
 
 g:ale_ruby_standardrb_executable              *g:ale_ruby_standardrb_executable*

--- a/doc/ale-ruby.txt
+++ b/doc/ale-ruby.txt
@@ -130,10 +130,10 @@ g:ale_ruby_solargraph_executable             *g:ale_ruby_solargraph_executable*
 
 
 ===============================================================================
-sorbet                                                       *ale-ruby-sorbet*
+sorbet                                                        *ale-ruby-sorbet*
 
-g:ale_ruby_sorbet_executable                    *g:ale_ruby_sorbet_executable*
-                                                *b:ale_ruby_sorbet_executable*
+g:ale_ruby_sorbet_executable                     *g:ale_ruby_sorbet_executable*
+                                                 *b:ale_ruby_sorbet_executable*
   Type: String
   Default: `'srb'`
 
@@ -141,8 +141,8 @@ g:ale_ruby_sorbet_executable                    *g:ale_ruby_sorbet_executable*
   `'bundle` `exec` srb'.
 
 
-g:ale_ruby_sorbet_options                         *g:ale_ruby_sorbet_options*
-                                                   *b:ale_ruby_sorbet_options*
+g:ale_ruby_sorbet_options                           *g:ale_ruby_sorbet_options*
+                                                    *b:ale_ruby_sorbet_options*
   Type: |String|
   Default: `''`
 

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -387,6 +387,7 @@ Notes:
   * `ruby`
   * `rufo`
   * `solargraph`
+  * `sorbet`
   * `standardrb`
 * Rust
   * `cargo`!!

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2206,6 +2206,7 @@ documented in additional help files.
     ruby..................................|ale-ruby-ruby|
     rufo..................................|ale-ruby-rufo|
     solargraph............................|ale-ruby-solargraph|
+    sorbet................................|ale-ruby-sorbet|
     standardrb............................|ale-ruby-standardrb|
   rust....................................|ale-rust-options|
     cargo.................................|ale-rust-cargo|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -396,6 +396,7 @@ formatting.
   * [ruby](https://www.ruby-lang.org)
   * [rufo](https://github.com/ruby-formatter/rufo)
   * [solargraph](https://solargraph.org)
+  * [sorbet](https://github.com/sorbet/sorbet)
   * [standardrb](https://github.com/testdouble/standard)
 * Rust
   * [cargo](https://github.com/rust-lang/cargo) :floppy_disk: (see `:help ale-integration-rust` for configuration instructions)

--- a/test/command_callback/test_sorbet_command_callback.vader
+++ b/test/command_callback/test_sorbet_command_callback.vader
@@ -1,0 +1,27 @@
+
+Before:
+  call ale#assert#SetUpLinterTest('ruby', 'sorbet')
+  call ale#test#SetFilename('dummy.rb')
+
+  let g:ale_ruby_sorbet_executable = 'srb'
+  let g:ale_ruby_sorbet_options = ''
+
+After:
+  call ale#assert#TearDownLinterTest()
+
+Execute(Executable should default to srb):
+  AssertLinter 'srb', ale#Escape('srb')
+  \   . ' tc --lsp --disable-watchman'
+
+Execute(Should be able to set a custom executable):
+  let g:ale_ruby_sorbet_executable = 'bin/srb'
+
+  AssertLinter 'bin/srb' , ale#Escape('bin/srb')
+  \   . ' tc --lsp --disable-watchman'
+
+Execute(Setting bundle appends 'exec srb tc'):
+  let g:ale_ruby_sorbet_executable = 'path to/bundle'
+
+  AssertLinter 'path to/bundle', ale#Escape('path to/bundle')
+  \   . ' exec srb'
+  \   . ' tc --lsp --disable-watchman'

--- a/test/fixers/test_sorbet_fixer_callback.vader
+++ b/test/fixers/test_sorbet_fixer_callback.vader
@@ -1,0 +1,42 @@
+
+Before:
+  Save g:ale_ruby_sorbet_executable
+  Save g:ale_ruby_sorbet_options
+
+  " Use an invalid global executable, so we don't match it.
+  let g:ale_ruby_sorbet_executable = 'xxxinvalid'
+  let g:ale_ruby_sorbet_options = ''
+
+  call ale#test#SetDirectory('/testplugin/test/fixers')
+  silent cd ..
+  silent cd command_callback
+  let g:dir = getcwd()
+
+After:
+  Restore
+
+  call ale#test#RestoreDirectory()
+
+Execute(The sorbet callback should return the correct default values):
+  call ale#test#SetFilename('ruby_paths/dummy.rb')
+
+  AssertEqual
+  \ {
+  \   'read_temporary_file': 1,
+  \   'command': ale#Escape(g:ale_ruby_sorbet_executable)
+  \     . ' tc --autocorrect --file %t',
+  \ },
+  \ ale#fixers#sorbet#Fix(bufnr(''))
+
+Execute(The sorbet callback should include custom sorbet options):
+  let g:ale_ruby_sorbet_options = '--enable-experimental-lsp-hover'
+  call ale#test#SetFilename('ruby_paths/with_config/dummy.rb')
+
+  AssertEqual
+  \ {
+  \   'read_temporary_file': 1,
+  \   'command': ale#Escape(g:ale_ruby_sorbet_executable)
+  \     . ' tc --enable-experimental-lsp-hover'
+  \     . ' --autocorrect --file %t',
+  \ },
+  \ ale#fixers#sorbet#Fix(bufnr(''))


### PR DESCRIPTION
Adds support for the [Sorbet](https://sorbet.org) type checker for Ruby that was just released publicly. I basically used the `rubocop` linter as a guide, along with a couple other LSP linters, so I'm not 100% sure that I did everything (or anything? 😂) in the best way -- especially the tests.

Thanks!