### PR TITLE
Update Rust cargo linter to better integrate with Clippy

### DIFF
--- a/ale_linters/rust/cargo.vim
+++ b/ale_linters/rust/cargo.vim
@@ -69,7 +69,15 @@ function! ale_linters#rust#cargo#GetCommand(buffer, version) abort
 
     if ale#Var(a:buffer, 'rust_cargo_use_clippy')
         let l:subcommand = 'clippy'
-        let l:clippy_options = ' ' . ale#Var(a:buffer, 'rust_cargo_clippy_options')
+
+        let l:clippy_options = ale#Var(a:buffer, 'rust_cargo_clippy_options')
+        if l:clippy_options =~ "^-- "
+            let l:clippy_options = join(split(l:clippy_options, '-- '))
+        endif
+
+        if l:clippy_options isnot# ''
+            let l:clippy_options = ' -- ' . l:clippy_options
+        endif
     endif
 
     return l:nearest_cargo_prefix . 'cargo '

--- a/ale_linters/rust/cargo.vim
+++ b/ale_linters/rust/cargo.vim
@@ -25,14 +25,11 @@ endfunction
 function! ale_linters#rust#cargo#GetCommand(buffer, version) abort
     let l:use_check = ale#Var(a:buffer, 'rust_cargo_use_check')
     \   && ale#semver#GTE(a:version, [0, 17, 0])
-    let l:use_all_targets = l:use_check
-    \   && ale#Var(a:buffer, 'rust_cargo_check_all_targets')
+    let l:use_all_targets = ale#Var(a:buffer, 'rust_cargo_check_all_targets')
     \   && ale#semver#GTE(a:version, [0, 22, 0])
-    let l:use_examples = l:use_check
-    \   && ale#Var(a:buffer, 'rust_cargo_check_examples')
+    let l:use_examples = ale#Var(a:buffer, 'rust_cargo_check_examples')
     \   && ale#semver#GTE(a:version, [0, 22, 0])
-    let l:use_tests = l:use_check
-    \   && ale#Var(a:buffer, 'rust_cargo_check_tests')
+    let l:use_tests = ale#Var(a:buffer, 'rust_cargo_check_tests')
     \   && ale#semver#GTE(a:version, [0, 22, 0])
 
     let l:include_features = ale#Var(a:buffer, 'rust_cargo_include_features')
@@ -69,9 +66,9 @@ function! ale_linters#rust#cargo#GetCommand(buffer, version) abort
 
     if ale#Var(a:buffer, 'rust_cargo_use_clippy')
         let l:subcommand = 'clippy'
-
         let l:clippy_options = ale#Var(a:buffer, 'rust_cargo_clippy_options')
-        if l:clippy_options =~ "^-- "
+
+        if l:clippy_options =~# '^-- '
             let l:clippy_options = join(split(l:clippy_options, '-- '))
         endif
 

--- a/test/command_callback/test_cargo_command_callbacks.vader
+++ b/test/command_callback/test_cargo_command_callbacks.vader
@@ -141,12 +141,20 @@ Execute(When ale_rust_cargo_use_clippy is set, cargo-clippy is used as linter):
   let b:ale_rust_cargo_use_clippy = 1
   AssertLinter 'cargo', [
   \ ale#Escape('cargo') . ' --version',
-  \ 'cargo clippy --frozen --message-format=json -q ',
+  \ 'cargo clippy --frozen --message-format=json -q',
   \]
 
 Execute(When ale_rust_cargo_clippy_options is set, cargo-clippy appends it to commandline):
   let b:ale_rust_cargo_use_clippy = 1
   let b:ale_rust_cargo_clippy_options = '-- -D warnings'
+  AssertLinter 'cargo', [
+  \ ale#Escape('cargo') . ' --version',
+  \ 'cargo clippy --frozen --message-format=json -q -- -D warnings',
+  \]
+
+Execute(When ale_rust_cargo_clippy_options does not start with --, it is added):
+  let b:ale_rust_cargo_use_clippy = 1
+  let b:ale_rust_cargo_clippy_options = '-D warnings'
   AssertLinter 'cargo', [
   \ ale#Escape('cargo') . ' --version',
   \ 'cargo clippy --frozen --message-format=json -q -- -D warnings',

--- a/test/command_callback/test_cargo_command_callbacks.vader
+++ b/test/command_callback/test_cargo_command_callbacks.vader
@@ -139,6 +139,7 @@ Execute(When a crate belongs to a workspace we chdir into the crate, unless we d
 
 Execute(When ale_rust_cargo_use_clippy is set, cargo-clippy is used as linter):
   let b:ale_rust_cargo_use_clippy = 1
+
   AssertLinter 'cargo', [
   \ ale#Escape('cargo') . ' --version',
   \ 'cargo clippy --frozen --message-format=json -q',
@@ -147,23 +148,51 @@ Execute(When ale_rust_cargo_use_clippy is set, cargo-clippy is used as linter):
 Execute(When ale_rust_cargo_clippy_options is set, cargo-clippy appends it to commandline):
   let b:ale_rust_cargo_use_clippy = 1
   let b:ale_rust_cargo_clippy_options = '-- -D warnings'
+
   AssertLinter 'cargo', [
   \ ale#Escape('cargo') . ' --version',
   \ 'cargo clippy --frozen --message-format=json -q -- -D warnings',
   \]
 
-Execute(When ale_rust_cargo_clippy_options does not start with --, it is added):
+Execute(Clippy options work without prepending --):
   let b:ale_rust_cargo_use_clippy = 1
   let b:ale_rust_cargo_clippy_options = '-D warnings'
+
   AssertLinter 'cargo', [
   \ ale#Escape('cargo') . ' --version',
   \ 'cargo clippy --frozen --message-format=json -q -- -D warnings',
+  \]
+
+Execute(Build supports all cargo flags):
+  let g:ale_rust_cargo_use_check = 0
+  let g:ale_rust_cargo_check_all_targets = 1
+  let g:ale_rust_cargo_check_tests = 1
+  let g:ale_rust_cargo_check_examples = 1
+  let b:ale_rust_cargo_default_feature_behavior = 'all'
+
+  AssertLinter 'cargo', [
+  \ ale#Escape('cargo') . ' --version',
+  \ 'cargo build --all-targets --examples --tests --frozen --message-format=json -q --all-features',
+  \]
+
+Execute(Clippy supports all cargo flags):
+  let b:ale_rust_cargo_use_clippy = 1
+  let g:ale_rust_cargo_check_all_targets = 1
+  let g:ale_rust_cargo_check_tests = 1
+  let g:ale_rust_cargo_check_examples = 1
+  let b:ale_rust_cargo_default_feature_behavior = 'all'
+  let b:ale_rust_cargo_clippy_options = '-D warnings'
+
+  AssertLinter 'cargo', [
+  \ ale#Escape('cargo') . ' --version',
+  \ 'cargo clippy --all-targets --examples --tests --frozen --message-format=json -q --all-features -- -D warnings',
   \]
 
 Execute(cargo-check does not refer ale_rust_cargo_clippy_options):
   let b:ale_rust_cargo_use_clippy = 0
   let b:ale_rust_cargo_use_check = 1
   let b:ale_rust_cargo_clippy_options = '-- -D warnings'
+
   AssertLinter 'cargo', [
   \ ale#Escape('cargo') . ' --version',
   \ 'cargo check --frozen --message-format=json -q',


### PR DESCRIPTION
Two changes:

* It was confusing (and not mentioned in the documentation) that `rust_cargo_clippy_options` required you to start the string with `--` (such as `-- -D warning`). It now accepts both forms (so also `-D warning`).
* For some reason (AFAIK incorrectly) all cargo-specific flags were only supported for `cargo check`, while these are also valid for `cargo build` and `cargo clippy`. This now works as expected.

Aside from the unit tests, I tested both changes in my local Rust project, and they worked as expected.