### PR TITLE
Fix 3941 - add version check to isort fixer

### DIFF
--- a/test/fixers/test_isort_fixer_callback.vader
+++ b/test/fixers/test_isort_fixer_callback.vader
@@ -11,45 +11,60 @@ After:
 
 Execute(The isort callback should return the correct default values):
   silent execute 'file ' . fnameescape(g:dir . '/../test-files/python/with_virtualenv/subdir/foo/bar.py')
-  AssertEqual
+
+  " --filename option exists only after 5.7.0
+  GivenCommandOutput ['VERSION 5.7.0']
+  AssertFixer
   \ {
   \   'cwd': '%s:h',
   \   'command': ale#Escape(ale#path#Simplify(g:dir . '/../test-files/python/with_virtualenv/env/' . b:bin_dir . '/isort')) . ' --filename %s' . ' -',
-  \ },
-  \ ale#fixers#isort#Fix(bufnr(''))
+  \ }
 
 Execute(The isort callback should respect custom options):
   let g:ale_python_isort_options = '--multi-line=3 --trailing-comma'
 
   silent execute 'file ' . fnameescape(g:dir . '/../test-files/python/with_virtualenv/subdir/foo/bar.py')
-  AssertEqual
+
+  " --filename option exists only after 5.7.0
+  GivenCommandOutput ['VERSION 5.7.0']
+  AssertFixer
   \ {
   \   'cwd': '%s:h',
   \   'command': ale#Escape(ale#path#Simplify(g:dir . '/../test-files/python/with_virtualenv/env/' . b:bin_dir . '/isort'))
   \     . ' --filename %s' . ' --multi-line=3 --trailing-comma -',
-  \ },
-  \ ale#fixers#isort#Fix(bufnr(''))
+  \ }
 
 Execute(Pipenv is detected when python_isort_auto_pipenv is set):
   let g:ale_python_isort_auto_pipenv = 1
 
   call ale#test#SetFilename('../test-files/python/pipenv/whatever.py')
 
-  AssertEqual
+  GivenCommandOutput ['VERSION 5.7.0']
+  AssertFixer
   \ {
   \   'cwd': '%s:h',
   \   'command': ale#Escape('pipenv') . ' run isort' . ' --filename %s' . ' -'
-  \ },
-  \ ale#fixers#isort#Fix(bufnr(''))
+  \ }
 
 Execute(Poetry is detected when python_isort_auto_poetry is set):
   let g:ale_python_isort_auto_poetry = 1
 
   call ale#test#SetFilename('../test-files/python/poetry/whatever.py')
 
-  AssertEqual
+  GivenCommandOutput ['VERSION 5.7.0']
+  AssertFixer
   \ {
   \   'cwd': '%s:h',
   \   'command': ale#Escape('poetry') . ' run isort' . ' --filename %s' . ' -'
-  \ },
-  \ ale#fixers#isort#Fix(bufnr(''))
+  \ }
+
+Execute(The isort callback should not use --filename for older versions):
+  silent execute 'file ' . fnameescape(g:dir . '/../test-files/python/with_virtualenv/subdir/foo/bar.py')
+
+  " --filename option exists only after 5.7.0
+  GivenCommandOutput ['VERSION 5.6.0']
+  AssertFixer
+  \ {
+  \   'cwd': '%s:h',
+  \   'command': ale#Escape(ale#path#Simplify(g:dir . '/../test-files/python/with_virtualenv/env/' . b:bin_dir . '/isort')) . ' -',
+  \ }


### PR DESCRIPTION
Checks isort version and adds the --filename option if larger or equal than 5.7.0.

For older version this bug will be reverted #3806 
