### PR TITLE
Fix 3207 - do not send didSave notification if not supported

### DIFF
--- a/autoload/ale/lsp.vim
+++ b/autoload/ale/lsp.vim
@@ -45,6 +45,7 @@ function! ale#lsp#Register(executable_or_address, project, init_options) abort
         \       'typeDefinition': 0,
         \       'symbol_search': 0,
         \       'code_actions': 0,
+        \       'did_save': 0,
         \       'includeText': 0,
         \   },
         \}
@@ -265,15 +266,19 @@ function! s:UpdateCapabilities(conn, capabilities) abort
         let a:conn.capabilities.symbol_search = 1
     endif
 
-    if has_key(a:capabilities, 'textDocumentSync')
-        if type(a:capabilities.textDocumentSync) is v:t_dict
-            let l:save = get(a:capabilities.textDocumentSync, 'save', v:false)
+    if type(get(a:capabilities, 'textDocumentSync')) is v:t_dict
+        let l:syncOptions = get(a:capabilities, 'textDocumentSync')
 
-            if type(l:save) is v:true
-                let a:conn.capabilities.includeText = 1
-            endif
+        if get(l:syncOptions, 'save') is v:true
+            let a:conn.capabilities.did_save = 1
+        endif
 
-            if type(l:save) is v:t_dict && get(a:capabilities.textDocumentSync.save, 'includeText', v:false) is v:true
+        if type(get(l:syncOptions, 'save')) is v:t_dict
+            let a:conn.capabilities.did_save = 1
+
+            let l:saveOptions = get(l:syncOptions, 'save')
+
+            if get(l:saveOptions, 'includeText') is v:true
                 let a:conn.capabilities.includeText = 1
             endif
         endif

--- a/autoload/ale/lsp_linter.vim
+++ b/autoload/ale/lsp_linter.vim
@@ -466,6 +466,7 @@ function! s:CheckWithLSP(linter, details) abort
     " If this was a file save event, also notify the server of that.
     if a:linter.lsp isnot# 'tsserver'
     \&& getbufvar(l:buffer, 'ale_save_event_fired', 0)
+    \&& ale#lsp#HasCapability(l:buffer, 'did_save')
         let l:include_text = ale#lsp#HasCapability(l:buffer, 'includeText')
         let l:save_message = ale#lsp#message#DidSave(l:buffer, l:include_text)
         let l:notified = ale#lsp#Send(l:id, l:save_message) != 0

--- a/test/lsp/test_did_save_event.vader
+++ b/test/lsp/test_did_save_event.vader
@@ -99,6 +99,30 @@ Execute(Server should be notified on save):
   \     },
   \     'contentChanges': [{'text': join(getline(1, '$'), "\n") . "\n"}],
   \   }],
+  \ ],
+  \ g:message_list
+
+Execute(Server should be notified on save with didSave is supported by server):
+
+  " Replace has capability function to simulate didSave server capability
+  function! ale#lsp#HasCapability(conn_id, capability) abort
+      if a:capability == 'did_save'
+          return 1
+      endif
+      return 0
+  endfunction
+
+  call ale#events#SaveEvent(bufnr(''))
+
+  AssertEqual
+  \ [
+  \   [1, 'textDocument/didChange', {
+  \     'textDocument': {
+  \       'uri': ale#path#ToURI(expand('%:p')),
+  \       'version': g:ale_lsp_next_version_id - 1,
+  \     },
+  \     'contentChanges': [{'text': join(getline(1, '$'), "\n") . "\n"}],
+  \   }],
   \   [1, 'textDocument/didSave', {
   \     'textDocument': {
   \       'uri': ale#path#ToURI(expand('%:p')),


### PR DESCRIPTION
Add did_save option to server capabilities and avoid sending didSave notification if the server does not support this capability.

Closes #3207 