### PR TITLE
Fix incorrect re-selection

### DIFF
--- a/autoload/ale/list.vim
+++ b/autoload/ale/list.vim
@@ -132,7 +132,7 @@ function! s:SetListsImpl(timer_id, buffer, loclist) abort
         endif
 
         " Return to original mode when applicable
-        if (mode() != l:mode)
+        if mode() != l:mode
             if l:mode is? 'v' || l:mode is# "\<c-v>"
                 " Reset our last visual selection
                 normal! gv

--- a/autoload/ale/list.vim
+++ b/autoload/ale/list.vim
@@ -110,8 +110,6 @@ function! s:SetListsImpl(timer_id, buffer, loclist) abort
     if s:ShouldOpen(a:buffer) && !empty(a:loclist)
         let l:winnr = winnr()
         let l:mode = mode()
-        let l:reset_visual_selection = l:mode is? 'v' || l:mode is# "\<c-v>"
-        let l:reset_character_selection = l:mode is? 's' || l:mode is# "\<c-s>"
 
         " open windows vertically instead of default horizontally
         let l:open_type = ''
@@ -133,12 +131,13 @@ function! s:SetListsImpl(timer_id, buffer, loclist) abort
             wincmd p
         endif
 
-        if l:reset_visual_selection || l:reset_character_selection
-            " If we were in a selection mode before, select the last selection.
-            normal! gv
-
-            if l:reset_character_selection
-                " Switch back to Select mode, if we were in that.
+        " Return to original mode when applicable
+        if (mode() != l:mode)
+            if l:mode is? 'v' || l:mode is# "\<c-v>"
+                " Reset our last visual selection
+                normal! gv
+            elseif l:mode is? 's' || l:mode is# "\<c-s>"
+                " Reset our last character selection
                 normal! "\<c-g>"
             endif
         endif


### PR DESCRIPTION
## summary
-changes in #788 fixed loss of selection when linter ran whilst in
visual selection mode. however this caused side-effects when the
modifications to the lists didn't result in a change of mode / loss
of selection, namely, a switch of current and previous selections
-add check to only revert mode on mode change

## issue
wrong selection post lint

### recipe

#### env
although this was hurting me with the latest setup, e.g. lint on `InsertLeave`, and `never` on `TextChanged`, as per #788, I set up my environment for testing the original setup with something like:
```
Plug 'w0rp/ale'
let g:ale_set_quickfix = 1
let g:ale_open_list = 1
let g:ale_keep_list_window_open = 0
let g:ale_lint_on_insert_leave = 0
let g:ale_lint_on_save = 0
let g:ale_lint_on_enter = 0
let g:ale_lint_on_text_changed = 'always'
let g:ale_lint_delay = 5000
```
#### steps
1. open file with 25+ lines that has errors / warnings
2. note no linting, thus no quickfix window as expected
3. visual selection lines 1-5, escape to normal mode
4. move to line 19
5. insert garbage text change to ensure linter triggered
6. exit insert-mode
7. quickly (within 5 seconds given my settings) visually select lines 20-24
8. wait

result, selection maintained

9. move to line 6
10. visual selection lines 6-10, escape to normal mode
11. repeat step 4-8

result, selection has been erroneous switched to previous selection of lines 6-10

### debugging
in `autoload/ale/list.vim -> s:SetListsImpl` with the likes of:
```
echom('[ale|pre] mode: ' . mode() . ', ''''<: ' . string(getpos("'<")) . ', ''''>: ' . string(getpos("'>")) . ', vs v: ' . string(getpos("v")) . ', .: ' . string(getpos(".")))
```
in suitable places yielded:

#### original

##### lint 1
```
[ale|pre] mode: v, ''<: [0, 1, 1, 0], ''>: [0, 5, 10, 0], vs v: [0, 20, 1, 0], .: [0, 24, 1, 0]
[ale|post] mode: n, ''<: [0, 0, 0, 0], ''>: [0, 0, 0, 0], vs v: [0, 1, 1, 0], .: [0, 1, 1, 0]
[ale|reset] mode: v, ''<: [0, 20, 1, 0], ''>: [0, 24, 1, 0], vs v: [0, 20, 1, 0], .: [0, 24, 1, 0]
```
##### lint 2
```
[ale|pre] mode: v, ''<: [0, 6, 1, 0], ''>: [0, 10, 35, 0], vs v: [0, 20, 1, 0], .: [0, 24, 1, 0]
[ale|post] mode: v, ''<: [0, 6, 1, 0], ''>: [0, 10, 35, 0], vs v: [0, 20, 1, 0], .: [0, 24, 1, 0]
[ale|reset] mode: v, ''<: [0, 20, 1, 0], ''>: [0, 24, 1, 0], vs v: [0, 6, 1, 0], .: [0, 10, 35, 0]
NOTE switched / incorrect current selection
```
#### patched
##### lint 1
```
[ale|pre] mode: v, ''<: [0, 1, 1, 0], ''>: [0, 5, 10, 0], vs v: [0, 20, 1, 0], .: [0, 24, 1, 0]
[ale|post] mode: n, ''<: [0, 0, 0, 0], ''>: [0, 0, 0, 0], vs v: [0, 1, 1, 0], .: [0, 1, 1, 0]
[ale|reset] mode: v, ''<: [0, 20, 1, 0], ''>: [0, 24, 1, 0], vs v: [0, 20, 1, 0], .: [0, 24, 1, 0]
```
##### lint 2
```
[ale|pre] mode: v, ''<: [0, 6, 1, 0], ''>: [0, 10, 35, 0], vs v: [0, 20, 1, 0], .: [0, 24, 1, 0]
[ale|post] mode: v, ''<: [0, 6, 1, 0], ''>: [0, 10, 35, 0], vs v: [0, 20, 1, 0], .: [0, 24, 1, 0]
NO RESET!
```
### explanation
as per the documentation:
```
gv | *gv* *v_gv* *reselect-Visual*

Start Visual mode with the same area as the previous area and the same mode.
In Visual mode the current and the previous Visual area are exchanged.
After using "p" or "P" in Visual mode the text that was put will be selected.
```
Clearly our use of `normal! gv` was causing the previous selection to be exchanged, which as stated above only occurs if we're in visual selection mode. This must mean our assumption that setting the qflist necessarily results in loss of selection is incorrect. This is backed up by the lines above showing that on the second lint (post setting of the list), the mode remains as 'v'. The solution is the trivial test against the 'post list set' mode, and effecting resets iff necessary

Note, I built and tested dozens of versions of vim back to:
```
commit 84dbd494dca599ecff05b2c2279d402c12e6d197 (HEAD, tag: v8.0.0021)
Date:   Sun Oct 2 23:09:31 2016 +0200
```
with no change in behaviour observed, that is, this issue has always existed and the patch appears to be valid throughout

wrt. implementation, I've deliberately removed the explicit variables as you directed to be added in #788. To maintain them in that position they'd need to be renamed with a *possible_* prefix and then set false after the set lists operation ..else they'd need to sit just above their position of use ..and thus I deemed them totally pointless.

wrt. tests, see [w0rp comment](https://github.com/w0rp/ale/pull/788#issuecomment-320778557), and hence no tests..

also note:
```
:help ale-dev
E149: Sorry, no help for ale-dev
```
no ale- related help topics work for me here so clearly something's amiss ..I'll be adding that to my issues list too :). I did read the contributing guidelines though.

Finally. Thank you for your massive contribution to the Vim ecosystem with this plugin