### PR TITLE
Add Deoplete's input_patterns for cpp

### DIFF
--- a/rplugin/python3/deoplete/sources/ale.py
+++ b/rplugin/python3/deoplete/sources/ale.py
@@ -30,6 +30,7 @@ class Source(Base):
             '_': r'\.\w*$',
             'rust': r'(\.|::)\w*$',
             'typescript': r'(\.|\'|")\w*$',
+            'cpp': r'(\.|::|->)\w*$',
         }
 
     # Returns an integer for the start position, as with omnifunc.

--- a/test/python/test_deoplete_source.py
+++ b/test/python/test_deoplete_source.py
@@ -45,6 +45,7 @@ class DeopleteSourceTest(unittest.TestCase):
                 '_': r'\.\w*$',
                 'rust': r'(\.|::)\w*$',
                 'typescript': r'(\.|\'|")\w*$',
+                'cpp': r'(\.|::|->)\w*$',
             },
             'is_bytepos': True,
             'mark': '[L]',


### PR DESCRIPTION
ref #2599 

`input_patterns` in `ale.py` should be updated when `s:trigger_character_map` in `completion.vim` have been updated.