### PR TITLE
Parse clj-kondo lines that don't include row/col

### DIFF
--- a/ale_linters/clojure/clj_kondo.vim
+++ b/ale_linters/clojure/clj_kondo.vim
@@ -16,7 +16,7 @@ endfunction
 function! ale_linters#clojure#clj_kondo#HandleCljKondoFormat(buffer, lines) abort
     " output format
     " <filename>:<line>:<column>: <issue type>: <message>
-    let l:pattern = '\v^[a-zA-Z]?:?[^:]+:(\d+):(\d+):? ((Exception|error|warning): ?(.+))$'
+    let l:pattern = '\v^[a-zA-Z]?:?[^:]+:(\d+)?:(\d+)?:? ((Exception|error|warning): ?(.+))$'
     let l:output = []
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)

--- a/test/handler/test_clojure_clj_kondo_handler.vader
+++ b/test/handler/test_clojure_clj_kondo_handler.vader
@@ -73,3 +73,17 @@ Execute(the clojure clj-kondo handler should be able to handle windows files):
   \ ale_linters#clojure#clj_kondo#HandleCljKondoFormat(0, [
   \   'C:\my\operating\system\is\silly\core.clj:123:44: error: Unexpected )',
   \ ])
+
+Execute(the clojure clj-kondo handler should be able to lines without row/col):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 0,
+  \     'col': 0,
+  \     'type': 'E',
+  \     'text': 'error: Unexpected )',
+  \   },
+  \ ],
+  \ ale_linters#clojure#clj_kondo#HandleCljKondoFormat(0, [
+  \   'test.clj::: error: Unexpected )',
+  \ ])


### PR DESCRIPTION
Some custom linter hooks don't include these numbers.
