### PR TITLE
Update README section about running linters on save

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,6 +596,7 @@ options off.
 ```vim
 " Write this in your vimrc file
 let g:ale_lint_on_text_changed = 'never'
+let g:ale_lint_on_insert_leave = 0
 " You can disable this option too
 " if you don't want linters to run on opening a file
 let g:ale_lint_on_enter = 0


### PR DESCRIPTION
The default for `g:ale_lint_on_insert_leave` was recently changed to 1,
so it now needs to be explicitly set to 0 to run linters only when files
are saved.