### PR TITLE
Re-apply #3538 - remove -T argument from ruby linter

### DIFF
--- a/ale_linters/ruby/ruby.vim
+++ b/ale_linters/ruby/ruby.vim
@@ -6,7 +6,7 @@ call ale#Set('ruby_ruby_executable', 'ruby')
 call ale#linter#Define('ruby', {
 \   'name': 'ruby',
 \   'executable': {b -> ale#Var(b, 'ruby_ruby_executable')},
-\   'command': '%e -w -c -T1 %t',
+\   'command': '%e -w -c %t',
 \   'output_stream': 'stderr',
 \   'callback': 'ale#handlers#ruby#HandleSyntaxErrors',
 \})

--- a/test/linter/test_ruby.vader
+++ b/test/linter/test_ruby.vader
@@ -5,9 +5,9 @@ After:
   call ale#assert#TearDownLinterTest()
 
 Execute(The default command should be correct):
-  AssertLinter 'ruby', ale#Escape('ruby') . ' -w -c -T1 %t'
+  AssertLinter 'ruby', ale#Escape('ruby') . ' -w -c %t'
 
 Execute(The executable should be configurable):
   let g:ale_ruby_ruby_executable = 'foobar'
 
-  AssertLinter 'foobar', ale#Escape('foobar') . ' -w -c -T1 %t'
+  AssertLinter 'foobar', ale#Escape('foobar') . ' -w -c %t'


### PR DESCRIPTION
The `-T` option (for "taint checking") was deprecated in ruby 2.7
and removed entirely in ruby 3.0. This causes the linter to fail
entirely for users of ruby 3.0.

This was reported in #3537, and then fixed in #3538 - but it seems as
though in 9fe7b1fe6a23fb55e6d782293585d58193123f59, it was accidentally and entirely undone.

This commit is essentially identical to #3538, aside from a path change
for the tests.
