### PR TITLE
Integrate ALE with Neovim LSP Client & Lua

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,7 @@ jobs:
           - '--vim-90-only'
           - '--neovim-07-only'
           - '--neovim-08-only'
+          - '--lua-only'
           - '--linters-only'
     steps:
       - uses: actions/checkout@v4

--- a/.luarc.json
+++ b/.luarc.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://raw.githubusercontent.com/LuaLS/vscode-lua/master/setting/schema.json",
+  "diagnostics.globals": [
+    "vim"
+  ],
+  "workspace.ignoreDir": [
+    "test"
+  ],
+  "workspace.library": [
+    "/usr/share/nvim/runtime/lua"
+  ],
+  "runtime.pathStrict": true,
+  "runtime.path": [
+    "lua/?.lua",
+    "lua/?/init.lua"
+  ],
+  "runtime.version": "LuaJIT",
+  "hint.enable": false
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,10 @@ ARG TESTBED_VIM_VERSION=24
 
 FROM testbed/vim:${TESTBED_VIM_VERSION}
 
-RUN install_vim -tag v8.0.0027 -build \
-                -tag v9.0.0297 -build \
-                -tag neovim:v0.7.0 -build \
-                -tag neovim:v0.8.0 -build
-
 ENV PACKAGES="\
+    lua5.1 \
+    lua5.1-dev \
+    lua5.1-busted \
     bash \
     git \
     python2 \
@@ -18,6 +16,11 @@ ENV PACKAGES="\
 "
 RUN apk --update add $PACKAGES && \
     rm -rf /var/cache/apk/* /tmp/* /var/tmp/*
+
+RUN install_vim -tag v8.0.0027 -build \
+                -tag v9.0.0297 -build \
+                -tag neovim:v0.7.0 -build \
+                -tag neovim:v0.8.0 -build
 
 RUN pip install vim-vint==0.3.21
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ linting and fixing of code in Vim. ALE offers the following.
 * Near-zero configuration with custom code for better defaults
 * Highly customizable and well-documented (`:help ale-options`)
 * Breaking changes for the plugin are extremely rare
+* Integrates with Neovim's LSP client (0.8+) and diagnostics (0.7+)
 * Support for older Vim and Neovim versions
 * Windows support
 * Well-integrated with other plugins
@@ -140,6 +141,12 @@ ALE offers some support for completion via hijacking of omnicompletion while you
 type. All of ALE's completion information must come from Language Server
 Protocol linters, or from `tsserver` for TypeScript.
 
+When running ALE in Neovim 0.8+, ALE will integrate with Neovim's LSP client by
+default, and any auto-completion plugin that uses the native LSP client will
+work when ALE runs language servers.
+[nvim-cmp](https://github.com/hrsh7th/nvim-cmp) is recommended as a
+completion plugin worth trying in Neovim.
+
 ALE integrates with [Deoplete](https://github.com/Shougo/deoplete.nvim) as a
 completion source, named `'ale'`. You can configure Deoplete to only use ALE as
 the source of completion information, or mix it with other sources.
@@ -186,7 +193,8 @@ LSP servers (e.g. eclipselsp). See `:help ale-completion` for more information.
 
 ALE supports jumping to the definition of words under your cursor with the
 `:ALEGoToDefinition` command using any enabled Language Server Protocol linters
-and `tsserver`.
+and `tsserver`. In Neovim 0.8+, you can also use Neovim's built in `gd` keybind
+and more.
 
 See `:help ale-go-to-definition` for more information.
 

--- a/ale_linters/python/flake8.vim
+++ b/ale_linters/python/flake8.vim
@@ -63,7 +63,7 @@ function! ale_linters#python#flake8#GetCwd(buffer) abort
     endif
 
     if (l:change_directory is# 'project' && empty(l:cwd))
-    \|| l:change_directory is# 1
+    \|| l:change_directory
     \|| l:change_directory is# 'file'
         let l:cwd = '%s:h'
     endif

--- a/ale_linters/python/flakehell.vim
+++ b/ale_linters/python/flakehell.vim
@@ -63,7 +63,7 @@ function! ale_linters#python#flakehell#GetCwd(buffer) abort
     endif
 
     if (l:change_directory is# 'project' && empty(l:cwd))
-    \|| l:change_directory is# 1
+    \|| l:change_directory
     \|| l:change_directory is# 'file'
         let l:cwd = '%s:h'
     endif

--- a/ale_linters/python/pylint.vim
+++ b/ale_linters/python/pylint.vim
@@ -82,7 +82,7 @@ function! ale_linters#python#pylint#Handle(buffer, lines) abort
             continue
         endif
 
-        if ale#Var(a:buffer, 'python_pylint_use_msg_id') is# 1
+        if ale#Var(a:buffer, 'python_pylint_use_msg_id')
             let l:code_out = l:code
         else
             let l:code_out = l:match[4]

--- a/autoload/ale/assert.vim
+++ b/autoload/ale/assert.vim
@@ -205,7 +205,10 @@ endfunction
 function! ale#assert#LSPLanguage(expected_language) abort
     let l:buffer = bufnr('')
     let l:linter = s:GetLinter()
-    let l:language = ale#linter#GetLanguage(l:buffer, l:linter)
+    let l:Language = l:linter.language
+    let l:language = type(l:Language) is v:t_func
+    \   ? l:Language(l:buffer)
+    \   : l:Language
 
     AssertEqual a:expected_language, l:language
 endfunction

--- a/autoload/ale/definition.vim
+++ b/autoload/ale/definition.vim
@@ -4,7 +4,7 @@
 let s:go_to_definition_map = {}
 
 " Enable automatic updates of the tagstack
-let g:ale_update_tagstack = get(g:, 'ale_update_tagstack', 1)
+let g:ale_update_tagstack = get(g:, 'ale_update_tagstack', v:true)
 let g:ale_default_navigation = get(g:, 'ale_default_navigation', 'buffer')
 
 " Used to get the definition map in tests.

--- a/autoload/ale/engine.vim
+++ b/autoload/ale/engine.vim
@@ -68,7 +68,7 @@ function! ale#engine#IsExecutable(buffer, executable) abort
 
     " Cache the executable check if we found it, or if the option to cache
     " failing checks is on.
-    if l:result || get(g:, 'ale_cache_executable_check_failures', 0)
+    if l:result || get(g:, 'ale_cache_executable_check_failures')
         let s:executable_cache_map[a:executable] = l:result
     endif
 

--- a/autoload/ale/engine.vim
+++ b/autoload/ale/engine.vim
@@ -259,7 +259,7 @@ function! ale#engine#SendResultsToNeovimDiagnostics(buffer, loclist) abort
 
     " Keep the Lua surface area really small in the VimL part of ALE,
     " and just require the diagnostics.lua module on demand.
-    let l:SendDiagnostics = luaeval('require("ale.diagnostics").sendAleResultsToDiagnostics')
+    let l:SendDiagnostics = luaeval('require("ale.diagnostics").send')
     call l:SendDiagnostics(a:buffer, a:loclist)
 endfunction
 

--- a/autoload/ale/events.vim
+++ b/autoload/ale/events.vim
@@ -173,7 +173,9 @@ function! ale#events#Init() abort
         autocmd BufWritePost * call ale#events#SaveEvent(str2nr(expand('<abuf>')))
 
         if g:ale_enabled
-            if l:text_changed is? 'always' || l:text_changed is# '1'
+            if l:text_changed is? 'always'
+            \|| l:text_changed is# '1'
+            \|| g:ale_lint_on_text_changed is v:true
                 autocmd TextChanged,TextChangedI * call ale#Queue(ale#Var(str2nr(expand('<abuf>')), 'lint_delay'))
             elseif l:text_changed is? 'normal'
                 autocmd TextChanged * call ale#Queue(ale#Var(str2nr(expand('<abuf>')), 'lint_delay'))

--- a/autoload/ale/linter.vim
+++ b/autoload/ale/linter.vim
@@ -446,9 +446,3 @@ function! ale#linter#GetAddress(buffer, linter) abort
 
     return type(l:Address) is v:t_func ? l:Address(a:buffer) : l:Address
 endfunction
-
-function! ale#linter#GetLanguage(buffer, linter) abort
-    let l:Language = a:linter.language
-
-    return type(l:Language) is v:t_func ? l:Language(a:buffer) : l:Language
-endfunction

--- a/autoload/ale/list.vim
+++ b/autoload/ale/list.vim
@@ -2,11 +2,11 @@
 " Description: Manages the loclist and quickfix lists
 
 " This flag dictates if ale open the configured loclist
-let g:ale_open_list = get(g:, 'ale_open_list', 0)
+let g:ale_open_list = get(g:, 'ale_open_list', v:false)
 " This flag dictates if ale keeps open loclist even if there is no error in loclist
 let g:ale_keep_list_window_open = get(g:, 'ale_keep_list_window_open', 0)
 " This flag dictates that quickfix windows should be opened vertically
-let g:ale_list_vertical = get(g:, 'ale_list_vertical', 0)
+let g:ale_list_vertical = get(g:, 'ale_list_vertical', v:false)
 " The window size to set for the quickfix and loclist windows
 let g:ale_list_window_size = get(g:, 'ale_list_window_size', 10)
 " A string format for the loclist messages.

--- a/autoload/ale/lsp.vim
+++ b/autoload/ale/lsp.vim
@@ -518,7 +518,7 @@ function! ale#lsp#StartProgram(conn_id, executable, command) abort
 
     if g:ale_use_neovim_lsp_api && !l:conn.is_tsserver
         " For Windows from 'cmd /s/c "foo bar"' we need 'foo bar'
-        let l:lsp_cmd = has('win32')
+        let l:lsp_cmd = has('win32') && type(a:command) is v:t_string
         \   ? ['cmd', '/s/c/', a:command[10:-2]]
         \   : a:command
 

--- a/autoload/ale/lsp.vim
+++ b/autoload/ale/lsp.vim
@@ -320,19 +320,21 @@ function! ale#lsp#UpdateConfig(conn_id, buffer, config) abort
 endfunction
 
 function! ale#lsp#CallInitCallbacks(conn_id) abort
-    let l:conn = s:connections[a:conn_id]
+    let l:conn = get(s:connections, a:conn_id, {})
 
-    " Ensure the connection is marked as initialized.
-    " For integration with Neovim's LSP tooling this ensures immediately
-    " call OnInit functions in Vim after the `on_init` callback is called.
-    let l:conn.initialized = 1
+    if !empty(l:conn)
+        " Ensure the connection is marked as initialized.
+        " For integration with Neovim's LSP tooling this ensures immediately
+        " call OnInit functions in Vim after the `on_init` callback is called.
+        let l:conn.initialized = 1
 
-    " Call capabilities callbacks queued for the project.
-    for l:Callback in l:conn.init_queue
-        call l:Callback()
-    endfor
+        " Call capabilities callbacks queued for the project.
+        for l:Callback in l:conn.init_queue
+            call l:Callback()
+        endfor
 
-    let l:conn.init_queue = []
+        let l:conn.init_queue = []
+    endif
 endfunction
 
 function! ale#lsp#HandleInitResponse(conn, response) abort

--- a/autoload/ale/lsp.vim
+++ b/autoload/ale/lsp.vim
@@ -47,6 +47,7 @@ function! ale#lsp#Register(executable_or_address, project, language, init_option
         \       'definition': 0,
         \       'typeDefinition': 0,
         \       'implementation': 0,
+        \       'pull_model': 0,
         \       'symbol_search': 0,
         \       'code_actions': 0,
         \       'did_save': 0,
@@ -276,6 +277,13 @@ function! ale#lsp#UpdateCapabilities(conn_id, capabilities) abort
         let l:conn.capabilities.implementation = 1
     endif
 
+    " Check if the language server supports pull model diagnostics.
+    if type(get(a:capabilities, 'diagnosticProvider')) is v:t_dict
+        if type(get(a:capabilities.diagnosticProvider, 'interFileDependencies')) is v:t_bool
+            let l:conn.capabilities.pull_model = 1
+        endif
+    endif
+
     if get(a:capabilities, 'workspaceSymbolProvider') is v:true
         let l:conn.capabilities.symbol_search = 1
     endif
@@ -485,6 +493,10 @@ function! s:SendInitMessage(conn) abort
     \               'implementation': {
     \                   'dynamicRegistration': v:false,
     \                   'linkSupport': v:false,
+    \               },
+    \               'diagnostic': {
+    \                   'dynamicRegistration': v:true,
+    \                   'relatedDocumentSupport': v:true,
     \               },
     \               'publishDiagnostics': {
     \                   'relatedInformation': v:true,

--- a/autoload/ale/lsp/message.vim
+++ b/autoload/ale/lsp/message.vim
@@ -200,6 +200,14 @@ function! ale#lsp#message#CodeAction(buffer, line, column, end_line, end_column,
     \}]
 endfunction
 
+function! ale#lsp#message#Diagnostic(buffer) abort
+    return [0, 'textDocument/diagnostic', {
+    \   'textDocument': {
+    \       'uri': ale#util#ToURI(expand('#' . a:buffer . ':p')),
+    \   },
+    \}]
+endfunction
+
 function! ale#lsp#message#ExecuteCommand(command, arguments) abort
     return [0, 'workspace/executeCommand', {
     \   'command': a:command,

--- a/autoload/ale/lsp/response.vim
+++ b/autoload/ale/lsp/response.vim
@@ -21,11 +21,11 @@ let s:SEVERITY_WARNING = 2
 let s:SEVERITY_INFORMATION = 3
 let s:SEVERITY_HINT = 4
 
-" Parse the message for textDocument/publishDiagnostics
-function! ale#lsp#response#ReadDiagnostics(response) abort
+" Convert Diagnostic[] data from a language server to an ALE loclist.
+function! ale#lsp#response#ReadDiagnostics(diagnostics) abort
     let l:loclist = []
 
-    for l:diagnostic in a:response.params.diagnostics
+    for l:diagnostic in a:diagnostics
         let l:severity = get(l:diagnostic, 'severity', 0)
         let l:loclist_item = {
         \   'text': substitute(l:diagnostic.message, '\(\r\n\|\n\|\r\)', ' ', 'g'),

--- a/autoload/ale/lsp_linter.vim
+++ b/autoload/ale/lsp_linter.vim
@@ -100,7 +100,7 @@ endfunction
 " Handle LSP diagnostics for a given URI.
 " The special value 'unchanged' can be used for diagnostics to indicate
 " that diagnostics haven't changed since we last checked.
-function! s:HandleLSPDiagnostics(conn_id, uri, diagnostics) abort
+function! ale#lsp_linter#HandleLSPDiagnostics(conn_id, uri, diagnostics) abort
     let l:linter = get(s:lsp_linter_map, a:conn_id)
 
     if empty(l:linter)
@@ -233,14 +233,14 @@ function! ale#lsp_linter#HandleLSPResponse(conn_id, response) abort
         let l:uri = a:response.params.uri
         let l:diagnostics = a:response.params.diagnostics
 
-        call s:HandleLSPDiagnostics(a:conn_id, l:uri, l:diagnostics)
+        call ale#lsp_linter#HandleLSPDiagnostics(a:conn_id, l:uri, l:diagnostics)
     elseif has_key(s:diagnostic_uri_map, get(a:response, 'id'))
         let l:uri = remove(s:diagnostic_uri_map, a:response.id)
         let l:diagnostics = a:response.result.kind is# 'unchanged'
         \   ? 'unchanged'
         \   : a:response.result.items
 
-        call s:HandleLSPDiagnostics(a:conn_id, l:uri, l:diagnostics)
+        call ale#lsp_linter#HandleLSPDiagnostics(a:conn_id, l:uri, l:diagnostics)
     elseif l:method is# 'window/showMessage'
         call ale#lsp_window#HandleShowMessage(
         \   s:lsp_linter_map[a:conn_id].name,

--- a/autoload/ale/lsp_linter.vim
+++ b/autoload/ale/lsp_linter.vim
@@ -219,7 +219,7 @@ function! ale#lsp_linter#HandleLSPResponse(conn_id, response) abort
         call s:HandleTSServerDiagnostics(a:response, 'syntax')
     elseif get(a:response, 'type', '') is# 'event'
     \&& get(a:response, 'event', '') is# 'suggestionDiag'
-    \&& get(g:, 'ale_lsp_suggestions', '1') == 1
+    \&& get(g:, 'ale_lsp_suggestions')
         call s:HandleTSServerDiagnostics(a:response, 'suggestion')
     endif
 endfunction

--- a/autoload/ale/lsp_linter.vim
+++ b/autoload/ale/lsp_linter.vim
@@ -488,6 +488,12 @@ function! ale#lsp_linter#StartLSP(buffer, linter, Callback) abort
 endfunction
 
 function! s:CheckWithLSP(linter, details) abort
+    if g:ale_use_neovim_lsp_api && a:linter.lsp isnot# 'tsserver'
+        " If running an LSP client via Neovim's API then Neovim will
+        " internally track buffers for changes for us, and we can stop here.
+        return
+    endif
+
     let l:buffer = a:details.buffer
     let l:info = get(g:ale_buffer_info, l:buffer)
 
@@ -546,6 +552,7 @@ function! s:OnReadyForCustomRequests(args, linter, lsp_details) abort
     let l:id = a:lsp_details.connection_id
     let l:request_id = ale#lsp#Send(l:id, a:args.message)
 
+    " TODO: Implement this whole flow with the lua API.
     if l:request_id > 0 && has_key(a:args, 'handler')
         let l:Callback = function('s:HandleLSPResponseToCustomRequests')
         call ale#lsp#RegisterCallback(l:id, l:Callback)

--- a/autoload/ale/lsp_linter.vim
+++ b/autoload/ale/lsp_linter.vim
@@ -306,11 +306,10 @@ function! ale#lsp_linter#OnInit(linter, details, Callback) abort
     let l:command = a:details.command
 
     let l:config = ale#lsp_linter#GetConfig(l:buffer, a:linter)
-    let l:language_id = ale#linter#GetLanguage(l:buffer, a:linter)
 
     call ale#lsp#UpdateConfig(l:conn_id, l:buffer, l:config)
 
-    if ale#lsp#OpenDocument(l:conn_id, l:buffer, l:language_id)
+    if ale#lsp#OpenDocument(l:conn_id, l:buffer)
         if g:ale_history_enabled && !empty(l:command)
             call ale#history#Add(l:buffer, 'started', l:conn_id, l:command)
         endif
@@ -357,11 +356,21 @@ function! s:StartLSP(options, address, executable, command) abort
     let l:init_options = ale#lsp_linter#GetOptions(l:buffer, l:linter)
 
     if l:linter.lsp is# 'socket'
-        let l:conn_id = ale#lsp#Register(a:address, l:root, l:init_options)
+        let l:conn_id = ale#lsp#Register(
+        \   a:address,
+        \   l:root,
+        \   l:linter.language,
+        \   l:init_options
+        \)
         let l:ready = ale#lsp#ConnectToAddress(l:conn_id, a:address)
         let l:command = ''
     else
-        let l:conn_id = ale#lsp#Register(a:executable, l:root, l:init_options)
+        let l:conn_id = ale#lsp#Register(
+        \   a:executable,
+        \   l:root,
+        \   l:linter.language,
+        \   l:init_options
+        \)
 
         " tsserver behaves differently, so tell the LSP API that it is tsserver.
         if l:linter.lsp is# 'tsserver'

--- a/autoload/ale/lua.vim
+++ b/autoload/ale/lua.vim
@@ -4,6 +4,7 @@
 " Find project root for a Lua language server.
 function! ale#lua#FindProjectRoot(buffer) abort
     let l:possible_project_roots = [
+    \   '.luarc.json',
     \   '.git',
     \   bufname(a:buffer),
     \]

--- a/autoload/ale/rename.vim
+++ b/autoload/ale/rename.vim
@@ -17,8 +17,8 @@ function! ale#rename#ClearLSPData() abort
     let s:rename_map = {}
 endfunction
 
-let g:ale_rename_tsserver_find_in_comments = get(g:, 'ale_rename_tsserver_find_in_comments')
-let g:ale_rename_tsserver_find_in_strings = get(g:, 'ale_rename_tsserver_find_in_strings')
+let g:ale_rename_tsserver_find_in_comments = get(g:, 'ale_rename_tsserver_find_in_comments', v:false)
+let g:ale_rename_tsserver_find_in_strings = get(g:, 'ale_rename_tsserver_find_in_strings', v:false)
 
 function! s:message(message) abort
     call ale#util#Execute('echom ' . string(a:message))

--- a/autoload/ale/sign.vim
+++ b/autoload/ale/sign.vim
@@ -7,7 +7,7 @@ scriptencoding utf8
 let g:ale_max_signs = get(g:, 'ale_max_signs', -1)
 " This flag can be set to 1 to enable changing the sign column colors when
 " there are errors.
-let g:ale_change_sign_column_color = get(g:, 'ale_change_sign_column_color', 0)
+let g:ale_change_sign_column_color = get(g:, 'ale_change_sign_column_color', v:false)
 " These variables dictate what signs are used to indicate errors and warnings.
 let g:ale_sign_error = get(g:, 'ale_sign_error', 'E')
 let g:ale_sign_style_error = get(g:, 'ale_sign_style_error', g:ale_sign_error)
@@ -20,8 +20,8 @@ let g:ale_sign_priority = get(g:, 'ale_sign_priority', 30)
 " The dummy sign will use the ID exactly equal to the offset.
 let g:ale_sign_offset = get(g:, 'ale_sign_offset', 1000000)
 " This flag can be set to 1 to keep sign gutter always open
-let g:ale_sign_column_always = get(g:, 'ale_sign_column_always', 0)
-let g:ale_sign_highlight_linenrs = get(g:, 'ale_sign_highlight_linenrs', 0)
+let g:ale_sign_column_always = get(g:, 'ale_sign_column_always', v:false)
+let g:ale_sign_highlight_linenrs = get(g:, 'ale_sign_highlight_linenrs', v:false)
 
 let s:supports_sign_groups = has('nvim-0.4.2') || has('patch-8.1.614')
 

--- a/autoload/ale/virtualtext.vim
+++ b/autoload/ale/virtualtext.vim
@@ -32,7 +32,7 @@ let g:ale_virtualtext_delay = get(g:, 'ale_virtualtext_delay', 10)
 let g:ale_virtualtext_column = get(g:, 'ale_virtualtext_column', 0)
 let g:ale_virtualtext_maxcolumn = get(g:, 'ale_virtualtext_maxcolumn', 0)
 " If 1, only show the first problem with virtualtext.
-let g:ale_virtualtext_single = get(g:, 'ale_virtualtext_single', 1)
+let g:ale_virtualtext_single = get(g:, 'ale_virtualtext_single', v:true)
 
 let s:cursor_timer = get(s:, 'cursor_timer', -1)
 let s:last_pos = get(s:, 'last_pos', [0, 0, 0])

--- a/doc/ale-ada.txt
+++ b/doc/ale-ada.txt
@@ -7,19 +7,25 @@ cspell                                                         *ale-ada-cspell*
 
 See |ale-cspell-options|
 
+
 ===============================================================================
 gcc                                                               *ale-ada-gcc*
 
-g:ale_ada_gcc_executable                             *g:ale_ada_gcc_executable*
+                                               *ale-options.ada_gcc_executable*
+                                                     *g:ale_ada_gcc_executable*
                                                      *b:ale_ada_gcc_executable*
+ada_gcc_executable
+g:ale_ada_gcc_executable
   Type: |String|
   Default: `'gcc'`
 
-This variable can be changed to use a different executable for gcc.
+  This variable can be changed to use a different executable for gcc.
 
-
-g:ale_ada_gcc_options                                   *g:ale_ada_gcc_options*
+                                                  *ale-options.ada_gcc_options*
+                                                        *g:ale_ada_gcc_options*
                                                         *b:ale_ada_gcc_options*
+ada_gcc_options
+g:ale_ada_gcc_options
   Type: |String|
   Default: `'-gnatwa -gnatq'`
 
@@ -29,8 +35,11 @@ g:ale_ada_gcc_options                                   *g:ale_ada_gcc_options*
 ===============================================================================
 gnatpp                                                         *ale-ada-gnatpp*
 
-g:ale_ada_gnatpp_options                             *g:ale_ada_gnatpp_options*
+                                               *ale-options.ada_gnatpp_options*
+                                                     *g:ale_ada_gnatpp_options*
                                                      *b:ale_ada_gnatpp_options*
+ada_gnatpp_options
+g:ale_ada_gnatpp_options
   Type: |String|
   Default: `''`
 
@@ -40,31 +49,38 @@ g:ale_ada_gnatpp_options                             *g:ale_ada_gnatpp_options*
 ===============================================================================
 ada-language-server                                   *ale-ada-language-server*
 
-g:ale_ada_adals_executable                         *g:ale_ada_adals_executable*
+                                             *ale-options.ada_adals_executable*
+                                                   *g:ale_ada_adals_executable*
                                                    *b:ale_ada_adals_executable*
+ada_adals_executable
+g:ale_ada_adals_executable
   Type: |String|
   Default: `'ada_language_server'`
 
   This variable can be changed to use a different executable for Ada Language
   Server.
 
-
-g:ale_ada_adals_project                               *g:ale_ada_adals_project*
+                                                *ale-options.ada_adals_project*
+                                                      *g:ale_ada_adals_project*
                                                       *b:ale_ada_adals_project*
+ada_adals_project
+g:ale_ada_adals_project
   Type: |String|
   Default: `'default.gpr'`
 
-This variable can be changed to use a different GPR file for
-Ada Language Server.
+  This variable can be changed to use a different GPR file for Ada Language
+  Server.
 
-
-g:ale_ada_adals_encoding                             *g:ale_ada_adals_encoding*
+                                               *ale-options.ada_adals_encoding*
+                                                     *g:ale_ada_adals_encoding*
                                                      *b:ale_ada_adals_encoding*
+ada_adals_encoding
+g:ale_ada_adals_encoding
   Type: |String|
   Default: `'utf-8'`
 
-This variable can be changed to use a different file encoding for
-Ada Language Server.
+  This variable can be changed to use a different file encoding for Ada
+  Language Server.
 
 
 ===============================================================================

--- a/doc/ale-ansible.txt
+++ b/doc/ale-ansible.txt
@@ -1,34 +1,43 @@
 ===============================================================================
 ALE Ansible Integration                                   *ale-ansible-options*
 
+
 ===============================================================================
-ansible-language-server                             *ale-ansible-language-server*
+ansible-language-server                           *ale-ansible-language-server*
 
 
-g:ale_ansible_language_server_executable          *g:ale_ansible_language_server*
-                                                  *b:ale_ansible_language_server*
-
+                               *ale-options.ansible_language_server_executable*
+                                     *g:ale_ansible_language_server_executable*
+                                     *b:ale_ansible_language_server_executable*
+ansible_language_server_executable
+g:ale_ansible_language_server_executable
   Type: |String|
-  Default: 'ansible-language-server'
+  Default: `'ansible-language-server'`
 
-  Variable can be used to modify the executable used for ansible language server.
+  Variable can be used to modify the executable used for Ansible language
+  server.
 
-
-g:ale_ansible_language_server_config        *g:ale_ansible_language_server_config*
-                                            *b:ale_ansible_language_server_config*
-
+                                   *ale-options.ansible_language_server_config*
+                                         *g:ale_ansible_language_server_config*
+                                         *b:ale_ansible_language_server_config*
+ansible_language_server_config
+g:ale_ansible_language_server_config
   Type: |Dictionary|
-  Default: '{}'
+  Default: `'{}'`
 
   Configuration parameters sent to the language server on start. Refer to the
   ansible language server configuration documentation for list of available
   options: https://als.readthedocs.io/en/latest/settings/
 
+
 ===============================================================================
 ansible-lint                                         *ale-ansible-ansible-lint*
 
-g:ale_ansible_ansible_lint_executable   *g:ale_ansible_ansible_lint_executable*
+                                  *ale-options.ansible_ansible_lint_executable*
+                                        *g:ale_ansible_ansible_lint_executable*
                                         *b:ale_ansible_ansible_lint_executable*
+ansible_ansible_lint_executable
+g:ale_ansible_ansible_lint_executable
   Type: |String|
   Default: `'ansible-lint'`
 

--- a/doc/ale-apkbuild.txt
+++ b/doc/ale-apkbuild.txt
@@ -5,27 +5,33 @@ ALE APKBUILD Integration                                 *ale-apkbuild-options*
 ===============================================================================
 apkbuild-fixer                                    *ale-apkbuild-apkbuild-fixer*
 
-g:apkbuild_apkbuild_fixer_options           *g:apkbuild_apkbuild_fixer_options*
-                                            *b:apkbuild_apkbuild_fixer_options*
+                                  *ale-options.apkbuild_apkbuild_fixer_options*
+                                        *g:ale_apkbuild_apkbuild_fixer_options*
+                                        *b:ale_apkbuild_apkbuild_fixer_options*
+apkbuild_apkbuild_fixer_options
+g:ale_apkbuild_apkbuild_fixer_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass additional options to the apkbuild_fixer
   fixer.
 
-
-g:apkbuild_apkbuild_fixer_executable     *g:apkbuild_apkbuild_fixer_executable*
-                                         *b:apkbuild_apkbuild_fixer_executable*
+                               *ale-options.apkbuild_apkbuild_fixer_executable*
+                                     *g:ale_apkbuild_apkbuild_fixer_executable*
+                                     *b:ale_apkbuild_apkbuild_fixer_executable*
+apkbuild_apkbuild_fixer_executable
+g:ale_apkbuild_apkbuild_fixer_executable
   Type: |String|
   Default: `'apkbuild-fixer'`
 
   This variable can be modified to change the executable path for
   `apkbuild-fixer`.
 
-
-g:apkbuild_apkbuild_fixer_lint_executable
-                                    *g:apkbuild_apkbuild_fixer_lint_executable*
-                                    *b:apkbuild_apkbuild_fixer_lint_executable*
+                          *ale-options.apkbuild_apkbuild_fixer_lint_executable*
+                                *g:ale_apkbuild_apkbuild_fixer_lint_executable*
+                                *b:ale_apkbuild_apkbuild_fixer_lint_executable*
+apkbuild_apkbuild_fixer_lint_executable
+g:ale_apkbuild_apkbuild_fixer_lint_executable
   Type: |String|
   Default: `'apkbuild-fixer'`
 
@@ -36,26 +42,30 @@ g:apkbuild_apkbuild_fixer_lint_executable
 ===============================================================================
 apkbuild-lint                                      *ale-apkbuild-apkbuild-lint*
 
-g:ale_apkbuild_apkbuild_lint_executable
+                                *ale-options.apkbuild_apkbuild_lint_executable*
                                       *g:ale_apkbuild_apkbuild_lint_executable*
                                       *b:ale_apkbuild_apkbuild_lint_executable*
-
+apkbuild_apkbuild_lint_executable
+g:ale_apkbuild_apkbuild_lint_executable
   Type: |String|
   Default: `'apkbuild-lint'`
 
   This variable can be set to change the path to apkbuild-lint
 
+
 ===============================================================================
 secfixes-check                                    *ale-apkbuild-secfixes-check*
 
-g:ale_apkbuild_secfixes_check_executable
+                               *ale-options.apkbuild_secfixes_check_executable*
                                      *g:ale_apkbuild_secfixes_check_executable*
                                      *b:ale_apkbuild_secfixes_check_executable*
-
+apkbuild_secfixes_check_executable
+g:ale_apkbuild_secfixes_check_executable
   Type: |String|
   Default: `'secfixes-check'`
 
   This variable can be set to change the path to secfixes-check
+
 
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-asm.txt
+++ b/doc/ale-asm.txt
@@ -5,16 +5,21 @@ ALE ASM Integration                                           *ale-asm-options*
 ===============================================================================
 gcc                                                               *ale-asm-gcc*
 
-g:ale_asm_gcc_executable                             *g:ale_asm_gcc_executable*
+                                               *ale-options.asm_gcc_executable*
+                                                     *g:ale_asm_gcc_executable*
                                                      *b:ale_asm_gcc_executable*
+asm_gcc_executable
+g:ale_asm_gcc_executable
   Type: |String|
   Default: `'gcc'`
 
-This variable can be changed to use a different executable for gcc.
+  This variable can be changed to use a different executable for gcc.
 
-
-g:ale_asm_gcc_options                                   *g:ale_asm_gcc_options*
+                                                  *ale-options.asm_gcc_options*
+                                                        *g:ale_asm_gcc_options*
                                                         *b:ale_asm_gcc_options*
+asm_gcc_options
+g:ale_asm_gcc_options
   Type: |String|
   Default: `'-Wall'`
 
@@ -24,16 +29,21 @@ g:ale_asm_gcc_options                                   *g:ale_asm_gcc_options*
 ===============================================================================
 llvm_mc                                                       *ale-asm-llvm_mc*
 
-g:ale_asm_clang_executable                       *g:ale_asm_llvm_mc_executable*
+                                           *ale-options.asm_llvm_mc_executable*
+                                                 *g:ale_asm_llvm_mc_executable*
                                                  *b:ale_asm_llvm_mc_executable*
+asm_llvm_mc_executable
+g:ale_asm_llvm_mc_executable
   Type: |String|
   Default: `'llvm-mc'`
 
 This variable can be changed to use a different executable for llvm-mc.
 
-
-g:ale_asm_clang_options                             *g:ale_asm_llvm_mc_options*
+                                              *ale-options.asm_llvm_mc_options*
+                                                    *g:ale_asm_llvm_mc_options*
                                                     *b:ale_asm_llvm_mc_options*
+asm_llvm_mc_options
+g:ale_asm_llvm_mc_options
   Type: |String|
   Default: `''`
 

--- a/doc/ale-avra.txt
+++ b/doc/ale-avra.txt
@@ -5,17 +5,21 @@ ALE AVRA Integration                                         *ale-avra-options*
 ===============================================================================
 avra                                                            *ale-avra-avra*
 
-g:ale_avra_avra_executable                         *g:ale_avra_avra_executable*
+                                             *ale-options.avra_avra_executable*
+                                                   *g:ale_avra_avra_executable*
                                                    *b:ale_avra_avra_executable*
-
+avra_avra_executable
+g:ale_avra_avra_executable
   Type: |String|
   Default `'avra'`
 
   This variable can be changed to use different executable for AVRA.
 
-
-g:ale_avra_avra_options                               *g:ale_avra_avra_options*
+                                                *ale-options.avra_avra_options*
+                                                      *g:ale_avra_avra_options*
                                                       *b:ale_avra_avra_options*
+avra_avra_options
+g:ale_avra_avra_options
   Type: |String|
   Default: `''`
 

--- a/doc/ale-awk.txt
+++ b/doc/ale-awk.txt
@@ -5,21 +5,27 @@ ALE Awk Integration                                           *ale-awk-options*
 ===============================================================================
 gawk                                                             *ale-awk-gawk*
 
-g:ale_awk_gawk_executable                           *g:ale_awk_gawk_executable*
+                                              *ale-options.awk_gawk_executable*
+                                                    *g:ale_awk_gawk_executable*
                                                     *b:ale_awk_gawk_executable*
+awk_gawk_executable
+g:ale_awk_gawk_executable
   Type: |String|
   Default: `'gawk'`
 
   This variable sets executable used for gawk.
 
-
-g:ale_awk_gawk_options                                 *g:ale_awk_gawk_options*
+                                                 *ale-options.awk_gawk_options*
+                                                       *g:ale_awk_gawk_options*
                                                        *b:ale_awk_gawk_options*
+awk_gawk_options
+g:ale_awk_gawk_options
   Type: |String|
   Default: `''`
 
-  With this variable we are able to pass extra arguments for gawk
-  for invocation.
+  With this variable we are able to pass extra arguments for gawk for
+  invocation.
+
 
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-bazel.txt
+++ b/doc/ale-bazel.txt
@@ -4,25 +4,36 @@ ALE Bazel Integration                                       *ale-bazel-options*
 ===============================================================================
 buildifier                                               *ale-bazel-buildifier*
 
-g:ale_bazel_buildifier_executable           *g:ale_bazel_buildifier_executable*
+                                      *ale-options.bazel_buildifier_executable*
+                                            *g:ale_bazel_buildifier_executable*
                                             *b:ale_bazel_buildifier_executable*
+bazel_buildifier_executable
+g:ale_bazel_buildifier_executable
   Type: |String|
   Default: `'buildifier'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_bazel_buildifier_options                 *g:ale_bazel_buildifier_options*
+                                         *ale-options.bazel_buildifier_options*
+                                               *g:ale_bazel_buildifier_options*
                                                *b:ale_bazel_buildifier_options*
+bazel_buildifier_options
+g:ale_bazel_buildifier_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass extra options to buildifier.
 
-
-g:ale_bazel_buildifier_use_global           *g:ale_bazel_buildifier_use_global*
+                                      *ale-options.bazel_buildifier_use_global*
+                                            *g:ale_bazel_buildifier_use_global*
                                             *b:ale_bazel_buildifier_use_global*
+bazel_buildifier_use_global
+g:ale_bazel_buildifier_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
   See |ale-integrations-local-executables|
+
+
+===============================================================================
+  vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-bib.txt
+++ b/doc/ale-bib.txt
@@ -5,15 +5,22 @@ ALE BibTeX Integration                                        *ale-bib-options*
 ===============================================================================
 bibclean                                                     *ale-bib-bibclean*
 
-g:ale_bib_bibclean_executable                   *g:ale_bib_bibclean_executable*
-
+                                          *ale-options.bib_bibclean_executable*
+                                                *g:ale_bib_bibclean_executable*
+                                                *b:ale_bib_bibclean_executable*
+bib_bibclean_executable
+g:ale_bib_bibclean_executable
   Type: |String|
   Default: `'bibclean'`
 
-g:ale_bib_bibclean_options                         *g:ale_bib_bibclean_options*
-
+                                             *ale-options.bib_bibclean_options*
+                                                   *g:ale_bib_bibclean_options*
+                                                   *b:ale_bib_bibclean_options*
+bib_bibclean_options
+g:ale_bib_bibclean_options
   Type: |String|
   Default: `'-align-equals'`
+
 
 ===============================================================================
 vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-bicep.txt
+++ b/doc/ale-bicep.txt
@@ -1,20 +1,25 @@
 ===============================================================================
-ALE Bicep Integration                                        *ale-bicep-options*
+ALE Bicep Integration                                       *ale-bicep-options*
 
 
 ===============================================================================
-bicep                                                          *ale-bicep-bicep*
+bicep                                                         *ale-bicep-bicep*
 
-g:ale_bicep_bicep_executable                      *g:ale_bicep_bicep_executable*
-                                                  *b:ale_bicep_bicep_executable*
+                                           *ale-options.bicep_bicep_executable*
+                                                 *g:ale_bicep_bicep_executable*
+                                                 *b:ale_bicep_bicep_executable*
+bicep_bicep_executable
+g:ale_bicep_bicep_executable
   Type: |String|
   Default: `'bicep'`
 
   This variable can be set to change the path to bicep.
 
-
-g:ale_bicep_bicep_options                            *g:ale_bicep_bicep_options*
-                                                     *b:ale_bicep_bicep_options*
+                                              *ale-options.bicep_bicep_options*
+                                                    *g:ale_bicep_bicep_options*
+                                                    *b:ale_bicep_bicep_options*
+bicep_bicep_options
+g:ale_bicep_bicep_options
   Type: |String|
   Default: `''`
 
@@ -22,22 +27,28 @@ g:ale_bicep_bicep_options                            *g:ale_bicep_bicep_options*
 
 
 ===============================================================================
-az_bicep                                                    *ale-bicep-az_bicep*
+az_bicep                                                   *ale-bicep-az_bicep*
 
-g:ale_bicep_az_bicep_executable                *g:ale_bicep_az_bicep_executable*
-                                               *b:ale_bicep_az_bicep_executable*
+                                        *ale-options.bicep_az_bicep_executable*
+                                              *g:ale_bicep_az_bicep_executable*
+                                              *b:ale_bicep_az_bicep_executable*
+bicep_az_bicep_executable
+g:ale_bicep_az_bicep_executable
   Type: |String|
   Default: `'az'`
 
   This variable can be set to change the path to az_bicep.
 
-
-g:ale_bicep_az_bicep_options                      *g:ale_bicep_az_bicep_options*
-                                                  *b:ale_bicep_az_bicep_options*
+                                           *ale-options.bicep_az_bicep_options*
+                                                 *g:ale_bicep_az_bicep_options*
+                                                 *b:ale_bicep_az_bicep_options*
+bicep_az_bicep_options
+g:ale_bicep_az_bicep_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass additional options to az_bicep.
+
 
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-bitbake.txt
+++ b/doc/ale-bitbake.txt
@@ -5,22 +5,31 @@ ALE BitBake Integration                                   *ale-bitbake-options*
 ===============================================================================
 oelint-adv                                             *ale-bitbake-oelint_adv*
 
-g:ale_bitbake_oelint_adv_executable       *g:ale_bitbake_oelint_adv_executable*
+                                    *ale-options.bitbake_oelint_adv_executable*
+                                          *g:ale_bitbake_oelint_adv_executable*
+                                          *b:ale_bitbake_oelint_adv_executable*
+bitbake_oelint_adv_executable
+g:ale_bitbake_oelint_adv_executable
 
   Type: |String|
   Default: `'oelint-adv'`
 
   This variable can be changed to use a different executable for oelint-adv.
 
-g:ale_bitbake_oelint_adv_options             *g:ale_bitbake_oelint_adv_options*
-
+                                       *ale-options.bitbake_oelint_adv_options*
+                                             *g:ale_bitbake_oelint_adv_options*
+                                             *b:ale_bitbake_oelint_adv_options*
+bitbake_oelint_adv_options
+g:ale_bitbake_oelint_adv_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass additional options to oelint-adv.
 
-  g:ale_bitbake_oelint_adv_config             *g:ale_bitbake_oelint_adv_config*
-
+                                        *ale-options.bitbake_oelint_adv_config*
+                                              *g:ale_bitbake_oelint_adv_config*
+                                              *b:ale_bitbake_oelint_adv_config*
+g:ale_bitbake_oelint_adv_config
   Type: |String|
   Default: `'.oelint.cfg'`
 

--- a/doc/ale-c.txt
+++ b/doc/ale-c.txt
@@ -7,9 +7,11 @@ runs either `clang`, or `gcc`. See |ale-c-cc|.
 
 ===============================================================================
 Global Options
-
-g:ale_c_always_make                                       *g:ale_c_always_make*
+                                                    *ale-options.c_always_make*
+                                                          *g:ale_c_always_make*
                                                           *b:ale_c_always_make*
+c_always_make
+g:ale_c_always_make
   Type: |Number|
   Default: `has('unix') && !has('macunix')`
 
@@ -18,10 +20,11 @@ g:ale_c_always_make                                       *g:ale_c_always_make*
   support this option, so you probably want to turn this option off when using
   a BSD variant.
 
-
-g:ale_c_build_dir_names                               *g:ale_c_build_dir_names*
+                                                *ale-options.c_build_dir_names*
+                                                      *g:ale_c_build_dir_names*
                                                       *b:ale_c_build_dir_names*
-
+c_build_dir_names
+g:ale_c_build_dir_names
   Type: |List|
   Default: `['build', 'bin']`
 
@@ -32,10 +35,11 @@ g:ale_c_build_dir_names                               *g:ale_c_build_dir_names*
   database.  This feature is useful for the clang tools wrapped around
   LibTooling (namely here, clang-tidy)
 
-
-g:ale_c_build_dir                                           *g:ale_c_build_dir*
+                                                      *ale-options.c_build_dir*
+                                                            *g:ale_c_build_dir*
                                                             *b:ale_c_build_dir*
-
+c_build_dir
+g:ale_c_build_dir
   Type: |String|
   Default: `''`
 
@@ -47,9 +51,11 @@ g:ale_c_build_dir                                           *g:ale_c_build_dir*
 
   This directory will be searched instead of |g:ale_c_build_dir_names|.
 
-
-g:ale_c_parse_compile_commands                 *g:ale_c_parse_compile_commands*
+                                         *ale-options.c_parse_compile_commands*
+                                               *g:ale_c_parse_compile_commands*
                                                *b:ale_c_parse_compile_commands*
+c_parse_compile_commands
+g:ale_c_parse_compile_commands
   Type: |Number|
   Default: `1`
 
@@ -59,9 +65,11 @@ g:ale_c_parse_compile_commands                 *g:ale_c_parse_compile_commands*
   `compile_commands.json` files in the directories for
   |g:ale_c_build_dir_names|.
 
-
-g:ale_c_parse_makefile                                 *g:ale_c_parse_makefile*
+                                                 *ale-options.c_parse_makefile*
+                                                       *g:ale_c_parse_makefile*
                                                        *b:ale_c_parse_makefile*
+c_parse_makefile
+g:ale_c_parse_makefile
   Type: |Number|
   Default: `0`
 
@@ -91,16 +99,21 @@ g:ale_c_parse_makefile                                 *g:ale_c_parse_makefile*
 ===============================================================================
 astyle                                                           *ale-c-astyle*
 
-g:ale_c_astyle_executable                           *g:ale_c_astyle_executable*
+                                              *ale-options.c_astyle_executable*
+                                                    *g:ale_c_astyle_executable*
                                                     *b:ale_c_astyle_executable*
+c_astyle_executable
+g:ale_c_astyle_executable
   Type: |String|
   Default: `'astyle'`
 
   This variable can be changed to use a different executable for astyle.
 
-
-g:ale_c_astyle_project_options                 *g:ale_c_astyle_project_options*
+                                         *ale-options.c_astyle_project_options*
+                                               *g:ale_c_astyle_project_options*
                                                *b:ale_c_astyle_project_options*
+c_astyle_project_options
+g:ale_c_astyle_project_options
   Type: |String|
   Default: `''`
 
@@ -117,8 +130,11 @@ cc                                                                   *ale-c-cc*
                                                                     *ale-c-gcc*
                                                                   *ale-c-clang*
 
-g:ale_c_cc_executable                                   *g:ale_c_cc_executable*
+                                                  *ale-options.c_cc_executable*
+                                                        *g:ale_c_cc_executable*
                                                         *b:ale_c_cc_executable*
+c_cc_executable
+g:ale_c_cc_executable
   Type: |String|
   Default: `'<auto>'`
 
@@ -127,17 +143,21 @@ g:ale_c_cc_executable                                   *g:ale_c_cc_executable*
   ALE will try to use `clang` if Clang is available, otherwise ALE will
   default to checking C code with `gcc`.
 
-
-g:ale_c_cc_options                                         *g:ale_c_cc_options*
+                                                     *ale-options.c_cc_options*
+                                                           *g:ale_c_cc_options*
                                                            *b:ale_c_cc_options*
+c_cc_options
+g:ale_c_cc_options
   Type: |String|
   Default: `'-std=c11 -Wall'`
 
   This variable can be changed to modify flags given to the C compiler.
 
-
-g:ale_c_cc_use_header_lang_flag               *g:ale_c_cc_use_header_lang_flag*
+                                        *ale-options.c_cc_use_header_lang_flag*
+                                              *g:ale_c_cc_use_header_lang_flag*
                                               *b:ale_c_cc_use_header_lang_flag*
+c_cc_use_header_lang_flag
+g:ale_c_cc_use_header_lang_flag
   Type: |Number|
   Default: `-1`
 
@@ -158,9 +178,11 @@ g:ale_c_cc_use_header_lang_flag               *g:ale_c_cc_use_header_lang_flag*
   which is what ALE does. This why, by default, ALE only uses `'-x c-header'`
   with Clang.
 
-
-g:ale_c_cc_header_exts                                 *g:ale_c_cc_header_exts*
+                                                 *ale-options.c_cc_header_exts*
+                                                       *g:ale_c_cc_header_exts*
                                                        *b:ale_c_cc_header_exts*
+c_cc_header_exts
+g:ale_c_cc_header_exts
   Type: |List|
   Default: `['h']`
 
@@ -174,29 +196,35 @@ g:ale_c_cc_header_exts                                 *g:ale_c_cc_header_exts*
 ===============================================================================
 ccls                                                               *ale-c-ccls*
 
-g:ale_c_ccls_executable                               *g:ale_c_ccls_executable*
+                                                *ale-options.c_ccls_executable*
+                                                      *g:ale_c_ccls_executable*
                                                       *b:ale_c_ccls_executable*
+c_ccls_executable
+g:ale_c_ccls_executable
   Type: |String|
   Default: `'ccls'`
 
   This variable can be changed to use a different executable for ccls.
 
-
-g:ale_c_ccls_init_options                           *g:ale_c_ccls_init_options*
+                                              *ale-options.c_ccls_init_options*
+                                                    *g:ale_c_ccls_init_options*
                                                     *b:ale_c_ccls_init_options*
+c_ccls_init_options
+g:ale_c_ccls_init_options
   Type: |Dictionary|
   Default: `{}`
 
   This variable can be changed to customize ccls initialization options.
-  Example: >
-      {
-    \   'cacheDirectory': '/tmp/ccls',
-    \   'cacheFormat': 'binary',
-    \   'diagnostics': {
-    \     'onOpen': 0,
-    \     'opChange': 1000,
-    \   },
-    \ }
+  For example: >
+
+  let g:ale_c_ccls_init_options = {
+  \   'cacheDirectory': '/tmp/ccls',
+  \   'cacheFormat': 'binary',
+  \   'diagnostics': {
+  \       'onOpen': 0,
+  \       'opChange': 1000,
+  \   },
+  \}
 <
   For all available options and explanations, visit
   https://github.com/MaskRay/ccls/wiki/Customization#initialization-options.
@@ -213,16 +241,23 @@ Therefore, `clang-check` linter reads the options |g:ale_c_build_dir| and
 overrides |g:ale_c_build_dir_names|.
 
 
-g:ale_c_clangcheck_executable                   *g:ale_c_clangcheck_executable*
+-------------------------------------------------------------------------------
+Options
+                                          *ale-options.c_clangcheck_executable*
+                                                *g:ale_c_clangcheck_executable*
                                                 *b:ale_c_clangcheck_executable*
+c_clangcheck_executable
+g:ale_c_clangcheck_executable
   Type: |String|
   Default: `'clang-check'`
 
   This variable can be changed to use a different executable for clangcheck.
 
-
-g:ale_c_clangcheck_options                         *g:ale_c_clangcheck_options*
+                                             *ale-options.c_clangcheck_options*
+                                                   *g:ale_c_clangcheck_options*
                                                    *b:ale_c_clangcheck_options*
+c_clangcheck_options
+g:ale_c_clangcheck_options
   Type: |String|
   Default: `''`
 
@@ -236,16 +271,21 @@ g:ale_c_clangcheck_options                         *g:ale_c_clangcheck_options*
 ===============================================================================
 clangd                                                           *ale-c-clangd*
 
-g:ale_c_clangd_executable                           *g:ale_c_clangd_executable*
+                                              *ale-options.c_clangd_executable*
+                                                    *g:ale_c_clangd_executable*
                                                     *b:ale_c_clangd_executable*
+c_clangd_executable
+g:ale_c_clangd_executable
   Type: |String|
   Default: `'clangd'`
 
   This variable can be changed to use a different executable for clangd.
 
-
-g:ale_c_clangd_options                                 *g:ale_c_clangd_options*
+                                                 *ale-options.c_clangd_options*
+                                                       *g:ale_c_clangd_options*
                                                        *b:ale_c_clangd_options*
+c_clangd_options
+g:ale_c_clangd_options
   Type: |String|
   Default: `''`
 
@@ -255,24 +295,31 @@ g:ale_c_clangd_options                                 *g:ale_c_clangd_options*
 ===============================================================================
 clang-format                                                *ale-c-clangformat*
 
-g:ale_c_clangformat_executable                 *g:ale_c_clangformat_executable*
+                                         *ale-options.c_clangformat_executable*
+                                               *g:ale_c_clangformat_executable*
                                                *b:ale_c_clangformat_executable*
+c_clangformat_executable
+g:ale_c_clangformat_executable
   Type: |String|
   Default: `'clang-format'`
 
   This variable can be changed to use a different executable for clang-format.
 
-
-g:ale_c_clangformat_options                       *g:ale_c_clangformat_options*
+                                            *ale-options.c_clangformat_options*
+                                                  *g:ale_c_clangformat_options*
                                                   *b:ale_c_clangformat_options*
+c_clangformat_options
+g:ale_c_clangformat_options
   Type: |String|
   Default: `''`
 
   This variable can be changed to modify flags given to clang-format.
 
-
-g:ale_c_clangformat_style_option             *g:ale_c_clangformat_style_option*
+                                       *ale-options.c_clangformat_style_option*
+                                             *g:ale_c_clangformat_style_option*
                                              *b:ale_c_clangformat_style_option*
+c_clangformat_style_option
+g:ale_c_clangformat_style_option
   Type: |String|
   Default: `''`
 
@@ -281,19 +328,21 @@ g:ale_c_clangformat_style_option             *g:ale_c_clangformat_style_option*
   flag of clang-format.
 
   Example: >
-      {
-    \ BasedOnStyle:                        Microsoft,
-    \ ColumnLimit:                         80,
-    \ AllowShortBlocksOnASingleLine:       Always,
-    \ AllowShortFunctionsOnASingleLine:    Inline,
-    \ }
+  let g:ale_c_clangformat_style_option = {
+  \   'BasedOnStyle': 'Microsoft',
+  \   'ColumnLimit': 80,
+  \   'AllowShortBlocksOnASingleLine': 'Always',
+  \   'AllowShortFunctionsOnASingleLine': 'Inline',
+  \}
 <
   If you set this variable, ensure you don't modify -style in
   |g:ale_c_clangformat_options|, as this will cause clang-format to error.
 
-
-g:ale_c_clangformat_use_local_file         *g:ale_c_clangformat_use_local_file*
+                                     *ale-options.c_clangformat_use_local_file*
+                                           *g:ale_c_clangformat_use_local_file*
                                            *b:ale_c_clangformat_use_local_file*
+c_clangformat_use_local_file
+g:ale_c_clangformat_use_local_file
   Type: |Number|
   Default: `0`
 
@@ -320,8 +369,13 @@ Therefore, `clang-tidy` linter reads the options |g:ale_c_build_dir| and
 overrides |g:ale_c_build_dir_names|.
 
 
-g:ale_c_clangtidy_checks                             *g:ale_c_clangtidy_checks*
+-------------------------------------------------------------------------------
+Options
+                                               *ale-options.c_clangtidy_checks*
+                                                     *g:ale_c_clangtidy_checks*
                                                      *b:ale_c_clangtidy_checks*
+c_clangtidy_checks
+g:ale_c_clangtidy_checks
   Type: |List|
   Default: `[]`
 
@@ -335,17 +389,21 @@ g:ale_c_clangtidy_checks                             *g:ale_c_clangtidy_checks*
   clang documentation for an up-to-date list of compatible checks:
   http://clang.llvm.org/extra/clang-tidy/checks/list.html
 
-
-g:ale_c_clangtidy_executable                     *g:ale_c_clangtidy_executable*
+                                           *ale-options.c_clangtidy_executable*
+                                                 *g:ale_c_clangtidy_executable*
                                                  *b:ale_c_clangtidy_executable*
+c_clangtidy_executable
+g:ale_c_clangtidy_executable
   Type: |String|
   Default: `'clang-tidy'`
 
   This variable can be changed to use a different executable for clangtidy.
 
-
-g:ale_c_clangtidy_options                           *g:ale_c_clangtidy_options*
+                                              *ale-options.c_clangtidy_options*
+                                                    *g:ale_c_clangtidy_options*
                                                     *b:ale_c_clangtidy_options*
+c_clangtidy_options
+g:ale_c_clangtidy_options
   Type: |String|
   Default: `''`
 
@@ -361,17 +419,21 @@ g:ale_c_clangtidy_options                           *g:ale_c_clangtidy_options*
   entirely manually, and no `compile_commands.json` file is in one
   of the |g:ale_c_build_dir_names| directories of the project tree.
 
-
-g:ale_c_clangtidy_extra_options               *g:ale_c_clangtidy_extra_options*
+                                        *ale-options.c_clangtidy_extra_options*
+                                              *g:ale_c_clangtidy_extra_options*
                                               *b:ale_c_clangtidy_extra_options*
+c_clangtidy_extra_options
+g:ale_c_clangtidy_extra_options
   Type: |String|
   Default: `''`
 
   This variable can be changed to modify flags given to clang-tidy.
 
-
-g:ale_c_clangtidy_fix_errors                     *g:ale_c_clangtidy_fix_errors*
+                                           *ale-options.c_clangtidy_fix_errors*
+                                                 *g:ale_c_clangtidy_fix_errors*
                                                  *b:ale_c_clangtidy_fix_errors*
+c_clangtidy_fix_errors
+g:ale_c_clangtidy_fix_errors
   Type: |Number|
   Default: `1`
 
@@ -382,16 +444,21 @@ g:ale_c_clangtidy_fix_errors                     *g:ale_c_clangtidy_fix_errors*
 ===============================================================================
 cppcheck                                                       *ale-c-cppcheck*
 
-g:ale_c_cppcheck_executable                       *g:ale_c_cppcheck_executable*
+                                            *ale-options.c_cppcheck_executable*
+                                                  *g:ale_c_cppcheck_executable*
                                                   *b:ale_c_cppcheck_executable*
+c_cppcheck_executable
+g:ale_c_cppcheck_executable
   Type: |String|
   Default: `'cppcheck'`
 
   This variable can be changed to use a different executable for cppcheck.
 
-
-g:ale_c_cppcheck_options                             *g:ale_c_cppcheck_options*
+                                               *ale-options.c_cppcheck_options*
+                                                     *g:ale_c_cppcheck_options*
                                                      *b:ale_c_cppcheck_options*
+c_cppcheck_options
+g:ale_c_cppcheck_options
   Type: |String|
   Default: `'--enable=style'`
 
@@ -401,21 +468,26 @@ g:ale_c_cppcheck_options                             *g:ale_c_cppcheck_options*
 ===============================================================================
 cquery                                                           *ale-c-cquery*
 
-g:ale_c_cquery_executable                           *g:ale_c_cquery_executable*
+                                              *ale-options.c_cquery_executable*
+                                                    *g:ale_c_cquery_executable*
                                                     *b:ale_c_cquery_executable*
+c_cquery_executable
+g:ale_c_cquery_executable
   Type: |String|
   Default: `'cquery'`
 
   This variable can be changed to use a different executable for cquery.
 
-
-g:ale_c_cquery_cache_directory                 *g:ale_c_cquery_cache_directory*
+                                         *ale-options.c_cquery_cache_directory*
+                                               *g:ale_c_cquery_cache_directory*
                                                *b:ale_c_cquery_cache_directory*
+c_cquery_cache_directory
+g:ale_c_cquery_cache_directory
   Type: |String|
   Default: `'~/.cache/cquery'`
 
   This variable can be changed to decide which directory cquery uses for its
-cache.
+  cache.
 
 
 ===============================================================================
@@ -427,31 +499,41 @@ See |ale-cspell-options|
 ===============================================================================
 flawfinder                                                   *ale-c-flawfinder*
 
-g:ale_c_flawfinder_executable                   *g:ale_c_flawfinder_executable*
+                                          *ale-options.c_flawfinder_executable*
+                                                *g:ale_c_flawfinder_executable*
                                                 *b:ale_c_flawfinder_executable*
+c_flawfinder_executable
+g:ale_c_flawfinder_executable
   Type: |String|
   Default: `'flawfinder'`
 
   This variable can be changed to use a different executable for flawfinder.
 
-
-g:ale_c_flawfinder_minlevel                       *g:ale_c_flawfinder_minlevel*
+                                            *ale-options.c_flawfinder_minlevel*
+                                                  *g:ale_c_flawfinder_minlevel*
                                                   *b:ale_c_flawfinder_minlevel*
+c_flawfinder_minlevel
+g:ale_c_flawfinder_minlevel
   Type: |Number|
   Default: `1`
 
   This variable can be changed to ignore risks under the given risk threshold.
 
-
-g:ale_c_flawfinder_options                                 *g:ale-c-flawfinder*
+                                             *ale-options.c_flawfinder_options*
+                                                   *g:ale_c_flawfinder_options*
                                                            *b:ale-c-flawfinder*
+c_flawfinder_options
+g:ale_c_flawfinder_options
   Type: |String|
   Default: `''`
 
   This variable can be used to pass extra options into the flawfinder command.
 
-g:ale_c_flawfinder_error_severity           *g:ale_c_flawfinder_error_severity*
+                                      *ale-options.c_flawfinder_error_severity*
+                                            *g:ale_c_flawfinder_error_severity*
                                             *b:ale_c_flawfinder_error_severity*
+c_flawfinder_error_severity
+g:ale_c_flawfinder_error_severity
   Type: |Number|
   Default: `6`
 
@@ -462,16 +544,21 @@ g:ale_c_flawfinder_error_severity           *g:ale_c_flawfinder_error_severity*
 ===============================================================================
 uncrustify                                                   *ale-c-uncrustify*
 
-g:ale_c_uncrustify_executable                   *g:ale_c_uncrustify_executable*
+                                          *ale-options.c_uncrustify_executable*
+                                                *g:ale_c_uncrustify_executable*
                                                 *b:ale_c_uncrustify_executable*
+c_uncrustify_executable
+g:ale_c_uncrustify_executable
   Type: |String|
   Default: `'uncrustify'`
 
   This variable can be changed to use a different executable for uncrustify.
 
-
-g:ale_c_uncrustify_options                         *g:ale_c_uncrustify_options*
+                                             *ale-options.c_uncrustify_options*
+                                                   *g:ale_c_uncrustify_options*
                                                    *b:ale_c_uncrustify_options*
+c_uncrustify_options
+g:ale_c_uncrustify_options
   Type: |String|
   Default: `''`
 

--- a/doc/ale-c3.txt
+++ b/doc/ale-c3.txt
@@ -4,26 +4,32 @@ ALE C3 Integration                                             *ale-c3-options*
 ===============================================================================
 c3lsp                                                            *ale-c3-c3lsp*
 
-g:ale_c3_c3lsp_executable                           *g:ale_c3_c3lsp_executable*
+                                              *ale-options.c3_c3lsp_executable*
+                                                    *g:ale_c3_c3lsp_executable*
                                                     *b:ale_c3_c3lsp_executable*
+c3_c3lsp_executable
+g:ale_c3_c3lsp_executable
   Type: |String|
   Default: `c3lsp`
 
   This variable can be changed to set the path to c3lsp executable.
 
-
-g:ale_c3_c3lsp_options                                 *g:ale_c3_c3lsp_options*
+                                                 *ale-options.c3_c3lsp_options*
+                                                       *g:ale_c3_c3lsp_options*
                                                        *b:ale_c3_c3lsp_options*
-
+c3_c3lsp_options
+g:ale_c3_c3lsp_options
   Type: |String|
   Default: `''`
 
   Add command line options to the c3lsp executable. This is useful to specify
   the path to the C3 standard library with '-stdlib-path=<path>'.
 
-
-g:ale_c3_c3lsp_init_options                       *g:ale_c3_c3lsp_init_options*
+                                            *ale-options.c3_c3lsp_init_options*
+                                                  *g:ale_c3_c3lsp_init_options*
                                                   *b:ale_c3_c3lsp_init_options*
+c3_c3lsp_init_options
+g:ale_c3_c3lsp_init_options
   Type: |Dictionary|
   Default: `{}`
 

--- a/doc/ale-cairo.txt
+++ b/doc/ale-cairo.txt
@@ -5,9 +5,12 @@ ALE Cairo Integration                                       *ale-cairo-options*
 ===============================================================================
 scarb                                                         *ale-cairo-scarb*
 
-g:ale_cairo_scarb_executable                     *g:ale_cairo_scarb_executable*
+                                           *ale-options.cairo_scarb_executable*
+                                                 *g:ale_cairo_scarb_executable*
                                                  *b:ale_cairo_scarb_executable*
-
+cairo_scarb_executable
+g:ale_cairo_scarb_executable
+  Type: |String|
   Default: `'scarb build'`
 
   For Cairo1 projects using Scarb
@@ -18,13 +21,18 @@ g:ale_cairo_scarb_executable                     *g:ale_cairo_scarb_executable*
 ===============================================================================
 starknet                                                   *ale-cairo-starknet*
 
-g:ale_cairo_starknet_executable               *g:ale_cairo_starknet_executable*
+                                        *ale-options.cairo_starknet_executable*
+                                              *g:ale_cairo_starknet_executable*
                                               *b:ale_cairo_starknet_executable*
-
+cairo_starknet_executable
+g:ale_cairo_starknet_executable
+  Type: |String|
   Default: `'starknet-compile'`
 
   Overrides the starknet-compile binary after installing the cairo-language.
 
   For more information read 'https://starknet.io/docs/quickstart.html'
 
+
 ===============================================================================
+  vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-chef.txt
+++ b/doc/ale-chef.txt
@@ -5,16 +5,21 @@ ALE Chef Integration                                         *ale-chef-options*
 ===============================================================================
 cookstyle                                                  *ale-chef-cookstyle*
 
-g:ale_chef_cookstyle_options                     *g:ale_chef_cookstyle_options*
+                                           *ale-options.chef_cookstyle_options*
+                                                 *g:ale_chef_cookstyle_options*
                                                  *b:ale_chef_cookstyle_options*
+chef_cookstyle_options
+g:ale_chef_cookstyle_options
   Type: |String|
   Default: `''`
 
   This variable can be changed to modify flags given to cookstyle.
 
-
-g:ale_chef_cookstyle_executable               *g:ale_chef_cookstyle_executable*
+                                        *ale-options.chef_cookstyle_executable*
+                                              *g:ale_chef_cookstyle_executable*
                                               *b:ale_chef_cookstyle_executable*
+chef_cookstyle_executable
+g:ale_chef_cookstyle_executable
   Type: |String|
   Default: `'cookstyle'`
 
@@ -25,16 +30,21 @@ g:ale_chef_cookstyle_executable               *g:ale_chef_cookstyle_executable*
 ===============================================================================
 foodcritic                                                *ale-chef-foodcritic*
 
-g:ale_chef_foodcritic_options                   *g:ale_chef_foodcritic_options*
+                                          *ale-options.chef_foodcritic_options*
+                                                *g:ale_chef_foodcritic_options*
                                                 *b:ale_chef_foodcritic_options*
+chef_foodcritic_options
+g:ale_chef_foodcritic_options
   Type: |String|
   Default: `''`
 
   This variable can be changed to modify flags given to foodcritic.
 
-
-g:ale_chef_foodcritic_executable             *g:ale_chef_foodcritic_executable*
+                                       *ale-options.chef_foodcritic_executable*
+                                             *g:ale_chef_foodcritic_executable*
                                              *b:ale_chef_foodcritic_executable*
+chef_foodcritic_executable
+g:ale_chef_foodcritic_executable
   Type: |String|
   Default: `'foodcritic'`
 

--- a/doc/ale-clojure.txt
+++ b/doc/ale-clojure.txt
@@ -9,12 +9,19 @@ A minimal and opinionated linter for code that sparks joy.
 
 https://github.com/borkdude/clj-kondo
 
-g:ale_clojure_clj_kondo_options               *g:ale_clojure_clj_kondo_options*
+
+-------------------------------------------------------------------------------
+Options
+                                        *ale-options.clojure_clj_kondo_options*
+                                              *g:ale_clojure_clj_kondo_options*
                                               *b:ale_clojure_clj_kondo_options*
+clojure_clj_kondo_options
+g:ale_clojure_clj_kondo_options
   Type: |String|
   Default: `'--cache'`
 
   This variable can be changed to modify options passed to clj-kondo.
+
 
 ===============================================================================
 cljfmt                                                     *ale-clojure-cljfmt*
@@ -43,6 +50,6 @@ directory.
 
 see https://github.com/candid82/joker#linter-mode for more information.
 
+
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:
-

--- a/doc/ale-cloudformation.txt
+++ b/doc/ale-cloudformation.txt
@@ -1,46 +1,45 @@
 ===============================================================================
-ALE CloudFormation Integration                      *ale-cloudformation-options*
+ALE CloudFormation Integration                     *ale-cloudformation-options*
 
 
 ===============================================================================
-cfn-python-lint                             *ale-cloudformation-cfn-python-lint*
+cfn-python-lint                            *ale-cloudformation-cfn-python-lint*
 
 cfn-python-lint is a linter for AWS CloudFormation template file.
 
 Website: https://github.com/awslabs/cfn-python-lint
 
-Installation
--------------------------------------------------------------------------------
 
+-------------------------------------------------------------------------------
+Installation
 
 Install cfn-python-lint using either pip or brew: >
 
-`pip install cfn-lint`. If pip is not available, run
-`python setup.py clean --all` then `python setup.py install`.
-
- Homebrew (macOS):
-
-`brew install cfn-lint`
-
+  pip install cfn-lint
 <
-Configuration
+If pip is not available use setuptools. >
+
+  python setup.py clean --all
+  python setup.py install
+<
+You can install the linter via brew on macOS. >
+
+  brew install cfn-lint
+<
+
 -------------------------------------------------------------------------------
+Configuration
 
-To get cloudformation linter to work on only CloudFormation files  we must set
-the buffer |filetype| to yaml.cloudformation.
-This causes ALE to lint the file with linters configured for cloudformation and
-yaml files.
+To get cloudformation linter to work on only CloudFormation files we must set
+the buffer |filetype| to `yaml.cloudformation`.  This causes ALE to lint the
+file with linters configured for cloudformation and YAML files.
 
-Just put:
+Just put the following in `ftdetect/cloudformation.vim`: >
 
->
+  au BufRead,BufNewFile *.template.yaml set filetype=yaml.cloudformation
 
- au BufRead,BufNewFile *.template.yaml set filetype=yaml.cloudformation
+This will get both cloudformation and yaml linters to work on any file with
+`.template.yaml` extension.
 
-<
-
-on `ftdetect/cloudformation.vim`
-
-This will get both cloudformation and yaml linters to work on any file with `.template.yaml` ext.
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-cmake.txt
+++ b/doc/ale-cmake.txt
@@ -5,16 +5,21 @@ ALE CMake Integration                                       *ale-cmake-options*
 ===============================================================================
 cmakelint                                                 *ale-cmake-cmakelint*
 
-g:ale_cmake_cmakelint_executable             *g:ale_cmake_cmakelint_executable*
+                                       *ale-options.cmake_cmakelint_executable*
+                                             *g:ale_cmake_cmakelint_executable*
                                              *b:ale_cmake_cmakelint_executable*
+cmake_cmakelint_executable
+g:ale_cmake_cmakelint_executable
   Type: |String|
   Default: `'cmakelint'`
 
   This variable can be set to change the path the cmakelint.
 
-
-g:ale_cmake_cmakelint_options                   *g:ale_cmake_cmakelint_options*
+                                          *ale-options.cmake_cmakelint_options*
+                                                *g:ale_cmake_cmakelint_options*
                                                 *b:ale_cmake_cmakelint_options*
+cmake_cmakelint_options
+g:ale_cmake_cmakelint_options
   Type: |String|
   Default: `''`
 
@@ -24,16 +29,21 @@ g:ale_cmake_cmakelint_options                   *g:ale_cmake_cmakelint_options*
 ===============================================================================
 cmake-lint                                                *ale-cmake-cmake-lint*
 
-g:ale_cmake_cmake_lint_executable            *g:ale_cmake_cmake_lint_executable*
+                                      *ale-options.cmake_cmake_lint_executable*
+                                            *g:ale_cmake_cmake_lint_executable*
                                              *b:ale_cmake_cmake_lint_executable*
+cmake_cmake_lint_executable
+g:ale_cmake_cmake_lint_executable
   Type: |String|
   Default: `'cmake-lint'`
 
   This variable can be set to change the path the cmake-lint.
 
-
-g:ale_cmake_cmake_lint_options                  *g:ale_cmake_cmake_lint_options*
+                                         *ale-options.cmake_cmake_lint_options*
+                                               *g:ale_cmake_cmake_lint_options*
                                                 *b:ale_cmake_cmake_lint_options*
+cmake_cmake_lint_options
+g:ale_cmake_cmake_lint_options
   Type: |String|
   Default: `''`
 
@@ -43,20 +53,26 @@ g:ale_cmake_cmake_lint_options                  *g:ale_cmake_cmake_lint_options*
 ===============================================================================
 cmake-format                                            *ale-cmake-cmakeformat*
 
-g:ale_cmake_cmakeformat_executable         *g:ale_cmake_cmakeformat_executable*
+                                     *ale-options.cmake_cmakeformat_executable*
+                                           *g:ale_cmake_cmakeformat_executable*
                                            *b:ale_cmake_cmakeformat_executable*
+cmake_cmakeformat_executable
+g:ale_cmake_cmakeformat_executable
   Type: |String|
   Default: `'cmakeformat'`
 
   This variable can be set to change the path the cmake-format.
 
-
-g:ale_cmake_cmakeformat_options               *g:ale_cmake_cmakeformat_options*
+                                        *ale-options.cmake_cmakeformat_options*
+                                              *g:ale_cmake_cmakeformat_options*
                                               *b:ale_cmake_cmakeformat_options*
+cmake_cmakeformat_options
+g:ale_cmake_cmakeformat_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass additional options to cmake-format.
+
 
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-cpp.txt
+++ b/doc/ale-cpp.txt
@@ -20,16 +20,21 @@ The following C options also apply to some C++ linters too.
 ===============================================================================
 astyle                                                         *ale-cpp-astyle*
 
-g:ale_cpp_astyle_executable                       *g:ale_cpp_astyle_executable*
+                                            *ale-options.cpp_astyle_executable*
+                                                  *g:ale_cpp_astyle_executable*
                                                   *b:ale_cpp_astyle_executable*
+cpp_astyle_executable
+g:ale_cpp_astyle_executable
   Type: |String|
   Default: `'astyle'`
 
   This variable can be changed to use a different executable for astyle.
 
-
-g:ale_cpp_astyle_project_options             *g:ale_cpp_astyle_project_options*
+                                       *ale-options.cpp_astyle_project_options*
+                                             *g:ale_cpp_astyle_project_options*
                                              *b:ale_cpp_astyle_project_options*
+cpp_astyle_project_options
+g:ale_cpp_astyle_project_options
   Type: |String|
   Default: `''`
 
@@ -46,8 +51,11 @@ cc                                                                 *ale-cpp-cc*
                                                                   *ale-cpp-gcc*
                                                                 *ale-cpp-clang*
 
-g:ale_cpp_cc_executable                               *g:ale_cpp_cc_executable*
+                                                *ale-options.cpp_cc_executable*
+                                                      *g:ale_cpp_cc_executable*
                                                       *b:ale_cpp_cc_executable*
+cpp_cc_executable
+g:ale_cpp_cc_executable
   Type: |String|
   Default: `'<auto>'`
 
@@ -56,17 +64,21 @@ g:ale_cpp_cc_executable                               *g:ale_cpp_cc_executable*
   ALE will try to use `clang++` if Clang is available, otherwise ALE will
   default to checking C++ code with `gcc`.
 
-
-g:ale_cpp_cc_options                                     *g:ale_cpp_cc_options*
+                                                   *ale-options.cpp_cc_options*
+                                                         *g:ale_cpp_cc_options*
                                                          *b:ale_cpp_cc_options*
+cpp_cc_options
+g:ale_cpp_cc_options
   Type: |String|
   Default: `'-std=c++14 -Wall'`
 
   This variable can be changed to modify flags given to the C++ compiler.
 
-
-g:ale_cpp_cc_use_header_lang_flag           *g:ale_cpp_cc_use_header_lang_flag*
+                                      *ale-options.cpp_cc_use_header_lang_flag*
+                                            *g:ale_cpp_cc_use_header_lang_flag*
                                             *b:ale_cpp_cc_use_header_lang_flag*
+cpp_cc_use_header_lang_flag
+g:ale_cpp_cc_use_header_lang_flag
   Type: |Number|
   Default: `-1`
 
@@ -76,20 +88,22 @@ g:ale_cpp_cc_use_header_lang_flag           *g:ale_cpp_cc_use_header_lang_flag*
   This variable can be changed to manually activate or deactivate this flag
   for header files.
 
-  - When set to `-1`, the default beviour is used, `'-x c++-header'` is used with
-    Clang and `'-x c++'` is used with other compilers.
+  - When set to `-1`, the default behavior is used, `'-x c++-header'` is used
+    with Clang and `'-x c++'` is used with other compilers.
   - When set to `0`, the flag is deactivated, `'-x c++'` is always used
     independently of the compiler.
   - When set to `1`, the flag is activated, `'-x c++-header'` is always used
     independently of the compiler.
 
-  Gcc does not support `'-x c++-header'` when using `'-'` as input filename,
+  GCC does not support `'-x c++-header'` when using `'-'` as input filename,
   which is what ALE does. This why, by default, ALE only uses `'-x c++-header'`
   with Clang.
 
-
-g:ale_cpp_cc_header_exts                             *g:ale_cpp_cc_header_exts*
+                                               *ale-options.cpp_cc_header_exts*
+                                                     *g:ale_cpp_cc_header_exts*
                                                      *b:ale_cpp_cc_header_exts*
+cpp_cc_header_exts
+g:ale_cpp_cc_header_exts
   Type: |List|
   Default: `['h', 'hpp']`
 
@@ -103,29 +117,35 @@ g:ale_cpp_cc_header_exts                             *g:ale_cpp_cc_header_exts*
 ===============================================================================
 ccls                                                             *ale-cpp-ccls*
 
-g:ale_cpp_ccls_executable                           *g:ale_cpp_ccls_executable*
+                                              *ale-options.cpp_ccls_executable*
+                                                    *g:ale_cpp_ccls_executable*
                                                     *b:ale_cpp_ccls_executable*
+cpp_ccls_executable
+g:ale_cpp_ccls_executable
   Type: |String|
   Default: `'ccls'`
 
   This variable can be changed to use a different executable for ccls.
 
-
-g:ale_cpp_ccls_init_options                       *g:ale_cpp_ccls_init_options*
+                                            *ale-options.cpp_ccls_init_options*
+                                                  *g:ale_cpp_ccls_init_options*
                                                   *b:ale_cpp_ccls_init_options*
+cpp_ccls_init_options
+g:ale_cpp_ccls_init_options
   Type: |Dictionary|
   Default: `{}`
 
   This variable can be changed to customize ccls initialization options.
   Example: >
-      {
-    \   'cacheDirectory': '/tmp/ccls',
-    \   'cacheFormat': 'binary',
-    \   'diagnostics': {
-    \     'onOpen': 0,
-    \     'opChange': 1000,
-    \   },
-    \ }
+
+  let g:ale_cpp_ccls_init_options = {
+  \   'cacheDirectory': '/tmp/ccls',
+  \   'cacheFormat': 'binary',
+  \   'diagnostics': {
+  \       'onOpen': 0,
+  \       'opChange': 1000,
+  \   },
+  \}
 <
   Visit https://github.com/MaskRay/ccls/wiki/Initialization-options for all
   available options and explanations.
@@ -136,22 +156,29 @@ clangcheck                                                 *ale-cpp-clangcheck*
 
 `clang-check` will be run only when files are saved to disk, so that
 `compile_commands.json` files can be used. It is recommended to use this
-linter in combination with `compile_commands.json` files.
-Therefore, `clang-check` linter reads the options |g:ale_c_build_dir| and
+linter in combination with `compile_commands.json` files.  Therefore,
+`clang-check` linter reads the options |g:ale_c_build_dir| and
 |g:ale_c_build_dir_names|. Also, setting |g:ale_c_build_dir| actually
 overrides |g:ale_c_build_dir_names|.
 
 
-g:ale_cpp_clangcheck_executable               *g:ale_cpp_clangcheck_executable*
+-------------------------------------------------------------------------------
+Options
+                                        *ale-options.cpp_clangcheck_executable*
+                                              *g:ale_cpp_clangcheck_executable*
                                               *b:ale_cpp_clangcheck_executable*
+cpp_clangcheck_executable
+g:ale_cpp_clangcheck_executable
   Type: |String|
   Default: `'clang-check'`
 
   This variable can be changed to use a different executable for clangcheck.
 
-
-g:ale_cpp_clangcheck_options                     *g:ale_cpp_clangcheck_options*
+                                           *ale-options.cpp_clangcheck_options*
+                                                 *g:ale_cpp_clangcheck_options*
                                                  *b:ale_cpp_clangcheck_options*
+cpp_clangcheck_options
+g:ale_cpp_clangcheck_options
   Type: |String|
   Default: `''`
 
@@ -165,16 +192,21 @@ g:ale_cpp_clangcheck_options                     *g:ale_cpp_clangcheck_options*
 ===============================================================================
 clangd                                                         *ale-cpp-clangd*
 
-g:ale_cpp_clangd_executable                       *g:ale_cpp_clangd_executable*
+                                            *ale-options.cpp_clangd_executable*
+                                                  *g:ale_cpp_clangd_executable*
                                                   *b:ale_cpp_clangd_executable*
+cpp_clangd_executable
+g:ale_cpp_clangd_executable
   Type: |String|
   Default: `'clangd'`
 
   This variable can be changed to use a different executable for clangd.
 
-
-g:ale_cpp_clangd_options                             *g:ale_cpp_clangd_options*
+                                               *ale-options.cpp_clangd_options*
+                                                     *g:ale_cpp_clangd_options*
                                                      *b:ale_cpp_clangd_options*
+cpp_clangd_options
+g:ale_cpp_clangd_options
   Type: |String|
   Default: `''`
 
@@ -199,8 +231,13 @@ Therefore, `clang-tidy` linter reads the options |g:ale_c_build_dir| and
 overrides |g:ale_c_build_dir_names|.
 
 
-g:ale_cpp_clangtidy_checks                         *g:ale_cpp_clangtidy_checks*
+-------------------------------------------------------------------------------
+Options
+                                             *ale-options.cpp_clangtidy_checks*
+                                                   *g:ale_cpp_clangtidy_checks*
                                                    *b:ale_cpp_clangtidy_checks*
+cpp_clangtidy_checks
+g:ale_cpp_clangtidy_checks
   Type: |List|
   Default: `[]`
 
@@ -210,17 +247,21 @@ g:ale_cpp_clangtidy_checks                         *g:ale_cpp_clangtidy_checks*
   the shell. The `-checks` flag can be removed entirely by setting this
   option to an empty List.
 
-
-g:ale_cpp_clangtidy_executable                 *g:ale_cpp_clangtidy_executable*
+                                         *ale-options.cpp_clangtidy_executable*
+                                               *g:ale_cpp_clangtidy_executable*
                                                *b:ale_cpp_clangtidy_executable*
+cpp_clangtidy_executable
+g:ale_cpp_clangtidy_executable
   Type: |String|
   Default: `'clang-tidy'`
 
   This variable can be changed to use a different executable for clangtidy.
 
-
-g:ale_cpp_clangtidy_options                       *g:ale_cpp_clangtidy_options*
+                                            *ale-options.cpp_clangtidy_options*
+                                                  *g:ale_cpp_clangtidy_options*
                                                   *b:ale_cpp_clangtidy_options*
+cpp_clangtidy_options
+g:ale_cpp_clangtidy_options
   Type: |String|
   Default: `''`
 
@@ -236,17 +277,21 @@ g:ale_cpp_clangtidy_options                       *g:ale_cpp_clangtidy_options*
   entirely manually, and no `compile_commands.json` file is in one
   of the |g:ale_c_build_dir_names| directories of the project tree.
 
-
-g:ale_cpp_clangtidy_extra_options           *g:ale_cpp_clangtidy_extra_options*
+                                      *ale-options.cpp_clangtidy_extra_options*
+                                            *g:ale_cpp_clangtidy_extra_options*
                                             *b:ale_cpp_clangtidy_extra_options*
+cpp_clangtidy_extra_options
+g:ale_cpp_clangtidy_extra_options
   Type: |String|
   Default: `''`
 
   This variable can be changed to modify flags given to clang-tidy.
 
-
-g:ale_cpp_clangtidy_fix_errors                 *g:ale_cpp_clangtidy_fix_errors*
+                                         *ale-options.cpp_clangtidy_fix_errors*
+                                               *g:ale_cpp_clangtidy_fix_errors*
                                                *b:ale_cpp_clangtidy_fix_errors*
+cpp_clangtidy_fix_errors
+g:ale_cpp_clangtidy_fix_errors
   Type: |Number|
   Default: `1`
 
@@ -257,16 +302,21 @@ g:ale_cpp_clangtidy_fix_errors                 *g:ale_cpp_clangtidy_fix_errors*
 ===============================================================================
 clazy                                                           *ale-cpp-clazy*
 
-g:ale_cpp_clazy_executable                         *g:ale_cpp_clazy_executable*
+                                             *ale-options.cpp_clazy_executable*
+                                                   *g:ale_cpp_clazy_executable*
                                                    *b:ale_cpp_clazy_executable*
+cpp_clazy_executable
+g:ale_cpp_clazy_executable
   Type: |String|
   Default: `'clazy-standalone'`
 
   This variable can be changed to use a different executable for clazy.
 
-
-g:ale_cpp_clazy_checks                                 *g:ale_cpp_clazy_checks*
+                                                 *ale-options.cpp_clazy_checks*
+                                                       *g:ale_cpp_clazy_checks*
                                                        *b:ale_cpp_clazy_checks*
+cpp_clazy_checks
+g:ale_cpp_clazy_checks
   Type: |List|
   Default: `['level1']`
 
@@ -276,9 +326,11 @@ g:ale_cpp_clazy_checks                                 *g:ale_cpp_clazy_checks*
   the shell. The `-checks` flag can be removed entirely by setting this
   option to an empty List.
 
-
-g:ale_cpp_clazy_options                               *g:ale_cpp_clazy_options*
+                                                *ale-options.cpp_clazy_options*
+                                                      *g:ale_cpp_clazy_options*
                                                       *b:ale_cpp_clazy_options*
+cpp_clazy_options
+g:ale_cpp_clazy_options
   Type: |String|
   Default: `''`
 
@@ -288,16 +340,21 @@ g:ale_cpp_clazy_options                               *g:ale_cpp_clazy_options*
 ===============================================================================
 cppcheck                                                     *ale-cpp-cppcheck*
 
-g:ale_cpp_cppcheck_executable                   *g:ale_cpp_cppcheck_executable*
+                                          *ale-options.cpp_cppcheck_executable*
+                                                *g:ale_cpp_cppcheck_executable*
                                                 *b:ale_cpp_cppcheck_executable*
+cpp_cppcheck_executable
+g:ale_cpp_cppcheck_executable
   Type: |String|
   Default: `'cppcheck'`
 
   This variable can be changed to use a different executable for cppcheck.
 
-
-g:ale_cpp_cppcheck_options                         *g:ale_cpp_cppcheck_options*
+                                             *ale-options.cpp_cppcheck_options*
+                                                   *g:ale_cpp_cppcheck_options*
                                                    *b:ale_cpp_cppcheck_options*
+cpp_cppcheck_options
+g:ale_cpp_cppcheck_options
   Type: |String|
   Default: `'--enable=style'`
 
@@ -307,31 +364,41 @@ g:ale_cpp_cppcheck_options                         *g:ale_cpp_cppcheck_options*
 ===============================================================================
 cpplint                                                       *ale-cpp-cpplint*
 
-g:ale_cpp_cpplint_executable                     *g:ale_cpp_cpplint_executable*
+                                           *ale-options.cpp_cpplint_executable*
+                                                 *g:ale_cpp_cpplint_executable*
                                                  *b:ale_cpp_cpplint_executable*
+cpp_cpplint_executable
+g:ale_cpp_cpplint_executable
   Type: |String|
   Default: `'cpplint'`
 
   This variable can be changed to use a different executable for cpplint.
 
-
-g:ale_cpp_cpplint_options                           *g:ale_cpp_cpplint_options*
+                                              *ale-options.cpp_cpplint_options*
+                                                    *g:ale_cpp_cpplint_options*
                                                     *b:ale_cpp_cpplint_options*
+cpp_cpplint_options
+g:ale_cpp_cpplint_options
   Type: |String|
   Default: `''`
 
   This variable can be changed to modify flags given to cpplint.
 
-g:ale_c_cpplint_executable                         *g:ale_c_cpplint_executable*
+                                             *ale-options.c_cpplint_executable*
+                                                   *g:ale_c_cpplint_executable*
                                                    *b:ale_c_cpplint_executable*
+c_cpplint_executable
+g:ale_c_cpplint_executable
   Type: |String|
   Default: `'cpplint'`
 
   This variable can be changed to use a different executable for cpplint.
 
-
-g:ale_c_cpplint_options                               *g:ale_c_cpplint_options*
+                                                *ale-options.c_cpplint_options*
+                                                      *g:ale_c_cpplint_options*
                                                       *b:ale_c_cpplint_options*
+c_cpplint_options
+g:ale_c_cpplint_options
   Type: |String|
   Default: `''`
 
@@ -341,16 +408,21 @@ g:ale_c_cpplint_options                               *g:ale_c_cpplint_options*
 ===============================================================================
 cquery                                                         *ale-cpp-cquery*
 
-g:ale_cpp_cquery_executable                       *g:ale_cpp_cquery_executable*
+                                            *ale-options.cpp_cquery_executable*
+                                                  *g:ale_cpp_cquery_executable*
                                                   *b:ale_cpp_cquery_executable*
+cpp_cquery_executable
+g:ale_cpp_cquery_executable
   Type: |String|
   Default: `'cquery'`
 
   This variable can be changed to use a different executable for cquery.
 
-
-g:ale_cpp_cquery_cache_directory             *g:ale_cpp_cquery_cache_directory*
+                                       *ale-options.cpp_cquery_cache_directory*
+                                             *g:ale_cpp_cquery_cache_directory*
                                              *b:ale_cpp_cquery_cache_directory*
+cpp_cquery_cache_directory
+g:ale_cpp_cquery_cache_directory
   Type: |String|
   Default: `'~/.cache/cquery'`
 
@@ -367,24 +439,31 @@ See |ale-cspell-options|
 ===============================================================================
 flawfinder                                                 *ale-cpp-flawfinder*
 
-g:ale_cpp_flawfinder_executable               *g:ale_cpp_flawfinder_executable*
+                                        *ale-options.cpp_flawfinder_executable*
+                                              *g:ale_cpp_flawfinder_executable*
                                               *b:ale_cpp_flawfinder_executable*
+cpp_flawfinder_executable
+g:ale_cpp_flawfinder_executable
   Type: |String|
   Default: `'flawfinder'`
 
   This variable can be changed to use a different executable for flawfinder.
 
-
-g:ale_cpp_flawfinder_minlevel                   *g:ale_cpp_flawfinder_minlevel*
+                                          *ale-options.cpp_flawfinder_minlevel*
+                                                *g:ale_cpp_flawfinder_minlevel*
                                                 *b:ale_cpp_flawfinder_minlevel*
+cpp_flawfinder_minlevel
+g:ale_cpp_flawfinder_minlevel
   Type: |Number|
   Default: `1`
 
   This variable can be changed to ignore risks under the given risk threshold.
 
-
-g:ale_cpp_flawfinder_options                             *g:ale-cpp-flawfinder*
+                                           *ale-options.cpp_flawfinder_options*
+                                                 *g:ale_cpp_flawfinder_options*
                                                          *b:ale-cpp-flawfinder*
+cpp_flawfinder_options
+g:ale_cpp_flawfinder_options
   Type: |String|
   Default: `''`
 

--- a/doc/ale-cs.txt
+++ b/doc/ale-cs.txt
@@ -1,7 +1,6 @@
 ===============================================================================
 ALE C# Integration                                             *ale-cs-options*
 
-
 In addition to the linters that are provided with ALE, C# code can be checked
 with the OmniSharp plugin. See here: https://github.com/OmniSharp/omnisharp-vim
 
@@ -16,34 +15,39 @@ Note that the C options are also used for C#.
 ===============================================================================
 csc                                                                *ale-cs-csc*
 
-  The |ale-cs-csc| linter checks for semantic errors when files are opened or
-  saved.
+The |ale-cs-csc| linter checks for semantic errors when files are opened or
+saved.
 
-  See |ale-lint-file-linters| for more information on linters which do not
-  check for problems while you type.
+See |ale-lint-file-linters| for more information on linters which do not check
+for problems while you type.
 
-  The csc linter uses the mono csc compiler, providing full C# 7 and newer
-  support, to generate a temporary module target file (/t:module). The module
-  includes all '*.cs' files contained in the directory tree rooted at the path
-  defined by the |g:ale_cs_csc_source| or |b:ale_cs_csc_source| variable and
-  all sub directories.
+The csc linter uses the mono csc compiler, providing full C# 7 and newer
+support, to generate a temporary module target file (/t:module). The module
+includes all '*.cs' files contained in the directory tree rooted at the path
+defined by the |g:ale_cs_csc_source| or |b:ale_cs_csc_source| variable and all
+sub directories.
 
-  It will in future replace the |ale-cs-mcs| and |ale-cs-mcsc| linters as both
-  utilize the mcsc compiler which, according to the mono project, is no longer
-  actively developed, and only receives maintenance updates. However, because
-  the csc compiler does not support the -syntax option, this linter does not
-  offer any as-you-type syntax checking, similar to the |ale-cs-mcsc| linter.
+It will in future replace the |ale-cs-mcs| and |ale-cs-mcsc| linters as both
+utilize the mcsc compiler which, according to the mono project, is no longer
+actively developed, and only receives maintenance updates. However, because
+the csc compiler does not support the -syntax option, this linter does not
+offer any as-you-type syntax checking, similar to the |ale-cs-mcsc| linter.
 
-  The paths to search for additional assembly files can be specified using the
-  |g:ale_cs_csc_assembly_path| or |b:ale_cs_csc_assembly_path| variables.
+The paths to search for additional assembly files can be specified using the
+|g:ale_cs_csc_assembly_path| or |b:ale_cs_csc_assembly_path| variables.
 
-  NOTE: ALE will not find any errors in files apart from syntax errors if any
-  one of the source files contains a syntax error. Syntax errors must be fixed
-  first before other errors will be shown.
+NOTE: ALE will not find any errors in files apart from syntax errors if any
+one of the source files contains a syntax error. Syntax errors must be fixed
+first before other errors will be shown.
 
 
-g:ale_cs_csc_options                                     *g:ale_cs_csc_options*
+-------------------------------------------------------------------------------
+Options
+                                                   *ale-options.cs_csc_options*
+                                                         *g:ale_cs_csc_options*
                                                          *b:ale_cs_csc_options*
+cs_csc_options
+g:ale_cs_csc_options
   Type: |String|
   Default: `''`
 
@@ -55,9 +59,11 @@ g:ale_cs_csc_options                                     *g:ale_cs_csc_options*
 <
   NOTE: the `/unsafe` option is always passed to `csc`.
 
-
-g:ale_cs_csc_source                                       *g:ale_cs_csc_source*
+                                                    *ale-options.cs_csc_source*
+                                                          *g:ale_cs_csc_source*
                                                           *b:ale_cs_csc_source*
+cs_csc_source
+g:ale_cs_csc_source
   Type: |String|
   Default: `''`
 
@@ -68,9 +74,11 @@ g:ale_cs_csc_source                                       *g:ale_cs_csc_source*
   NOTE: Currently it is not possible to specify sub directories and
   directory sub trees which shall not be searched for *.cs files.
 
-
-g:ale_cs_csc_assembly_path                         *g:ale_cs_csc_assembly_path*
+                                             *ale-options.cs_csc_assembly_path*
+                                                   *g:ale_cs_csc_assembly_path*
                                                    *b:ale_cs_csc_assembly_path*
+cs_csc_assembly_path
+g:ale_cs_csc_assembly_path
   Type: |List|
   Default: `[]`
 
@@ -78,9 +86,11 @@ g:ale_cs_csc_assembly_path                         *g:ale_cs_csc_assembly_path*
   assembly files. The list is passed to the csc compiler using the `/lib:`
   flag.
 
-
-g:ale_cs_csc_assemblies                               *g:ale_cs_csc_assemblies*
+                                                *ale-options.cs_csc_assemblies*
+                                                      *g:ale_cs_csc_assemblies*
                                                       *b:ale_cs_csc_assemblies*
+cs_csc_assemblies
+g:ale_cs_csc_assemblies
   Type: |List|
   Default: `[]`
 
@@ -90,11 +100,11 @@ g:ale_cs_csc_assemblies                               *g:ale_cs_csc_assemblies*
 
   For example: >
 
-    " Compile C# programs with the Unity engine DLL file on Mac.
-    let g:ale_cs_mcsc_assemblies = [
-    \ '/Applications/Unity/Unity.app/Contents/Frameworks/Managed/UnityEngine.dll',
-    \ 'path-to-unityproject/obj/Debug',
-    \]
+  " Compile C# programs with the Unity engine DLL file on Mac.
+  let g:ale_cs_mcsc_assemblies = [
+  \ '/Applications/Unity/Unity.app/Contents/Frameworks/Managed/UnityEngine.dll',
+  \ 'path-to-unityproject/obj/Debug',
+  \]
 <
 
 ===============================================================================
@@ -106,8 +116,9 @@ See |ale-cspell-options|
 ===============================================================================
 dotnet-format                                            *ale-cs-dotnet-format*
 
-Installation
+
 -------------------------------------------------------------------------------
+Installation
 
 Installing .NET SDK should probably ensure that `dotnet` is in your `$PATH`.
 For .NET 6 the `dotnet format` tool is already included in the .NET SDK. For
@@ -115,20 +126,24 @@ For .NET 6 the `dotnet format` tool is already included in the .NET SDK. For
 from listed in this repository: https://github.com/dotnet/format
 
 
-Options
 -------------------------------------------------------------------------------
-
-g:ale_cs_dotnet_format_executable           *g:ale_cs_dotnet_format_executable*
+Options
+                                      *ale-options.cs_dotnet_format_executable*
+                                            *g:ale_cs_dotnet_format_executable*
                                             *b:ale_cs_dotnet_format_executable*
+cs_dotnet_format_executable
+g:ale_cs_dotnet_format_executable
   Type: |String|
   Default: `'dotnet'`
 
   This variable can be set to specify an absolute path to the
   `dotnet` executable (or to specify an alternate executable).
 
-
-g:ale_cs_dotnet_format_options                 *g:ale_cs_dotnet_format_options*
+                                         *ale-options.cs_dotnet_format_options*
+                                               *g:ale_cs_dotnet_format_options*
                                                *b:ale_cs_dotnet_format_options*
+cs_dotnet_format_options
+g:ale_cs_dotnet_format_options
   Type: |String|
   Default: `''`
 
@@ -139,15 +154,19 @@ g:ale_cs_dotnet_format_options                 *g:ale_cs_dotnet_format_options*
 ===============================================================================
 mcs                                                                *ale-cs-mcs*
 
-  The `mcs` linter looks only for syntax errors while you type. See
-  |ale-cs-mcsc| for the separately configured linter for checking for semantic
-   errors.
+The `mcs` linter looks only for syntax errors while you type. See
+|ale-cs-mcsc| for the separately configured linter for checking for semantic
+errors.
 
 
-g:ale_cs_mcs_options                                     *g:ale_cs_mcs_options*
+-------------------------------------------------------------------------------
+Options
+                                                   *ale-options.cs_mcs_options*
+                                                         *g:ale_cs_mcs_options*
                                                          *b:ale_cs_mcs_options*
-
-  Type: String
+cs_mcs_options
+g:ale_cs_mcs_options
+  Type: |String|
   Default: `''`
 
   This variable can be changed to pass additional flags given to mcs.
@@ -160,26 +179,31 @@ g:ale_cs_mcs_options                                     *g:ale_cs_mcs_options*
 ===============================================================================
 mcsc                                                              *ale-cs-mcsc*
 
-  The mcsc linter checks for semantic errors when files are opened or saved
-  See |ale-lint-file-linters| for more information on linters which do not
-  check for problems while you type.
+The mcsc linter checks for semantic errors when files are opened or saved See
+|ale-lint-file-linters| for more information on linters which do not check for
+problems while you type.
 
-  The mcsc linter uses the mono mcs compiler to generate a temporary module
-  target file (-t:module). The module includes including all '*.cs' files
-  contained in the directory tree rooted at the path defined by the
-  |g:ale_cs_mcsc_source| or |b:ale_cs_mcsc_source| variable.
-  variable and all sub directories.
+The mcsc linter uses the mono mcs compiler to generate a temporary module
+target file (-t:module). The module includes including all '*.cs' files
+contained in the directory tree rooted at the path defined by the
+|g:ale_cs_mcsc_source| or |b:ale_cs_mcsc_source| variable.  variable and all
+sub directories.
 
-  The paths to search for additional assembly files can be specified using the
-  |g:ale_cs_mcsc_assembly_path| or |b:ale_cs_mcsc_assembly_path| variables.
+The paths to search for additional assembly files can be specified using the
+|g:ale_cs_mcsc_assembly_path| or |b:ale_cs_mcsc_assembly_path| variables.
 
-  NOTE: ALE will not find any errors in files apart from syntax errors if any
-  one of the source files contains a syntax error. Syntax errors must be fixed
-  first before other errors will be shown.
+NOTE: ALE will not find any errors in files apart from syntax errors if any
+one of the source files contains a syntax error. Syntax errors must be fixed
+first before other errors will be shown.
 
 
-g:ale_cs_mcsc_options                                   *g:ale_cs_mcsc_options*
+-------------------------------------------------------------------------------
+Options
+                                                  *ale-options.cs_mcsc_options*
+                                                        *g:ale_cs_mcsc_options*
                                                         *b:ale_cs_mcsc_options*
+cs_mcsc_options
+g:ale_cs_mcsc_options
   Type: |String|
   Default: `''`
 
@@ -187,13 +211,15 @@ g:ale_cs_mcsc_options                                   *g:ale_cs_mcsc_options*
 
   For example, to add the dotnet package which is not added per default: >
 
-      let g:ale_cs_mcs_options = '-pkg:dotnet'
+  let g:ale_cs_mcs_options = '-pkg:dotnet'
 <
   NOTE: the `-unsafe` option is always passed to `mcs`.
 
-
-g:ale_cs_mcsc_source                                     *g:ale_cs_mcsc_source*
+                                                   *ale-options.cs_mcsc_source*
+                                                         *g:ale_cs_mcsc_source*
                                                          *b:ale_cs_mcsc_source*
+cs_mcsc_source
+g:ale_cs_mcsc_source
   Type: |String|
   Default: `''`
 
@@ -204,9 +230,11 @@ g:ale_cs_mcsc_source                                     *g:ale_cs_mcsc_source*
   NOTE: Currently it is not possible to specify sub directories and
   directory sub trees which shall not be searched for *.cs files.
 
-
-g:ale_cs_mcsc_assembly_path                       *g:ale_cs_mcsc_assembly_path*
+                                            *ale-options.cs_mcsc_assembly_path*
+                                                  *g:ale_cs_mcsc_assembly_path*
                                                   *b:ale_cs_mcsc_assembly_path*
+cs_mcsc_assembly_path
+g:ale_cs_mcsc_assembly_path
   Type: |List|
   Default: `[]`
 
@@ -214,9 +242,11 @@ g:ale_cs_mcsc_assembly_path                       *g:ale_cs_mcsc_assembly_path*
   assembly files. The list is passed to the mcs compiler using the `-lib:`
   flag.
 
-
-g:ale_cs_mcsc_assemblies                             *g:ale_cs_mcsc_assemblies*
+                                               *ale-options.cs_mcsc_assemblies*
+                                                     *g:ale_cs_mcsc_assemblies*
                                                      *b:ale_cs_mcsc_assemblies*
+cs_mcsc_assemblies
+g:ale_cs_mcsc_assemblies
   Type: |List|
   Default: `[]`
 
@@ -226,11 +256,11 @@ g:ale_cs_mcsc_assemblies                             *g:ale_cs_mcsc_assemblies*
 
   For example: >
 
-    " Compile C# programs with the Unity engine DLL file on Mac.
-    let g:ale_cs_mcsc_assemblies = [
-    \ '/Applications/Unity/Unity.app/Contents/Frameworks/Managed/UnityEngine.dll',
-    \ 'path-to-unityproject/obj/Debug',
-    \]
+  " Compile C# programs with the Unity engine DLL file on Mac.
+  let g:ale_cs_mcsc_assemblies = [
+  \ '/Applications/Unity/Unity.app/Contents/Frameworks/Managed/UnityEngine.dll',
+  \ 'path-to-unityproject/obj/Debug',
+  \]
 <
 
 ===============================================================================

--- a/doc/ale-css.txt
+++ b/doc/ale-css.txt
@@ -11,24 +11,31 @@ See |ale-cspell-options|
 ===============================================================================
 css-beautify                                             *ale-css-css-beautify*
 
-g:ale_css_css_beautify_executable           *g:ale_css_css_beautify_executable*
+                                      *ale-options.css_css_beautify_executable*
+                                            *g:ale_css_css_beautify_executable*
                                             *b:ale_css_css_beautify_executable*
+css_css_beautify_executable
+g:ale_css_css_beautify_executable
   Type: |String|
   Default: `'css-beautify'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_css_css_beautify_options                 *g:ale_css_css_beautify_options*
+                                         *ale-options.css_css_beautify_options*
+                                               *g:ale_css_css_beautify_options*
                                                *b:ale_css_css_beautify_options*
+css_css_beautify_options
+g:ale_css_css_beautify_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass additional options to css-beautify.
 
-
-g:ale_css_css_beautify_use_global           *g:ale_css_css_beautify_use_global*
+                                      *ale-options.css_css_beautify_use_global*
+                                            *g:ale_css_css_beautify_use_global*
                                             *b:ale_css_css_beautify_use_global*
+css_css_beautify_use_global
+g:ale_css_css_beautify_use_global
   Type: |String|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
@@ -52,24 +59,31 @@ See |ale-javascript-prettier| for information about the available options.
 ===============================================================================
 stylelint                                                   *ale-css-stylelint*
 
-g:ale_css_stylelint_executable                 *g:ale_css_stylelint_executable*
+                                         *ale-options.css_stylelint_executable*
+                                               *g:ale_css_stylelint_executable*
                                                *b:ale_css_stylelint_executable*
+css_stylelint_executable
+g:ale_css_stylelint_executable
   Type: |String|
   Default: `'stylelint'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_css_stylelint_options                       *g:ale_css_stylelint_options*
+                                            *ale-options.css_stylelint_options*
+                                                  *g:ale_css_stylelint_options*
                                                   *b:ale_css_stylelint_options*
+css_stylelint_options
+g:ale_css_stylelint_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass additional options to stylelint.
 
-
-g:ale_css_stylelint_use_global                 *g:ale_css_stylelint_use_global*
+                                         *ale-options.css_stylelint_use_global*
+                                               *g:ale_css_stylelint_use_global*
                                                *b:ale_css_stylelint_use_global*
+css_stylelint_use_global
+g:ale_css_stylelint_use_global
   Type: |String|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
@@ -81,8 +95,9 @@ vscodecss                                                      *ale-css-vscode*
 
 Website: https://github.com/hrsh7th/vscode-langservers-extracted
 
-Installation
+
 -------------------------------------------------------------------------------
+Installation
 
 Install VSCode css language server either globally or locally: >
 

--- a/doc/ale-cuda.txt
+++ b/doc/ale-cuda.txt
@@ -12,16 +12,21 @@ Note that the C options are also used for CUDA.
 ===============================================================================
 clangd                                                        *ale-cuda-clangd*
 
-g:ale_cuda_clangd_executable                     *g:ale_cuda_clangd_executable*
+                                           *ale-options.cuda_clangd_executable*
+                                                 *g:ale_cuda_clangd_executable*
                                                  *b:ale_cuda_clangd_executable*
+cuda_clangd_executable
+g:ale_cuda_clangd_executable
   Type: |String|
   Default: `'clangd'`
 
   This variable can be changed to use a different executable for clangd.
 
-
-g:ale_cuda_clangd_options                           *g:ale_cuda_clangd_options*
+                                              *ale-options.cuda_clangd_options*
+                                                    *g:ale_cuda_clangd_options*
                                                     *b:ale_cuda_clangd_options*
+cuda_clangd_options
+g:ale_cuda_clangd_options
   Type: |String|
   Default: `''`
 
@@ -31,17 +36,22 @@ g:ale_cuda_clangd_options                           *g:ale_cuda_clangd_options*
 ===============================================================================
 nvcc                                                            *ale-cuda-nvcc*
 
-g:ale_cuda_nvcc_executable                         *g:ale_cuda_nvcc_executable*
+                                             *ale-options.cuda_nvcc_executable*
+                                                   *g:ale_cuda_nvcc_executable*
                                                    *b:ale_cuda_nvcc_executable*
+cuda_nvcc_executable
+g:ale_cuda_nvcc_executable
   Type: |String|
   Default: `'nvcc'`
 
   This variable can be changed to use a different executable for nvcc.
   Currently only nvcc 8.0 is supported.
 
-
-g:ale_cuda_nvcc_options                               *g:ale_cuda_nvcc_options*
+                                                *ale-options.cuda_nvcc_options*
+                                                      *g:ale_cuda_nvcc_options*
                                                       *b:ale_cuda_nvcc_options*
+cuda_nvcc_options
+g:ale_cuda_nvcc_options
   Type: |String|
   Default: `'-std=c++11'`
 

--- a/doc/ale-d.txt
+++ b/doc/ale-d.txt
@@ -1,25 +1,32 @@
 ===============================================================================
 ALE D Integration                                               *ale-d-options*
 
+
 ===============================================================================
 dfmt                                                               *ale-d-dfmt*
 
-g:ale_d_dfmt_options                                     *g:ale_d_dfmt_options*
+                                                   *ale-options.d_dfmt_options*
+                                                         *g:ale_d_dfmt_options*
                                                          *b:ale_d_dfmt_options*
+d_dfmt_options
+g:ale_d_dfmt_options
   Type: |String|
   Default: `''`
 
-This variable can be set to pass additional options to the dfmt fixer.
+  This variable can be set to pass additional options to the dfmt fixer.
 
 ===============================================================================
 dls                                                                 *ale-d-dls*
 
-g:ale_d_dls_executable                                 *g:ale_d_dls_executable*
+                                                 *ale-options.d_dls_executable*
+                                                       *g:ale_d_dls_executable*
                                                        *b:ale_d_dls_executable*
+d_dls_executable
+g:ale_d_dls_executable
   Type: |String|
   Default: `dls`
 
-See |ale-integrations-local-executables|
+  See |ale-integrations-local-executables|
 
 
 ===============================================================================

--- a/doc/ale-dafny.txt
+++ b/doc/ale-dafny.txt
@@ -5,12 +5,16 @@ ALE Dafny Integration                                       *ale-dafny-options*
 ===============================================================================
 dafny                                                         *ale-dafny-dafny*
 
-g:ale_dafny_dafny_timelimit                       *g:ale_dafny_dafny_timelimit*
+                                            *ale-options.dafny_dafny_timelimit*
+                                                  *g:ale_dafny_dafny_timelimit*
                                                   *b:ale_dafny_dafny_timelimit*
+dafny_dafny_timelimit
+g:ale_dafny_dafny_timelimit
   Type: |Number|
   Default: `10`
 
   This variable sets the `/timeLimit` used for dafny.
 
 
+===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-dart.txt
+++ b/doc/ale-dart.txt
@@ -5,8 +5,9 @@ ALE Dart Integration                                         *ale-dart-options*
 ===============================================================================
 analysis_server                                      *ale-dart-analysis_server*
 
-Installation
+
 -------------------------------------------------------------------------------
+Installation
 
 Install Dart via whatever means. `analysis_server` will be included in the SDK.
 
@@ -16,20 +17,23 @@ its absolute path. : >
   let g:ale_dart_analysis_server_executable = '/usr/local/bin/dart'
 <
 
-Options
 -------------------------------------------------------------------------------
-
-g:ale_dart_analysis_server_executable   *g:ale_dart_analysis_server_executable*
+Options
+                                  *ale-options.dart_analysis_server_executable*
+                                        *g:ale_dart_analysis_server_executable*
                                         *b:ale_dart_analysis_server_executable*
+dart_analysis_server_executable
+g:ale_dart_analysis_server_executable
   Type: |String|
   Default: `'dart'`
 
   This variable can be set to change the path of dart.
 
-
-g:ale_dart_analysis_server_enable_language_server
+                      *ale-options.dart_analysis_server_enable_language_server*
                             *g:ale_dart_analysis_server_enable_language_server*
                             *b:ale_dart_analysis_server_enable_language_server*
+dart_analysis_server_enable_language_server
+g:ale_dart_analysis_server_enable_language_server
   Type: |Number|
   Default: `1`
 
@@ -43,8 +47,9 @@ g:ale_dart_analysis_server_enable_language_server
 ===============================================================================
 dart-analyze                                                 *ale-dart-analyze*
 
-Installation
+
 -------------------------------------------------------------------------------
+Installation
 
 Installing Dart should probably ensure that `dart` is in your `$PATH`.
 
@@ -55,11 +60,14 @@ In case it is not, try to set the executable option to its absolute path. : >
 
 Install Dart via whatever means. `dart analyze` will be included in the SDK.
 
-Options
--------------------------------------------------------------------------------
 
-g:ale_dart_analyze_executable                   *g:ale_dart_analyze_executable*
+-------------------------------------------------------------------------------
+Options
+                                          *ale-options.dart_analyze_executable*
+                                                *g:ale_dart_analyze_executable*
                                                 *b:ale_dart_analyze_executable*
+dart_analyze_executable
+g:ale_dart_analyze_executable
   Type: |String|
   Default: `'dart'`
 
@@ -70,30 +78,36 @@ g:ale_dart_analyze_executable                   *g:ale_dart_analyze_executable*
 ===============================================================================
 dart-format                                                   *ale-dart-format*
 
-Installation
+
 -------------------------------------------------------------------------------
+Installation
 
 Installing Dart should probably ensure that `dart` is in your `$PATH`.
 
-In case it is not, try to set the executable option to its absolute path. : >
+In case it is not, try to set the executable option to its absolute path: >
+
   " Set the executable path for dart to the absolute path to it.
   let g:ale_dart_format_executable = '/usr/lib/dart/bin/dart'
- >
+<
 
-Options
 -------------------------------------------------------------------------------
-
-g:ale_dart_format_executable                     *g:ale_dart_format_executable*
+Options
+                                           *ale-options.dart_format_executable*
+                                                 *g:ale_dart_format_executable*
                                                  *b:ale_dart_format_executable*
+dart_format_executable
+g:ale_dart_format_executable
   Type: |String|
   Default: `'dart'`
 
   This variable can be set to specify an absolute path to the
   format executable (or to specify an alternate executable).
 
-
-g:ale_dart_format_options                           *g:ale_dart_format_options*
+                                              *ale-options.dart_format_options*
+                                                    *g:ale_dart_format_options*
                                                     *b:ale_dart_format_options*
+dart_format_options
+g:ale_dart_format_options
   Type: |String|
   Default: `''`
 
@@ -103,35 +117,41 @@ g:ale_dart_format_options                           *g:ale_dart_format_options*
 ===============================================================================
 dartfmt                                                      *ale-dart-dartfmt*
 
-Installation
+
 -------------------------------------------------------------------------------
+Installation
 
 Installing Dart should probably ensure that `dartfmt` is in your `$PATH`.
 
-In case it is not, try to set the executable option to its absolute path. : >
+In case it is not, try to set the executable option to its absolute path: >
+
   " Set the executable path for dartfmt to the absolute path to it.
   let g:ale_dart_dartfmt_executable = '/usr/lib/dart/bin/dartfmt'
- >
+<
 
-Options
 -------------------------------------------------------------------------------
-
-g:ale_dart_dartfmt_executable                   *g:ale_dart_dartfmt_executable*
+Options
+                                          *ale-options.dart_dartfmt_executable*
+                                                *g:ale_dart_dartfmt_executable*
                                                 *b:ale_dart_dartfmt_executable*
+dart_dartfmt_executable
+g:ale_dart_dartfmt_executable
   Type: |String|
   Default: `''`
 
   This variable can be set to specify an absolute path to the
   dartfmt executable (or to specify an alternate executable).
 
-
-g:ale_dart_dartfmt_options                         *g:ale_dart_dartfmt_options*
+                                             *ale-options.dart_dartfmt_options*
+                                                   *g:ale_dart_dartfmt_options*
                                                    *b:ale_dart_dartfmt_options*
+dart_dartfmt_options
+g:ale_dart_dartfmt_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass additional options to the dartfmt fixer.
 
-===============================================================================
 
+===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-desktop.txt
+++ b/doc/ale-desktop.txt
@@ -8,14 +8,19 @@ desktop-file-validate                       *ale-desktop-desktop-file-validate*
 ALE supports checking .desktop files with `desktop-file-validate.`
 
 
-g:ale_desktop_desktop_file_validate_options
+-------------------------------------------------------------------------------
+Options
+                            *ale-options.desktop_desktop_file_validate_options*
                                   *g:ale_desktop_desktop_file_validate_options*
                                   *b:ale_desktop_desktop_file_validate_options*
+desktop_desktop_file_validate_options
+g:ale_desktop_desktop_file_validate_options
   Type: |String|
   Default: `''`
 
   This variable can be changed to set options for `desktop-file-validate`,
   such as `'--warn-kde'`.
+
 
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-development.txt
+++ b/doc/ale-development.txt
@@ -17,6 +17,7 @@ CONTENTS                                             *ale-development-contents*
   5. Contributing.........................|ale-development-contributing|
     5.1. Preparing a Release..............|ale-development-release|
 
+
 ===============================================================================
 1. Introduction                                  *ale-development-introduction*
 
@@ -24,6 +25,7 @@ This document contains helpful information for ALE developers, including
 design goals, information on how to run the tests, coding standards, and so
 on. You should read this document if you want to get involved with ALE
 development.
+
 
 ===============================================================================
 2. Design Goals                                              *ale-design-goals*
@@ -65,6 +67,7 @@ better support for LSP features as time goes on.
 
 When merging pull requests, you should respond with `Cheers! :beers:`, purely
 for comedy value.
+
 
 ===============================================================================
 3. Coding Standards                                      *ale-coding-standards*
@@ -146,6 +149,7 @@ Apply the following rules when writing Bash scripts.
 * Run `shellcheck`, and do everything it says.
   See: https://github.com/koalaman/shellcheck
 * Try to write scripts so they will run on Linux, BSD, or Mac OSX.
+
 
 ===============================================================================
 4. Testing ALE              *ale-development-tests* *ale-dev-tests* *ale-tests*
@@ -246,6 +250,7 @@ margin. For example, if you add a heading for an `aardvark` tool to
 Make sure to make the table of contents match the headings, and to keep the
 doc tags on the right margin.
 
+
 ===============================================================================
 4.1 Writing Linter Tests                         *ale-development-linter-tests*
 
@@ -326,6 +331,7 @@ given the above setup are as follows.
 `AssertLSPProject project_root`    - Check the root given to an LSP server.
 `AssertLSPAddress address`         - Check the address to an LSP server.
 
+
 ===============================================================================
 4.2 Writing Fixer Tests                           *ale-development-fixer-tests*
 
@@ -366,6 +372,7 @@ given the above setup are as follows.
 `AssertFixerCwd cwd`               - Check the `cwd` for the fixer.
 `AssertFixer results`              - Check the fixer results
 `AssertFixerNotExecuted`           - Check that fixers will not be executed.
+
 
 ===============================================================================
 4.3 Running Tests in a Windows VM               *ale-development-windows-tests*
@@ -443,6 +450,7 @@ You can run a specific test by passing the filename as an argument to the
 batch file, for example: `run-tests test/test_c_flag_parsing.vader` . This will
 give you results much more quickly.
 
+
 ===============================================================================
 5. Contributing                                  *ale-development-contributing*
 
@@ -460,6 +468,7 @@ and profile settings. See: https://docs.github.com/en/account-and-profile/
 
 Unless configuring GitHub to expose contact details, commits will be rewritten
 to appear by `USERNAME <RANDOM_NUMBER+USERNAME@users.noreply.github.com>` .
+
 
 ===============================================================================
 5.1 Preparing a Release                               *ale-development-release*
@@ -531,6 +540,7 @@ Once you do, follow these steps.
 
 Have fun creating ALE releases. Drink responsibly, or not at all, which is the
 preference of w0rp.
+
 
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-dhall.txt
+++ b/doc/ale-dhall.txt
@@ -1,13 +1,21 @@
 ===============================================================================
 ALE Dhall Integration                                       *ale-dhall-options*
 
-g:ale_dhall_executable                                 *g:ale_dhall_executable*
+Dhall - https://dhall-lang.org/
+
+                                                 *ale-options.dhall_executable*
+                                                       *g:ale_dhall_executable*
                                                        *b:ale_dhall_executable*
+dhall_executable
+g:ale_dhall_executable
   Type: |String|
   Default: `'dhall'`
 
-g:ale_dhall_options                                       *g:ale_dhall_options*
+                                                    *ale-options.dhall_options*
+                                                          *g:ale_dhall_options*
                                                           *b:ale_dhall_options*
+dhall_options
+g:ale_dhall_options
   Type: |String|
   Default: `''`
 
@@ -20,18 +28,18 @@ g:ale_dhall_options                                       *g:ale_dhall_options*
 ===============================================================================
 dhall-format                                                 *ale-dhall-format*
 
-Dhall
-  (https://dhall-lang.org/)
-
 
 ===============================================================================
 dhall-freeze                                                 *ale-dhall-freeze*
 
-Dhall
-  (https://dhall-lang.org/)
 
-g:ale_dhall_freeze_options                         *g:ale_dhall_freeze_options*
+-------------------------------------------------------------------------------
+Options
+                                             *ale-options.dhall_freeze_options*
+                                                   *g:ale_dhall_freeze_options*
                                                    *b:ale_dhall_freeze_options*
+dhall_freeze_options
+g:ale_dhall_freeze_options
   Type: |String|
   Default: `''`
 
@@ -43,9 +51,6 @@ g:ale_dhall_freeze_options                         *g:ale_dhall_freeze_options*
 
 ===============================================================================
 dhall-lint                                                     *ale-dhall-lint*
-
-Dhall
-  (https://dhall-lang.org/)
 
 
 ===============================================================================

--- a/doc/ale-dockerfile.txt
+++ b/doc/ale-dockerfile.txt
@@ -5,19 +5,22 @@ ALE Dockerfile Integration                             *ale-dockerfile-options*
 ===============================================================================
 dockerfile_lint                                *ale-dockerfile-dockerfile_lint*
 
-g:ale_dockerfile_dockerfile_lint_executable
+                            *ale-options.dockerfile_dockerfile_lint_executable*
                                   *g:ale_dockerfile_dockerfile_lint_executable*
                                   *b:ale_dockerfile_dockerfile_lint_executable*
+dockerfile_dockerfile_lint_executable
+g:ale_dockerfile_dockerfile_lint_executable
   Type: |String|
   Default: `'dockerfile_lint'`
 
   This variable can be changed to specify the executable used to run
   dockerfile_lint.
 
-
-g:ale_dockerfile_dockerfile_lint_options
+                               *ale-options.dockerfile_dockerfile_lint_options*
                                      *g:ale_dockerfile_dockerfile_lint_options*
                                      *b:ale_dockerfile_dockerfile_lint_options*
+dockerfile_dockerfile_lint_options
+g:ale_dockerfile_dockerfile_lint_options
   Type: |String|
   Default: `''`
 
@@ -28,9 +31,11 @@ g:ale_dockerfile_dockerfile_lint_options
 ===============================================================================
 dockerlinter                                      *ale-dockerfile-dockerlinter*
 
-g:ale_dockerfile_dockerlinter_executable
+                               *ale-options.dockerfile_dockerlinter_executable*
                                      *g:ale_dockerfile_dockerlinter_executable*
                                      *b:ale_dockerfile_dockerlinter_executable*
+dockerfile_dockerlinter_executable
+g:ale_dockerfile_dockerlinter_executable
   Type: |String|
   Default: `'dockerlinter'`
 
@@ -38,16 +43,16 @@ g:ale_dockerfile_dockerlinter_executable
   dockerlinter.
 
 
-g:ale_dockerfile_dockerlinter_options
+                                  *ale-options.dockerfile_dockerlinter_options*
                                         *g:ale_dockerfile_dockerlinter_options*
                                         *b:ale_dockerfile_dockerlinter_options*
+dockerfile_dockerlinter_options
+g:ale_dockerfile_dockerlinter_options
   Type: |String|
   Default: `''`
 
   This variable can be changed to add additional command-line arguments to
   the dockerfile lint invocation - like custom rule file definitions.
-
-    dockerlinter
 
 
 ===============================================================================
@@ -59,11 +64,16 @@ See |ale-dprint-options| and https://dprint.dev/plugins/dockerfile
 ===============================================================================
 hadolint                                              *ale-dockerfile-hadolint*
 
-  hadolint can be found at: https://github.com/hadolint/hadolint
+hadolint can be found at: https://github.com/hadolint/hadolint
 
 
-g:ale_dockerfile_hadolint_options           *g:ale_dockerfile_hadolint_options*
+-------------------------------------------------------------------------------
+Options
+                                      *ale-options.dockerfile_hadolint_options*
+                                            *g:ale_dockerfile_hadolint_options*
                                             *b:ale_dockerfile_hadolint_options*
+dockerfile_hadolint_options
+g:ale_dockerfile_hadolint_options
   Type: |String|
   Default: `''`
 
@@ -71,9 +81,11 @@ g:ale_dockerfile_hadolint_options           *g:ale_dockerfile_hadolint_options*
   invocation. These arguments will be used whether docker is being used or not
   (see below).
 
-
-g:ale_dockerfile_hadolint_use_docker     *g:ale_dockerfile_hadolint_use_docker*
+                                   *ale-options.dockerfile_hadolint_use_docker*
+                                         *g:ale_dockerfile_hadolint_use_docker*
                                          *b:ale_dockerfile_hadolint_use_docker*
+dockerfile_hadolint_use_docker
+g:ale_dockerfile_hadolint_use_docker
   Type: |String|
   Default: `'never'`
 
@@ -85,16 +97,18 @@ g:ale_dockerfile_hadolint_use_docker     *g:ale_dockerfile_hadolint_use_docker*
   For now, the default is 'never'.  This may change as ale's support for using
   docker to lint evolves.
 
-
-g:ale_dockerfile_hadolint_image               *g:ale_dockerfile_hadolint_image*
+                                        *ale-options.dockerfile_hadolint_image*
+                                              *g:ale_dockerfile_hadolint_image*
                                               *b:ale_dockerfile_hadolint_image*
+dockerfile_hadolint_image
+g:ale_dockerfile_hadolint_image
   Type: |String|
   Default: `'hadolint/hadolint'`
 
   This variable controls the docker image used to run hadolint.  The default
   is hadolint's author's build, and can be found at:
 
-    https://hub.docker.com/r/hadolint/hadolint/
+  https://hub.docker.com/r/hadolint/hadolint/
 
 
 ===============================================================================

--- a/doc/ale-elixir.txt
+++ b/doc/ale-elixir.txt
@@ -8,9 +8,11 @@ mix                                                            *ale-elixir-mix*
 The `mix` linter is disabled by default, as it can be too expensive to run.
 See `:help g:ale_linters`
 
-
-g:ale_elixir_mix_options                             *g:ale_elixir_mix_options*
+                                               *ale-options.elixir_mix_options*
+                                                     *g:ale_elixir_mix_options*
                                                      *b:ale_elixir_mix_options*
+elixir_mix_options
+g:ale_elixir_mix_options
   Type: |String|
   Default: `'mix'`
 
@@ -21,8 +23,11 @@ g:ale_elixir_mix_options                             *g:ale_elixir_mix_options*
 ===============================================================================
 mix_format                                              *ale-elixir-mix-format*
 
-g:ale_elixir_mix_format_options               *g:ale_elixir_mix_format_options*
+                                        *ale-options.elixir_mix_format_options*
+                                              *g:ale_elixir_mix_format_options*
                                               *b:ale_elixir_mix_format_options*
+elixir_mix_format_options
+g:ale_elixir_mix_format_options
   Type: |String|
   Default: `''`
 
@@ -52,26 +57,33 @@ elixir-ls                                                *ale-elixir-elixir-ls*
 
 Elixir Language Server (https://github.com/JakeBecker/elixir-ls)
 
-g:ale_elixir_elixir_ls_release                 *g:ale_elixir_elixir_ls_release*
+                                         *ale-options.elixir_elixir_ls_release*
+                                               *g:ale_elixir_elixir_ls_release*
                                                *b:ale_elixir_elixir_ls_release*
+elixir_elixir_ls_release
+g:ale_elixir_elixir_ls_release
   Type: |String|
   Default: `'elixir-ls'`
 
   Location of the elixir-ls release directory. This directory must contain
   the language server scripts (language_server.sh and language_server.bat).
 
-g:ale_elixir_elixir_ls_config                   *g:ale_elixir_elixir_ls_config*
+                                          *ale-options.elixir_elixir_ls_config*
+                                                *g:ale_elixir_elixir_ls_config*
                                                 *b:ale_elixir_elixir_ls_config*
+elixir_elixir_ls_config
+g:ale_elixir_elixir_ls_config
   Type: |Dictionary|
   Default: `{}`
 
   Dictionary containing configuration settings that will be passed to the
   language server. For example, to disable Dialyzer: >
-      {
-    \   'elixirLS': {
-    \     'dialyzerEnabled': v:false,
-    \   },
-    \ }
+
+  let g:ale_elixir_elixir_ls_config = {
+  \   'elixirLS': {
+  \       'dialyzerEnabled': v:false,
+  \   },
+  \}
 <
   Consult the ElixirLS documentation for more information about settings.
 
@@ -81,17 +93,22 @@ credo                                                        *ale-elixir-credo*
 
 Credo (https://github.com/rrrene/credo)
 
-g:ale_elixir_credo_strict                           *g:ale_elixir_credo_strict*
-
+                                              *ale-options.elixir_credo_strict*
+                                                    *g:ale_elixir_credo_strict*
+                                                    *b:ale_elixir_credo_strict*
+elixir_credo_strict
+g:ale_elixir_credo_strict
   Type: |Integer|
   Default: `0`
 
   Tells credo to run in strict mode or suggest mode.  Set variable to 1 to
   enable --strict mode.
 
-
-g:ale_elixir_credo_config_file                 *g:ale_elixir_credo_config_file*
-
+                                         *ale-options.elixir_credo_config_file*
+                                               *g:ale_elixir_credo_config_file*
+                                               *b:ale_elixir_credo_config_file*
+elixir_credo_config_file
+g:ale_elixir_credo_config_file
   Type: |String|
   Default: `''`
 
@@ -109,8 +126,11 @@ lexical                                                    *ale-elixir-lexical*
 
 Lexical (https://github.com/lexical-lsp/lexical)
 
-g:ale_elixir_lexical_release                     *g:ale_elixir_lexical_release*
+                                           *ale-options.elixir_lexical_release*
+                                                 *g:ale_elixir_lexical_release*
                                                  *b:ale_elixir_lexical_release*
+elixir_lexical_release
+g:ale_elixir_lexical_release
   Type: |String|
   Default: `'lexical'`
 

--- a/doc/ale-elm.txt
+++ b/doc/ale-elm.txt
@@ -5,96 +5,124 @@ ALE Elm Integration                                           *ale-elm-options*
 ===============================================================================
 elm-format                                                 *ale-elm-elm-format*
 
-g:ale_elm_format_executable                       *g:ale_elm_format_executable*
+                                            *ale-options.elm_format_executable*
+                                                  *g:ale_elm_format_executable*
                                                   *b:ale_elm_format_executable*
+elm_format_executable
+g:ale_elm_format_executable
   Type: |String|
   Default: `'elm-format'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_elm_format_use_global                       *g:ale_elm_format_use_global*
+                                            *ale-options.elm_format_use_global*
+                                                  *g:ale_elm_format_use_global*
                                                   *b:ale_elm_format_use_global*
+elm_format_use_global
+g:ale_elm_format_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_elm_format_options                             *g:ale_elm_format_options*
+                                               *ale-options.elm_format_options*
+                                                     *g:ale_elm_format_options*
                                                      *b:ale_elm_format_options*
+elm_format_options
+g:ale_elm_format_options
   Type: |String|
   Default: `'--yes'`
 
   This variable can be set to pass additional options to elm-format.
 
+
 ===============================================================================
 elm-ls                                                         *ale-elm-elm-ls*
 
-g:ale_elm_ls_executable                               *g:ale_elm_ls_executable*
+                                                *ale-options.elm_ls_executable*
+                                                      *g:ale_elm_ls_executable*
                                                       *b:ale_elm_ls_executable*
+elm_ls_executable
+g:ale_elm_ls_executable
   Type: |String|
   Default: `'elm-language-server'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_elm_ls_use_global                               *g:ale_elm_ls_use_global*
+                                                *ale-options.elm_ls_use_global*
+                                                      *g:ale_elm_ls_use_global*
                                                       *b:ale_elm_ls_use_global*
+elm_ls_use_global
+g:ale_elm_ls_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 1)`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_elm_ls_elm_path                                   *g:ale_elm_ls_elm_path*
+                                                  *ale-options.elm_ls_elm_path*
+                                                        *g:ale_elm_ls_elm_path*
                                                         *b:ale_elm_ls_elm_path*
+elm_ls_elm_path
+g:ale_elm_ls_elm_path
   Type: |String|
   Default: `''`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_elm_ls_elm_format_path                     *g:ale_elm_ls_elm_format_path*
+                                           *ale-options.elm_ls_elm_format_path*
+                                                 *g:ale_elm_ls_elm_format_path*
                                                  *b:ale_elm_ls_elm_format_path*
+elm_ls_elm_format_path
+g:ale_elm_ls_elm_format_path
   Type: |String|
   Default: `''`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_elm_ls_elm_test_path                         *g:ale_elm_ls_elm_test_path*
+                                             *ale-options.elm_ls_elm_test_path*
+                                                   *g:ale_elm_ls_elm_test_path*
                                                    *b:ale_elm_ls_elm_test_path*
+elm_ls_elm_test_path
+g:ale_elm_ls_elm_test_path
   Type: |String|
   Default: `''`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_elm_ls_elm_analyse_trigger             *g:ale_elm_ls_elm_analyse_trigger*
+                                       *ale-options.elm_ls_elm_analyse_trigger*
+                                             *g:ale_elm_ls_elm_analyse_trigger*
                                              *b:ale_elm_ls_elm_analyse_trigger*
+elm_ls_elm_analyse_trigger
+g:ale_elm_ls_elm_analyse_trigger
   Type: |String|
   Default: `'change'`
 
   One of 'change', 'save' or 'never'
 
+
 ===============================================================================
 elm-make                                                     *ale-elm-elm-make*
 
-g:ale_elm_make_executable                           *g:ale_elm_make_executable*
+                                              *ale-options.elm_make_executable*
+                                                    *g:ale_elm_make_executable*
                                                     *b:ale_elm_make_executable*
+elm_make_executable
+g:ale_elm_make_executable
   Type: |String|
   Default: `'elm'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_elm_make_use_global                           *g:ale_elm_make_use_global*
+                                              *ale-options.elm_make_use_global*
+                                                    *g:ale_elm_make_use_global*
                                                     *b:ale_elm_make_use_global*
+elm_make_use_global
+g:ale_elm_make_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
   See |ale-integrations-local-executables|
+
 
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-erlang.txt
+++ b/doc/ale-erlang.txt
@@ -5,34 +5,44 @@ ALE Erlang Integration                                     *ale-erlang-options*
 ===============================================================================
 dialyzer                                                  *ale-erlang-dialyzer*
 
-g:ale_erlang_dialyzer_executable             *g:ale_erlang_dialyzer_executable*
+                                       *ale-options.erlang_dialyzer_executable*
+                                             *g:ale_erlang_dialyzer_executable*
                                              *b:ale_erlang_dialyzer_executable*
+erlang_dialyzer_executable
+g:ale_erlang_dialyzer_executable
   Type: |String|
   Default: `'dialyzer'`
 
   This variable can be changed to specify the dialyzer executable.
 
-
-g:ale_erlang_dialyzer_options                   *g:ale_erlang_dialyzer_options*
+                                          *ale-options.erlang_dialyzer_options*
+                                                *g:ale_erlang_dialyzer_options*
                                                 *b:ale_erlang_dialyzer_options*
+erlang_dialyzer_options
+g:ale_erlang_dialyzer_options
   Type: |String|
   Default: `'-Wunmatched_returns -Werror_handling -Wrace_conditions -Wunderspec'`
 
   This variable can be changed to specify the options to pass to the dialyzer
   executable.
-
-g:ale_erlang_dialyzer_plt_file                 *g:ale_erlang_dialyzer_plt_file*
+                                         *ale-options.erlang_dialyzer_plt_file*
+                                               *g:ale_erlang_dialyzer_plt_file*
                                                *b:ale_erlang_dialyzer_plt_file*
+erlang_dialyzer_plt_file
+g:ale_erlang_dialyzer_plt_file
   Type: |String|
+  Default: `''`
 
   This variable can be changed to specify the path to the PLT file. By
   default, it will search for the PLT file inside the `_build` directory. If
   there isn't one, it will fallback to the path `$REBAR_PLT_DIR/dialyzer/plt`.
   Otherwise, it will default to `$HOME/.dialyzer_plt`.
 
-
-g:ale_erlang_dialyzer_rebar3_profile     *g:ale_erlang_dialyzer_rebar3_profile*
+                                   *ale-options.erlang_dialyzer_rebar3_profile*
+                                         *g:ale_erlang_dialyzer_rebar3_profile*
                                          *b:ale_erlang_dialyzer_rebar3_profile*
+erlang_dialyzer_rebar3_profile
+g:ale_erlang_dialyzer_rebar3_profile
   Type: |String|
   Default: `'default'`
 
@@ -40,106 +50,138 @@ g:ale_erlang_dialyzer_rebar3_profile     *g:ale_erlang_dialyzer_rebar3_profile*
   run dialyzer with rebar3.
 
 
--------------------------------------------------------------------------------
+===============================================================================
 elvis                                                        *ale-erlang-elvis*
 
-g:ale_erlang_elvis_executable                   *g:ale_erlang_elvis_executable*
+                                          *ale-options.erlang_elvis_executable*
+                                                *g:ale_erlang_elvis_executable*
                                                 *b:ale_erlang_elvis_executable*
+erlang_elvis_executable
+g:ale_erlang_elvis_executable
   Type: |String|
   Default: `'elvis'`
 
   This variable can be changed to specify the elvis executable.
 
 
--------------------------------------------------------------------------------
+===============================================================================
 erlang-mode                                            *ale-erlang-erlang-mode*
 
-g:ale_erlang_erlang_mode_emacs_executable
+                              *ale-options.erlang_erlang_mode_emacs_executable*
                                     *g:ale_erlang_erlang_mode_emacs_executable*
                                     *b:ale_erlang_erlang_mode_emacs_executable*
+erlang_erlang_mode_emacs_executable
+g:ale_erlang_erlang_mode_emacs_executable
   Type: |String|
   Default: `'emacs'`
 
   This variable can be changed to specify the Emacs executable.
 
-g:ale_erlang_erlang_mode_indent_level   *g:ale_erlang_erlang_mode_indent_level*
+                                  *ale-options.erlang_erlang_mode_indent_level*
+                                        *g:ale_erlang_erlang_mode_indent_level*
                                         *b:ale_erlang_erlang_mode_indent_level*
+erlang_erlang_mode_indent_level
+g:ale_erlang_erlang_mode_indent_level
   Type: |Number|
   Default: `4`
 
   Indentation of Erlang calls/clauses within blocks.
 
-g:ale_erlang_erlang_mode_icr_indent       *g:ale_erlang_erlang_mode_icr_indent*
+                                    *ale-options.erlang_erlang_mode_icr_indent*
+                                          *g:ale_erlang_erlang_mode_icr_indent*
                                           *b:ale_erlang_erlang_mode_icr_indent*
+erlang_erlang_mode_icr_indent
+g:ale_erlang_erlang_mode_icr_indent
   Type: `'nil'` or |Number|
   Default: `'nil'`
 
   Indentation of Erlang if/case/receive patterns. `'nil'` means keeping default
   behavior. When non-`'nil'`, indent to the column of if/case/receive.
 
-g:ale_erlang_erlang_mode_indent_guard   *g:ale_erlang_erlang_mode_indent_guard*
+                                  *ale-options.erlang_erlang_mode_indent_guard*
+                                        *g:ale_erlang_erlang_mode_indent_guard*
                                         *b:ale_erlang_erlang_mode_indent_guard*
+erlang_erlang_mode_indent_guard
+g:ale_erlang_erlang_mode_indent_guard
   Type: |Number|
   Default: `2`
 
   Indentation of Erlang guards.
 
-g:ale_erlang_erlang_mode_argument_indent
+                               *ale-options.erlang_erlang_mode_argument_indent*
                                      *g:ale_erlang_erlang_mode_argument_indent*
                                      *b:ale_erlang_erlang_mode_argument_indent*
+erlang_erlang_mode_argument_indent
+g:ale_erlang_erlang_mode_argument_indent
   Type: `'nil'` or |Number|
   Default: `2`
 
   Indentation of the first argument in a function call. When `'nil'`, indent
   to the column after the `'('` of the function.
 
-g:ale_erlang_erlang_mode_indent_tabs_mode
+                              *ale-options.erlang_erlang_mode_indent_tabs_mode*
                                     *g:ale_erlang_erlang_mode_indent_tabs_mode*
                                     *b:ale_erlang_erlang_mode_indent_tabs_mode*
+erlang_erlang_mode_indent_tabs_mode
+g:ale_erlang_erlang_mode_indent_tabs_mode
   Type: `'nil'` or `'t'`
   Default: `'nil'`
 
   Indentation can insert tabs if this is non-`'nil'`.
 
 
--------------------------------------------------------------------------------
+===============================================================================
 erlang_ls                                                *ale-erlang-erlang_ls*
 
-g:ale_erlang_erlang_ls_executable           *g:ale_erlang_erlang_ls_executable*
+                                      *ale-options.erlang_erlang_ls_executable*
+                                            *g:ale_erlang_erlang_ls_executable*
                                             *b:ale_erlang_erlang_ls_executable*
+erlang_erlang_ls_executable
+g:ale_erlang_erlang_ls_executable
   Type: |String|
   Default: `'erlang_ls'`
 
   This variable can be changed to specify the erlang_ls executable.
 
-g:ale_erlang_erlang_ls_log_dir                 *g:ale_erlang_erlang_ls_log_dir*
+                                         *ale-options.erlang_erlang_ls_log_dir*
+                                               *g:ale_erlang_erlang_ls_log_dir*
                                                *b:ale_erlang_erlang_ls_log_dir*
+erlang_erlang_ls_log_dir
+g:ale_erlang_erlang_ls_log_dir
   Type: |String|
   Default: `''`
 
   If set this variable overrides default directory where logs will be written.
 
-g:ale_erlang_erlang_ls_log_level             *g:ale_erlang_erlang_ls_log_level*
+                                       *ale-options.erlang_erlang_ls_log_level*
+                                             *g:ale_erlang_erlang_ls_log_level*
                                              *b:ale_erlang_erlang_ls_log_level*
+erlang_erlang_ls_log_level
+g:ale_erlang_erlang_ls_log_level
   Type: |String|
   Default: `'info'`
 
   This variable can be changed to specify log level.
 
 
--------------------------------------------------------------------------------
+===============================================================================
 erlc                                                          *ale-erlang-erlc*
 
-g:ale_erlang_erlc_executable                     *g:ale_erlang_erlc_executable*
+                                           *ale-options.erlang_erlc_executable*
+                                                 *g:ale_erlang_erlc_executable*
                                                  *b:ale_erlang_erlc_executable*
+erlang_erlc_executable
+g:ale_erlang_erlc_executable
   Type: |String|
   Default: `'erlc'`
 
   This variable can be changed to specify the erlc executable.
 
-
-g:ale_erlang_erlc_options                           *g:ale_erlang_erlc_options*
+                                              *ale-options.erlang_erlc_options*
+                                                    *g:ale_erlang_erlc_options*
                                                     *b:ale_erlang_erlc_options*
+erlang_erlc_options
+g:ale_erlang_erlc_options
   Type: |String|
   Default: `''`
 
@@ -147,19 +189,24 @@ g:ale_erlang_erlc_options                           *g:ale_erlang_erlc_options*
   or `-pa`.
 
 
--------------------------------------------------------------------------------
+===============================================================================
 erlfmt                                                      *ale-erlang-erlfmt*
 
-g:ale_erlang_erlfmt_executable                 *g:ale_erlang_erlfmt_executable*
+                                         *ale-options.erlang_erlfmt_executable*
+                                               *g:ale_erlang_erlfmt_executable*
                                                *b:ale_erlang_erlfmt_executable*
+erlang_erlfmt_executable
+g:ale_erlang_erlfmt_executable
   Type: |String|
   Default: `'erlfmt'`
 
   This variable can be changed to specify the erlfmt executable.
 
-
-g:ale_erlang_erlfmt_options                       *g:ale_erlang_erlfmt_options*
+                                            *ale-options.erlang_erlfmt_options*
+                                                  *g:ale_erlang_erlfmt_options*
                                                   *b:ale_erlang_erlfmt_options*
+erlang_erlfmt_options
+g:ale_erlang_erlfmt_options
   Type: |String|
   Default: `''`
 
@@ -167,11 +214,14 @@ g:ale_erlang_erlfmt_options                       *g:ale_erlang_erlfmt_options*
   `--insert-pragma` or `--print-width`.
 
 
--------------------------------------------------------------------------------
+===============================================================================
 syntaxerl                                                *ale-erlang-syntaxerl*
 
-g:ale_erlang_syntaxerl_executable           *g:ale_erlang_syntaxerl_executable*
+                                      *ale-options.erlang_syntaxerl_executable*
+                                            *g:ale_erlang_syntaxerl_executable*
                                             *b:ale_erlang_syntaxerl_executable*
+erlang_syntaxerl_executable
+g:ale_erlang_syntaxerl_executable
   Type: |String|
   Default: `'syntaxerl'`
 

--- a/doc/ale-eruby.txt
+++ b/doc/ale-eruby.txt
@@ -19,8 +19,11 @@ the result. To selectively enable a subset, see |g:ale_linters|.
 ===============================================================================
 erb-formatter                                          *ale-eruby-erbformatter*
 
-g:ale_eruby_erbformatter_executable       *g:ale_eruby_erbformatter_executable*
+                                    *ale-options.eruby_erbformatter_executable*
+                                          *g:ale_eruby_erbformatter_executable*
                                           *b:ale_eruby_erbformatter_executable*
+eruby_erbformatter_executable
+g:ale_eruby_erbformatter_executable
   Type: |String|
   Default: `'erb-formatter'`
 
@@ -31,17 +34,22 @@ g:ale_eruby_erbformatter_executable       *g:ale_eruby_erbformatter_executable*
 ===============================================================================
 erblint                                                     *ale-eruby-erblint*
 
-g:ale_eruby_erblint_executable                 *g:ale_eruby_erblint_executable*
+                                         *ale-options.eruby_erblint_executable*
+                                               *g:ale_eruby_erblint_executable*
                                                *b:ale_eruby_erblint_executable*
+eruby_erblint_executable
+g:ale_eruby_erblint_executable
   Type: |String|
   Default: `'erblint'`
 
   Override the invoked erblint binary. This is useful for running erblint
   from binstubs or a bundle.
 
-
-g:ale_eruby_erblint_options                        *g:ale_ruby_erblint_options*
+                                            *ale-options.eruby_erblint_options*
+                                                  *g:ale_eruby_erblint_options*
                                                    *b:ale_ruby_erblint_options*
+eruby_erblint_options
+g:ale_eruby_erblint_options
   Type: |String|
   Default: `''`
 
@@ -51,8 +59,11 @@ g:ale_eruby_erblint_options                        *g:ale_ruby_erblint_options*
 ===============================================================================
 htmlbeautifier                                       *ale-eruby-htmlbeautifier*
 
-g:ale_eruby_htmlbeautifier_executable   *g:ale_eruby_htmlbeautifier_executable*
+                                  *ale-options.eruby_htmlbeautifier_executable*
+                                        *g:ale_eruby_htmlbeautifier_executable*
                                         *b:ale_eruby_htmlbeautifier_executable*
+eruby_htmlbeautifier_executable
+g:ale_eruby_htmlbeautifier_executable
   Type: |String|
   Default: `'htmlbeautifier'`
 
@@ -63,17 +74,22 @@ g:ale_eruby_htmlbeautifier_executable   *g:ale_eruby_htmlbeautifier_executable*
 ===============================================================================
 ruumba                                                       *ale-eruby-ruumba*
 
-g:ale_eruby_ruumba_executable                   *g:ale_eruby_ruumba_executable*
+                                          *ale-options.eruby_ruumba_executable*
+                                                *g:ale_eruby_ruumba_executable*
                                                 *b:ale_eruby_ruumba_executable*
+eruby_ruumba_executable
+g:ale_eruby_ruumba_executable
   Type: |String|
   Default: `'ruumba'`
 
   Override the invoked ruumba binary. This is useful for running ruumba
   from binstubs or a bundle.
 
-
-g:ale_eruby_ruumba_options                          *g:ale_ruby_ruumba_options*
+                                             *ale-options.eruby_ruumba_options*
+                                                   *g:ale_eruby_ruumba_options*
                                                     *b:ale_ruby_ruumba_options*
+eruby_ruumba_options
+g:ale_eruby_ruumba_options
   Type: |String|
   Default: `''`
 

--- a/doc/ale-fish.txt
+++ b/doc/ale-fish.txt
@@ -10,22 +10,30 @@ displaying errors if an error message is not found.
 If ALE is not showing any errors but your file does not run as expected, run
 `fish -n <file.fish>` from the command line.
 
-===============================================================================
-fish_indent                                               *ale-fish-fish_indent*
 
-g:ale_fish_fish_indent_executable            *g:ale_fish_fish_indent_executable*
-                                             *b:ale_fish_fish_indent_executable*
+===============================================================================
+fish_indent                                              *ale-fish-fish_indent*
+
+                                      *ale-options.fish_fish_indent_executable*
+                                            *g:ale_fish_fish_indent_executable*
+                                            *b:ale_fish_fish_indent_executable*
+fish_fish_indent_executable
+g:ale_fish_fish_indent_executable
   Type: |String|
   Default: `'fish_indent'`
 
   This variable can be changed to use a different executable for fish_indent.
 
-g:ale_fish_fish_indent_options                  *g:ale_fish_fish_indent_options*
-                                                *b:ale_fish_fish_indent_options*
+                                         *ale-options.fish_fish_indent_options*
+                                               *g:ale_fish_fish_indent_options*
+                                               *b:ale_fish_fish_indent_options*
+fish_fish_indent_options
+g:ale_fish_fish_indent_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass additional options to fish_indent.
+
 
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-fortran.txt
+++ b/doc/ale-fortran.txt
@@ -5,25 +5,32 @@ ALE Fortran Integration                                   *ale-fortran-options*
 ===============================================================================
 gcc                                                           *ale-fortran-gcc*
 
-g:ale_fortran_gcc_executable                     *g:ale_fortran_gcc_executable*
+                                           *ale-options.fortran_gcc_executable*
+                                                 *g:ale_fortran_gcc_executable*
                                                  *b:ale_fortran_gcc_executable*
+fortran_gcc_executable
+g:ale_fortran_gcc_executable
   Type: |String|
   Default: `'gcc'`
 
   This variable can be changed to modify the executable used for checking
   Fortran code with GCC.
 
-
-g:ale_fortran_gcc_options                           *g:ale_fortran_gcc_options*
+                                              *ale-options.fortran_gcc_options*
+                                                    *g:ale_fortran_gcc_options*
                                                     *b:ale_fortran_gcc_options*
+fortran_gcc_options
+g:ale_fortran_gcc_options
   Type: |String|
   Default: `'-Wall'`
 
   This variable can be changed to modify flags given to gcc.
 
-
-g:ale_fortran_gcc_use_free_form               *g:ale_fortran_gcc_use_free_form*
+                                        *ale-options.fortran_gcc_use_free_form*
+                                              *g:ale_fortran_gcc_use_free_form*
                                               *b:ale_fortran_gcc_use_free_form*
+fortran_gcc_use_free_form
+g:ale_fortran_gcc_use_free_form
   Type: |Number|
   Default: `1`
 
@@ -33,18 +40,24 @@ g:ale_fortran_gcc_use_free_form               *g:ale_fortran_gcc_use_free_form*
 
 
 ===============================================================================
-language_server                                    *ale-fortran-language-server*
+language_server                                   *ale-fortran-language-server*
 
-g:ale_fortran_language_server_executable  *g:ale_fortran_language_server_executable*
-                                         *b:ale_fortran_language_server_executable*
+                               *ale-options.fortran_language_server_executable*
+                                     *g:ale_fortran_language_server_executable*
+                                     *b:ale_fortran_language_server_executable*
+fortran_language_server_executable
+g:ale_fortran_language_server_executable
   Type: |String|
   Default: `'fortls'`
 
   This variable can be changed to modify the executable used for the Fortran
   Language Server.
 
-g:ale_fortran_language_server_use_global  *g:ale_fortran_language_server_use_global*
-                                         *b:ale_fortran_language_server_use_global*
+                               *ale-options.fortran_language_server_use_global*
+                                     *g:ale_fortran_language_server_use_global*
+                                     *b:ale_fortran_language_server_use_global*
+fortran_language_server_use_global
+g:ale_fortran_language_server_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 

--- a/doc/ale-fuse.txt
+++ b/doc/ale-fuse.txt
@@ -5,16 +5,21 @@ ALE FusionScript Integration                                 *ale-fuse-options*
 ===============================================================================
 fusion-lint                                               *ale-fuse-fusionlint*
 
-g:ale_fusion_fusionlint_executable           *g:ale_fuse_fusionlint_executable*
+                                     *ale-options.fusion_fusionlint_executable*
+                                           *g:ale_fusion_fusionlint_executable*
                                              *b:ale_fuse_fusionlint_executable*
+fusion_fusionlint_executable
+g:ale_fusion_fusionlint_executable
   Type: |String|
   Default: `'fusion-lint'`
 
   This variable can be changed to change the path to fusion-lint.
 
-
-g:ale_fuse_fusionlint_options                   *g:ale_fuse_fusionlint_options*
+                                          *ale-options.fuse_fusionlint_options*
+                                                *g:ale_fuse_fusionlint_options*
                                                 *b:ale_fuse_fusionlint_options*
+fuse_fusionlint_options
+g:ale_fuse_fusionlint_options
   Type: |String|
   Default: `''`
 

--- a/doc/ale-gitcommit.txt
+++ b/doc/ale-gitcommit.txt
@@ -5,32 +5,39 @@ ALE Git Commit Integration                              *ale-gitcommit-options*
 ===============================================================================
 gitlint                                                 *ale-gitcommit-gitlint*
 
-g:ale_gitcommit_gitlint_executable         *g:ale_gitcommit_gitlint_executable*
+                                     *ale-options.gitcommit_gitlint_executable*
+                                           *g:ale_gitcommit_gitlint_executable*
                                            *b:ale_gitcommit_gitlint_executable*
+gitcommit_gitlint_executable
+g:ale_gitcommit_gitlint_executable
   Type: |String|
   Default: `'gitlint'`
 
   This variable can be changed to modify the executable used for gitlint.
 
-
-g:ale_gitcommit_gitlint_options               *g:ale_gitcommit_gitlint_options*
+                                        *ale-options.gitcommit_gitlint_options*
+                                              *g:ale_gitcommit_gitlint_options*
                                               *b:ale_gitcommit_gitlint_options*
+gitcommit_gitlint_options
+g:ale_gitcommit_gitlint_options
   Type: |String|
   Default: `''`
 
   This variable can be changed to add command-line arguments to the gitlint
   invocation. For example, you can specify the path to a configuration file. >
 
-    let g:ale_gitcommit_gitlint_options = '-C /home/user/.config/gitlint.ini'
+  let g:ale_gitcommit_gitlint_options = '-C /home/user/.config/gitlint.ini'
 <
   You can also disable particular error codes using this option. For example,
   you can ignore errors for git commits with a missing body. >
 
-    let g:ale_gitcommit_gitlint_options = '--ignore B6'
+  let g:ale_gitcommit_gitlint_options = '--ignore B6'
 <
-
-g:ale_gitcommit_gitlint_use_global         *g:ale_gitcommit_gitlint_use_global*
+                                     *ale-options.gitcommit_gitlint_use_global*
+                                           *g:ale_gitcommit_gitlint_use_global*
                                            *b:ale_gitcommit_gitlint_use_global*
+gitcommit_gitlint_use_global
+g:ale_gitcommit_gitlint_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
@@ -39,6 +46,7 @@ g:ale_gitcommit_gitlint_use_global         *g:ale_gitcommit_gitlint_use_global*
   always use |g:ale_gitcommit_gitlint_executable| for the executable path.
 
   Both variables can be set with `b:` buffer variables instead.
+
 
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-gleam.txt
+++ b/doc/ale-gleam.txt
@@ -6,8 +6,11 @@ ALE Gleam Integration                                       *ale-gleam-options*
 ===============================================================================
 gleam_format                                           *ale-gleam-gleam_format*
 
-g:ale_gleam_gleam_format_executable       *g:ale_gleam_gleam_format_executable*
+                                    *ale-options.gleam_gleam_format_executable*
+                                          *g:ale_gleam_gleam_format_executable*
                                           *b:ale_gleam_gleam_format_executable*
+gleam_gleam_format_executable
+g:ale_gleam_gleam_format_executable
   Type: |String|
   Default: `'gleam'`
 
@@ -18,8 +21,11 @@ g:ale_gleam_gleam_format_executable       *g:ale_gleam_gleam_format_executable*
 ===============================================================================
 gleamlsp                                                   *ale-gleam-gleamlsp*
 
-g:ale_gleam_gleamlsp_executable               *g:ale_gleam_gleamlsp_executable*
+                                        *ale-options.gleam_gleamlsp_executable*
+                                              *g:ale_gleam_gleamlsp_executable*
                                               *b:ale_gleam_gleamlsp_executable*
+gleam_gleamlsp_executable
+g:ale_gleam_gleamlsp_executable
   Type: |String|
   Default: `'gleam'`
 

--- a/doc/ale-glsl.txt
+++ b/doc/ale-glsl.txt
@@ -16,16 +16,21 @@ Integration Information
 ===============================================================================
 glslang                                                      *ale-glsl-glslang*
 
-g:ale_glsl_glslang_executable                   *g:ale_glsl_glslang_executable*
+                                          *ale-options.glsl_glslang_executable*
+                                                *g:ale_glsl_glslang_executable*
                                                 *b:ale_glsl_glslang_executable*
+glsl_glslang_executable
+g:ale_glsl_glslang_executable
   Type: |String|
   Default: `'glslangValidator'`
 
   This variable can be changed to change the path to glslangValidator.
 
-
-g:ale_glsl_glslang_options                         *g:ale_glsl_glslang_options*
+                                             *ale-options.glsl_glslang_options*
+                                                   *g:ale_glsl_glslang_options*
                                                    *b:ale_glsl_glslang_options*
+glsl_glslang_options
+g:ale_glsl_glslang_options
   Type: |String|
   Default: `''`
 
@@ -35,16 +40,22 @@ g:ale_glsl_glslang_options                         *g:ale_glsl_glslang_options*
 ===============================================================================
 glslls                                                        *ale-glsl-glslls*
 
-g:ale_glsl_glslls_executable                     *g:ale_glsl_glslls_executable*
+                                           *ale-options.glsl_glslls_executable*
+                                                 *g:ale_glsl_glslls_executable*
                                                  *b:ale_glsl_glslls_executable*
+glsl_glslls_executable
+g:ale_glsl_glslls_executable
   Type: |String|
   Default: `'glslls'`
 
   This variable can be changed to change the path to glslls.
   See |ale-integrations-local-executables|
 
-g:ale_glsl_glslls_logfile                           *g:ale_glsl_glslls_logfile*
+                                              *ale-options.glsl_glslls_logfile*
+                                                    *g:ale_glsl_glslls_logfile*
                                                     *b:ale_glsl_glslls_logfile*
+glsl_glslls_logfile
+g:ale_glsl_glslls_logfile
   Type: |String|
   Default: `''`
 

--- a/doc/ale-go.txt
+++ b/doc/ale-go.txt
@@ -14,19 +14,22 @@ A possible configuration is to enable golangci-lint and `gofmt:
   " Enable all of the linters you want for Go.
   let g:ale_linters = {'go': ['golangci-lint', 'gofmt']}
 <
-
-g:ale_go_go_executable                                 *g:ale_go_go_executable*
+                                                 *ale-options.go_go_executable*
+                                                       *g:ale_go_go_executable*
                                                        *b:ale_go_go_executable*
-
+go_go_executable
+g:ale_go_go_executable
   Type: |String|
   Default: `'go'`
 
   The executable that will be run for the `gobuild` and `govet` linters, and
   the `gomod` fixer.
 
-
-g:ale_go_go111module                                     *g:ale_go_go111module*
+                                                   *ale-options.go_go111module*
+                                                         *g:ale_go_go111module*
                                                          *b:ale_go_go111module*
+go_go111module
+g:ale_go_go111module
   Type: |String|
   Default: `''`
 
@@ -37,16 +40,21 @@ g:ale_go_go111module                                     *g:ale_go_go111module*
 ===============================================================================
 bingo                                                            *ale-go-bingo*
 
-g:ale_go_bingo_executable                           *g:ale_go_bingo_executable*
+                                              *ale-options.go_bingo_executable*
+                                                    *g:ale_go_bingo_executable*
                                                     *b:ale_go_bingo_executable*
+go_bingo_executable
+g:ale_go_bingo_executable
   Type: |String|
   Default: `'bingo'`
 
   Location of the bingo binary file.
 
-
-g:ale_go_bingo_options                                 *g:ale_go_bingo_options*
+                                                 *ale-options.go_bingo_options*
+                                                       *g:ale_go_bingo_options*
                                                        *b:ale_go_bingo_options*
+go_bingo_options
+g:ale_go_bingo_options
   Type: |String|
   Default: `''`
 
@@ -56,11 +64,15 @@ cspell                                                          *ale-go-cspell*
 
 See |ale-cspell-options|
 
+
 ===============================================================================
 gobuild                                                        *ale-go-gobuild*
 
-g:ale_go_gobuild_options                             *g:ale_go_gobuild_options*
+                                               *ale-options.go_gobuild_options*
+                                                     *g:ale_go_gobuild_options*
                                                      *b:ale_go_gobuild_options*
+go_gobuild_options
+g:ale_go_gobuild_options
   Type: |String|
   Default: `''`
 
@@ -71,8 +83,11 @@ g:ale_go_gobuild_options                             *g:ale_go_gobuild_options*
 ===============================================================================
 gofmt                                                            *ale-go-gofmt*
 
-g:ale_go_gofmt_options                                 *g:ale_go_gofmt_options*
+                                                 *ale-options.go_gofmt_options*
+                                                       *g:ale_go_gofmt_options*
                                                        *b:ale_go_gofmt_options*
+go_gofmt_options
+g:ale_go_gofmt_options
   Type: |String|
   Default: `''`
 
@@ -82,15 +97,21 @@ g:ale_go_gofmt_options                                 *g:ale_go_gofmt_options*
 ===============================================================================
 gofumpt                                                        *ale-go-gofumpt*
 
-g:ale_go_gofumpt_executable                       *g:ale_go_gofumpt_executable*
+                                            *ale-options.go_gofumpt_executable*
+                                                  *g:ale_go_gofumpt_executable*
                                                   *b:ale_go_gofumpt_executable*
+go_gofumpt_executable
+g:ale_go_gofumpt_executable
   Type: |String|
   Default: `'gofumpt'`
 
   Executable to run to use as the gofumpt fixer.
 
-g:ale_go_gofumpt_options                             *g:ale_go_gofumpt_options*
+                                               *ale-options.go_gofumpt_options*
+                                                     *g:ale_go_gofumpt_options*
                                                      *b:ale_go_gofumpt_options*
+go_gofumpt_options
+g:ale_go_gofumpt_options
   Type: |String|
   Default: `''`
 
@@ -104,25 +125,32 @@ golangci-lint                                            *ale-go-golangci-lint*
 written to disk. This differs from the default behavior of linting the buffer.
 See: |ale-lint-file|
 
-g:ale_go_golangci_lint_executable           *g:ale_go_golangci_lint_executable*
+                                      *ale-options.go_golangci_lint_executable*
+                                            *g:ale_go_golangci_lint_executable*
                                             *b:ale_go_golangci_lint_executable*
+go_golangci_lint_executable
+g:ale_go_golangci_lint_executable
   Type: |String|
   Default: `'golangci-lint'`
 
   The executable that will be run for golangci-lint.
 
-
-g:ale_go_golangci_lint_options                 *g:ale_go_golangci_lint_options*
+                                         *ale-options.go_golangci_lint_options*
+                                               *g:ale_go_golangci_lint_options*
                                                *b:ale_go_golangci_lint_options*
+go_golangci_lint_options
+g:ale_go_golangci_lint_options
   Type: |String|
   Default: `''`
 
   This variable can be changed to alter the command-line arguments to the
   golangci-lint invocation.
 
-
-g:ale_go_golangci_lint_package                 *g:ale_go_golangci_lint_package*
+                                         *ale-options.go_golangci_lint_package*
+                                               *g:ale_go_golangci_lint_package*
                                                *b:ale_go_golangci_lint_package*
+go_golangci_lint_package
+g:ale_go_golangci_lint_package
   Type: |Number|
   Default: `0`
 
@@ -133,16 +161,21 @@ g:ale_go_golangci_lint_package                 *g:ale_go_golangci_lint_package*
 ===============================================================================
 golangserver                                              *ale-go-golangserver*
 
-g:ale_go_langserver_executable                 *g:ale_go_langserver_executable*
+                                         *ale-options.go_langserver_executable*
+                                               *g:ale_go_langserver_executable*
                                                *b:ale_go_langserver_executable*
+go_langserver_executable
+g:ale_go_langserver_executable
   Type: |String|
   Default: `'go-langserver'`
 
   Location of the go-langserver binary file.
 
-
-g:ale_go_langserver_options                       *g:ale_go_langserver_options*
+                                            *ale-options.go_langserver_options*
+                                                  *g:ale_go_langserver_options*
                                                   *b:ale_go_langserver_options*
+go_langserver_options
+g:ale_go_langserver_options
   Type: |String|
   Default: `''`
 
@@ -154,15 +187,21 @@ g:ale_go_langserver_options                       *g:ale_go_langserver_options*
 ===============================================================================
 golines                                                        *ale-go-golines*
 
-g:ale_go_golines_executable                         *g:ale_go_lines_executable*
+                                            *ale-options.go_golines_executable*
+                                                  *g:ale_go_golines_executable*
                                                     *b:ale_go_lines_executable*
+go_golines_executable
+g:ale_go_golines_executable
   Type: |String|
   Default: `'golines'`
 
   Location of the golines binary file
 
-g:ale_go_golines_options                             *g:ale_go_golines_options*
+                                               *ale-options.go_golines_options*
+                                                     *g:ale_go_golines_options*
                                                      *b:ale_go_golines_options*
+go_golines_options
+g:ale_go_golines_options
   Type: |String|
   Default: `''`
 
@@ -187,8 +226,13 @@ do anything else. See the `gopls` README file for more information:
 https://github.com/golang/tools/blob/master/gopls/README.md
 
 
-g:ale_go_gopls_executable                           *g:ale_go_gopls_executable*
+-------------------------------------------------------------------------------
+Options
+                                              *ale-options.go_gopls_executable*
+                                                    *g:ale_go_gopls_executable*
                                                     *b:ale_go_gopls_executable*
+go_gopls_executable
+g:ale_go_gopls_executable
   Type: |String|
   Default: `'gopls'`
 
@@ -198,52 +242,64 @@ g:ale_go_gopls_executable                           *g:ale_go_gopls_executable*
   default, and fall back on a globally installed `gopls` if it can't be found
   otherwise.
 
-
-g:ale_go_gopls_options                                 *g:ale_go_gopls_options*
+                                                 *ale-options.go_gopls_options*
+                                                       *g:ale_go_gopls_options*
                                                        *b:ale_go_gopls_options*
+go_gopls_options
+g:ale_go_gopls_options
   Type: |String|
   Default: `''`
 
   Command-line options passed to the gopls executable. See `gopls -h`.
 
-
-g:ale_go_gopls_fix_executable                   *g:ale_go_gopls_fix_executable*
+                                          *ale-options.go_gopls_fix_executable*
+                                                *g:ale_go_gopls_fix_executable*
                                                 *b:ale_go_gopls_fix_executable*
+go_gopls_fix_executable
+g:ale_go_gopls_fix_executable
   Type: |String|
   Default: `'gopls'`
 
   Executable to run to use as the gopls fixer.
 
-g:ale_go_gopls_fix_options                         *g:ale_go_gopls_fix_options*
+                                             *ale-options.go_gopls_fix_options*
+                                                   *g:ale_go_gopls_fix_options*
                                                    *b:ale_go_gopls_fix_options*
+go_gopls_fix_options
+g:ale_go_gopls_fix_options
   Type: |String|
   Default: `''`
 
   Options to pass to the gopls fixer.
 
-
-g:ale_go_gopls_init_options                       *g:ale_go_gopls_init_options*
+                                            *ale-options.go_gopls_init_options*
+                                                  *g:ale_go_gopls_init_options*
                                                   *b:ale_go_gopls_init_options*
+go_gopls_init_options
+g:ale_go_gopls_init_options
   Type: |Dictionary|
   Default: `{}`
 
   LSP initialization options passed to gopls. This can be used to configure
   the behaviour of gopls.
 
-  Example: >
-  let g:ale_go_gopls_init_options = {'ui.diagnostic.analyses': {
-        \ 'composites': v:false,
-        \ 'unusedparams': v:true,
-        \ 'unusedresult': v:true,
-        \ }}
+  For example: >
+  let g:ale_go_gopls_init_options = {
+  \   'ui.diagnostic.analyses': {
+  \       'composites': v:false,
+  \       'unusedparams': v:true,
+  \       'unusedresult': v:true,
+  \   },
+  \}
 <
-
   For a full list of supported analyzers, see:
   https://github.com/golang/tools/blob/master/gopls/doc/analyzers.md
 
-
-g:ale_go_gopls_use_global                           *g:ale_go_gopls_use_global*
+                                              *ale-options.go_gopls_use_global*
+                                                    *g:ale_go_gopls_use_global*
                                                     *b:ale_go_gopls_use_global*
+go_gopls_use_global
+g:ale_go_gopls_use_global
   Type: |String|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
@@ -253,8 +309,11 @@ g:ale_go_gopls_use_global                           *g:ale_go_gopls_use_global*
 ===============================================================================
 govet                                                            *ale-go-govet*
 
-g:ale_go_govet_options                                 *g:ale_go_govet_options*
+                                                 *ale-options.go_govet_options*
+                                                       *g:ale_go_govet_options*
                                                        *b:ale_go_govet_options*
+go_govet_options
+g:ale_go_govet_options
   Type: |String|
   Default: `''`
 
@@ -264,16 +323,21 @@ g:ale_go_govet_options                                 *g:ale_go_govet_options*
 ===============================================================================
 revive                                                          *ale-go-revive*
 
-g:ale_go_revive_executable                         *g:ale_go_revive_executable*
+                                             *ale-options.go_revive_executable*
+                                                   *g:ale_go_revive_executable*
                                                    *b:ale_go_revive_executable*
+go_revive_executable
+g:ale_go_revive_executable
   Type: |String|
   Default: `'revive'`
 
   This variable can be set to change the revive executable path.
 
-
-g:ale_go_revive_options                               *g:ale_go_revive_options*
+                                                *ale-options.go_revive_options*
+                                                      *g:ale_go_revive_options*
                                                       *b:ale_go_revive_options*
+go_revive_options
+g:ale_go_revive_options
   Type: |String|
   Default: `''`
 
@@ -283,8 +347,11 @@ g:ale_go_revive_options                               *g:ale_go_revive_options*
 ===============================================================================
 staticcheck                                                *ale-go-staticcheck*
 
-g:ale_go_staticcheck_executable               *g:ale_go_staticcheck_executable*
+                                        *ale-options.go_staticcheck_executable*
+                                              *g:ale_go_staticcheck_executable*
                                               *b:ale_go_staticcheck_executable*
+go_staticcheck_executable
+g:ale_go_staticcheck_executable
   Type: |String|
   Default: `'staticcheck'`
 
@@ -294,27 +361,33 @@ g:ale_go_staticcheck_executable               *g:ale_go_staticcheck_executable*
   default, and fall back on a globally installed `staticcheck` if it can't be
   found otherwise.
 
-
-g:ale_go_staticcheck_options                     *g:ale_go_staticcheck_options*
+                                           *ale-options.go_staticcheck_options*
+                                                 *g:ale_go_staticcheck_options*
                                                  *b:ale_go_staticcheck_options*
+go_staticcheck_options
+g:ale_go_staticcheck_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass additional options to the staticcheck
   linter.
 
-
-g:ale_go_staticcheck_lint_package           *g:ale_go_staticcheck_lint_package*
+                                      *ale-options.go_staticcheck_lint_package*
+                                            *g:ale_go_staticcheck_lint_package*
                                             *b:ale_go_staticcheck_lint_package*
+go_staticcheck_lint_package
+g:ale_go_staticcheck_lint_package
   Type: |Number|
   Default: `1`
 
   When set to `1`, the whole Go package will be checked instead of only the
   current file.
 
-
-g:ale_go_staticcheck_use_global               *g:ale_go_staticcheck_use_global*
+                                        *ale-options.go_staticcheck_use_global*
+                                              *g:ale_go_staticcheck_use_global*
                                               *b:ale_go_staticcheck_use_global*
+go_staticcheck_use_global
+g:ale_go_staticcheck_use_global
   Type: |String|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 

--- a/doc/ale-groovy.txt
+++ b/doc/ale-groovy.txt
@@ -12,24 +12,31 @@ Linting and fixing of Groovy files is enabled with the integration of
 ===============================================================================
 npm-groovy-lint                                    *ale-groovy-npm-groovy-lint*
 
-g:ale_groovy_npmgroovylint_executable   *g:ale_groovy_npmgroovylint_executable*
+                                  *ale-options.groovy_npmgroovylint_executable*
+                                        *g:ale_groovy_npmgroovylint_executable*
                                         *b:ale_groovy_npmgroovylint_executable*
+groovy_npmgroovylint_executable
+g:ale_groovy_npmgroovylint_executable
   Type: |String|
   Default: `'npm-groovy-lint'`
 
   Location of the npm-groovy-lint binary file.
 
-
-g:ale_groovy_npmgroovylint_options         *g:ale_groovy_npmgroovylint_options*
+                                     *ale-options.groovy_npmgroovylint_options*
+                                           *g:ale_groovy_npmgroovylint_options*
                                            *b:ale_groovy_npmgroovylint_options*
+groovy_npmgroovylint_options
+g:ale_groovy_npmgroovylint_options
   Type: |String|
   Default: `'--loglevel warning'`
 
   Additional npm-groovy-lint linter options.
 
-
-g:ale_groovy_npmgroovylint_fix_options *g:ale_groovy_npmgroovylint_fix_options*
+                                 *ale-options.groovy_npmgroovylint_fix_options*
+                                       *g:ale_groovy_npmgroovylint_fix_options*
                                        *b:ale_groovy_npmgroovylint_fix_options*
+groovy_npmgroovylint_fix_options
+g:ale_groovy_npmgroovylint_fix_options
   Type: |String|
   Default: `'--fix'`
 

--- a/doc/ale-hack.txt
+++ b/doc/ale-hack.txt
@@ -4,18 +4,23 @@ ALE Hack Integration                                         *ale-hack-options*
 
   HHAST is disabled by default, as it executes code in the project root.
 
-  Currently linters must be enabled globally.  HHAST can be enabled with:
+  Currently linters must be enabled globally. HHAST can be enabled in ftplugin
+  files like so: >
 
->
-  let g:ale_linters = {'hack': ['hack', 'hhast']}
+  let b:ale_linters = ['hack', 'hhast']
+<
+  Or in Lua: >
+  require("ale").setup.buffer({linters = {"hack", "hhast"}})
 <
 
 ===============================================================================
 hack                                                            *ale-hack-hack*
 
-g:ale_hack_hack_executable                         *g:ale_hack_hack_executable*
+                                             *ale-options.hack_hack_executable*
+                                                   *g:ale_hack_hack_executable*
                                                    *b:ale_hack_hack_executable*
-
+hack_hack_executable
+g:ale_hack_hack_executable
   Type: |String|
   Default: `'hh_client'`
 
@@ -26,8 +31,11 @@ g:ale_hack_hack_executable                         *g:ale_hack_hack_executable*
 ===============================================================================
 hackfmt                                                      *ale-hack-hackfmt*
 
-g:ale_hack_hackfmt_options                         *g:ale_hack_hackfmt_options*
+                                             *ale-options.hack_hackfmt_options*
+                                                   *g:ale_hack_hackfmt_options*
                                                    *b:ale_hack_hackfmt_options*
+hack_hackfmt_options
+g:ale_hack_hackfmt_options
   Type: |String|
   Default: `''`
 
@@ -37,9 +45,11 @@ g:ale_hack_hackfmt_options                         *g:ale_hack_hackfmt_options*
 ===============================================================================
 hhast                                                          *ale-hack-hhast*
 
-g:ale_hack_hhast_executable                       *g:ale_hack_hhast_executable*
+                                            *ale-options.hack_hhast_executable*
+                                                  *g:ale_hack_hhast_executable*
                                                   *b:ale_hack_hhast_executable*
-
+hack_hhast_executable
+g:ale_hack_hhast_executable
   Type: |String|
   Default: `'vendor/bin/hhast-lint'`
 

--- a/doc/ale-handlebars.txt
+++ b/doc/ale-handlebars.txt
@@ -7,7 +7,6 @@ djlint                                                  *ale-handlebars-djlint*
 
 See |ale-html-djlint|
 
-===============================================================================
 
 ===============================================================================
 prettier                                              *ale-handlebars-prettier*
@@ -19,18 +18,21 @@ Uses glimmer parser by default.
 ===============================================================================
 ember-template-lint                          *ale-handlebars-embertemplatelint*
 
-g:ale_handlebars_embertemplatelint_executable
+                          *ale-options.handlebars_embertemplatelint_executable*
                                 *g:ale_handlebars_embertemplatelint_executable*
                                 *b:ale_handlebars_embertemplatelint_executable*
+handlebars_embertemplatelint_executable
+g:ale_handlebars_embertemplatelint_executable
   Type: |String|
   Default: `'ember-template-lint'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_handlebars_embertemplatelint_use_global
+                          *ale-options.handlebars_embertemplatelint_use_global*
                                 *g:ale_handlebars_embertemplatelint_use_global*
                                 *b:ale_handlebars_embertemplatelint_use_global*
+handlebars_embertemplatelint_use_global
+g:ale_handlebars_embertemplatelint_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 

--- a/doc/ale-haskell.txt
+++ b/doc/ale-haskell.txt
@@ -5,8 +5,11 @@ ALE Haskell Integration                                   *ale-haskell-options*
 ===============================================================================
 brittany                                                 *ale-haskell-brittany*
 
-g:ale_haskell_brittany_executable           *g:ale_haskell_brittany_executable*
+                                      *ale-options.haskell_brittany_executable*
+                                            *g:ale_haskell_brittany_executable*
                                             *b:ale_haskell_brittany_executable*
+haskell_brittany_executable
+g:ale_haskell_brittany_executable
   Type: |String|
   Default: `'brittany'`
 
@@ -22,8 +25,11 @@ See |ale-cspell-options|
 ===============================================================================
 floskell                                                 *ale-haskell-floskell*
 
-g:ale_haskell_floskell_executable           *g:ale_haskell_floskell_executable*
+                                      *ale-options.haskell_floskell_executable*
+                                            *g:ale_haskell_floskell_executable*
                                             *b:ale_haskell_floskell_executable*
+haskell_floskell_executable
+g:ale_haskell_floskell_executable
   Type: |String|
   Default: `'floskell'`
 
@@ -33,8 +39,11 @@ g:ale_haskell_floskell_executable           *g:ale_haskell_floskell_executable*
 ===============================================================================
 ghc                                                           *ale-haskell-ghc*
 
-g:ale_haskell_ghc_options                           *g:ale_haskell_ghc_options*
+                                              *ale-options.haskell_ghc_options*
+                                                    *g:ale_haskell_ghc_options*
                                                     *b:ale_haskell_ghc_options*
+haskell_ghc_options
+g:ale_haskell_ghc_options
   Type: |String|
   Default: `'-fno-code -v0'`
 
@@ -44,8 +53,11 @@ g:ale_haskell_ghc_options                           *g:ale_haskell_ghc_options*
 ===============================================================================
 ghc-mod                                                   *ale-haskell-ghc-mod*
 
-g:ale_haskell_ghc_mod_executable             *g:ale_haskell_ghc_mod_executable*
+                                       *ale-options.haskell_ghc_mod_executable*
+                                             *g:ale_haskell_ghc_mod_executable*
                                              *b:ale_haskell_ghc_mod_executable*
+haskell_ghc_mod_executable
+g:ale_haskell_ghc_mod_executable
   Type: |String|
   Default: `'ghc-mod'`
 
@@ -55,8 +67,11 @@ g:ale_haskell_ghc_mod_executable             *g:ale_haskell_ghc_mod_executable*
 ===============================================================================
 cabal-ghc                                               *ale-haskell-cabal-ghc*
 
-g:ale_haskell_cabal_ghc_options               *g:ale_haskell_cabal_ghc_options*
+                                        *ale-options.haskell_cabal_ghc_options*
+                                              *g:ale_haskell_cabal_ghc_options*
                                               *b:ale_haskell_cabal_ghc_options*
+haskell_cabal_ghc_options
+g:ale_haskell_cabal_ghc_options
   Type: |String|
   Default: `'-fno-code -v0'`
 
@@ -67,16 +82,21 @@ g:ale_haskell_cabal_ghc_options               *g:ale_haskell_cabal_ghc_options*
 ===============================================================================
 hdevtools                                               *ale-haskell-hdevtools*
 
-g:ale_haskell_hdevtools_executable         *g:ale_haskell_hdevtools_executable*
+                                     *ale-options.haskell_hdevtools_executable*
+                                           *g:ale_haskell_hdevtools_executable*
                                            *b:ale_haskell_hdevtools_executable*
+haskell_hdevtools_executable
+g:ale_haskell_hdevtools_executable
   Type: |String|
   Default: `'hdevtools'`
 
   This variable can be changed to use a different executable for hdevtools.
 
-
-g:ale_haskell_hdevtools_options               *g:ale_haskell_hdevtools_options*
+                                        *ale-options.haskell_hdevtools_options*
+                                              *g:ale_haskell_hdevtools_options*
                                               *b:ale_haskell_hdevtools_options*
+haskell_hdevtools_options
+g:ale_haskell_hdevtools_options
   Type: |String|
   Default: `get(g:, 'hdevtools_options', '-g -Wall')`
 
@@ -91,8 +111,11 @@ g:ale_haskell_hdevtools_options               *g:ale_haskell_hdevtools_options*
 ===============================================================================
 hfmt                                                         *ale-haskell-hfmt*
 
-g:ale_haskell_hfmt_executable                   *g:ale_haskell_hfmt_executable*
+                                          *ale-options.haskell_hfmt_executable*
+                                                *g:ale_haskell_hfmt_executable*
                                                 *b:ale_haskell_hfmt_executable*
+haskell_hfmt_executable
+g:ale_haskell_hfmt_executable
   Type: |String|
   Default: `'hfmt'`
 
@@ -102,8 +125,11 @@ g:ale_haskell_hfmt_executable                   *g:ale_haskell_hfmt_executable*
 ===============================================================================
 hindent                                                   *ale-haskell-hindent*
 
-g:ale_haskell_hindent_executable             *g:ale_haskell_hindent_executable*
+                                       *ale-options.haskell_hindent_executable*
+                                             *g:ale_haskell_hindent_executable*
                                              *b:ale_haskell_hindent_executable*
+haskell_hindent_executable
+g:ale_haskell_hindent_executable
   Type: |String|
   Default: `'hindent'`
 
@@ -113,16 +139,21 @@ g:ale_haskell_hindent_executable             *g:ale_haskell_hindent_executable*
 ===============================================================================
 hlint                                                       *ale-haskell-hlint*
 
-g:ale_haskell_hlint_executable                 *g:ale_haskell_hlint_executable*
+                                         *ale-options.haskell_hlint_executable*
+                                               *g:ale_haskell_hlint_executable*
                                                *b:ale_haskell_hlint_executable*
+haskell_hlint_executable
+g:ale_haskell_hlint_executable
   Type: |String|
   Default: `'hlint'`
 
   This variable can be changed to use a different executable for hlint.
 
-
-g:ale_haskell_hlint_options                       g:ale_haskell_hlint_options
-                                                  b:ale_haskell_hlint_options
+                                            *ale-options.haskell_hlint_options*
+                                                  *g:ale_haskell_hlint_options*
+                                                  *b:ale_haskell_hlint_options*
+haskell_hlint_options
+g:ale_haskell_hlint_options
   Type: |String|
   Default: `''`
 
@@ -133,17 +164,22 @@ g:ale_haskell_hlint_options                       g:ale_haskell_hlint_options
 ===============================================================================
 hls                                                           *ale-haskell-hls*
 
-g:ale_haskell_hls_executable                     *g:ale_haskell_hls_executable*
+                                           *ale-options.haskell_hls_executable*
+                                                 *g:ale_haskell_hls_executable*
                                                  *b:ale_haskell_hls_executable*
+haskell_hls_executable
+g:ale_haskell_hls_executable
   Type: |String|
   Default: `'haskell-language-server-wrapper'`
 
   This variable can be changed to use a different executable for the haskell
   language server.
 
-
-g:ale_haskell_hls_config                             *g:ale_haskell_hls_config*
+                                               *ale-options.haskell_hls_config*
+                                                     *g:ale_haskell_hls_config*
                                                      *b:ale_haskell_hls_config*
+haskell_hls_config
+g:ale_haskell_hls_config
   Type: |Dictionary|
   Default: `{}`
 
@@ -159,8 +195,11 @@ g:ale_haskell_hls_config                             *g:ale_haskell_hls_config*
 ===============================================================================
 stack-build                                           *ale-haskell-stack-build*
 
-g:ale_haskell_stack_build_options           *g:ale_haskell_stack_build_options*
+                                      *ale-options.haskell_stack_build_options*
+                                            *g:ale_haskell_stack_build_options*
                                             *b:ale_haskell_stack_build_options*
+haskell_stack_build_options
+g:ale_haskell_stack_build_options
   Type: |String|
   Default: `'--fast'`
 
@@ -171,8 +210,11 @@ g:ale_haskell_stack_build_options           *g:ale_haskell_stack_build_options*
 ===============================================================================
 stack-ghc                                               *ale-haskell-stack-ghc*
 
-g:ale_haskell_stack_ghc_options               *g:ale_haskell_stack_ghc_options*
+                                        *ale-options.haskell_stack_ghc_options*
+                                              *g:ale_haskell_stack_ghc_options*
                                               *b:ale_haskell_stack_ghc_options*
+haskell_stack_ghc_options
+g:ale_haskell_stack_ghc_options
   Type: |String|
   Default: `'-fno-code -v0'`
 
@@ -183,9 +225,11 @@ g:ale_haskell_stack_ghc_options               *g:ale_haskell_stack_ghc_options*
 ===============================================================================
 stylish-haskell                                   *ale-haskell-stylish-haskell*
 
-g:ale_haskell_stylish_haskell_executable
+                               *ale-options.haskell_stylish_haskell_executable*
                                      *g:ale_haskell_stylish_haskell_executable*
                                      *b:ale_haskell_stylish_haskell_executable*
+haskell_stylish_haskell_executable
+g:ale_haskell_stylish_haskell_executable
   Type: |String|
   Default: `'stylish-haskell'`
 
@@ -195,8 +239,11 @@ g:ale_haskell_stylish_haskell_executable
 ===============================================================================
 hie                                                           *ale-haskell-hie*
 
-g:ale_haskell_hie_executable                     *g:ale_haskell_hie_executable*
+                                           *ale-options.haskell_hie_executable*
+                                                 *g:ale_haskell_hie_executable*
                                                  *b:ale_haskell_hie_executable*
+haskell_hie_executable
+g:ale_haskell_hie_executable
   Type: |String|
   Default: `'hie'`
 
@@ -207,16 +254,21 @@ g:ale_haskell_hie_executable                     *g:ale_haskell_hie_executable*
 ===============================================================================
 ormolu                                                     *ale-haskell-ormolu*
 
-g:ale_haskell_ormolu_executable               *g:ale_haskell_ormolu_executable*
+                                        *ale-options.haskell_ormolu_executable*
+                                              *g:ale_haskell_ormolu_executable*
                                               *b:ale_haskell_ormolu_executable*
+haskell_ormolu_executable
+g:ale_haskell_ormolu_executable
   Type: |String|
   Default: `'ormolu'`
 
   This variable can be changed to use a different executable for ormolu.
 
-
-g:ale_haskell_ormolu_options                     *g:ale_haskell_ormolu_options*
+                                           *ale-options.haskell_ormolu_options*
+                                                 *g:ale_haskell_ormolu_options*
                                                  *b:ale_haskell_ormolu_options*
+haskell_ormolu_options
+g:ale_haskell_ormolu_options
   Type: |String|
   Default: `''`
 
@@ -227,16 +279,21 @@ g:ale_haskell_ormolu_options                     *g:ale_haskell_ormolu_options*
 ===============================================================================
 fourmolu                                                 *ale-haskell-fourmolu*
 
-g:ale_haskell_fourmolu_executable           *g:ale_haskell_fourmolu_executable*
+                                      *ale-options.haskell_fourmolu_executable*
+                                            *g:ale_haskell_fourmolu_executable*
                                             *b:ale_haskell_fourmolu_executable*
+haskell_fourmolu_executable
+g:ale_haskell_fourmolu_executable
   Type: |String|
   Default: `'fourmolu'`
 
   This variable can be changed to use a different executable for fourmolu.
 
-
-g:ale_haskell_fourmolu_options                 *g:ale_haskell_fourmolu_options*
+                                         *ale-options.haskell_fourmolu_options*
+                                               *g:ale_haskell_fourmolu_options*
                                                *b:ale_haskell_fourmolu_options*
+haskell_fourmolu_options
+g:ale_haskell_fourmolu_options
   Type: |String|
   Default: `''`
 

--- a/doc/ale-html.txt
+++ b/doc/ale-html.txt
@@ -11,17 +11,21 @@ ALE supports language server features for Angular. You can install it via `npm`:
 <
 Angular 11 and up are supported.
 
-
-g:ale_html_angular_executable                   *g:ale_html_angular_executable*
+                                          *ale-options.html_angular_executable*
+                                                *g:ale_html_angular_executable*
                                                 *b:ale_html_angular_executable*
+html_angular_executable
+g:ale_html_angular_executable
   Type: |String|
   Default: `'ngserver'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_html_angular_use_global                   *g:ale_html_angular_use_global*
+                                          *ale-options.html_angular_use_global*
+                                                *g:ale_html_angular_use_global*
                                                 *b:ale_html_angular_use_global*
+html_angular_use_global
+g:ale_html_angular_use_global
   Type: |String|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
@@ -33,22 +37,28 @@ cspell                                                        *ale-html-cspell*
 
 See |ale-cspell-options|
 
+
 ===============================================================================
 djlint                                                        *ale-html-djlint*
 
 `djlint` options for HTML are the same as the options for htmlangular,
 htmldjango, jinja, handlebars, nunjucks and gotmplhtml.
 
-g:ale_html_djlint_executable                     *g:ale_html_djlint_executable*
+                                           *ale-options.html_djlint_executable*
+                                                 *g:ale_html_djlint_executable*
                                                  *b:ale_html_djlint_executable*
+html_djlint_executable
+g:ale_html_djlint_executable
   Type: |String|
   Default: `'djlint'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_html_djlint_options                            *g:ale_html_djlint_options*
-                                                     *b:ale_html_djlint_options*
+                                              *ale-options.html_djlint_options*
+                                                    *g:ale_html_djlint_options*
+                                                    *b:ale_html_djlint_options*
+html_djlint_options
+g:ale_html_djlint_options
   Type: |String|
   Default: `''`
 
@@ -67,24 +77,31 @@ See: |ale-javascript-fecs|.
 ===============================================================================
 html-beautify                                               *ale-html-beautify*
 
-g:ale_html_beautify_executable                 *g:ale_html_beautify_executable*
+                                         *ale-options.html_beautify_executable*
+                                               *g:ale_html_beautify_executable*
                                                *b:ale_html_beautify_executable*
+html_beautify_executable
+g:ale_html_beautify_executable
   Type: |String|
   Default: `'html-beautify'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_html_beautify_options                       *g:ale_html_beautify_options*
+                                            *ale-options.html_beautify_options*
+                                                  *g:ale_html_beautify_options*
                                                   *b:ale_html_beautify_options*
+html_beautify_options
+g:ale_html_beautify_options
   Type: |String|
   Default: `''`
 
   This variable can be changed to modify flags given to html-beautify.
 
-
-g:ale_html_beautify_use_global                 *g:ale_html_beautify_use_global*
+                                         *ale-options.html_beautify_use_global*
+                                               *g:ale_html_beautify_use_global*
                                                *b:ale_html_beautify_use_global*
+html_beautify_use_global
+g:ale_html_beautify_use_global
   Type: |String|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
@@ -94,24 +111,31 @@ g:ale_html_beautify_use_global                 *g:ale_html_beautify_use_global*
 ===============================================================================
 htmlhint                                                    *ale-html-htmlhint*
 
-g:ale_html_htmlhint_executable                 *g:ale_html_htmlhint_executable*
+                                         *ale-options.html_htmlhint_executable*
+                                               *g:ale_html_htmlhint_executable*
                                                *b:ale_html_htmlhint_executable*
+html_htmlhint_executable
+g:ale_html_htmlhint_executable
   Type: |String|
   Default: `'htmlhint'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_html_htmlhint_options                       *g:ale_html_htmlhint_options*
+                                            *ale-options.html_htmlhint_options*
+                                                  *g:ale_html_htmlhint_options*
                                                   *b:ale_html_htmlhint_options*
+html_htmlhint_options
+g:ale_html_htmlhint_options
   Type: |String|
   Default: `''`
 
   This variable can be changed to modify flags given to HTMLHint.
 
-
-g:ale_html_htmlhint_use_global                 *g:ale_html_htmlhint_use_global*
+                                         *ale-options.html_htmlhint_use_global*
+                                               *g:ale_html_htmlhint_use_global*
                                                *b:ale_html_htmlhint_use_global*
+html_htmlhint_use_global
+g:ale_html_htmlhint_use_global
   Type: |String|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
@@ -127,16 +151,21 @@ See |ale-javascript-prettier| for information about the available options.
 ===============================================================================
 rustywind                                                  *ale-html-rustywind*
 
-g:ale_html_rustywind_executable               *g:ale_html_rustywind_executable*
+                                        *ale-options.html_rustywind_executable*
+                                              *g:ale_html_rustywind_executable*
                                               *b:ale_html_rustywind_executable*
+html_rustywind_executable
+g:ale_html_rustywind_executable
   Type: |String|
   Default: `'rustywind'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_html_rustywind_options                     *g:ale_html_rustywind_options*
+                                           *ale-options.html_rustywind_options*
+                                                 *g:ale_html_rustywind_options*
                                                  *b:ale_html_rustywind_options*
+html_rustywind_options
+g:ale_html_rustywind_options
   Type: |String|
   Default: `''`
 
@@ -146,24 +175,31 @@ g:ale_html_rustywind_options                     *g:ale_html_rustywind_options*
 ===============================================================================
 stylelint                                                  *ale-html-stylelint*
 
-g:ale_html_stylelint_executable               *g:ale_html_stylelint_executable*
+                                        *ale-options.html_stylelint_executable*
+                                              *g:ale_html_stylelint_executable*
                                               *b:ale_html_stylelint_executable*
+html_stylelint_executable
+g:ale_html_stylelint_executable
   Type: |String|
   Default: `'stylelint'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_html_stylelint_options                     *g:ale_html_stylelint_options*
+                                           *ale-options.html_stylelint_options*
+                                                 *g:ale_html_stylelint_options*
                                                  *b:ale_html_stylelint_options*
+html_stylelint_options
+g:ale_html_stylelint_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass additional options to stylelint.
 
-
-g:ale_html_stylelint_use_global               *g:ale_html_stylelint_use_global*
+                                        *ale-options.html_stylelint_use_global*
+                                              *g:ale_html_stylelint_use_global*
                                               *b:ale_html_stylelint_use_global*
+html_stylelint_use_global
+g:ale_html_stylelint_use_global
   Type: |String|
   Default: `0`
 
@@ -188,16 +224,24 @@ To use `tidy` on macOS, please install the latest version with Homebrew:
 <
 `/usr/local/bin/tidy` is installed.
 
-g:ale_html_tidy_executable                         *g:ale_html_tidy_executable*
+
+-------------------------------------------------------------------------------
+Options
+                                             *ale-options.html_tidy_executable*
+                                                   *g:ale_html_tidy_executable*
                                                    *b:ale_html_tidy_executable*
+html_tidy_executable
+g:ale_html_tidy_executable
   Type: |String|
   Default: `'tidy'`
 
   This variable can be changed to change the path to tidy.
 
-
-g:ale_html_tidy_options                               *g:ale_html_tidy_options*
+                                                *ale-options.html_tidy_options*
+                                                      *g:ale_html_tidy_options*
                                                       *b:ale_html_tidy_options*
+html_tidy_options
+g:ale_html_tidy_options
   Type: |String|
   Default: `'-q -e -language en'`
 
@@ -211,9 +255,10 @@ g:ale_html_tidy_options                               *g:ale_html_tidy_options*
   cp850 (ibm858), cp932 (shiftjis), iso-2022-jp (iso-2022), latin1, macroman
   (mac), sjis (shiftjis), utf-16le, utf-16, utf-8
 
-
-g:ale_html_tidy_use_global                             *g:html_tidy_use_global*
-
+                                             *ale-options.html_tidy_use_global*
+                                                   *g:ale_html_tidy_use_global*
+html_tidy_use_global
+g:ale_html_tidy_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
@@ -225,8 +270,9 @@ vscodehtml                                                    *ale-html-vscode*
 
 Website: https://github.com/hrsh7th/vscode-langservers-extracted
 
-Installation
+
 -------------------------------------------------------------------------------
+Installation
 
 Install VSCode html language server either globally or locally: >
 

--- a/doc/ale-http.txt
+++ b/doc/ale-http.txt
@@ -5,8 +5,11 @@ ALE HTTP Integration                                         *ale-http-options*
 ===============================================================================
 kulala_fmt                                                *ale-http-kulala_fmt*
 
-g:ale_http_kulala_fmt                        *g:ale_http_kulala_fmt_executable*
+                                       *ale-options.http_kulala_fmt_executable*
+                                             *g:ale_http_kulala_fmt_executable*
                                              *b:ale_http_kulala_fmt_executable*
+http_kulala_fmt
+g:ale_http_kulala_fmt
   Type: |String|
   Default: `'kulala_fmt'`
 

--- a/doc/ale-hurl.txt
+++ b/doc/ale-hurl.txt
@@ -5,8 +5,11 @@ ALE Hurl Integration                                         *ale-hurl-options*
 ===============================================================================
 hurlfmt                                                      *ale-hurl-hurlfmt*
 
-g:ale_hurl_hurlfmt_executable                   *g:ale_hurl_hurlfmt_executable*
+                                          *ale-options.hurl_hurlfmt_executable*
+                                                *g:ale_hurl_hurlfmt_executable*
                                                 *b:ale_hurl_hurlfmt_executable*
+hurl_hurlfmt_executable
+g:ale_hurl_hurlfmt_executable
   Type: |String|
   Default: `'hurlfmt'`
 

--- a/doc/ale-idris.txt
+++ b/doc/ale-idris.txt
@@ -1,23 +1,30 @@
 ===============================================================================
 ALE Idris Integration                                       *ale-idris-options*
 
+
 ===============================================================================
 idris                                                         *ale-idris-idris*
 
-g:ale_idris_idris_executable                     *g:ale_idris_idris_executable*
+                                           *ale-options.idris_idris_executable*
+                                                 *g:ale_idris_idris_executable*
                                                  *b:ale_idris_idris_executable*
+idris_idris_executable
+g:ale_idris_idris_executable
   Type: |String|
   Default: `'idris'`
 
   This variable can be changed to change the path to idris.
 
-
-g:ale_idris_idris_options                           *g:ale_idris_idris_options*
+                                              *ale-options.idris_idris_options*
+                                                    *g:ale_idris_idris_options*
                                                     *b:ale_idris_idris_options*
+idris_idris_options
+g:ale_idris_idris_options
   Type: |String|
   Default: `'--total --warnpartial --warnreach --warnipkg'`
 
   This variable can be changed to modify flags given to idris.
+
 
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-ink.txt
+++ b/doc/ale-ink.txt
@@ -5,19 +5,23 @@ ALE Ink Integration                                           *ale-ink-options*
 ===============================================================================
 ink-language-server                                   *ale-ink-language-server*
 
-Ink Language Server
-  (https://github.com/ephraim/ink-language-server)
+Ink Language Server - https://github.com/ephraim/ink-language-server
 
-g:ale_ink_ls_executable                               g:ale_ink_ls_executable
-                                                      b:ale_ink_ls_executable
+                                                *ale-options.ink_ls_executable*
+                                                      *g:ale_ink_ls_executable*
+                                                      *b:ale_ink_ls_executable*
+ink_ls_executable
+g:ale_ink_ls_executable
   Type: |String|
   Default: `'ink-language-server'`
 
   Ink language server executable.
 
+                                    *ale-options.ink_ls_initialization_options*
+                                          *g:ale_ink_ls_initialization_options*
+                                          *b:ale_ink_ls_initialization_options*
+ink_ls_initialization_options
 g:ale_ink_ls_initialization_options
-                                          g:ale_ink_ls_initialization_options
-                                          b:ale_ink_ls_initialization_options
   Type: |Dictionary|
   Default: `{}`
 
@@ -27,14 +31,16 @@ g:ale_ink_ls_initialization_options
   change these settings - see the ink-language-server website for more
   information.
 
-  An example of setting non-default options:
-		{
-		\  'ink': {
-		\    'mainStoryPath': 'init.ink',
-		\    'inklecateExecutablePath': '/usr/local/bin/inklecate',
-		\    'runThroughMono': v:false
-		\  }
-		\}
+  An example of setting non-default options: >
+
+  let g:ale_ink_ls_initialization_options = {
+  \   'ink': {
+  \       'mainStoryPath': 'init.ink',
+  \       'inklecateExecutablePath': '/usr/local/bin/inklecate',
+  \       'runThroughMono': v:false,
+  \   },
+  \}
+<
 
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-inko.txt
+++ b/doc/ale-inko.txt
@@ -2,16 +2,15 @@
 ALE Inko Integration                                         *ale-inko-options*
                                                          *ale-integration-inko*
 
-===============================================================================
-Integration Information
-
-  Currently, the only supported linter for Inko is the Inko compiler itself.
 
 ===============================================================================
 inko                                                            *ale-inko-inko*
 
-g:ale_inko_inko_executable                         *g:ale_inko_inko_executable*
+                                             *ale-options.inko_inko_executable*
+                                                   *g:ale_inko_inko_executable*
                                                    *b:ale_inko_inko_executable*
+inko_inko_executable
+g:ale_inko_inko_executable
   Type: |String|
   Default: `'inko'`
 

--- a/doc/ale-ispc.txt
+++ b/doc/ale-ispc.txt
@@ -5,20 +5,26 @@ ALE ISPC Integration                                         *ale-ispc-options*
 ===============================================================================
 ispc                                                            *ale-ispc-ispc*
 
-g:ale_ispc_ispc_executable                         *g:ale_ispc_ispc_executable*
+                                             *ale-options.ispc_ispc_executable*
+                                                   *g:ale_ispc_ispc_executable*
                                                    *b:ale_ispc_ispc_executable*
+ispc_ispc_executable
+g:ale_ispc_ispc_executable
   Type: |String|
   Default: `'ispc'`
 
   This variable can be changed to use a different executable for ispc.
 
-
-g:ale_ispc_ispc_options                               *g:ale_ispc_ispc_options*
+                                                *ale-options.ispc_ispc_options*
+                                                      *g:ale_ispc_ispc_options*
                                                       *b:ale_ispc_ispc_options*
+ispc_ispc_options
+g:ale_ispc_ispc_options
   Type: |String|
   Default: `''`
 
   This variable can be changed to modify flags given to ispc.
+
 
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-java.txt
+++ b/doc/ale-java.txt
@@ -5,9 +5,11 @@ ALE Java Integration                                         *ale-java-options*
 ===============================================================================
 checkstyle                                                *ale-java-checkstyle*
 
-g:ale_java_checkstyle_config                     *g:ale_java_checkstyle_config*
+                                           *ale-options.java_checkstyle_config*
+                                                 *g:ale_java_checkstyle_config*
                                                  *b:ale_java_checkstyle_config*
-
+java_checkstyle_config
+g:ale_java_checkstyle_config
   Type: |String|
   Default: `'/google_checks.xml'`
 
@@ -19,19 +21,21 @@ g:ale_java_checkstyle_config                     *g:ale_java_checkstyle_config*
   The path to the configuration file can be an absolute path or a relative
   path. ALE will search for the relative path in parent directories.
 
-
-g:ale_java_checkstyle_executable             *g:ale_java_checkstyle_executable*
+                                       *ale-options.java_checkstyle_executable*
+                                             *g:ale_java_checkstyle_executable*
                                              *b:ale_java_checkstyle_executable*
-
+java_checkstyle_executable
+g:ale_java_checkstyle_executable
   Type: |String|
   Default: `'checkstyle'`
 
   This variable can be changed to modify the executable used for checkstyle.
 
-
-g:ale_java_checkstyle_options                   *g:ale_java_checkstyle_options*
+                                          *ale-options.java_checkstyle_options*
+                                                *g:ale_java_checkstyle_options*
                                                 *b:ale_java_checkstyle_options*
-
+java_checkstyle_options
+g:ale_java_checkstyle_options
   Type: |String|
   Default: `''`
 
@@ -57,68 +61,80 @@ See |ale-cspell-options|
 ===============================================================================
 javac                                                          *ale-java-javac*
 
-g:ale_java_javac_classpath                         *g:ale_java_javac_classpath*
+                                             *ale-options.java_javac_classpath*
+                                                   *g:ale_java_javac_classpath*
                                                    *b:ale_java_javac_classpath*
+java_javac_classpath
+g:ale_java_javac_classpath
   Type: |String| or |List|
   Default: `''`
 
   This variable can be set to change the global classpath for Java.
 
-
-g:ale_java_javac_executable                       *g:ale_java_javac_executable*
+                                            *ale-options.java_javac_executable*
+                                                  *g:ale_java_javac_executable*
                                                   *b:ale_java_javac_executable*
+java_javac_executable
+g:ale_java_javac_executable
   Type: |String|
   Default: `'javac'`
 
   This variable can be set to change the executable path used for javac.
 
-
-g:ale_java_javac_options                             *g:ale_java_javac_options*
+                                               *ale-options.java_javac_options*
+                                                     *g:ale_java_javac_options*
                                                      *b:ale_java_javac_options*
+java_javac_options
+g:ale_java_javac_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass additional options to javac.
 
-g:ale_java_javac_sourcepath                       *g:ale_java_javac_sourcepath*
+                                            *ale-options.java_javac_sourcepath*
+                                                  *g:ale_java_javac_sourcepath*
                                                   *b:ale_java_javac_sourcepath*
+java_javac_sourcepath
+g:ale_java_javac_sourcepath
   Type: |String| or |List|
   Default: `''`
 
-This variable can set multiple source code paths, the source code path is a
-relative path (relative to the project root directory).
+  This variable can set multiple source code paths, the source code path is a
+  relative path (relative to the project root directory).
 
-Example:
+  The source path can be set as a String with a system-dependent path
+  separator. Note that the Unix path separator is a colon (`:`), and on
+  Windows the path separator is a semicolon (`;`). >
 
-String type:
-Note that the unix system separator is a colon(`:`) window system
-is a semicolon(`;`).
->
   let g:ale_java_javac_sourcepath = 'build/gen/source/xx/main:build/gen/source'
 <
-List type:
->
+  The source path can be set as a List so ALE will add the appropriate path
+  separator for the host system automatically. >
+
   let g:ale_java_javac_sourcepath = [
-    \ 'build/generated/source/querydsl/main',
-    \ 'target/generated-sources/source/querydsl/main'
-  \ ]
+  \   'build/generated/source/querydsl/main',
+  \   'target/generated-sources/source/querydsl/main',
+  \]
 <
 
 ===============================================================================
 google-java-format                                *ale-java-google-java-format*
 
-
-g:ale_java_google_java_format_executable
+                               *ale-options.java_google_java_format_executable*
                                      *g:ale_java_google_java_format_executable*
                                      *b:ale_java_google_java_format_executable*
+java_google_java_format_executable
+g:ale_java_google_java_format_executable
   Type: |String|
   Default: `'google-java-format'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_java_google_java_format_options   *g:ale_java_google_java_format_options*
+                                  *ale-options.java_google_java_format_options*
+                                        *g:ale_java_google_java_format_options*
                                         *b:ale_java_google_java_format_options*
+java_google_java_format_options
+g:ale_java_google_java_format_options
   Type: |String|
   Default: `''`
 
@@ -128,9 +144,11 @@ g:ale_java_google_java_format_options   *g:ale_java_google_java_format_options*
 ===============================================================================
 pmd                                                              *ale-java-pmd*
 
-g:ale_java_pmd_options                                 *g:ale_java_pmd_options*
+                                                 *ale-options.java_pmd_options*
+                                                       *g:ale_java_pmd_options*
                                                        *b:ale_java_pmd_options*
-
+java_pmd_options
+g:ale_java_pmd_options
   Type: |String|
   Default: `'-R category/java/bestpractices'`
 
@@ -151,56 +169,77 @@ set.
 After downloading the source code and installing all pre-requisites you can
 build the language server with the included build.sh script:
 
-   scripts/build.sh
+   `scripts/build.sh`
 
 This will create launch scripts for Linux, Mac, and Windows in the dist folder
 within the repo:
 
-  - lang_server_linux.sh
-  - lang_server_mac.sh
-  - lang_server_windows.sh
+  - `lang_server_linux.sh`
+  - `lang_server_mac.sh`
+  - `lang_server_windows.sh`
 
-To let ALE use this language server you need to set the
-g:ale_java_javalsp_executable variable to the absolute path of the launcher
-executable for your platform.
+To let ALE use this language server you need to set the executable, as
+documented below.
 
-g:ale_java_javalsp_executable                   *g:ale_java_javalsp_executable*
+                                          *ale-options.java_javalsp_executable*
+                                                *g:ale_java_javalsp_executable*
                                                 *b:ale_java_javalsp_executable*
+java_javalsp_executable
+g:ale_java_javalsp_executable
   Type: |String|
   Default: `''`
 
-This variable must be set to the absolute path of the language server launcher
-executable. For example:
->
-  let g:ale_java_javalsp_executable=/java-language-server/dist/lang_server_linux.sh
-<
+  This variable must be set to the absolute path of the language server
+  launcher executable. For example: >
 
-g:ale_java_javalsp_config                           *g:ale_java_javalsp_config*
+  let g:ale_java_javalsp_executable = '/java-language-server/dist/lang_server_linux.sh'
+<
+                                              *ale-options.java_javalsp_config*
+                                                    *g:ale_java_javalsp_config*
                                                     *b:ale_java_javalsp_config*
+java_javalsp_config
+g:ale_java_javalsp_config
   Type: |Dictionary|
   Default: `{}`
 
-The javalsp linter automatically detects external dependencies for Maven and
-Gradle projects. In case the javalsp fails to detect some of them, you can
-specify them setting a dictionary to |g:ale_java_javalsp_config| variable.
->
-  let g:ale_java_javalsp_config =
-  \ {
-  \   'java': {
-  \     'externalDependencies': [
-  \       'junit:junit:jar:4.12:test',   " Maven format
-  \       'junit:junit:4.1'              " Gradle format
-  \     ],
-  \     'classPath': [
-  \       'lib/some-dependency.jar',
-  \       '/android-sdk/platforms/android-28.jar'
-  \     ]
-  \   }
-  \ }
+  The javalsp linter automatically detects external dependencies for Maven and
+  Gradle projects. In case the javalsp fails to detect some of them, you can
+  specify them configuring settings for the language server, such as in your
+  ftplugin file. >
 
-The Java language server will look for the dependencies you specify in
-`externalDependencies` array in your Maven and Gradle caches ~/.m2 and
-~/.gradle.
+  let b:ale_java_javalsp_config = {
+  \   'java': {
+  \       'externalDependencies': [
+  \           'junit:junit:jar:4.12:test',
+  \           'junit:junit:4.1'
+  \       ],
+  \       'classPath': [
+  \           'lib/some-dependency.jar',
+  \           '/android-sdk/platforms/android-28.jar',
+  \       ],
+  \   },
+  \}
+<
+  Or in Lua: >
+
+  require("ale").setup.buffer({
+      java_lsp_config = {
+          java = {
+              externalDependencies = {
+                  "junit:junit:jar:4.12:test",
+                  "junit:junit:4.1"
+              },
+              classPath = {
+                  "lib/some-dependency.jar",
+                  "/android-sdk/platforms/android-28.jar",
+              },
+          },
+      }
+  })
+<
+  The Java language server will look for the dependencies you specify in
+  `externalDependencies` array in your Maven and Gradle caches ~/.m2 and
+  ~/.gradle.
 
 
 ===============================================================================
@@ -210,7 +249,7 @@ To enable Eclipse JDT LSP linter you need to clone and build the eclipse.jdt.ls
 language server from https://github.com/eclipse/eclipse.jdt.ls. Simply
 clone the source code repo and then build the plugin:
 
-   ./mvnw clean verify
+   `./mvnw clean verify`
 
 Note: currently, the build can only run when launched with JDK 11. More
 recent versions can be used to run the server though.
@@ -224,9 +263,11 @@ Under your project folder, modify the file `.settings/org.eclipse.jdt.core.prefs
 with options presented at
 https://help.eclipse.org/neon/topic/org.eclipse.jdt.doc.isv/reference/api/org/eclipse/jdt/core/JavaCore.html.
 
-g:ale_java_eclipselsp_path                         *g:ale_java_eclipselsp_path*
+                                             *ale-options.java_eclipselsp_path*
+                                                   *g:ale_java_eclipselsp_path*
                                                    *b:ale_java_eclipselsp_path*
-
+java_eclipselsp_path
+g:ale_java_eclipselsp_path
   Type: |String|
   Default: `'$HOME/eclipse.jdt.ls'`
 
@@ -235,32 +276,37 @@ g:ale_java_eclipselsp_path                         *g:ale_java_eclipselsp_path*
   extensions folder (e.g. $HOME/.vscode/extensions/redhat.java-0.4x.0 in
   Linux).
 
-
-g:ale_java_eclipselsp_executable                *g:ale_java_eclipse_executable*
+                                       *ale-options.java_eclipselsp_executable*
+                                             *g:ale_java_eclipselsp_executable*
                                                 *b:ale_java_eclipse_executable*
+java_eclipselsp_executable
+g:ale_java_eclipselsp_executable
   Type: |String|
   Default: `'java'`
 
   This variable can be set to change the executable path used for java.
 
-
-g:ale_java_eclipselsp_config_path              *g:ale_java_eclipse_config_path*
+                                      *ale-options.java_eclipselsp_config_path*
+                                            *g:ale_java_eclipselsp_config_path*
                                                *b:ale_java_eclipse_config_path*
+java_eclipselsp_config_path
+g:ale_java_eclipselsp_config_path
   Type: |String|
   Default: `''`
 
   Set this variable to change the configuration directory path used by
-  eclipselsp (e.g. `$HOME/.jdtls` in Linux).
-  By default ALE will attempt to use the configuration within the installation
-  directory.
+  eclipselsp (e.g. `$HOME/.jdtls` in Linux). By default ALE will attempt to
+  use the configuration within the installation directory.
+
   This setting is particularly useful when eclipselsp is installed in a
   non-writable directory like `/usr/share/java/jdtls`, as is the case when
   installed via system package.
 
-
-g:ale_java_eclipselsp_workspace_path     *g:ale_java_eclipselsp_workspace_path*
+                                   *ale-options.java_eclipselsp_workspace_path*
+                                         *g:ale_java_eclipselsp_workspace_path*
                                          *b:ale_java_eclipselsp_workspace_path*
-
+java_eclipselsp_workspace_path
+g:ale_java_eclipselsp_workspace_path
   Type: |String|
   Default: `''`
 
@@ -268,16 +314,18 @@ g:ale_java_eclipselsp_workspace_path     *g:ale_java_eclipselsp_workspace_path*
   absolute path of the Eclipse workspace. If not set this value will be set to
   the parent folder of the project root.
 
-g:ale_java_eclipselsp_javaagent               *g:ale_java_eclipselsp_javaagent*
+                                        *ale-options.java_eclipselsp_javaagent*
+                                              *g:ale_java_eclipselsp_javaagent*
                                               *b:ale_java_eclipselsp_javaagent*
-
+java_eclipselsp_javaagent
+g:ale_java_eclipselsp_javaagent
   Type: |String|
   Default: `''`
 
   A variable to add java agent for annotation processing such as Lombok.
   If you have multiple java agent files, use space to separate them.
-  For example:
->
+  For example: >
+
   let g:ale_java_eclipselsp_javaagent='/eclipse/lombok.jar /eclipse/jacoco.jar'
 <
 

--- a/doc/ale-javascript.txt
+++ b/doc/ale-javascript.txt
@@ -1,6 +1,5 @@
 ===============================================================================
 ALE JavaScript Integration                             *ale-javascript-options*
-
                                         *ale-eslint-nested-configuration-files*
 
 For fixing files with ESLint, nested configuration files with `root: false`
@@ -23,7 +22,6 @@ To this: >
   /path/foo/.eslintrc.js # extends: ["/path/foo/.base-eslintrc.js"]
   /path/foo/bar/.eslintrc.js # extends: ["/path/foo/.base-eslintrc.js"]
 <
-
 
 ===============================================================================
 biome                                                    *ale-javascript-biome*
@@ -59,33 +57,42 @@ See |ale-dprint-options| and https://dprint.dev/plugins/typescript
 ===============================================================================
 eslint                                                  *ale-javascript-eslint*
 
-g:ale_javascript_eslint_executable         *g:ale_javascript_eslint_executable*
+                                     *ale-options.javascript_eslint_executable*
+                                           *g:ale_javascript_eslint_executable*
                                            *b:ale_javascript_eslint_executable*
+javascript_eslint_executable
+g:ale_javascript_eslint_executable
   Type: |String|
   Default: `'eslint'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_javascript_eslint_options               *g:ale_javascript_eslint_options*
+                                        *ale-options.javascript_eslint_options*
+                                              *g:ale_javascript_eslint_options*
                                               *b:ale_javascript_eslint_options*
+javascript_eslint_options
+g:ale_javascript_eslint_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass additional options to eslint.
 
-
-g:ale_javascript_eslint_use_global         *g:ale_javascript_eslint_use_global*
+                                     *ale-options.javascript_eslint_use_global*
+                                           *g:ale_javascript_eslint_use_global*
                                            *b:ale_javascript_eslint_use_global*
+javascript_eslint_use_global
+g:ale_javascript_eslint_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
   See |ale-integrations-local-executables|
 
 
-g:ale_javascript_eslint_suppress_eslintignore
+                          *ale-options.javascript_eslint_suppress_eslintignore*
                                 *g:ale_javascript_eslint_suppress_eslintignore*
                                 *b:ale_javascript_eslint_suppress_eslintignore*
+javascript_eslint_suppress_eslintignore
+g:ale_javascript_eslint_suppress_eslintignore
   Type: |Number|
   Default: `0`
 
@@ -93,9 +100,11 @@ g:ale_javascript_eslint_suppress_eslintignore
   by eslint.
 
 
-g:ale_javascript_eslint_suppress_missing_config
+                        *ale-options.javascript_eslint_suppress_missing_config*
                               *g:ale_javascript_eslint_suppress_missing_config*
                               *b:ale_javascript_eslint_suppress_missing_config*
+javascript_eslint_suppress_missing_config
+g:ale_javascript_eslint_suppress_missing_config
   Type: |Number|
   Default: `0`
 
@@ -116,17 +125,21 @@ fecs                                                      *ale-javascript-fecs*
 And the configuration file is located at `./fecsrc`, see http://fecs.baidu.com
 for more options.
 
-
-g:ale_javascript_fecs_executable             *g:ale_javascript_fecs_executable*
+                                       *ale-options.javascript_fecs_executable*
+                                             *g:ale_javascript_fecs_executable*
                                              *b:ale_javascript_fecs_executable*
+javascript_fecs_executable
+g:ale_javascript_fecs_executable
   Type: |String|
   Default: `'fecs'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_javascript_fecs_use_global             *g:ale_javascript_fecs_use_global*
+                                       *ale-options.javascript_fecs_use_global*
+                                             *g:ale_javascript_fecs_use_global*
                                              *b:ale_javascript_fecs_use_global*
+javascript_fecs_use_global
+g:ale_javascript_fecs_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
@@ -136,16 +149,21 @@ g:ale_javascript_fecs_use_global             *g:ale_javascript_fecs_use_global*
 ===============================================================================
 flow                                                      *ale-javascript-flow*
 
-g:ale_javascript_flow_executable             *g:ale_javascript_flow_executable*
+                                       *ale-options.javascript_flow_executable*
+                                             *g:ale_javascript_flow_executable*
                                              *b:ale_javascript_flow_executable*
+javascript_flow_executable
+g:ale_javascript_flow_executable
   Type: |String|
   Default: `'flow'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_javascript_flow_use_home_config   *g:ale_javascript_flow_use_home_config*
+                                  *ale-options.javascript_flow_use_home_config*
+                                        *g:ale_javascript_flow_use_home_config*
                                         *b:ale_javascript_flow_use_home_config*
+javascript_flow_use_home_config
+g:ale_javascript_flow_use_home_config
   Type: |Number|
   Default: `0`
 
@@ -154,18 +172,21 @@ g:ale_javascript_flow_use_home_config   *g:ale_javascript_flow_use_home_config*
   configuration files by default, as doing so can lead to Vim consuming all of
   your RAM and CPU power.
 
-
-g:ale_javascript_flow_use_global             *g:ale_javascript_flow_use_global*
+                                       *ale-options.javascript_flow_use_global*
+                                             *g:ale_javascript_flow_use_global*
                                              *b:ale_javascript_flow_use_global*
+javascript_flow_use_global
+g:ale_javascript_flow_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_javascript_flow_use_respect_pragma
+                               *ale-options.javascript_flow_use_respect_pragma*
                                      *g:ale_javascript_flow_use_respect_pragma*
                                      *b:ale_javascript_flow_use_respect_pragma*
+javascript_flow_use_respect_pragma
+g:ale_javascript_flow_use_respect_pragma
   Type: |Number|
   Default: `1`
 
@@ -177,8 +198,11 @@ g:ale_javascript_flow_use_respect_pragma
 ===============================================================================
 importjs                                              *ale-javascript-importjs*
 
-g:ale_javascript_importjs_executable     *g:ale_javascript_importjs_executable*
+                                   *ale-options.javascript_importjs_executable*
+                                         *g:ale_javascript_importjs_executable*
                                          *b:ale_javascript_importjs_executable*
+javascript_importjs_executable
+g:ale_javascript_importjs_executable
   Type: |String|
   Default: `'importjs'`
 
@@ -186,16 +210,21 @@ g:ale_javascript_importjs_executable     *g:ale_javascript_importjs_executable*
 ===============================================================================
 jscs                                                      *ale-javascript-jscs*
 
-g:ale_javascript_jscs_executable             *g:ale_javascript_jscs_executable*
+                                       *ale-options.javascript_jscs_executable*
+                                             *g:ale_javascript_jscs_executable*
                                              *b:ale_javascript_jscs_executable*
+javascript_jscs_executable
+g:ale_javascript_jscs_executable
   Type: |String|
   Default: `'jscs'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_javascript_jscs_use_global             *g:ale_javascript_jscs_use_global*
+                                       *ale-options.javascript_jscs_use_global*
+                                             *g:ale_javascript_jscs_use_global*
                                              *b:ale_javascript_jscs_use_global*
+javascript_jscs_use_global
+g:ale_javascript_jscs_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
@@ -205,16 +234,21 @@ g:ale_javascript_jscs_use_global             *g:ale_javascript_jscs_use_global*
 ===============================================================================
 jshint                                                  *ale-javascript-jshint*
 
-g:ale_javascript_jshint_executable         *g:ale_javascript_jshint_executable*
+                                     *ale-options.javascript_jshint_executable*
+                                           *g:ale_javascript_jshint_executable*
                                            *b:ale_javascript_jshint_executable*
+javascript_jshint_executable
+g:ale_javascript_jshint_executable
   Type: |String|
   Default: `'jshint'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_javascript_jshint_use_global         *g:ale_javascript_jshint_use_global*
+                                     *ale-options.javascript_jshint_use_global*
+                                           *g:ale_javascript_jshint_use_global*
                                            *b:ale_javascript_jshint_use_global*
+javascript_jshint_use_global
+g:ale_javascript_jshint_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
@@ -224,24 +258,31 @@ g:ale_javascript_jshint_use_global         *g:ale_javascript_jshint_use_global*
 ===============================================================================
 prettier                                              *ale-javascript-prettier*
 
-g:ale_javascript_prettier_executable     *g:ale_javascript_prettier_executable*
+                                   *ale-options.javascript_prettier_executable*
+                                         *g:ale_javascript_prettier_executable*
                                          *b:ale_javascript_prettier_executable*
+javascript_prettier_executable
+g:ale_javascript_prettier_executable
   Type: |String|
   Default: `'prettier'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_javascript_prettier_options           *g:ale_javascript_prettier_options*
+                                      *ale-options.javascript_prettier_options*
+                                            *g:ale_javascript_prettier_options*
                                             *b:ale_javascript_prettier_options*
+javascript_prettier_options
+g:ale_javascript_prettier_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass additional options to prettier.
 
-
-g:ale_javascript_prettier_use_global     *g:ale_javascript_prettier_use_global*
+                                   *ale-options.javascript_prettier_use_global*
+                                         *g:ale_javascript_prettier_use_global*
                                          *b:ale_javascript_prettier_use_global*
+javascript_prettier_use_global
+g:ale_javascript_prettier_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
@@ -251,27 +292,32 @@ g:ale_javascript_prettier_use_global     *g:ale_javascript_prettier_use_global*
 ===============================================================================
 prettier-eslint                                *ale-javascript-prettier-eslint*
 
-g:ale_javascript_prettier_eslint_executable
+                            *ale-options.javascript_prettier_eslint_executable*
                                   *g:ale_javascript_prettier_eslint_executable*
                                   *b:ale_javascript_prettier_eslint_executable*
+javascript_prettier_eslint_executable
+g:ale_javascript_prettier_eslint_executable
   Type: |String|
   Default: `'prettier-eslint'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_javascript_prettier_eslint_options
+                               *ale-options.javascript_prettier_eslint_options*
                                      *g:ale_javascript_prettier_eslint_options*
                                      *b:ale_javascript_prettier_eslint_options*
+javascript_prettier_eslint_options
+g:ale_javascript_prettier_eslint_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass additional options to prettier-eslint.
 
 
-g:ale_javascript_prettier_eslint_use_global
+                            *ale-options.javascript_prettier_eslint_use_global*
                                   *g:ale_javascript_prettier_eslint_use_global*
                                   *b:ale_javascript_prettier_eslint_use_global*
+javascript_prettier_eslint_use_global
+g:ale_javascript_prettier_eslint_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
@@ -282,56 +328,67 @@ g:ale_javascript_prettier_eslint_use_global
 prettier-standard                            *ale-javascript-prettier-standard*
 
 
-g:ale_javascript_prettier_standard_executable
+                          *ale-options.javascript_prettier_standard_executable*
                                 *g:ale_javascript_prettier_standard_executable*
                                 *b:ale_javascript_prettier_standard_executable*
+javascript_prettier_standard_executable
+g:ale_javascript_prettier_standard_executable
   Type: |String|
   Default: `'prettier-standard'`
 
   See |ale-integrations-local-executables|
 
 
-g:ale_javascript_prettier_standard_options
+                             *ale-options.javascript_prettier_standard_options*
                                    *g:ale_javascript_prettier_standard_options*
                                    *b:ale_javascript_prettier_standard_options*
+javascript_prettier_standard_options
+g:ale_javascript_prettier_standard_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass additional options to prettier-standard.
 
 
-g:ale_javascript_prettier_standard_use_global
+                          *ale-options.javascript_prettier_standard_use_global*
                                 *g:ale_javascript_prettier_standard_use_global*
                                 *b:ale_javascript_prettier_standard_use_global*
+javascript_prettier_standard_use_global
+g:ale_javascript_prettier_standard_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
   See |ale-integrations-local-executables|
 
 
-
-
 ===============================================================================
 standard                                              *ale-javascript-standard*
 
-g:ale_javascript_standard_executable     *g:ale_javascript_standard_executable*
+                                   *ale-options.javascript_standard_executable*
+                                         *g:ale_javascript_standard_executable*
                                          *b:ale_javascript_standard_executable*
+javascript_standard_executable
+g:ale_javascript_standard_executable
   Type: |String|
   Default: `'standard'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_javascript_standard_options           *g:ale_javascript_standard_options*
+                                      *ale-options.javascript_standard_options*
+                                            *g:ale_javascript_standard_options*
                                             *b:ale_javascript_standard_options*
+javascript_standard_options
+g:ale_javascript_standard_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass additional options to standard.
 
-
-g:ale_javascript_standard_use_global     *g:ale_javascript_standard_use_global*
+                                   *ale-options.javascript_standard_use_global*
+                                         *g:ale_javascript_standard_use_global*
                                          *b:ale_javascript_standard_use_global*
+javascript_standard_use_global
+g:ale_javascript_standard_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
@@ -341,24 +398,31 @@ g:ale_javascript_standard_use_global     *g:ale_javascript_standard_use_global*
 ===============================================================================
 xo                                                          *ale-javascript-xo*
 
-g:ale_javascript_xo_executable                 *g:ale_javascript_xo_executable*
+                                         *ale-options.javascript_xo_executable*
+                                               *g:ale_javascript_xo_executable*
                                                *b:ale_javascript_xo_executable*
+javascript_xo_executable
+g:ale_javascript_xo_executable
   Type: |String|
   Default: `'xo'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_javascript_xo_options                       *g:ale_javascript_xo_options*
+                                            *ale-options.javascript_xo_options*
+                                                  *g:ale_javascript_xo_options*
                                                   *b:ale_javascript_xo_options*
+javascript_xo_options
+g:ale_javascript_xo_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass additional options to xo.
 
-
-g:ale_javascript_xo_use_global                 *g:ale_javascript_xo_use_global*
+                                         *ale-options.javascript_xo_use_global*
+                                               *g:ale_javascript_xo_use_global*
                                                *b:ale_javascript_xo_use_global*
+javascript_xo_use_global
+g:ale_javascript_xo_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 

--- a/doc/ale-json.txt
+++ b/doc/ale-json.txt
@@ -57,26 +57,34 @@ You can install it using npm:
 <
 ALE provides fixjson integration as a fixer. See |ale-fix|.
 
-g:ale_json_fixjson_executable                   *g:ale_json_fixjson_executable*
+-------------------------------------------------------------------------------
+Options
+                                          *ale-options.json_fixjson_executable*
+                                                *g:ale_json_fixjson_executable*
                                                 *b:ale_json_fixjson_executable*
-
+json_fixjson_executable
+g:ale_json_fixjson_executable
   Type: |String|
   Default: `'fixjson'`
 
   The executable that will be run for fixjson.
 
-g:ale_json_fixjson_options                         *g:ale_json_fixjson_options*
+                                             *ale-options.json_fixjson_options*
+                                                   *g:ale_json_fixjson_options*
                                                    *b:ale_json_fixjson_options*
-
+json_fixjson_options
+g:ale_json_fixjson_options
   Type: |String|
   Default: `''`
 
   This variable can add extra options to the command executed for running
   fixjson.
 
-g:ale_json_fixjson_use_global                   *g:ale_json_fixjson_use_global*
+                                          *ale-options.json_fixjson_use_global*
+                                                *g:ale_json_fixjson_use_global*
                                                 *b:ale_json_fixjson_use_global*
-
+json_fixjson_use_global
+g:ale_json_fixjson_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
@@ -88,18 +96,22 @@ pytool                                                        *ale-json-pytool*
 
 Use python's json.tool module to reformat json.
 
-g:ale_json_pytool_executable                     *g:ale_json_pytool_executable*
+                                           *ale-options.json_pytool_executable*
+                                                 *g:ale_json_pytool_executable*
                                                  *b:ale_json_pytool_executable*
-
+json_pytool_executable
+g:ale_json_pytool_executable
   Type: |String|
   Default: `'python'`
 
   The python executable that run to use its json.tool module. This fixer
   requires python 3, which includes the json module.
 
-g:ale_json_pytool_options                           *g:ale_json_pytool_options*
+                                              *ale-options.json_pytool_options*
+                                                    *g:ale_json_pytool_options*
                                                     *b:ale_json_pytool_options*
-
+json_pytool_options
+g:ale_json_pytool_options
   Type: |String|
   Default: `''`
 
@@ -108,9 +120,11 @@ g:ale_json_pytool_options                           *g:ale_json_pytool_options*
 <  See docs for all options:
     https://docs.python.org/3/library/json.html#module-json.tool
 
-g:ale_json_pytool_use_global                     *g:ale_json_pytool_use_global*
+                                           *ale-options.json_pytool_use_global*
+                                                 *g:ale_json_pytool_use_global*
                                                  *b:ale_json_pytool_use_global*
-
+json_pytool_use_global
+g:ale_json_pytool_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
@@ -120,17 +134,21 @@ g:ale_json_pytool_use_global                     *g:ale_json_pytool_use_global*
 ===============================================================================
 jsonlint                                                    *ale-json-jsonlint*
 
-g:ale_json_jsonlint_executable                 *g:ale_json_jsonlint_executable*
+                                         *ale-options.json_jsonlint_executable*
+                                               *g:ale_json_jsonlint_executable*
                                                *b:ale_json_jsonlint_executable*
-
+json_jsonlint_executable
+g:ale_json_jsonlint_executable
   Type: |String|
   Default: `'jsonlint'`
 
   The executable that will be run for jsonlint.
 
-g:ale_json_jsonlint_use_global                  *g:ale_json_jsonlint_use_global*
-                                                *b:ale_json_jsonlint_use_global*
-
+                                         *ale-options.json_jsonlint_use_global*
+                                               *g:ale_json_jsonlint_use_global*
+                                               *b:ale_json_jsonlint_use_global*
+json_jsonlint_use_global
+g:ale_json_jsonlint_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
@@ -140,23 +158,32 @@ g:ale_json_jsonlint_use_global                  *g:ale_json_jsonlint_use_global*
 ===============================================================================
 jq                                                                *ale-json-jq*
 
-g:ale_json_jq_executable                             *g:ale_json_jq_executable*
+                                               *ale-options.json_jq_executable*
+                                                     *g:ale_json_jq_executable*
                                                      *b:ale_json_jq_executable*
+json_jq_executable
+g:ale_json_jq_executable
   Type: |String|
   Default: `'jq'`
 
   This option can be changed to change the path for `jq`.
 
 
-g:ale_json_jq_options                                   *g:ale_json_jq_options*
+                                                  *ale-options.json_jq_options*
+                                                        *g:ale_json_jq_options*
                                                         *b:ale_json_jq_options*
+json_jq_options
+g:ale_json_jq_options
   Type: |String|
   Default: `''`
 
   This option can be changed to pass extra options to `jq`.
 
-g:ale_json_jq_filters                                   *g:ale_json_jq_filters*
+                                                  *ale-options.json_jq_filters*
+                                                        *g:ale_json_jq_filters*
                                                         *b:ale_json_jq_filters*
+json_jq_filters
+g:ale_json_jq_filters
   Type: |String|
   Default: `'.'`
 
@@ -174,8 +201,9 @@ spectral                                                    *ale-json-spectral*
 
 Website: https://github.com/stoplightio/spectral
 
-Installation
+
 -------------------------------------------------------------------------------
+Installation
 
 Install spectral either globally or locally: >
 
@@ -183,30 +211,37 @@ Install spectral either globally or locally: >
   npm install @stoplight/spectral     # local
 <
 
-Options
 -------------------------------------------------------------------------------
+Options
 
-g:ale_json_spectral_executable                 *g:ale_json_spectral_executable*
+                                         *ale-options.json_spectral_executable*
+                                               *g:ale_json_spectral_executable*
                                                *b:ale_json_spectral_executable*
+json_spectral_executable
+g:ale_json_spectral_executable
   Type: |String|
   Default: `'spectral'`
 
   This variable can be set to change the path to spectral.
 
-g:ale_json_spectral_use_global                 *g:ale_json_spectral_use_global*
+                                         *ale-options.json_spectral_use_global*
+                                               *g:ale_json_spectral_use_global*
                                                *b:ale_json_spectral_use_global*
+json_spectral_use_global
+g:ale_json_spectral_use_global
   Type: |String|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
   See |ale-integrations-local-executables|
+
 
 ===============================================================================
 vscodejson                                                    *ale-json-vscode*
 
 Website: https://github.com/hrsh7th/vscode-langservers-extracted
 
-Installation
 -------------------------------------------------------------------------------
+Installation
 
 Install VSCode json language server either globally or locally: >
 

--- a/doc/ale-jsonnet.txt
+++ b/doc/ale-jsonnet.txt
@@ -5,16 +5,21 @@ ALE Jsonnet Integration                                   *ale-jsonnet-options*
 ===============================================================================
 jsonnetfmt                                             *ale-jsonnet-jsonnetfmt*
 
-g:ale_jsonnet_jsonnetfmt_executable       *g:ale_jsonnet_jsonnetfmt_executable*
+                                    *ale-options.jsonnet_jsonnetfmt_executable*
+                                          *g:ale_jsonnet_jsonnetfmt_executable*
                                           *b:ale_jsonnet_jsonnetfmt_executable*
+jsonnet_jsonnetfmt_executable
+g:ale_jsonnet_jsonnetfmt_executable
   Type: |String|
   Default: `'jsonnetfmt'`
 
   This option can be changed to change the path for `jsonnetfmt`.
 
-
-g:ale_jsonnet_jsonnetfmt_options             *g:ale_jsonnet_jsonnetfmt_options*
+                                       *ale-options.jsonnet_jsonnetfmt_options*
+                                             *g:ale_jsonnet_jsonnetfmt_options*
                                              *b:ale_jsonnet_jsonnetfmt_options*
+jsonnet_jsonnetfmt_options
+g:ale_jsonnet_jsonnetfmt_options
   Type: |String|
   Default: `''`
 
@@ -24,20 +29,26 @@ g:ale_jsonnet_jsonnetfmt_options             *g:ale_jsonnet_jsonnetfmt_options*
 ===============================================================================
 jsonnet-lint                                         *ale-jsonnet-jsonnet-lint*
 
-g:ale_jsonnet_jsonnet_lint_executable   *g:ale_jsonnet_jsonnet_lint_executable*
+                                  *ale-options.jsonnet_jsonnet_lint_executable*
+                                        *g:ale_jsonnet_jsonnet_lint_executable*
                                         *b:ale_jsonnet_jsonnet_lint_executable*
+jsonnet_jsonnet_lint_executable
+g:ale_jsonnet_jsonnet_lint_executable
   Type: |String|
   Default: `'jsonnet-lint'`
 
   This option can be changed to change the path for `jsonnet-lint`.
 
-
-g:ale_jsonnet_jsonnet_lint_options          *g:ale_jsonnet_jsonnet_lint_options*
-                                            *b:ale_jsonnet_jsonnet_lint_options*
+                                     *ale-options.jsonnet_jsonnet_lint_options*
+                                           *g:ale_jsonnet_jsonnet_lint_options*
+                                           *b:ale_jsonnet_jsonnet_lint_options*
+jsonnet_jsonnet_lint_options
+g:ale_jsonnet_jsonnet_lint_options
   Type: |String|
   Default: `''`
 
   This option can be changed to pass extra options to `jsonnet-lint`.
 
 
+===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-julia.txt
+++ b/doc/ale-julia.txt
@@ -1,20 +1,23 @@
 ===============================================================================
 ALE Julia Integration                                       *ale-julia-options*
 
+
 ===============================================================================
 languageserver                                       *ale-julia-languageserver*
 
 To enable Julia LSP linter you need to install the LanguageServer.jl package
 within julia.
 
-g:ale_julia_executable                                 *g:ale_julia_executable*
+                                                 *ale-options.julia_executable*
+                                                       *g:ale_julia_executable*
                                                        *b:ale_julia_executable*
-
+julia_executable
+g:ale_julia_executable
   Type: |String|
   Default: `'julia'`
 
   Path to the julia exetuable.
 
+
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:
-

--- a/doc/ale-kotlin.txt
+++ b/doc/ale-kotlin.txt
@@ -15,47 +15,75 @@ Integration Information
 ===============================================================================
 kotlinc                                                    *ale-kotlin-kotlinc*
 
-g:ale_kotlin_kotlinc_options                     *g:ale_kotlin_kotlinc_options*
+                                           *ale-options.kotlin_kotlinc_options*
+                                                 *g:ale_kotlin_kotlinc_options*
+                                                 *b:ale_kotlin_kotlinc_options*
+kotlin_kotlinc_options
+g:ale_kotlin_kotlinc_options
   Type: |String|
   Default: `''`
 
   Additional options to pass to the kotlin compiler
 
-g:ale_kotlin_kotlinc_enable_config         *g:ale_kotlin_kotlinc_enable_config*
+                                     *ale-options.kotlin_kotlinc_enable_config*
+                                           *g:ale_kotlin_kotlinc_enable_config*
+                                           *b:ale_kotlin_kotlinc_enable_config*
+kotlin_kotlinc_enable_config
+g:ale_kotlin_kotlinc_enable_config
   Type: |Number|
   Default: `0`
 
   Setting this variable to `1` tells the linter to load a configuration file.
   This should be set in your vimrc
 
-g:ale_kotlin_kotlinc_config_file             *g:ale_kotlin_kotlinc_config_file*
+                                       *ale-options.kotlin_kotlinc_config_file*
+                                             *g:ale_kotlin_kotlinc_config_file*
+                                             *b:ale_kotlin_kotlinc_config_file*
+kotlin_kotlinc_config_file
+g:ale_kotlin_kotlinc_config_file
   Type: |String|
   Default: `'.ale_kotlin_kotlinc_config'`
 
   Filename of the configuration file. This should be set in your vimrc
 
-g:ale_kotlin_kotlinc_classpath                 *g:ale_kotlin_kotlinc_classpath*
+                                         *ale-options.kotlin_kotlinc_classpath*
+                                               *g:ale_kotlin_kotlinc_classpath*
+                                               *b:ale_kotlin_kotlinc_classpath*
+kotlin_kotlinc_classpath
+g:ale_kotlin_kotlinc_classpath
   Type: |String|
   Default: `''`
 
   A string containing the paths (separated by the appropriate path separator)
   of the source directories.
 
-g:ale_kotlin_kotlinc_sourcepath               *g:ale_kotlin_kotlinc_sourcepath*
+                                        *ale-options.kotlin_kotlinc_sourcepath*
+                                              *g:ale_kotlin_kotlinc_sourcepath*
+                                              *b:ale_kotlin_kotlinc_sourcepath*
+kotlin_kotlinc_sourcepath
+g:ale_kotlin_kotlinc_sourcepath
   Type: |String|
   Default: `''`
 
   A string containing the paths (separated by space) of the source
   directories.
 
-g:ale_kotlin_kotlinc_use_module_file     *g:ale_kotlin_kotlinc_use_module_file*
+                                   *ale-options.kotlin_kotlinc_use_module_file*
+                                         *g:ale_kotlin_kotlinc_use_module_file*
+                                         *b:ale_kotlin_kotlinc_use_module_file*
+kotlin_kotlinc_use_module_file
+g:ale_kotlin_kotlinc_use_module_file
   Type: |Number|
   Default: `0`
 
   This option indicates whether the linter should use a module file. It is off
   by default.
 
-g:ale_kotlin_kotlinc_module_filename     *g:ale_kotlin_kotlinc_module_filename*
+                                   *ale-options.kotlin_kotlinc_module_filename*
+                                         *g:ale_kotlin_kotlinc_module_filename*
+                                         *b:ale_kotlin_kotlinc_module_filename*
+kotlin_kotlinc_module_filename
+g:ale_kotlin_kotlinc_module_filename
   Type: |String|
   Default: `'module.xml'`
 
@@ -66,7 +94,11 @@ g:ale_kotlin_kotlinc_module_filename     *g:ale_kotlin_kotlinc_module_filename*
 ===============================================================================
 ktlint                                                      *ale-kotlin-ktlint*
 
-g:ale_kotlin_ktlint_executable                 *g:ale_kotlin_ktlint_executable*
+                                         *ale-options.kotlin_ktlint_executable*
+                                               *g:ale_kotlin_ktlint_executable*
+                                               *b:ale_kotlin_ktlint_executable*
+kotlin_ktlint_executable
+g:ale_kotlin_ktlint_executable
   Type: |String|
   Default: `''`
 
@@ -77,29 +109,41 @@ g:ale_kotlin_ktlint_executable                 *g:ale_kotlin_ktlint_executable*
   bet will be to download the ktlint jar and set this option to something
   similar to `'java -jar /path/to/ktlint.jar'`
 
-g:ale_kotlin_ktlint_rulesets                     *g:ale_kotlin_ktlint_rulesets*
-  Type: |List| of |String|s
+                                           *ale-options.kotlin_ktlint_rulesets*
+                                                 *g:ale_kotlin_ktlint_rulesets*
+                                                 *b:ale_kotlin_ktlint_rulesets*
+kotlin_ktlint_rulesets
+g:ale_kotlin_ktlint_rulesets
+  Type: |List|
   Default: `[]`
 
   This list should contain paths to ruleset jars and/or strings of maven
-  artifact triples. Example:
-  >
+  artifact triples. Example: >
+
   let g:ale_kotlin_ktlint_rulesets = ['/path/to/custom-ruleset.jar',
   'com.ktlint.rulesets:mycustomrule:1.0.0']
-
-g:ale_kotlin_ktlint_options                       *g:ale_kotlin_ktlint_options*
+<
+                                            *ale-options.kotlin_ktlint_options*
+                                                  *g:ale_kotlin_ktlint_options*
+                                                  *b:ale_kotlin_ktlint_options*
+kotlin_ktlint_options
+g:ale_kotlin_ktlint_options
   Type: |String|
   Default: `''`
 
-  Additional options to pass to ktlint for both linting and fixing. Example:
-  >
-  let g:ale_kotlin_ktlint_options = '--android'
+  Options to pass to ktlint for both linting and fixing. For example: >
 
+  let g:ale_kotlin_ktlint_options = '--android'
+<
 
 ===============================================================================
 languageserver                                      *ale-kotlin-languageserver*
 
-g:ale_kotlin_languageserver_executable *g:ale_kotlin_languageserver_executable*
+                                 *ale-options.kotlin_languageserver_executable*
+                                       *g:ale_kotlin_languageserver_executable*
+                                       *b:ale_kotlin_languageserver_executable*
+kotlin_languageserver_executable
+g:ale_kotlin_languageserver_executable
   Type: |String|
   Default: `''`
 

--- a/doc/ale-less.txt
+++ b/doc/ale-less.txt
@@ -5,24 +5,31 @@ ALE Less Integration                                         *ale-less-options*
 ===============================================================================
 lessc                                                          *ale-less-lessc*
 
-g:ale_less_lessc_executable                       *g:ale_less_lessc_executable*
+                                            *ale-options.less_lessc_executable*
+                                                  *g:ale_less_lessc_executable*
                                                   *b:ale_less_lessc_executable*
+less_lessc_executable
+g:ale_less_lessc_executable
   Type: |String|
   Default: `'lessc'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_less_lessc_options                             *g:ale_less_lessc_options*
+                                               *ale-options.less_lessc_options*
+                                                     *g:ale_less_lessc_options*
                                                      *b:ale_less_lessc_options*
+less_lessc_options
+g:ale_less_lessc_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass additional options to lessc.
 
-
-g:ale_less_lessc_use_global                       *g:ale_less_lessc_use_global*
+                                            *ale-options.less_lessc_use_global*
+                                                  *g:ale_less_lessc_use_global*
                                                   *b:ale_less_lessc_use_global*
+less_lessc_use_global
+g:ale_less_lessc_use_global
   Type: |String|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
@@ -38,24 +45,31 @@ See |ale-javascript-prettier| for information about the available options.
 ===============================================================================
 stylelint                                                  *ale-less-stylelint*
 
-g:ale_less_stylelint_executable               *g:ale_less_stylelint_executable*
+                                        *ale-options.less_stylelint_executable*
+                                              *g:ale_less_stylelint_executable*
                                               *b:ale_less_stylelint_executable*
+less_stylelint_executable
+g:ale_less_stylelint_executable
   Type: |String|
   Default: `'stylelint'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_less_stylelint_options                     *g:ale_less_stylelint_options*
+                                           *ale-options.less_stylelint_options*
+                                                 *g:ale_less_stylelint_options*
                                                  *b:ale_less_stylelint_options*
+less_stylelint_options
+g:ale_less_stylelint_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass additional options to stylelint.
 
-
-g:ale_less_stylelint_use_global               *g:ale_less_stylelint_use_global*
+                                        *ale-options.less_stylelint_use_global*
+                                              *g:ale_less_stylelint_use_global*
                                               *b:ale_less_stylelint_use_global*
+less_stylelint_use_global
+g:ale_less_stylelint_use_global
   Type: |String|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 

--- a/doc/ale-llvm.txt
+++ b/doc/ale-llvm.txt
@@ -5,9 +5,11 @@ ALE LLVM Integration                                         *ale-llvm-options*
 ===============================================================================
 llc                                                              *ale-llvm-llc*
 
-g:ale_llvm_llc_executable                           *g:ale_llvm_llc_executable*
+                                              *ale-options.llvm_llc_executable*
+                                                    *g:ale_llvm_llc_executable*
                                                     *b:ale_llvm_llc_executable*
-
+llvm_llc_executable
+g:ale_llvm_llc_executable
   Type: |String|
   Default: `"llc"`
 

--- a/doc/ale-lua.txt
+++ b/doc/ale-lua.txt
@@ -11,16 +11,21 @@ See |ale-cspell-options|
 ===============================================================================
 lua-format                                                 *ale-lua-lua-format*
 
-g:ale_lua_lua_format_executable               *g:ale_lua_lua_format_executable*
+                                        *ale-options.lua_lua_format_executable*
+                                              *g:ale_lua_lua_format_executable*
                                               *b:ale_lua_lua_format_executable*
+lua_lua_format_executable
+g:ale_lua_lua_format_executable
   Type: |String|
   Default: `'lua-format'`
 
   This variable can be changed to change the path to lua-format.
 
-
-g:ale_lua_lua_format_options                     *g:ale_lua_lua_format_options*
+                                           *ale-options.lua_lua_format_options*
+                                                 *g:ale_lua_lua_format_options*
                                                  *b:ale_lua_lua_format_options*
+lua_lua_format_options
+g:ale_lua_lua_format_options
   Type: |String|
   Default: `''`
 
@@ -31,8 +36,11 @@ g:ale_lua_lua_format_options                     *g:ale_lua_lua_format_options*
 lua-language-server                               *ale-lua-lua-language-server*
                                                       *ale-lua-language-server*
 
-g:ale_lua_language_server_executable     *g:ale_lua_language_server_executable*
+                                   *ale-options.lua_language_server_executable*
+                                         *g:ale_lua_language_server_executable*
                                          *b:ale_lua_language_server_executable*
+lua_language_server_executable
+g:ale_lua_language_server_executable
   Type: |String|
   Default: `'lua-language-server'`
 
@@ -41,9 +49,11 @@ g:ale_lua_language_server_executable     *g:ale_lua_language_server_executable*
   If you have compiled the language server yourself in `/some/path`, the path
   will be `'/some/path/bin/lua-language-server'`.
 
-
-g:ale_lua_lua_language_server_config     *g:ale_lua_lua_language_server_config*
+                                   *ale-options.lua_lua_language_server_config*
+                                         *g:ale_lua_lua_language_server_config*
                                          *b:ale_lua_lua_language_server_config*
+lua_lua_language_server_config
+g:ale_lua_lua_language_server_config
   Type: |Dictionary|
   Default: `{}`
 
@@ -54,8 +64,11 @@ g:ale_lua_lua_language_server_config     *g:ale_lua_lua_language_server_config*
 ===============================================================================
 luac                                                             *ale-lua-luac*
 
-g:ale_lua_luac_executable                           *g:ale_lua_luac_executable*
+                                              *ale-options.lua_luac_executable*
+                                                    *g:ale_lua_luac_executable*
                                                     *b:ale_lua_luac_executable*
+lua_luac_executable
+g:ale_lua_luac_executable
   Type: |String|
   Default: `'luac'`
 
@@ -65,16 +78,21 @@ g:ale_lua_luac_executable                           *g:ale_lua_luac_executable*
 ===============================================================================
 luacheck                                                     *ale-lua-luacheck*
 
-g:ale_lua_luacheck_executable                   *g:ale_lua_luacheck_executable*
+                                          *ale-options.lua_luacheck_executable*
+                                                *g:ale_lua_luacheck_executable*
                                                 *b:ale_lua_luacheck_executable*
+lua_luacheck_executable
+g:ale_lua_luacheck_executable
   Type: |String|
   Default: `'luacheck'`
 
   This variable can be changed to change the path to luacheck.
 
-
-g:ale_lua_luacheck_options                         *g:ale_lua_luacheck_options*
+                                             *ale-options.lua_luacheck_options*
+                                                   *g:ale_lua_luacheck_options*
                                                    *b:ale_lua_luacheck_options*
+lua_luacheck_options
+g:ale_lua_luacheck_options
   Type: |String|
   Default: `''`
 
@@ -84,16 +102,21 @@ g:ale_lua_luacheck_options                         *g:ale_lua_luacheck_options*
 ===============================================================================
 luafmt                                                         *ale-lua-luafmt*
 
-g:ale_lua_luafmt_executable                       *g:ale_lua_luafmt_executable*
+                                            *ale-options.lua_luafmt_executable*
+                                                  *g:ale_lua_luafmt_executable*
                                                   *b:ale_lua_luafmt_executable*
+lua_luafmt_executable
+g:ale_lua_luafmt_executable
   Type: |String|
   Default: `'luafmt'`
 
   This variable can be set to use a different executable for luafmt.
 
-
-g:ale_lua_luafmt_options                             *g:ale_lua_luafmt_options*
+                                               *ale-options.lua_luafmt_options*
+                                                     *g:ale_lua_luafmt_options*
                                                      *b:ale_lua_luafmt_options*
+lua_luafmt_options
+g:ale_lua_luafmt_options
   Type: |String|
   Default: `''`
 
@@ -103,16 +126,21 @@ g:ale_lua_luafmt_options                             *g:ale_lua_luafmt_options*
 ===============================================================================
 selene                                                         *ale-lua-selene*
 
-g:ale_lua_selene_executable                       *g:ale_lua_selene_executable*
+                                            *ale-options.lua_selene_executable*
+                                                  *g:ale_lua_selene_executable*
                                                   *b:ale_lua_selene_executable*
+lua_selene_executable
+g:ale_lua_selene_executable
   Type: |String|
   Default: `'selene'`
 
   This variable can be set to use a different executable for selene.
 
-
-g:ale_lua_selene_options                             *g:ale_lua_selene_options*
+                                               *ale-options.lua_selene_options*
+                                                     *g:ale_lua_selene_options*
                                                      *b:ale_lua_selene_options*
+lua_selene_options
+g:ale_lua_selene_options
   Type: |String|
   Default: `''`
 
@@ -122,16 +150,21 @@ g:ale_lua_selene_options                             *g:ale_lua_selene_options*
 ===============================================================================
 stylua                                                         *ale-lua-stylua*
 
-g:ale_lua_stylua_executable                       *g:ale_lua_stylua_executable*
+                                            *ale-options.lua_stylua_executable*
+                                                  *g:ale_lua_stylua_executable*
                                                   *b:ale_lua_stylua_executable*
+lua_stylua_executable
+g:ale_lua_stylua_executable
   Type: |String|
   Default: `'stylua'`
 
   This variable can be set to use a different executable for stylua.
 
-
-g:ale_lua_stylua_options                             *g:ale_lua_stylua_options*
+                                               *ale-options.lua_stylua_options*
+                                                     *g:ale_lua_stylua_options*
                                                      *b:ale_lua_stylua_options*
+lua_stylua_options
+g:ale_lua_stylua_options
   Type: |String|
   Default: `''`
 

--- a/doc/ale-make.txt
+++ b/doc/ale-make.txt
@@ -5,14 +5,18 @@ ALE Make Integration                                           *ale-make-options
 ===============================================================================
 checkmake                                                    *ale-make-checkmake*
 
-g:ale_make_checkmake_config                         *g:ale_make_checkmake_config*
+                                            *ale-options.make_checkmake_config*
+                                                  *g:ale_make_checkmake_config*
                                                     *b:ale_make_checkmake_config*
+make_checkmake_config
+g:ale_make_checkmake_config
   Type: |String|
   Default: `''`
 
   This variable can be used to set the `--config` option of checkmake command.
   if the value is empty, the checkmake command will not be invoked with the
   option.
+
 
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-markdown.txt
+++ b/doc/ale-markdown.txt
@@ -17,17 +17,22 @@ See |ale-dprint-options| and https://dprint.dev/plugins/markdown
 ===============================================================================
 markdownlint                                        *ale-markdown-markdownlint*
 
-g:ale_markdown_markdownlint_executable *g:ale_markdown_markdownlint_executable*
+                                 *ale-options.markdown_markdownlint_executable*
+                                       *g:ale_markdown_markdownlint_executable*
                                        *b:ale_markdown_markdownlint_executable*
+markdown_markdownlint_executable
+g:ale_markdown_markdownlint_executable
   Type: |String|
   Default: `'markdownlint'`
 
   Override the invoked `markdownlint` binary. You can use other binaries such as
   `markdownlint-cli2`.
 
-
-g:ale_markdown_markdownlint_options       *g:ale_markdown_markdownlint_options*
+                                    *ale-options.markdown_markdownlint_options*
+                                          *g:ale_markdown_markdownlint_options*
                                           *b:ale_markdown_markdownlint_options*
+markdown_markdownlint_options
+g:ale_markdown_markdownlint_options
   Type: |String|
   Default: `''`
 
@@ -37,8 +42,11 @@ g:ale_markdown_markdownlint_options       *g:ale_markdown_markdownlint_options*
 ===============================================================================
 marksman                                                *ale-markdown-marksman*
 
-g:ale_markdown_marksman_executable         *g:ale_markdown_marksman_executable*
+                                     *ale-options.markdown_marksman_executable*
+                                           *g:ale_markdown_marksman_executable*
                                            *b:ale_markdown_marksman_executable*
+markdown_marksman_executable
+g:ale_markdown_marksman_executable
   Type: |String|
   Default: `'marksman'`
 
@@ -48,17 +56,22 @@ g:ale_markdown_marksman_executable         *g:ale_markdown_marksman_executable*
 ===============================================================================
 mdl                                                          *ale-markdown-mdl*
 
-g:ale_markdown_mdl_executable                   *g:ale_markdown_mdl_executable*
+                                          *ale-options.markdown_mdl_executable*
+                                                *g:ale_markdown_mdl_executable*
                                                 *b:ale_markdown_mdl_executable*
+markdown_mdl_executable
+g:ale_markdown_mdl_executable
   Type: |String|
   Default: `'mdl'`
 
   Override the invoked mdl binary. This is useful for running mdl from
   binstubs or a bundle.
 
-
-g:ale_markdown_mdl_options                         *g:ale_markdown_mdl_options*
+                                             *ale-options.markdown_mdl_options*
+                                                   *g:ale_markdown_mdl_options*
                                                    *b:ale_markdown_mdl_options*
+markdown_mdl_options
+g:ale_markdown_mdl_options
   Type: |String|
   Default: `''`
 
@@ -68,20 +81,26 @@ g:ale_markdown_mdl_options                         *g:ale_markdown_mdl_options*
 ===============================================================================
 pandoc                                                    *ale-markdown-pandoc*
 
-g:ale_markdown_pandoc_executable             *g:ale_markdown_pandoc_executable*
+                                       *ale-options.markdown_pandoc_executable*
+                                             *g:ale_markdown_pandoc_executable*
                                              *b:ale_markdown_pandoc_executable*
+markdown_pandoc_executable
+g:ale_markdown_pandoc_executable
   Type: |String|
   Default: `'pandoc'`
 
   This variable can be set to specify where to find the pandoc executable
 
-
-g:ale_markdown_pandoc_options                   *g:ale_markdown_pandoc_options*
+                                          *ale-options.markdown_pandoc_options*
+                                                *g:ale_markdown_pandoc_options*
                                                 *b:ale_markdown_pandoc_options*
+markdown_pandoc_options
+g:ale_markdown_pandoc_options
   Type: |String|
   Default: `'-f gfm -t gfm -s -'`
 
   This variable can be set to change the default options passed to pandoc
+
 
 ===============================================================================
 prettier                                                *ale-markdown-prettier*
@@ -92,8 +111,11 @@ See |ale-javascript-prettier| for information about the available options.
 ===============================================================================
 pymarkdown                                            *ale-markdown-pymarkdown*
 
-g:ale_markdown_pymarkdown_executable       *g:ale_markdown_pymarkdown_executable*
+                                   *ale-options.markdown_pymarkdown_executable*
+                                         *g:ale_markdown_pymarkdown_executable*
                                           *b:ale_markdown_pymarkdown_executable*
+markdown_pymarkdown_executable
+g:ale_markdown_pymarkdown_executable
   Type: |String|
   Default: `'pymarkdown'`
 
@@ -102,44 +124,54 @@ g:ale_markdown_pymarkdown_executable       *g:ale_markdown_pymarkdown_executable
   Set this to `'pipenv'` to invoke `'pipenv` `run` `pymarkdown'`.
   Set this to `'poetry'` to invoke `'poetry` `run` `pymarkdown'`.
 
-
-g:ale_markdown_pymarkdown_options             *g:ale_markdown_pymarkdown_options*
+                                      *ale-options.markdown_pymarkdown_options*
+                                            *g:ale_markdown_pymarkdown_options*
                                              *b:ale_markdown_pymarkdown_options*
+markdown_pymarkdown_options
+g:ale_markdown_pymarkdown_options
   Type: |String|
   Default: `''`
 
   This variable can be changed to add command-line arguments to the
   pymarkdown invocation.
 
-
-g:ale_markdown_pymarkdown_use_global       *g:ale_markdown_pymarkdown_use_global*
+                                   *ale-options.markdown_pymarkdown_use_global*
+                                         *g:ale_markdown_pymarkdown_use_global*
                                           *b:ale_markdown_pymarkdown_use_global*
+markdown_pymarkdown_use_global
+g:ale_markdown_pymarkdown_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_markdown_pymarkdown_auto_pipenv     *g:ale_markdown_pymarkdown_auto_pipenv*
+                                  *ale-options.markdown_pymarkdown_auto_pipenv*
+                                        *g:ale_markdown_pymarkdown_auto_pipenv*
                                          *b:ale_markdown_pymarkdown_auto_pipenv*
+markdown_pymarkdown_auto_pipenv
+g:ale_markdown_pymarkdown_auto_pipenv
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a pipenv, and set the executable to `pipenv`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_markdown_pymarkdown_auto_poetry     *g:ale_markdown_pymarkdown_auto_poetry*
+                                  *ale-options.markdown_pymarkdown_auto_poetry*
+                                        *g:ale_markdown_pymarkdown_auto_poetry*
                                          *b:ale_markdown_pymarkdown_auto_poetry*
+markdown_pymarkdown_auto_poetry
+g:ale_markdown_pymarkdown_auto_poetry
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a poetry, and set the executable to `poetry`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_markdown_pymarkdown_auto_uv             *g:ale_markdown_pymarkdown_auto_uv*
+                                      *ale-options.markdown_pymarkdown_auto_uv*
+                                            *g:ale_markdown_pymarkdown_auto_uv*
                                              *b:ale_markdown_pymarkdown_auto_uv*
+markdown_pymarkdown_auto_uv
+g:ale_markdown_pymarkdown_auto_uv
   Type: |Number|
   Default: `0`
 
@@ -150,24 +182,31 @@ g:ale_markdown_pymarkdown_auto_uv             *g:ale_markdown_pymarkdown_auto_uv
 ===============================================================================
 remark-lint                                          *ale-markdown-remark-lint*
 
-g:ale_markdown_remark_lint_executable   *g:ale_markdown_remark_lint_executable*
+                                  *ale-options.markdown_remark_lint_executable*
+                                        *g:ale_markdown_remark_lint_executable*
                                         *b:ale_markdown_remark_lint_executable*
+markdown_remark_lint_executable
+g:ale_markdown_remark_lint_executable
   Type: |String|
   Default: `'remark'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_markdown_remark_lint_options         *g:ale_markdown_remark_lint_options*
+                                     *ale-options.markdown_remark_lint_options*
+                                           *g:ale_markdown_remark_lint_options*
                                            *b:ale_markdown_remark_lint_options*
+markdown_remark_lint_options
+g:ale_markdown_remark_lint_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass additional options to remark-lint.
 
-
-g:ale_markdown_remark_lint_use_global   *g:ale_markdown_remark_lint_use_global*
+                                  *ale-options.markdown_remark_lint_use_global*
+                                        *g:ale_markdown_remark_lint_use_global*
                                         *b:ale_markdown_remark_lint_use_global*
+markdown_remark_lint_use_global
+g:ale_markdown_remark_lint_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 

--- a/doc/ale-mercury.txt
+++ b/doc/ale-mercury.txt
@@ -5,17 +5,21 @@ ALE Mercury Integration                                   *ale-mercury-options*
 ===============================================================================
 mmc                                                           *ale-mercury-mmc*
 
-
-g:ale_mercury_mmc_executable                     *g:ale_mercury_mmc_executable*
+                                           *ale-options.mercury_mmc_executable*
+                                                 *g:ale_mercury_mmc_executable*
                                                  *b:ale_mercury_mmc_executable*
+mercury_mmc_executable
+g:ale_mercury_mmc_executable
   Type: |String|
   Default: `'mmc'`
 
   This variable can be changed to use a different executable for mmc.
 
-
-g:ale_mercury_mmc_options                           *g:ale_mercury_mmc_options*
+                                              *ale-options.mercury_mmc_options*
+                                                    *g:ale_mercury_mmc_options*
                                                     *b:ale_mercury_mmc_options*
+mercury_mmc_options
+g:ale_mercury_mmc_options
   Type: |String|
   Default: `'--make --output-compile-error-lines 100'`
 

--- a/doc/ale-nasm.txt
+++ b/doc/ale-nasm.txt
@@ -5,17 +5,21 @@ ALE NASM Integration                                         *ale-nasm-options*
 ===============================================================================
 nasm                                                            *ale-nasm-nasm*
 
-g:ale_nasm_nasm_executable                         *g:ale_nasm_nasm_executable*
+                                             *ale-options.nasm_nasm_executable*
+                                                   *g:ale_nasm_nasm_executable*
                                                    *b:ale_nasm_nasm_executable*
-
+nasm_nasm_executable
+g:ale_nasm_nasm_executable
   Type: |String|
   Default `'nasm'`
 
   This variable can be changed to use different executable for NASM.
 
-
-g:ale_nasm_nasm_options                               *g:ale_nasm_nasm_options*
+                                                *ale-options.nasm_nasm_options*
+                                                      *g:ale_nasm_nasm_options*
                                                       *b:ale_nasm_nasm_options*
+nasm_nasm_options
+g:ale_nasm_nasm_options
   Type: |String|
   Default: `''`
 

--- a/doc/ale-nickel.txt
+++ b/doc/ale-nickel.txt
@@ -1,20 +1,25 @@
 ===============================================================================
-ALE Nickel Integration                                      *ale-nickel-options*
+ALE Nickel Integration                                     *ale-nickel-options*
 
 
 ===============================================================================
-nickel_format                                         *ale-nickel-nickel-format*
+nickel_format                                        *ale-nickel-nickel-format*
 
-g:ale_nickel_nickel_format_executable    *g:ale_nickel_nickel_format_executable*
-                                         *b:ale_nickel_nickel_format_executable*
+                                  *ale-options.nickel_nickel_format_executable*
+                                        *g:ale_nickel_nickel_format_executable*
+                                        *b:ale_nickel_nickel_format_executable*
+nickel_nickel_format_executable
+g:ale_nickel_nickel_format_executable
   Type: |String|
   Default: `'nickel'`
 
   This option can be changed to change the path for `nickel`.
 
-
-g:ale_nickel_nickel_format_options          *g:ale_nickel_nickel_format_options*
-                                            *b:ale_nickel_nickel_format_options*
+                                     *ale-options.nickel_nickel_format_options*
+                                           *g:ale_nickel_nickel_format_options*
+                                           *b:ale_nickel_nickel_format_options*
+nickel_nickel_format_options
+g:ale_nickel_nickel_format_options
   Type: |String|
   Default: `''`
 

--- a/doc/ale-nim.txt
+++ b/doc/ale-nim.txt
@@ -12,8 +12,10 @@ nimcheck                                                     *ale-nim-nimcheck*
 ===============================================================================
 nimlsp                                                         *ale-nim-nimlsp*
 
-g:nim_nimlsp_nim_sources                             *g:nim_nimlsp_nim_sources*
-
+                                           *ale-options.nim_nimlsp_nim_sources*
+                                                 *g:ale_nim_nimlsp_nim_sources*
+                                                 *b:ale_nim_nimlsp_nim_sources*
+g:ale_nim_nimlsp_nim_sources
   Type: |String|
   Default: `''`
 
@@ -24,17 +26,21 @@ g:nim_nimlsp_nim_sources                             *g:nim_nimlsp_nim_sources*
 ===============================================================================
 nimpretty                                                   *ale-nim-nimpretty*
 
-
-g:ale_nim_nimpretty_executable                 *g:ale_nim_nimpretty_executable*
+                                         *ale-options.nim_nimpretty_executable*
+                                               *g:ale_nim_nimpretty_executable*
                                                *b:ale_nim_nimpretty_executable*
+nim_nimpretty_executable
+g:ale_nim_nimpretty_executable
   Type: |String|
   Default: `'nimpretty'`
 
   This variable can be changed to use a different executable for nimpretty.
 
-
-g:ale_nim_nimpretty_options                       *g:ale_nim_nimpretty_options*
+                                            *ale-options.nim_nimpretty_options*
+                                                  *g:ale_nim_nimpretty_options*
                                                   *b:ale_nim_nimpretty_options*
+nim_nimpretty_options
+g:ale_nim_nimpretty_options
   Type: |String|
   Default: `'--maxLineLen:80'`
 

--- a/doc/ale-nix.txt
+++ b/doc/ale-nix.txt
@@ -5,15 +5,21 @@ ALE Nix Integration                                           *ale-nix-options*
 ===============================================================================
 alejandra                                                   *ale-nix-alejandra*
 
-g:ale_nix_alejandra_executable                 *g:ale_nix_alejandra_executable*
+                                         *ale-options.nix_alejandra_executable*
+                                               *g:ale_nix_alejandra_executable*
                                                *b:ale_nix_alejandra_executable*
+nix_alejandra_executable
+g:ale_nix_alejandra_executable
   Type: |String|
   Default: `'alejandra'`
 
   This variable sets the executable used for alejandra.
 
-g:ale_nix_alejandra_options                       *g:ale_nix_alejandra_options*
+                                            *ale-options.nix_alejandra_options*
+                                                  *g:ale_nix_alejandra_options*
                                                   *b:ale_nix_alejandra_options*
+nix_alejandra_options
+g:ale_nix_alejandra_options
   Type: |String|
   Default: `''`
 
@@ -23,15 +29,21 @@ g:ale_nix_alejandra_options                       *g:ale_nix_alejandra_options*
 ===============================================================================
 nixfmt                                                         *ale-nix-nixfmt*
 
-g:ale_nix_nixfmt_executable                       *g:ale_nix_nixfmt_executable*
+                                            *ale-options.nix_nixfmt_executable*
+                                                  *g:ale_nix_nixfmt_executable*
                                                   *b:ale_nix_nixfmt_executable*
+nix_nixfmt_executable
+g:ale_nix_nixfmt_executable
   Type: |String|
   Default: `'nixfmt'`
 
   This variable sets the executable used for nixfmt.
 
-g:ale_nix_nixfmt_options                             *g:ale_nix_nixfmt_options*
+                                               *ale-options.nix_nixfmt_options*
+                                                     *g:ale_nix_nixfmt_options*
                                                      *b:ale_nix_nixfmt_options*
+nix_nixfmt_options
+g:ale_nix_nixfmt_options
   Type: |String|
   Default: `''`
 
@@ -41,15 +53,21 @@ g:ale_nix_nixfmt_options                             *g:ale_nix_nixfmt_options*
 ===============================================================================
 nixpkgs-fmt                                               *ale-nix-nixpkgs-fmt*
 
-g:ale_nix_nixpkgsfmt_executable               *g:ale_nix_nixpkgsfmt_executable*
+                                        *ale-options.nix_nixpkgsfmt_executable*
+                                              *g:ale_nix_nixpkgsfmt_executable*
                                               *b:ale_nix_nixpkgsfmt_executable*
+nix_nixpkgsfmt_executable
+g:ale_nix_nixpkgsfmt_executable
   Type: |String|
   Default: `'nixpkgs-fmt'`
 
   This variable sets executable used for nixpkgs-fmt.
 
-g:ale_nix_nixpkgsfmt_options                     *g:ale_nix_nixpkgsfmt_options*
+                                           *ale-options.nix_nixpkgsfmt_options*
+                                                 *g:ale_nix_nixpkgsfmt_options*
                                                  *b:ale_nix_nixpkgsfmt_options*
+nix_nixpkgsfmt_options
+g:ale_nix_nixpkgsfmt_options
   Type: |String|
   Default: `''`
 
@@ -60,32 +78,44 @@ g:ale_nix_nixpkgsfmt_options                     *g:ale_nix_nixpkgsfmt_options*
 ===============================================================================
 statix                                                         *ale-nix-statix*
 
-g:ale_nix_statix_check_executable           *g:ale_nix_statix_check_executable*
+                                      *ale-options.nix_statix_check_executable*
+                                            *g:ale_nix_statix_check_executable*
                                             *b:ale_nix_statix_check_executable*
+nix_statix_check_executable
+g:ale_nix_statix_check_executable
   Type: |String|
   Default: `'statix'`
 
   This variable sets the executable used for statix when running it as a
   linter.
 
-g:ale_nix_statix_check_options                 *g:ale_nix_statix_check_options*
+                                         *ale-options.nix_statix_check_options*
+                                               *g:ale_nix_statix_check_options*
                                                *b:ale_nix_statix_check_options*
+nix_statix_check_options
+g:ale_nix_statix_check_options
   Type: |String|
   Default: `''`
 
   This variable can be used to pass additional options to statix when running
   it as a linter.
 
-g:ale_nix_statix_fix_executable                *g:ale_nix_fix_check_executable*
+                                        *ale-options.nix_statix_fix_executable*
+                                              *g:ale_nix_statix_fix_executable*
                                                *b:ale_nix_fix_check_executable*
+nix_statix_fix_executable
+g:ale_nix_statix_fix_executable
   Type: |String|
   Default: `'statix'`
 
   This variable sets the executable used for statix when running it as a
   fixer.
 
-g:ale_nix_statix_fix_options                     *g:ale_nix_statix_fix_options*
+                                           *ale-options.nix_statix_fix_options*
+                                                 *g:ale_nix_statix_fix_options*
                                                  *b:ale_nix_statix_fix_options*
+nix_statix_fix_options
+g:ale_nix_statix_fix_options
   Type: |String|
   Default: `''`
 
@@ -96,15 +126,21 @@ g:ale_nix_statix_fix_options                     *g:ale_nix_statix_fix_options*
 ===============================================================================
 deadnix                                                       *ale-nix-deadnix*
 
-g:ale_nix_deadnix_executable                     *g:ale_nix_deadnix_executable*
+                                           *ale-options.nix_deadnix_executable*
+                                                 *g:ale_nix_deadnix_executable*
                                                  *b:ale_nix_deadnix_executable*
+nix_deadnix_executable
+g:ale_nix_deadnix_executable
   Type: |String|
   Default: `'deadnix'`
 
   This variable sets the executable used for deadnix.
 
-g:ale_nix_deadnix_options                           *g:ale_nix_deadnix_options*
+                                              *ale-options.nix_deadnix_options*
+                                                    *g:ale_nix_deadnix_options*
                                                     *b:ale_nix_deadnix_options*
+nix_deadnix_options
+g:ale_nix_deadnix_options
   Type: |String|
   Default: `''`
 

--- a/doc/ale-objc.txt
+++ b/doc/ale-objc.txt
@@ -5,29 +5,35 @@ ALE Objective-C Integration                                  *ale-objc-options*
 ===============================================================================
 ccls                                                            *ale-objc-ccls*
 
-g:ale_objc_ccls_executable                         *g:ale_objc_ccls_executable*
+                                             *ale-options.objc_ccls_executable*
+                                                   *g:ale_objc_ccls_executable*
                                                    *b:ale_objc_ccls_executable*
+objc_ccls_executable
+g:ale_objc_ccls_executable
   Type: |String|
   Default: `'ccls'`
 
   This variable can be changed to use a different executable for ccls.
 
-
-g:ale_objc_ccls_init_options                     *g:ale_objc_ccls_init_options*
+                                           *ale-options.objc_ccls_init_options*
+                                                 *g:ale_objc_ccls_init_options*
                                                  *b:ale_objc_ccls_init_options*
+objc_ccls_init_options
+g:ale_objc_ccls_init_options
   Type: |Dictionary|
   Default: `{}`
 
   This variable can be changed to customize ccls initialization options.
   Example: >
-      {
-    \   'cacheDirectory': '/tmp/ccls',
-    \   'cacheFormat': 'binary',
-    \   'diagnostics': {
-    \     'onOpen': 0,
-    \     'opChange': 1000,
-    \   },
-    \ }
+
+  let g:ale_objc_ccls_init_options = {
+  \   'cacheDirectory': '/tmp/ccls',
+  \   'cacheFormat': 'binary',
+  \   'diagnostics': {
+  \       'onOpen': 0,
+  \       'opChange': 1000,
+  \   },
+  \}
 <
   Visit https://github.com/MaskRay/ccls/wiki/Initialization-options for all
   available options and explanations.
@@ -36,8 +42,11 @@ g:ale_objc_ccls_init_options                     *g:ale_objc_ccls_init_options*
 ===============================================================================
 clang                                                          *ale-objc-clang*
 
-g:ale_objc_clang_options                             *g:ale_objc_clang_options*
+                                               *ale-options.objc_clang_options*
+                                                     *g:ale_objc_clang_options*
                                                      *b:ale_objc_clang_options*
+objc_clang_options
+g:ale_objc_clang_options
   Type: |String|
   Default: `'-std=c11 -Wall'`
 
@@ -54,16 +63,21 @@ Note that the C options are also used for Objective-C.
 ===============================================================================
 clangd                                                        *ale-objc-clangd*
 
-g:ale_objc_clangd_executable                     *g:ale_objc_clangd_executable*
+                                           *ale-options.objc_clangd_executable*
+                                                 *g:ale_objc_clangd_executable*
                                                  *b:ale_objc_clangd_executable*
+objc_clangd_executable
+g:ale_objc_clangd_executable
   Type: |String|
   Default: `'clangd'`
 
   This variable can be changed to use a different executable for clangd.
 
-
-g:ale_objc_clangd_options                           *g:ale_objc_clangd_options*
+                                              *ale-options.objc_clangd_options*
+                                                    *g:ale_objc_clangd_options*
                                                     *b:ale_objc_clangd_options*
+objc_clangd_options
+g:ale_objc_clangd_options
   Type: |String|
   Default: `''`
 

--- a/doc/ale-objcpp.txt
+++ b/doc/ale-objcpp.txt
@@ -5,8 +5,11 @@ ALE Objective-C++ Integration                              *ale-objcpp-options*
 ===============================================================================
 clang                                                        *ale-objcpp-clang*
 
-g:ale_objcpp_clang_options                         *g:ale_objcpp_clang_options*
+                                             *ale-options.objcpp_clang_options*
+                                                   *g:ale_objcpp_clang_options*
                                                    *b:ale_objcpp_clang_options*
+objcpp_clang_options
+g:ale_objcpp_clang_options
   Type: |String|
   Default: `'-std=c++14 -Wall'`
 
@@ -16,16 +19,21 @@ g:ale_objcpp_clang_options                         *g:ale_objcpp_clang_options*
 ===============================================================================
 clangd                                                      *ale-objcpp-clangd*
 
-g:ale_objcpp_clangd_executable                 *g:ale_objcpp_clangd_executable*
+                                         *ale-options.objcpp_clangd_executable*
+                                               *g:ale_objcpp_clangd_executable*
                                                *b:ale_objcpp_clangd_executable*
+objcpp_clangd_executable
+g:ale_objcpp_clangd_executable
   Type: |String|
   Default: `'clangd'`
 
   This variable can be changed to use a different executable for clangd.
 
-
-g:ale_objcpp_clangd_options                       *g:ale_objcpp_clangd_options*
+                                            *ale-options.objcpp_clangd_options*
+                                                  *g:ale_objcpp_clangd_options*
                                                   *b:ale_objcpp_clangd_options*
+objcpp_clangd_options
+g:ale_objcpp_clangd_options
   Type: |String|
   Default: `''`
 

--- a/doc/ale-ocaml.txt
+++ b/doc/ale-ocaml.txt
@@ -8,19 +8,26 @@ dune                                                           *ale-ocaml-dune*
   Dune is a build system for OCaml projects. The `dune format` command is
   supported for automatically formatting `dune` and `dune-project` files.
 
-g:ale_ocaml_dune_executable                       *g:ale_ocaml_dune_executable*
+                                            *ale-options.ocaml_dune_executable*
+                                                  *g:ale_ocaml_dune_executable*
                                                   *b:ale_ocaml_dune_executable*
+ocaml_dune_executable
+g:ale_ocaml_dune_executable
   Type: |String|
   Default: `'dune'`
 
   This variable can be set to pass the path to dune.
 
-g:ale_ocaml_dune_options                             *g:ale_ocaml_dune_options*
+                                               *ale-options.ocaml_dune_options*
+                                                     *g:ale_ocaml_dune_options*
                                                      *b:ale_ocaml_dune_options*
+ocaml_dune_options
+g:ale_ocaml_dune_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass additional options to the dune fixer.
+
 
 ===============================================================================
 merlin                                                       *ale-ocaml-merlin*
@@ -30,6 +37,7 @@ merlin                                                       *ale-ocaml-merlin*
   detailed instructions
   (https://github.com/the-lambda-church/merlin/wiki/vim-from-scratch).
 
+
 ===============================================================================
 ocamllsp                                                   *ale-ocaml-ocamllsp*
 
@@ -37,8 +45,11 @@ ocamllsp                                                   *ale-ocaml-ocamllsp*
   Server Protocol. See the installation instructions:
   https://github.com/ocaml/ocaml-lsp#installation
 
-g:ale_ocaml_ocamllsp_use_opam                   *g:ale_ocaml_ocamllsp_use_opam*
+                                          *ale-options.ocaml_ocamllsp_use_opam*
+                                                *g:ale_ocaml_ocamllsp_use_opam*
                                                 *b:ale_ocaml_ocamllsp_use_opam*
+ocaml_ocamllsp_use_opam
+g:ale_ocaml_ocamllsp_use_opam
   Type: |Number|
   Default: `get(g:, 'ale_ocaml_ocamllsp_use_opam', 1)`
 
@@ -53,57 +64,80 @@ ols                                                             *ale-ocaml-ols*
   instructions:
   https://github.com/freebroccolo/ocaml-language-server#installation
 
-g:ale_ocaml_ols_executable                         *g:ale_ocaml_ols_executable*
+                                             *ale-options.ocaml_ols_executable*
+                                                   *g:ale_ocaml_ols_executable*
                                                    *b:ale_ocaml_ols_executable*
+ocaml_ols_executable
+g:ale_ocaml_ols_executable
   Type: |String|
   Default: `'ocaml-language-server'`
 
   This variable can be set to change the executable path for `ols`.
 
-g:ale_ocaml_ols_use_global                         *g:ale_ocaml_ols_use_global*
+                                             *ale-options.ocaml_ols_use_global*
+                                                   *g:ale_ocaml_ols_use_global*
                                                    *b:ale_ocaml_ols_use_global*
+ocaml_ols_use_global
+g:ale_ocaml_ols_use_global
   Type: |String|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
   This variable can be set to `1` to always use the globally installed
   executable. See also |ale-integrations-local-executables|.
 
+
 ===============================================================================
 ocamlformat                                             *ale-ocaml-ocamlformat*
 
-g:ale_ocaml_ocamlformat_executable         *g:ale_ocaml_ocamlformat_executable*
+                                     *ale-options.ocaml_ocamlformat_executable*
+                                           *g:ale_ocaml_ocamlformat_executable*
                                            *b:ale_ocaml_ocamlformat_executable*
+ocaml_ocamlformat_executable
+g:ale_ocaml_ocamlformat_executable
   Type: |String|
   Default: `'ocamlformat'`
 
   This variable can be set to pass the path of the ocamlformat fixer.
 
-g:ale_ocaml_ocamlformat_options               *g:ale_ocaml_ocamlformat_options*
+                                        *ale-options.ocaml_ocamlformat_options*
+                                              *g:ale_ocaml_ocamlformat_options*
                                               *b:ale_ocaml_ocamlformat_options*
+ocaml_ocamlformat_options
+g:ale_ocaml_ocamlformat_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass additional options to the ocamlformat fixer.
 
+
 ===============================================================================
 ocp-indent                                               *ale-ocaml-ocp-indent*
 
-g:ale_ocaml_ocp_indent_executable           *g:ale_ocaml_ocp_indent_executable*
+                                      *ale-options.ocaml_ocp_indent_executable*
+                                            *g:ale_ocaml_ocp_indent_executable*
                                             *b:ale_ocaml_ocp_indent_executable*
+ocaml_ocp_indent_executable
+g:ale_ocaml_ocp_indent_executable
   Type: |String|
   Default: `ocp-indent`
 
   This variable can be set to pass the path of the ocp-indent.
 
-g:ale_ocaml_ocp_indent_options                 *g:ale_ocaml_ocp_indent_options*
+                                         *ale-options.ocaml_ocp_indent_options*
+                                               *g:ale_ocaml_ocp_indent_options*
                                                *b:ale_ocaml_ocp_indent_options*
+ocaml_ocp_indent_options
+g:ale_ocaml_ocp_indent_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass additional options to the ocp-indent.
 
-g:ale_ocaml_ocp_indent_config                   *g:ale_ocaml_ocp_indent_config*
+                                          *ale-options.ocaml_ocp_indent_config*
+                                                *g:ale_ocaml_ocp_indent_config*
                                                 *b:ale_ocaml_ocp_indent_config*
+ocaml_ocp_indent_config
+g:ale_ocaml_ocp_indent_config
   Type: |String|
   Default: `''`
 

--- a/doc/ale-odin.txt
+++ b/doc/ale-odin.txt
@@ -3,27 +3,28 @@ ALE Odin Integration                                         *ale-odin-options*
                                                          *ale-integration-odin*
 
 ===============================================================================
-Integration Information
-
-  Currently, the only supported linter for Odin is ols.
-
-===============================================================================
 ols                                                              *ale-odin-ols*
 
-g:ale_odin_ols_executable                           *g:ale_odin_ols_executable*
+                                              *ale-options.odin_ols_executable*
+                                                    *g:ale_odin_ols_executable*
                                                     *b:ale_odin_ols_executable*
+odin_ols_executable
+g:ale_odin_ols_executable
   Type: |String|
   Default: `'ols'`
 
   This variable can be modified to change the executable path for `ols`.
 
-
-g:ale_odin_ols_config                                   *g:ale_odin_ols_config*
+                                                  *ale-options.odin_ols_config*
+                                                        *g:ale_odin_ols_config*
                                                         *b:ale_odin_ols_config*
+odin_ols_config
+g:ale_odin_ols_config
   Type: |Dictionary|
   Default: `{}`
 
   Dictionary with configuration settings for ols.
+
 
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-openapi.txt
+++ b/doc/ale-openapi.txt
@@ -1,22 +1,24 @@
 ===============================================================================
 ALE OpenApi Integration                                     *ale-openapi-options*
 
+
 ===============================================================================
 ibm_validator                                        *ale-openapi-ibm-validator*
 
 Website: https://github.com/IBM/openapi-validator
 
 
-Installation
 -------------------------------------------------------------------------------
+Installation
 
 Install ibm-openapi-validator either globally or locally: >
 
   npm install ibm-openapi-validator -g  # global
   npm install ibm-openapi-validator     # local
 <
-Configuration
+
 -------------------------------------------------------------------------------
+Configuration
 
 OpenAPI files can be written in YAML or JSON so in order for ALE plugins to
 work with these files we must set the buffer |filetype| to either |openapi.yaml|
@@ -39,19 +41,24 @@ filetype to |openapi.yaml| or |openapi.json|:
 
   https://github.com/hsanson/vim-openapi
 
-Options
--------------------------------------------------------------------------------
 
-g:ale_openapi_ibm_validator_executable   *g:ale_openapi_ibm_validator_executable*
+-------------------------------------------------------------------------------
+Options
+                                 *ale-options.openapi_ibm_validator_executable*
+                                       *g:ale_openapi_ibm_validator_executable*
                                          *b:ale_openapi_ibm_validator_executable*
+openapi_ibm_validator_executable
+g:ale_openapi_ibm_validator_executable
   Type: |String|
   Default: `'lint-openapi'`
 
   This variable can be set to change the path to lint-openapi.
 
-
-g:ale_openapi_ibm_validator_options       *g:ale_openapi_ibm_validator_options*
+                                    *ale-options.openapi_ibm_validator_options*
+                                          *g:ale_openapi_ibm_validator_options*
                                           *b:ale_openapi_ibm_validator_options*
+openapi_ibm_validator_options
+g:ale_openapi_ibm_validator_options
   Type: |String|
   Default: `''`
 

--- a/doc/ale-openscad.txt
+++ b/doc/ale-openscad.txt
@@ -5,16 +5,21 @@ ALE OpenSCAD Integration                                 *ale-openscad-options*
 ===============================================================================
 sca2d                                                      *ale-openscad-sca2d*
 
-g:ale_openscad_sca2d_executable               *g:ale_openscad_sca2d_executable*
+                                        *ale-options.openscad_sca2d_executable*
+                                              *g:ale_openscad_sca2d_executable*
                                               *b:ale_openscad_sca2d_executable*
+openscad_sca2d_executable
+g:ale_openscad_sca2d_executable
   Type: |String|
   Default: `'sca2d'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_openscad_sca2d_options                     *g:ale_openscad_sca2d_options*
+                                           *ale-options.openscad_sca2d_options*
+                                                 *g:ale_openscad_sca2d_options*
                                                  *b:ale_openscad_sca2d_options*
+openscad_sca2d_options
+g:ale_openscad_sca2d_options
   Type: |String|
   Default: `''`
 
@@ -24,20 +29,26 @@ g:ale_openscad_sca2d_options                     *g:ale_openscad_sca2d_options*
 ===============================================================================
 scadformat                                            *ale-openscad-scadformat*
 
-g:ale_openscad_scadformat_executable     *g:ale_openscad_scadformat_executable*
+                                   *ale-options.openscad_scadformat_executable*
+                                         *g:ale_openscad_scadformat_executable*
                                          *b:ale_openscad_scadformat_executable*
+openscad_scadformat_executable
+g:ale_openscad_scadformat_executable
   Type: |String|
   Default: `'scadformat'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_openscad_scadformat_options           *g:ale_openscad_scadformat_options*
+                                      *ale-options.openscad_scadformat_options*
+                                            *g:ale_openscad_scadformat_options*
                                             *b:ale_openscad_scadformat_options*
+openscad_scadformat_options
+g:ale_openscad_scadformat_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass options to scadformat.
+
 
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-packer.txt
+++ b/doc/ale-packer.txt
@@ -5,19 +5,25 @@ ALE Packer Integration                                     *ale-packer-options*
 ===============================================================================
 packer-fmt-fixer                                         *ale-packer-fmt-fixer*
 
-g:ale_packer_fmt_executable                       *g:ale_packer_fmt_executable*
+                                            *ale-options.packer_fmt_executable*
+                                                  *g:ale_packer_fmt_executable*
                                                   *b:ale_packer_fmt_executable*
-
+packer_fmt_executable
+g:ale_packer_fmt_executable
   Type: |String|
   Default: `'packer'`
 
   This variable can be changed to use a different executable for packer.
 
-
-g:ale_packer_fmt_options                             *g:ale_packer_fmt_options*
+                                               *ale-options.packer_fmt_options*
+                                                     *g:ale_packer_fmt_options*
                                                      *b:ale_packer_fmt_options*
+packer_fmt_options
+g:ale_packer_fmt_options
   Type: |String|
   Default: `''`
+
+  This variable can be set to change command lines options for `packer fmt`
 
 
 ===============================================================================

--- a/doc/ale-pascal.txt
+++ b/doc/ale-pascal.txt
@@ -1,23 +1,29 @@
 ===============================================================================
 ALE Pascal Integration                                     *ale-pascal-options*
 
+
 ===============================================================================
 ptop                                                          *ale-pascal-ptop*
 
-g:ale_pascal_ptop_executable                     *g:ale_pascal_ptop_executable*
+                                           *ale-options.pascal_ptop_executable*
+                                                 *g:ale_pascal_ptop_executable*
                                                  *b:ale_pascal_ptop_executable*
+pascal_ptop_executable
+g:ale_pascal_ptop_executable
   Type: |String|
   Default: `'ptop'`
 
   This variable can be changed to specify the ptop executable.
 
-
-g:ale_pascal_ptop_options                           *g:ale_pascal_ptop_options*
+                                              *ale-options.pascal_ptop_options*
+                                                    *g:ale_pascal_ptop_options*
                                                     *b:ale_pascal_ptop_options*
+pascal_ptop_options
+g:ale_pascal_ptop_options
   Type: |String|
   Default: `''`
 
-This variable can be set to pass additional options to the ptop fixer.
+  This variable can be set to pass additional options to the ptop fixer.
 
 
 ===============================================================================

--- a/doc/ale-perl.txt
+++ b/doc/ale-perl.txt
@@ -13,16 +13,21 @@ See |g:ale_linters|.
 ===============================================================================
 perl                                                            *ale-perl-perl*
 
-g:ale_perl_perl_executable                         *g:ale_perl_perl_executable*
+                                             *ale-options.perl_perl_executable*
+                                                   *g:ale_perl_perl_executable*
                                                    *b:ale_perl_perl_executable*
+perl_perl_executable
+g:ale_perl_perl_executable
   Type: |String|
   Default: `'perl'`
 
   This variable can be changed to modify the executable used for linting perl.
 
-
-g:ale_perl_perl_options                               *g:ale_perl_perl_options*
+                                                *ale-options.perl_perl_options*
+                                                      *g:ale_perl_perl_options*
                                                       *b:ale_perl_perl_options*
+perl_perl_options
+g:ale_perl_perl_options
   Type: |String|
   Default: `'-c -Mwarnings -Ilib'`
 
@@ -33,17 +38,22 @@ g:ale_perl_perl_options                               *g:ale_perl_perl_options*
 ===============================================================================
 perlcritic                                                *ale-perl-perlcritic*
 
-g:ale_perl_perlcritic_executable              *g:ale_perl_perlcritic_executable*
-                                              *b:ale_perl_perlcritic_executable*
+                                       *ale-options.perl_perlcritic_executable*
+                                             *g:ale_perl_perlcritic_executable*
+                                             *b:ale_perl_perlcritic_executable*
+perl_perlcritic_executable
+g:ale_perl_perlcritic_executable
   Type: |String|
   Default: `'perlcritic'`
 
   This variable can be changed to modify the perlcritic executable used for
   linting perl.
 
-
-g:ale_perl_perlcritic_profile                    *g:ale_perl_perlcritic_profile*
-                                                 *b:ale_perl_perlcritic_profile*
+                                          *ale-options.perl_perlcritic_profile*
+                                                *g:ale_perl_perlcritic_profile*
+                                                *b:ale_perl_perlcritic_profile*
+perl_perlcritic_profile
+g:ale_perl_perlcritic_profile
   Type: |String|
   Default: `'.perlcriticrc'`
 
@@ -59,33 +69,42 @@ g:ale_perl_perlcritic_profile                    *g:ale_perl_perlcritic_profile*
   string and pass `'--no-profile'`to perlcritic via the
   |g:ale_perl_perlcritic_options| variable.
 
-
-g:ale_perl_perlcritic_options                    *g:ale_perl_perlcritic_options*
-                                                 *b:ale_perl_perlcritic_options*
+                                          *ale-options.perl_perlcritic_options*
+                                                *g:ale_perl_perlcritic_options*
+                                                *b:ale_perl_perlcritic_options*
+perl_perlcritic_options
+g:ale_perl_perlcritic_options
   Type: |String|
   Default: `''`
 
   This variable can be changed to supply additional command-line arguments to
   the perlcritic invocation.
 
-
-g:ale_perl_perlcritic_showrules               *g:ale_perl_perlcritic_showrules*
-
+                                        *ale-options.perl_perlcritic_showrules*
+                                              *g:ale_perl_perlcritic_showrules*
+perl_perlcritic_showrules
+g:ale_perl_perlcritic_showrules
   Type: |Number|
   Default: `0`
 
   Controls whether perlcritic rule names are shown after the error message.
   Defaults to off to reduce length of message.
+
+
 ===============================================================================
 perltidy                                                    *ale-perl-perltidy*
 
-g:ale_perl_perltidy_options                       *g:ale_perl_perltidy_options*
+                                            *ale-options.perl_perltidy_options*
+                                                  *g:ale_perl_perltidy_options*
                                                   *b:ale_perl_perltidy_options*
+perl_perltidy_options
+g:ale_perl_perltidy_options
   Type: |String|
   Default: `''`
 
   This variable can be changed to alter the command-line arguments to
   the perltidy invocation.
+
 
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-perl6.txt
+++ b/doc/ale-perl6.txt
@@ -22,22 +22,28 @@ See |g:ale_linters|.
 ===============================================================================
 perl6                                                         *ale-perl6-perl6*
 
-g:ale_perl6_perl6_executable                     *g:ale_perl6_perl6_executable*
+                                           *ale-options.perl6_perl6_executable*
+                                                 *g:ale_perl6_perl6_executable*
                                                  *b:ale_perl6_perl6_executable*
+perl6_perl6_executable
+g:ale_perl6_perl6_executable
   Type: |String|
   Default: `'perl6'`
 
   This variable can be changed to modify the executable used for linting
   perl6.
 
-
-g:ale_perl6_perl6_options                           *g:ale_perl6_perl6_options*
+                                              *ale-options.perl6_perl6_options*
+                                                    *g:ale_perl6_perl6_options*
                                                     *b:ale_perl6_perl6_options*
+perl6_perl6_options
+g:ale_perl6_perl6_options
   Type: |String|
   Default: `'-c -Ilib'`
 
   This variable can be changed to alter the command-line arguments to the
   perl6 invocation.
+
 
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-php.txt
+++ b/doc/ale-php.txt
@@ -11,8 +11,11 @@ See |ale-cspell-options|
 ===============================================================================
 langserver                                                 *ale-php-langserver*
 
-g:ale_php_langserver_executable               *g:ale_php_langserver_executable*
+                                        *ale-options.php_langserver_executable*
+                                              *g:ale_php_langserver_executable*
                                               *b:ale_php_langserver_executable*
+php_langserver_executable
+g:ale_php_langserver_executable
   Type: |String|
   Default: `'php-language-server.php'`
 
@@ -22,9 +25,11 @@ g:ale_php_langserver_executable               *g:ale_php_langserver_executable*
 
   See: |ale-integrations-local-executables|
 
-
-g:ale_php_langserver_use_global               *g:ale_php_langserver_use_global*
+                                        *ale-options.php_langserver_use_global*
+                                              *g:ale_php_langserver_use_global*
                                               *b:ale_php_langserver_use_global*
+php_langserver_use_global
+g:ale_php_langserver_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
@@ -41,24 +46,31 @@ WARNING: please use the phan_client linter if you have an configuration file
 for your project because the phan will look into your entirely project and
 ale will display in the current buffer warnings that may belong to other file.
 
-g:ale_php_phan_minimum_severity               *g:ale_php_phan_minimum_severity*
+                                        *ale-options.php_phan_minimum_severity*
+                                              *g:ale_php_phan_minimum_severity*
                                               *b:ale_php_phan_minimum_severity*
+php_phan_minimum_severity
+g:ale_php_phan_minimum_severity
   Type: |Number|
   Default: `0`
 
   This variable defines the minimum severity level.
 
-
-g:ale_php_phan_executable                           *g:ale_php_phan_executable*
+                                              *ale-options.php_phan_executable*
+                                                    *g:ale_php_phan_executable*
                                                     *b:ale_php_phan_executable*
+php_phan_executable
+g:ale_php_phan_executable
   Type: |String|
   Default: `'phan'`
 
   This variable sets executable used for phan or phan_client.
 
-
-g:ale_php_phan_use_client                           *g:ale_php_phan_use_client*
+                                              *ale-options.php_phan_use_client*
+                                                    *g:ale_php_phan_use_client*
                                                     *b:ale_php_phan_use_client*
+php_phan_use_client
+g:ale_php_phan_use_client
   Type: |Number|
   Default: `get(g:, 'ale_php_phan_use_client', 0)`
 
@@ -69,16 +81,21 @@ g:ale_php_phan_use_client                           *g:ale_php_phan_use_client*
 ===============================================================================
 phpcbf                                                         *ale-php-phpcbf*
 
-g:ale_php_phpcbf_executable                       *g:ale_php_phpcbf_executable*
+                                            *ale-options.php_phpcbf_executable*
+                                                  *g:ale_php_phpcbf_executable*
                                                   *b:ale_php_phpcbf_executable*
+php_phpcbf_executable
+g:ale_php_phpcbf_executable
   Type: |String|
   Default: `'phpcbf'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_php_phpcbf_standard                           *g:ale_php_phpcbf_standard*
+                                              *ale-options.php_phpcbf_standard*
+                                                    *g:ale_php_phpcbf_standard*
                                                     *b:ale_php_phpcbf_standard*
+php_phpcbf_standard
+g:ale_php_phpcbf_standard
   Type: |String|
   Default: `''`
 
@@ -86,17 +103,21 @@ g:ale_php_phpcbf_standard                           *g:ale_php_phpcbf_standard*
   coding standard is specified, phpcbf will default to fixing against the
   PEAR coding standard, or the standard you have set as the default.
 
-
-g:ale_php_phpcbf_use_global                       *g:ale_php_phpcbf_use_global*
+                                            *ale-options.php_phpcbf_use_global*
+                                                  *g:ale_php_phpcbf_use_global*
                                                   *b:ale_php_phpcbf_use_global*
+php_phpcbf_use_global
+g:ale_php_phpcbf_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_php_phpcbf_options                              *g:ale_php_phpcbf_options*
+                                               *ale-options.php_phpcbf_options*
+                                                     *g:ale_php_phpcbf_options*
                                                       *b:ale_php_phpcbf_options*
+php_phpcbf_options
+g:ale_php_phpcbf_options
   Type: |String|
   Default: `''`
 
@@ -106,16 +127,21 @@ g:ale_php_phpcbf_options                              *g:ale_php_phpcbf_options*
 ===============================================================================
 phpcs                                                           *ale-php-phpcs*
 
-g:ale_php_phpcs_executable                         *g:ale_php_phpcs_executable*
+                                             *ale-options.php_phpcs_executable*
+                                                   *g:ale_php_phpcs_executable*
                                                    *b:ale_php_phpcs_executable*
+php_phpcs_executable
+g:ale_php_phpcs_executable
   Type: |String|
   Default: `'phpcs'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_php_phpcs_standard                             *g:ale_php_phpcs_standard*
+                                               *ale-options.php_phpcs_standard*
+                                                     *g:ale_php_phpcs_standard*
                                                      *b:ale_php_phpcs_standard*
+php_phpcs_standard
+g:ale_php_phpcs_standard
   Type: |String|
   Default: `''`
 
@@ -123,17 +149,21 @@ g:ale_php_phpcs_standard                             *g:ale_php_phpcs_standard*
   coding standard is specified, phpcs will default to checking against the
   PEAR coding standard, or the standard you have set as the default.
 
-
-g:ale_php_phpcs_use_global                         *g:ale_php_phpcs_use_global*
+                                             *ale-options.php_phpcs_use_global*
+                                                   *g:ale_php_phpcs_use_global*
                                                    *b:ale_php_phpcs_use_global*
+php_phpcs_use_global
+g:ale_php_phpcs_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_php_phpcs_options                               *g:ale_php_phpcs_options*
+                                                *ale-options.php_phpcs_options*
+                                                      *g:ale_php_phpcs_options*
                                                       *b:ale_php_phpcs_options*
+php_phpcs_options
+g:ale_php_phpcs_options
   Type: |String|
   Default: `''`
 
@@ -143,16 +173,21 @@ g:ale_php_phpcs_options                               *g:ale_php_phpcs_options*
 ===============================================================================
 phpmd                                                           *ale-php-phpmd*
 
-g:ale_php_phpmd_executable                         *g:ale_php_phpmd_executable*
+                                             *ale-options.php_phpmd_executable*
+                                                   *g:ale_php_phpmd_executable*
                                                    *b:ale_php_phpmd_executable*
+php_phpmd_executable
+g:ale_php_phpmd_executable
   Type: |String|
   Default: `'phpmd'`
 
   This variable sets executable used for phpmd.
 
-
-g:ale_php_phpmd_ruleset                               *g:ale_php_phpmd_ruleset*
+                                                *ale-options.php_phpmd_ruleset*
+                                                      *g:ale_php_phpmd_ruleset*
                                                       *b:ale_php_phpmd_ruleset*
+php_phpmd_ruleset
+g:ale_php_phpmd_ruleset
   Type: |String|
   Default: `'cleancode,codesize,controversial,design,naming,unusedcode'`
 
@@ -163,16 +198,21 @@ g:ale_php_phpmd_ruleset                               *g:ale_php_phpmd_ruleset*
 ===============================================================================
 phpstan                                                       *ale-php-phpstan*
 
-g:ale_php_phpstan_executable                     *g:ale_php_phpstan_executable*
+                                           *ale-options.php_phpstan_executable*
+                                                 *g:ale_php_phpstan_executable*
                                                  *b:ale_php_phpstan_executable*
+php_phpstan_executable
+g:ale_php_phpstan_executable
   Type: |String|
   Default: `'phpstan'`
 
   This variable sets executable used for phpstan.
 
-
-g:ale_php_phpstan_level                               *g:ale_php_phpstan_level*
+                                                *ale-options.php_phpstan_level*
+                                                      *g:ale_php_phpstan_level*
                                                       *b:ale_php_phpstan_level*
+php_phpstan_level
+g:ale_php_phpstan_level
   Type: |String|
   Default: `''`
 
@@ -181,25 +221,31 @@ g:ale_php_phpstan_level                               *g:ale_php_phpstan_level*
   the configuration file. If no configuration file can be detected, `'7'` will
   be used instead.
 
-
-g:ale_php_phpstan_configuration               *g:ale_php_phpstan_configuration*
+                                        *ale-options.php_phpstan_configuration*
+                                              *g:ale_php_phpstan_configuration*
                                               *b:ale_php_phpstan_configuration*
+php_phpstan_configuration
+g:ale_php_phpstan_configuration
   Type: |String|
   Default: `''`
 
   This variable sets path to phpstan configuration file.
 
-
-g:ale_php_phpstan_autoload                         *g:ale_php_phpstan_autoload*
+                                             *ale-options.php_phpstan_autoload*
+                                                   *g:ale_php_phpstan_autoload*
                                                    *b:ale_php_phpstan_autoload*
+php_phpstan_autoload
+g:ale_php_phpstan_autoload
   Type: |String|
   Default: `''`
 
   This variable sets path to phpstan autoload file.
 
-
-g:ale_php_phpstan_memory_limit                 *g:ale_php_phpstan_memory-limit*
+                                         *ale-options.php_phpstan_memory_limit*
+                                               *g:ale_php_phpstan_memory_limit*
                                                *b:ale_php_phpstan_memory-limit*
+php_phpstan_memory_limit
+g:ale_php_phpstan_memory_limit
   Type: |String|
   Default: `''`
 
@@ -210,24 +256,31 @@ g:ale_php_phpstan_memory_limit                 *g:ale_php_phpstan_memory-limit*
 ===============================================================================
 psalm                                                           *ale-php-psalm*
 
-g:ale_php_psalm_executable                         *g:ale_php_psalm_executable*
+                                             *ale-options.php_psalm_executable*
+                                                   *g:ale_php_psalm_executable*
                                                    *b:ale_php_psalm_executable*
+php_psalm_executable
+g:ale_php_psalm_executable
   Type: |String|
   Default: `'psalm'`
 
   This variable sets the executable used for psalm.
 
-
-g:ale_php_psalm_options                               *g:ale_php_psalm_options*
+                                                *ale-options.php_psalm_options*
+                                                      *g:ale_php_psalm_options*
                                                       *b:ale_php_psalm_options*
+php_psalm_options
+g:ale_php_psalm_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass additional options to psalm.
 
-
-g:ale_php_psalm_use_global                         *g:ale_php_psalm_use_global*
+                                             *ale-options.php_psalm_use_global*
+                                                   *g:ale_php_psalm_use_global*
                                                    *b:ale_php_psalm_use_global*
+php_psalm_use_global
+g:ale_php_psalm_use_global
   Type: |Boolean|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
@@ -237,24 +290,31 @@ g:ale_php_psalm_use_global                         *g:ale_php_psalm_use_global*
 ===============================================================================
 php-cs-fixer                                             *ale-php-php-cs-fixer*
 
-g:ale_php_cs_fixer_executable                   *g:ale_php_cs_fixer_executable*
+                                          *ale-options.php_cs_fixer_executable*
+                                                *g:ale_php_cs_fixer_executable*
                                                 *b:ale_php_cs_fixer_executable*
+php_cs_fixer_executable
+g:ale_php_cs_fixer_executable
   Type: |String|
   Default: `'php-cs-fixer'`
 
   This variable sets executable used for php-cs-fixer.
 
-
-g:ale_php_cs_fixer_options                         *g:ale_php_cs_fixer_options*
+                                             *ale-options.php_cs_fixer_options*
+                                                   *g:ale_php_cs_fixer_options*
                                                    *b:ale_php_cs_fixer_options*
+php_cs_fixer_options
+g:ale_php_cs_fixer_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass additional options to php-cs-fixer.
 
-
-g:ale_php_cs_fixer_use_global                   *g:ale_php_cs_fixer_use_global*
+                                          *ale-options.php_cs_fixer_use_global*
+                                                *g:ale_php_cs_fixer_use_global*
                                                 *b:ale_php_cs_fixer_use_global*
+php_cs_fixer_use_global
+g:ale_php_cs_fixer_use_global
   Type: |Boolean|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
@@ -264,8 +324,11 @@ g:ale_php_cs_fixer_use_global                   *g:ale_php_cs_fixer_use_global*
 ===============================================================================
 php                                                               *ale-php-php*
 
-g:ale_php_php_executable                             *g:ale_php_php_executable*
+                                               *ale-options.php_php_executable*
+                                                     *g:ale_php_php_executable*
                                                      *b:ale_php_php_executable*
+php_php_executable
+g:ale_php_php_executable
   Type: |String|
   Default: `'php'`
 
@@ -275,24 +338,31 @@ g:ale_php_php_executable                             *g:ale_php_php_executable*
 ===============================================================================
 pint                                                             *ale-php-pint*
 
-g:ale_php_pint_executable                           *g:ale_php_pint_executable*
+                                              *ale-options.php_pint_executable*
+                                                    *g:ale_php_pint_executable*
                                                     *b:ale_php_pint_executable*
+php_pint_executable
+g:ale_php_pint_executable
   Type: |String|
   Default: `'pint'`
 
   This variable sets the executable used for pint.
 
-
-g:ale_php_pint_options                                 *g:ale_php_pint_options*
+                                                 *ale-options.php_pint_options*
+                                                       *g:ale_php_pint_options*
                                                        *b:ale_php_pint_options*
+php_pint_options
+g:ale_php_pint_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass additional options to pint.
 
-
-g:ale_php_pint_use_global                           *g:ale_php_pint_use_global*
+                                              *ale-options.php_pint_use_global*
+                                                    *g:ale_php_pint_use_global*
                                                     *b:ale_php_pint_use_global*
+php_pint_use_global
+g:ale_php_pint_use_global
   Type: |Boolean|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
@@ -302,24 +372,31 @@ g:ale_php_pint_use_global                           *g:ale_php_pint_use_global*
 ===============================================================================
 tlint                                                           *ale-php-tlint*
 
-g:ale_php_tlint_executable                         *g:ale_php_tlint_executable*
+                                             *ale-options.php_tlint_executable*
+                                                   *g:ale_php_tlint_executable*
                                                    *b:ale_php_tlint_executable*
+php_tlint_executable
+g:ale_php_tlint_executable
   Type: |String|
   Default: `'tlint'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_php_tlint_use_global                         *g:ale_php_tlint_use_global*
+                                             *ale-options.php_tlint_use_global*
+                                                   *g:ale_php_tlint_use_global*
                                                    *b:ale_php_tlint_use_global*
+php_tlint_use_global
+g:ale_php_tlint_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_php_tlint_options                               *g:ale_php_tlint_options*
+                                                *ale-options.php_tlint_options*
+                                                      *g:ale_php_tlint_options*
                                                       *b:ale_php_tlint_options*
+php_tlint_options
+g:ale_php_tlint_options
   Type: |String|
   Default: `''`
 
@@ -329,8 +406,11 @@ g:ale_php_tlint_options                               *g:ale_php_tlint_options*
 ===============================================================================
 intelephense                                             *ale-php-intelephense*
 
-g:ale_php_intelephense_executable           *g:ale_php_intelephense_executable*
+                                      *ale-options.php_intelephense_executable*
+                                            *g:ale_php_intelephense_executable*
                                             *b:ale_php_intelephense_executable*
+php_intelephense_executable
+g:ale_php_intelephense_executable
   Type: |String|
   Default: `'intelephense'`
 
@@ -341,9 +421,11 @@ g:ale_php_intelephense_executable           *g:ale_php_intelephense_executable*
 
   See: |ale-integrations-local-executables|
 
-
-g:ale_php_intelephense_use_global           *g:ale_php_intelephense_use_global*
+                                      *ale-options.php_intelephense_use_global*
+                                            *g:ale_php_intelephense_use_global*
                                             *b:ale_php_intelephense_use_global*
+php_intelephense_use_global
+g:ale_php_intelephense_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
@@ -352,9 +434,11 @@ g:ale_php_intelephense_use_global           *g:ale_php_intelephense_use_global*
 
   See: |ale-integrations-local-executables|
 
-
-g:ale_php_intelephense_config                   *g:ale_php_intelephense_config*
+                                          *ale-options.php_intelephense_config*
+                                                *g:ale_php_intelephense_config*
                                                 *b:ale_php_intelephense_config*
+php_intelephense_config
+g:ale_php_intelephense_config
   Type: |Dictionary|
   Default: `{}`
 

--- a/doc/ale-pony.txt
+++ b/doc/ale-pony.txt
@@ -5,16 +5,21 @@ ALE Pony Integration                                         *ale-pony-options*
 ===============================================================================
 ponyc                                                          *ale-pony-ponyc*
 
-g:ale_pony_ponyc_executable                       *g:ale_pony_ponyc_executable*
+                                            *ale-options.pony_ponyc_executable*
+                                                  *g:ale_pony_ponyc_executable*
                                                   *b:ale_pony_ponyc_executable*
+pony_ponyc_executable
+g:ale_pony_ponyc_executable
   Type: |String|
   Default: `'ponyc'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_pony_ponyc_options                             *g:ale_pony_ponyc_options*
+                                               *ale-options.pony_ponyc_options*
+                                                     *g:ale_pony_ponyc_options*
                                                      *b:ale_pony_ponyc_options*
+pony_ponyc_options
+g:ale_pony_ponyc_options
   Type: |String|
   Default: `'--pass paint'`
 

--- a/doc/ale-powershell.txt
+++ b/doc/ale-powershell.txt
@@ -11,8 +11,11 @@ See |ale-cspell-options|
 ===============================================================================
 powershell                                          *ale-powershell-powershell*
 
-g:ale_powershell_powershell_executable *g:ale_powershell_powershell_executable*
+                                 *ale-options.powershell_powershell_executable*
+                                       *g:ale_powershell_powershell_executable*
                                        *b:ale_powershell_powershell_executable*
+powershell_powershell_executable
+g:ale_powershell_powershell_executable
   Type: |String|
   Default: `'pwsh'`
 
@@ -26,15 +29,21 @@ g:ale_powershell_powershell_executable *g:ale_powershell_powershell_executable*
 ===============================================================================
 psscriptanalyzer                              *ale-powershell-psscriptanalyzer*
 
-Installation
+
 -------------------------------------------------------------------------------
+Installation
 
 Install PSScriptAnalyzer by any means, so long as it can be automatically
 imported in PowerShell.
 
-g:ale_powershell_psscriptanalyzer_executable
-*g:ale_powershell_psscriptanalyzer_executable*
+
+-------------------------------------------------------------------------------
+Options
+                           *ale-options.powershell_psscriptanalyzer_executable*
+                                 *g:ale_powershell_psscriptanalyzer_executable*
                                  *b:ale_powershell_psscriptanalyzer_executable*
+powershell_psscriptanalyzer_executable
+g:ale_powershell_psscriptanalyzer_executable
   Type: |String|
   Default: `'pwsh'`
 
@@ -45,27 +54,29 @@ g:ale_powershell_psscriptanalyzer_executable
   let g:ale_powershell_psscriptanalyzer_executable = 'powershell.exe'
 <
 
-g:ale_powershell_psscriptanalyzer_module
-*g:ale_powershell_psscriptanalyzer_module*
+                               *ale-options.powershell_psscriptanalyzer_module*
+                                     *g:ale_powershell_psscriptanalyzer_module*
                                      *b:ale_powershell_psscriptanalyzer_module*
-  Type: |String
+powershell_psscriptanalyzer_module
+g:ale_powershell_psscriptanalyzer_module
+  Type: |String|
   Default: `'psscriptanalyzer'`
 
   This variable sets the name of the psscriptanalyzer module.
   for psscriptanalyzer invocation.
 
-
-g:ale_powershell_psscriptanalyzer_exclusions
-*g:ale_powershell_psscriptanalyzer_exclusions*
+                           *ale-options.powershell_psscriptanalyzer_exclusions*
+                                 *g:ale_powershell_psscriptanalyzer_exclusions*
                                  *b:ale_powershell_psscriptanalyzer_exclusions*
+powershell_psscriptanalyzer_exclusions
+g:ale_powershell_psscriptanalyzer_exclusions
   Type: |String|
   Default: `''`
 
   Set this variable to exclude test(s) for psscriptanalyzer
   (-ExcludeRule option).  To exclude more than one option, separate them with
-  commas.
+  commas. >
 
->
   " Suppress Write-Host and Global vars warnings
   let g:ale_powershell_psscriptanalyzer_exclusions =
   \  'PSAvoidUsingWriteHost,PSAvoidGlobalVars'

--- a/doc/ale-prolog.txt
+++ b/doc/ale-prolog.txt
@@ -5,15 +5,21 @@ ALE Prolog Integration                                     *ale-prolog-options*
 ===============================================================================
 swipl                                                        *ale-prolog-swipl*
 
-g:ale_prolog_swipl_executable                   *g:ale_prolog_swipl_executable*
+                                          *ale-options.prolog_swipl_executable*
+                                                *g:ale_prolog_swipl_executable*
                                                 *b:ale_prolog_swipl_executable*
+prolog_swipl_executable
+g:ale_prolog_swipl_executable
   Type: |String|
   Default: `'swipl'`
 
   The executable that will be run for the `swipl` linter.
 
-g:ale_prolog_swipl_load                               *g:ale_prolog_swipl_load*
+                                                *ale-options.prolog_swipl_load*
+                                                      *g:ale_prolog_swipl_load*
                                                       *b:ale_prolog_swipl_load*
+prolog_swipl_load
+g:ale_prolog_swipl_load
   Type: |String|
   Default: `'current_prolog_flag(argv, [File]), load_files(File, [sandboxed(true)]), halt.'`
 
@@ -25,8 +31,11 @@ g:ale_prolog_swipl_load                               *g:ale_prolog_swipl_load*
 
   NOTE: `sandboxed(true)` prohibits executing some directives such as 'initialization main'.
 
-g:ale_prolog_swipl_timeout                         *g:ale_prolog_swipl_timeout*
+                                             *ale-options.prolog_swipl_timeout*
+                                                   *g:ale_prolog_swipl_timeout*
                                                    *b:ale_prolog_swipl_timeout*
+prolog_swipl_timeout
+g:ale_prolog_swipl_timeout
   Type: |Number|
   Default: `3`
 
@@ -34,8 +43,11 @@ g:ale_prolog_swipl_timeout                         *g:ale_prolog_swipl_timeout*
   It is done by setting SIGALRM.
   See |g:ale_prolog_swipl_alarm| and |g:ale_prolog_swipl_alarm_handler|.
 
-g:ale_prolog_swipl_alarm                             *g:ale_prolog_swipl_alarm*
+                                               *ale-options.prolog_swipl_alarm*
+                                                     *g:ale_prolog_swipl_alarm*
                                                      *b:ale_prolog_swipl_alarm*
+prolog_swipl_alarm
+g:ale_prolog_swipl_alarm
   Type: |String|
   Default: `'alarm(%t, (%h), _, [])'`
 
@@ -43,8 +55,11 @@ g:ale_prolog_swipl_alarm                             *g:ale_prolog_swipl_alarm*
   `%t` is replaced by |g:ale_prolog_swipl_timeout|.
   `%h` is replaced by |g:ale_prolog_swipl_alarm_handler|.
 
-g:ale_prolog_swipl_alarm_handler             *g:ale_prolog_swipl_alarm_handler*
+                                       *ale-options.prolog_swipl_alarm_handler*
+                                             *g:ale_prolog_swipl_alarm_handler*
                                              *b:ale_prolog_swipl_alarm_handler*
+prolog_swipl_alarm_handler
+g:ale_prolog_swipl_alarm_handler
   Type: |String|
   Default: `'writeln(user_error, "ERROR: Exceeded %t seconds, Please change g:prolog_swipl_timeout to modify the limit."), halt(1)'`
 

--- a/doc/ale-proto.txt
+++ b/doc/ale-proto.txt
@@ -1,5 +1,5 @@
 ===============================================================================
-ALE Proto Integration                                         *ale-proto-options*
+ALE Proto Integration                                       *ale-proto-options*
 
 
 ===============================================================================
@@ -10,23 +10,23 @@ To enable `.proto` file linting, update |g:ale_linters| as appropriate:
   " Enable linter for .proto files
   let g:ale_linters = {'proto': ['buf-lint', 'protoc-gen-lint', 'protolint']}
 <
-
 To enable `.proto` file fixing, update |g:ale_fixers| as appropriate:
 >
   " Enable linter for .proto files
   let b:ale_fixers = {'proto': ['buf-format', 'protolint']}
 <
 
-
 ===============================================================================
-buf-format                                                *ale-proto-buf-format*
+buf-format                                               *ale-proto-buf-format*
 
   The formatter uses `buf`, a fully-featured Protobuf compiler that doesn't depend
   on `protoc`. Make sure the `buf` binary is available in the system path, or
   set ale_proto_buf_format_executable.
 
-g:ale_proto_buf_format_executable           *g:ale_proto_buf_format_executable*
-
+                                      *ale-options.proto_buf_format_executable*
+                                            *g:ale_proto_buf_format_executable*
+proto_buf_format_executable
+g:ale_proto_buf_format_executable
   Type: |String|
   Default: `'buf'`
 
@@ -34,21 +34,25 @@ g:ale_proto_buf_format_executable           *g:ale_proto_buf_format_executable*
 
 
 ===============================================================================
-buf-lint                                                    *ale-proto-buf-lint*
+buf-lint                                                   *ale-proto-buf-lint*
 
   The linter uses `buf`, a fully-featured Protobuf compiler that doesn't depend
   on `protoc`. Make sure the `buf` binary is available in the system path, or
   set ale_proto_buf_lint_executable.
 
-g:ale_proto_buf_lint_executable               *g:ale_proto_buf_lint_executable*
-
+                                        *ale-options.proto_buf_lint_executable*
+                                              *g:ale_proto_buf_lint_executable*
+proto_buf_lint_executable
+g:ale_proto_buf_lint_executable
   Type: |String|
   Default: `'buf'`
 
   This variable can be changed to modify the executable used for buf.
 
-g:ale_proto_buf_lint_config                       *g:ale_proto_buf_lint_config*
-
+                                            *ale-options.proto_buf_lint_config*
+                                                  *g:ale_proto_buf_lint_config*
+proto_buf_lint_config
+g:ale_proto_buf_lint_config
   Type: |String|
   Default: `''`
 
@@ -66,13 +70,15 @@ Note that the C options are also used for Proto.
 
 
 ===============================================================================
-protoc-gen-lint                                      *ale-proto-protoc-gen-lint*
+protoc-gen-lint                                     *ale-proto-protoc-gen-lint*
 
   The linter is a plugin for the `protoc` binary. As long as the binary resides
   in the system path, `protoc` will find it.
 
-g:ale_proto_protoc_gen_lint_options       *g:ale_proto_protoc_gen_lint_options*
-
+                                    *ale-options.proto_protoc_gen_lint_options*
+                                          *g:ale_proto_protoc_gen_lint_options*
+proto_protoc_gen_lint_options
+g:ale_proto_protoc_gen_lint_options
   Type: |String|
   Default: `''`
 
@@ -82,7 +88,7 @@ g:ale_proto_protoc_gen_lint_options       *g:ale_proto_protoc_gen_lint_options*
 
 
 ===============================================================================
-protolint                                                   *ale-proto-protolint*
+protolint                                                 *ale-proto-protolint*
 
   The linter is a pluggable tool that doesn't depend on the `protoc` binary.
   This supports both linting and fixing.
@@ -90,15 +96,19 @@ protolint                                                   *ale-proto-protolint
   ale_proto_protolint_executable.
   Note that the binary with v0.22.0 or above is supported.
 
-g:ale_proto_protolint_executable             *g:ale_proto_protolint_executable*
-
+                                       *ale-options.proto_protolint_executable*
+                                             *g:ale_proto_protolint_executable*
+proto_protolint_executable
+g:ale_proto_protolint_executable
   Type: |String|
   Default: `'protolint'`
 
   This variable can be changed to modify the executable used for protolint.
 
-g:ale_proto_protolint_config                     *g:ale_proto_protolint_config*
-
+                                           *ale-options.proto_protolint_config*
+                                                 *g:ale_proto_protolint_config*
+proto_protolint_config
+g:ale_proto_protolint_config
   Type: |String|
   Default: `''`
 

--- a/doc/ale-pug.txt
+++ b/doc/ale-pug.txt
@@ -16,24 +16,31 @@ filename automatically. Configuration files will be loaded in this order:
 You might need to create a configuration file for your project to get
 meaningful results.
 
-g:ale_pug_puglint_executable                     *g:ale_pug_puglint_executable*
+                                           *ale-options.pug_puglint_executable*
+                                                 *g:ale_pug_puglint_executable*
                                                  *b:ale_pug_puglint_executable*
+pug_puglint_executable
+g:ale_pug_puglint_executable
   Type: |String|
   Default: `'pug-lint'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_pug_puglint_options                           *g:ale_pug_puglint_options*
+                                              *ale-options.pug_puglint_options*
+                                                    *g:ale_pug_puglint_options*
                                                     *b:ale_pug_puglint_options*
+pug_puglint_options
+g:ale_pug_puglint_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass additional options to pug-lint.
 
-
-g:ale_pug_puglint_use_global                     *g:ale_pug_puglint_use_global*
+                                           *ale-options.pug_puglint_use_global*
+                                                 *g:ale_pug_puglint_use_global*
                                                  *b:ale_pug_puglint_use_global*
+pug_puglint_use_global
+g:ale_pug_puglint_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 

--- a/doc/ale-puppet.txt
+++ b/doc/ale-puppet.txt
@@ -5,16 +5,21 @@ ALE Puppet Integration                                     *ale-puppet-options*
 ===============================================================================
 puppet                                                      *ale-puppet-puppet*
 
-g:ale_puppet_puppet_executable                 *g:ale_puppet_puppet_executable*
+                                         *ale-options.puppet_puppet_executable*
+                                               *g:ale_puppet_puppet_executable*
                                                *b:ale_puppet_puppet_executable*
+puppet_puppet_executable
+g:ale_puppet_puppet_executable
   Type: |String|
   Default: `'puppet'`
 
   This variable can be changed to specify the executable used for puppet.
 
-
-g:ale_puppet_puppet_options                       *g:ale_puppet_puppet_options*
+                                            *ale-options.puppet_puppet_options*
+                                                  *g:ale_puppet_puppet_options*
                                                   *b:ale_puppet_puppet_options*
+puppet_puppet_options
+g:ale_puppet_puppet_options
   Type: |String|
   Default: `''`
 
@@ -25,16 +30,21 @@ g:ale_puppet_puppet_options                       *g:ale_puppet_puppet_options*
 ===============================================================================
 puppetlint                                              *ale-puppet-puppetlint*
 
-g:ale_puppet_puppetlint_executable         *g:ale_puppet_puppetlint_executable*
+                                     *ale-options.puppet_puppetlint_executable*
+                                           *g:ale_puppet_puppetlint_executable*
                                            *b:ale_puppet_puppetlint_executable*
+puppet_puppetlint_executable
+g:ale_puppet_puppetlint_executable
   Type: |String|
   Default: `'puppet-lint'`
 
   This variable can be changed to specify the executable used for puppet-lint.
 
-
-g:ale_puppet_puppetlint_options               *g:ale_puppet_puppetlint_options*
+                                        *ale-options.puppet_puppetlint_options*
+                                              *g:ale_puppet_puppetlint_options*
                                               *b:ale_puppet_puppetlint_options*
+puppet_puppetlint_options
+g:ale_puppet_puppetlint_options
   Type: |String|
   Default: `'--no-autoloader_layout-check'`
 
@@ -45,13 +55,17 @@ g:ale_puppet_puppetlint_options               *g:ale_puppet_puppetlint_options*
 ===============================================================================
 puppet-languageserver                               *ale-puppet-languageserver*
 
-g:ale_puppet_languageserver_executable  *g:ale_puppet_languageserver_executable*
+                                 *ale-options.puppet_languageserver_executable*
+                                       *g:ale_puppet_languageserver_executable*
                                         *b:ale_puppet_languageserver_executable*
+puppet_languageserver_executable
+g:ale_puppet_languageserver_executable
   type: |String|
   Default: `'puppet-languageserver'`
 
   This variable can be used to specify the executable used for
   puppet-languageserver.
+
 
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-purescript.txt
+++ b/doc/ale-purescript.txt
@@ -8,46 +8,64 @@ purescript-language-server                     *ale-purescript-language-server*
 PureScript Language Server
   (https://github.com/nwolverson/purescript-language-server)
 
-g:ale_purescript_ls_executable                 g:ale_purescript_ls_executable
-                                               b:ale_purescript_ls_executable
+                                         *ale-options.purescript_ls_executable*
+                                               *g:ale_purescript_ls_executable*
+                                               *b:ale_purescript_ls_executable*
+purescript_ls_executable
+g:ale_purescript_ls_executable
   Type: |String|
   Default: `'purescript-language-server'`
 
   PureScript language server executable.
 
-g:ale_purescript_ls_config                         g:ale_purescript_ls_config
-                                                   b:ale_purescript_ls_config
+                                             *ale-options.purescript_ls_config*
+                                                   *g:ale_purescript_ls_config*
+                                                   *b:ale_purescript_ls_config*
+purescript_ls_config
+g:ale_purescript_ls_config
   Type: |Dictionary|
   Default: `{}`
 
   Dictionary containing configuration settings that will be passed to the
-  language server. For example, with a spago project:
-		{
-		\  'purescript': {
-		\    'addSpagoSources': v:true,
-		\    'addNpmPath': v:true,
-		\    'buildCommand': 'spago --quiet build --purs-args --json-errors'
-		\  }
-		\}
+  language server. For example, with a spago project: >
+
+  let g:ale_purescript_ls_config = {
+  \   'purescript': {
+  \       'addSpagoSources': v:true,
+  \       'addNpmPath': v:true,
+  \       'buildCommand': 'spago --quiet build --purs-args --json-errors',
+  \   },
+  \}
+<
+
 ===============================================================================
 purs-tidy                                                 *ale-purescript-tidy*
 
-g:ale_purescript_tidy_executable             *g:ale_purescript_tidy_executable*
+                                       *ale-options.purescript_tidy_executable*
+                                             *g:ale_purescript_tidy_executable*
                                              *b:ale_purescript_tidy_executable*
+purescript_tidy_executable
+g:ale_purescript_tidy_executable
   Type: |String|
   Default: `'purs-tidy'`
 
   This variable can be changed to use a different executable for purs-tidy.
 
-g:ale_purescript_tidy_use_global             *g:ale_purescript_tidy_use_global*
+                                       *ale-options.purescript_tidy_use_global*
+                                             *g:ale_purescript_tidy_use_global*
                                              *b:ale_purescript_tidy_use_global*
+purescript_tidy_use_global
+g:ale_purescript_tidy_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
   See |ale-integrations-local-executables|
 
-g:ale_purescript_tidy_options                   *g:ale_purescript_tidy_options*
+                                          *ale-options.purescript_tidy_options*
+                                                *g:ale_purescript_tidy_options*
                                                 *b:ale_purescript_tidy_options*
+purescript_tidy_options
+g:ale_purescript_tidy_options
   Type: |String|
   Default: `''`
 
@@ -56,14 +74,20 @@ g:ale_purescript_tidy_options                   *g:ale_purescript_tidy_options*
 >
   let g:ale_purescript_options = '--indent 3'
 <
+
 ===============================================================================
 purty                                                    *ale-purescript-purty*
 
-g:ale_purescript_purty_executable           *g:ale_purescript_purty_executable*
+                                      *ale-options.purescript_purty_executable*
+                                            *g:ale_purescript_purty_executable*
                                             *b:ale_purescript_purty_executable*
+purescript_purty_executable
+g:ale_purescript_purty_executable
   Type: |String|
   Default: `'purty'`
 
   This variable can be changed to use a different executable for purty.
+
+
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-pyrex.txt
+++ b/doc/ale-pyrex.txt
@@ -5,16 +5,21 @@ ALE Pyrex (Cython) Integration                              *ale-pyrex-options*
 ===============================================================================
 cython                                                       *ale-pyrex-cython*
 
-g:ale_pyrex_cython_executable                   *g:ale_pyrex_cython_executable*
+                                          *ale-options.pyrex_cython_executable*
+                                                *g:ale_pyrex_cython_executable*
                                                 *b:ale_pyrex_cython_executable*
+pyrex_cython_executable
+g:ale_pyrex_cython_executable
   Type: |String|
   Default: `'cython'`
 
   This variable can be changed to use a different executable for cython.
 
-
-g:ale_pyrex_cython_options                         *g:ale_pyrex_cython_options*
+                                             *ale-options.pyrex_cython_options*
+                                                   *g:ale_pyrex_cython_options*
                                                    *b:ale_pyrex_cython_options*
+pyrex_cython_options
+g:ale_pyrex_cython_options
   Type: |String|
   Default: `'--warning-extra --warning-errors'`
 

--- a/doc/ale-python.txt
+++ b/doc/ale-python.txt
@@ -1,36 +1,44 @@
 ===============================================================================
 ALE Python Integration                                     *ale-python-options*
 
-
-g:ale_python_auto_pipenv                             *g:ale_python_auto_pipenv*
+                                               *ale-options.python_auto_pipenv*
+                                                     *g:ale_python_auto_pipenv*
                                                      *b:ale_python_auto_pipenv*
+python_auto_pipenv
+g:ale_python_auto_pipenv
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a pipenv, and set the executable to `pipenv`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_auto_poetry                             *g:ale_python_auto_poetry*
+                                               *ale-options.python_auto_poetry*
+                                                     *g:ale_python_auto_poetry*
                                                      *b:ale_python_auto_poetry*
+python_auto_poetry
+g:ale_python_auto_poetry
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a poetry, and set the executable to `poetry`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_auto_uv                                     *g:ale_python_auto_uv*
+                                                   *ale-options.python_auto_uv*
+                                                         *g:ale_python_auto_uv*
                                                          *b:ale_python_auto_uv*
+python_auto_uv
+g:ale_python_auto_uv
   Type: |Number|
   Default: `0`
 
   Set the executable to `uv` if true. This is overridden by a manually-set
   executable.
 
-
-g:ale_python_auto_virtualenv                     *g:ale_python_auto_virtualenv*
+                                           *ale-options.python_auto_virtualenv*
+                                                 *g:ale_python_auto_virtualenv*
                                                  *b:ale_python_auto_virtualenv*
+python_auto_virtualenv
+g:ale_python_auto_virtualenv
   Type: |Number|
   Default: `0`
 
@@ -81,50 +89,63 @@ The first directory containing any of the files named above will be used.
 ===============================================================================
 autoflake                                                *ale-python-autoflake*
 
-g:ale_python_autoflake_executable           *g:ale_python_autoflake_executable*
+                                      *ale-options.python_autoflake_executable*
+                                            *g:ale_python_autoflake_executable*
                                             *b:ale_python_autoflake_executable*
+python_autoflake_executable
+g:ale_python_autoflake_executable
   Type: |String|
   Default: `'autoflake'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_python_autoflake_options                 *g:ale_python_autoflake_options*
+                                         *ale-options.python_autoflake_options*
+                                               *g:ale_python_autoflake_options*
                                                *b:ale_python_autoflake_options*
+python_autoflake_options
+g:ale_python_autoflake_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass extra options to autoflake.
 
-
-g:ale_python_autoflake_use_global           *g:ale_python_autoflake_use_global*
+                                      *ale-options.python_autoflake_use_global*
+                                            *g:ale_python_autoflake_use_global*
                                             *b:ale_python_autoflake_use_global*
+python_autoflake_use_global
+g:ale_python_autoflake_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_python_autoflake_auto_pipenv         *g:ale_python_autoflake_auto_pipenv*
+                                     *ale-options.python_autoflake_auto_pipenv*
+                                           *g:ale_python_autoflake_auto_pipenv*
                                            *b:ale_python_autoflake_auto_pipenv*
+python_autoflake_auto_pipenv
+g:ale_python_autoflake_auto_pipenv
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a pipenv, and set the executable to `pipenv`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_autoflake_auto_poetry            *g:ale_python_autoflake_auto_poetry*
-                                              *b:ale_python_autoflake_auto_poetry*
+                                     *ale-options.python_autoflake_auto_poetry*
+                                           *g:ale_python_autoflake_auto_poetry*
+                                           *b:ale_python_autoflake_auto_poetry*
+python_autoflake_auto_poetry
+g:ale_python_autoflake_auto_poetry
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a poetry, and set the executable to `poetry`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_autoflake_auto_uv                 *g:ale_python_autoflake_auto_uv*
+                                         *ale-options.python_autoflake_auto_uv*
+                                               *g:ale_python_autoflake_auto_uv*
                                                *b:ale_python_autoflake_auto_uv*
+python_autoflake_auto_uv
+g:ale_python_autoflake_auto_uv
   Type: |Number|
   Default: `0`
 
@@ -135,50 +156,64 @@ g:ale_python_autoflake_auto_uv                 *g:ale_python_autoflake_auto_uv*
 ===============================================================================
 autoimport                                              *ale-python-autoimport*
 
-g:ale_python_autoimport_executable         *g:ale_python_autoimport_executable*
+                                     *ale-options.python_autoimport_executable*
+                                           *g:ale_python_autoimport_executable*
                                            *b:ale_python_autoimport_executable*
+python_autoimport_executable
+g:ale_python_autoimport_executable
   Type: |String|
   Default: `'autoimport'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_python_autoimport_options               *g:ale_python_autoimport_options*
+                                        *ale-options.python_autoimport_options*
+                                              *g:ale_python_autoimport_options*
                                               *b:ale_python_autoimport_options*
+python_autoimport_options
+g:ale_python_autoimport_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass extra options to autoimport.
 
-
-g:ale_python_autoimport_use_global         *g:ale_python_autoimport_use_global*
+                                     *ale-options.python_autoimport_use_global*
+                                           *g:ale_python_autoimport_use_global*
                                            *b:ale_python_autoimport_use_global*
+python_autoimport_use_global
+g:ale_python_autoimport_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
   See |ale-integrations-local-executables|
 
 
-g:ale_python_autoimport_auto_pipenv       *g:ale_python_autoimport_auto_pipenv*
+                                    *ale-options.python_autoimport_auto_pipenv*
+                                          *g:ale_python_autoimport_auto_pipenv*
                                           *b:ale_python_autoimport_auto_pipenv*
+python_autoimport_auto_pipenv
+g:ale_python_autoimport_auto_pipenv
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a pipenv, and set the executable to `pipenv`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_autoimport_auto_poetry          *g:ale_python_autoimport_auto_poetry*
-                                             *b:ale_python_autoimport_auto_poetry*
+                                    *ale-options.python_autoimport_auto_poetry*
+                                          *g:ale_python_autoimport_auto_poetry*
+                                          *b:ale_python_autoimport_auto_poetry*
+python_autoimport_auto_poetry
+g:ale_python_autoimport_auto_poetry
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a poetry, and set the executable to `poetry`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_autoimport_auto_uv               *g:ale_python_autoimport_auto_uv*
+                                        *ale-options.python_autoimport_auto_uv*
+                                              *g:ale_python_autoimport_auto_uv*
                                               *b:ale_python_autoimport_auto_uv*
+python_autoimport_auto_uv
+g:ale_python_autoimport_auto_uv
   Type: |Number|
   Default: `0`
 
@@ -189,50 +224,63 @@ g:ale_python_autoimport_auto_uv               *g:ale_python_autoimport_auto_uv*
 ===============================================================================
 autopep8                                                  *ale-python-autopep8*
 
-g:ale_python_autopep8_executable             *g:ale_python_autopep8_executable*
+                                       *ale-options.python_autopep8_executable*
+                                             *g:ale_python_autopep8_executable*
                                              *b:ale_python_autopep8_executable*
+python_autopep8_executable
+g:ale_python_autopep8_executable
   Type: |String|
   Default: `'autopep8'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_python_autopep8_options                   *g:ale_python_autopep8_options*
+                                          *ale-options.python_autopep8_options*
+                                                *g:ale_python_autopep8_options*
                                                 *b:ale_python_autopep8_options*
+python_autopep8_options
+g:ale_python_autopep8_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass extra options to autopep8.
 
-
-g:ale_python_autopep8_use_global             *g:ale_python_autopep8_use_global*
+                                       *ale-options.python_autopep8_use_global*
+                                             *g:ale_python_autopep8_use_global*
                                              *b:ale_python_autopep8_use_global*
+python_autopep8_use_global
+g:ale_python_autopep8_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_python_autopep8_auto_pipenv           *g:ale_python_autopep8_auto_pipenv*
+                                      *ale-options.python_autopep8_auto_pipenv*
+                                            *g:ale_python_autopep8_auto_pipenv*
                                             *b:ale_python_autopep8_auto_pipenv*
+python_autopep8_auto_pipenv
+g:ale_python_autopep8_auto_pipenv
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a pipenv, and set the executable to `pipenv`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_autopep8_auto_poetry              *g:ale_python_autopep8_auto_poetry*
-                                               *b:ale_python_autopep8_auto_poetry*
+                                      *ale-options.python_autopep8_auto_poetry*
+                                            *g:ale_python_autopep8_auto_poetry*
+                                            *b:ale_python_autopep8_auto_poetry*
+python_autopep8_auto_poetry
+g:ale_python_autopep8_auto_poetry
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a poetry, and set the executable to `poetry`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_autopep8_auto_uv                   *g:ale_python_autopep8_auto_uv*
+                                          *ale-options.python_autopep8_auto_uv*
+                                                *g:ale_python_autopep8_auto_uv*
                                                 *b:ale_python_autopep8_auto_uv*
+python_autopep8_auto_uv
+g:ale_python_autopep8_auto_uv
   Type: |Number|
   Default: `0`
 
@@ -243,8 +291,11 @@ g:ale_python_autopep8_auto_uv                   *g:ale_python_autopep8_auto_uv*
 ===============================================================================
 bandit                                                      *ale-python-bandit*
 
-g:ale_python_bandit_executable                 *g:ale_python_bandit_executable*
+                                         *ale-options.python_bandit_executable*
+                                               *g:ale_python_bandit_executable*
                                                *b:ale_python_bandit_executable*
+python_bandit_executable
+g:ale_python_bandit_executable
   Type: |String|
   Default: `'bandit'`
 
@@ -253,18 +304,22 @@ g:ale_python_bandit_executable                 *g:ale_python_bandit_executable*
   Set this to `'pipenv'` to invoke `'pipenv` `run` `bandit'`.
   Set this to `'poetry'` to invoke `'poetry` `run` `bandit'`.
 
-
-g:ale_python_bandit_options                       *g:ale_python_bandit_options*
+                                            *ale-options.python_bandit_options*
+                                                  *g:ale_python_bandit_options*
                                                   *b:ale_python_bandit_options*
+python_bandit_options
+g:ale_python_bandit_options
   Type: |String|
   Default: `''`
 
   This variable can be changed to add command-line arguments to the
   bandit invocation.
 
-
-g:ale_python_bandit_use_config                 *g:ale_python_bandit_use_config*
+                                         *ale-options.python_bandit_use_config*
+                                               *g:ale_python_bandit_use_config*
                                                *b:ale_python_bandit_use_config*
+python_bandit_use_config
+g:ale_python_bandit_use_config
   Type: |Number|
   Default: `1`
 
@@ -273,35 +328,43 @@ g:ale_python_bandit_use_config                 *g:ale_python_bandit_use_config*
   `bandit` command for the nearest `.bandit` file.  Set this variable false to
   disable adding the `--ini` option automatically.
 
-
-g:ale_python_bandit_use_global                 *g:ale_python_bandit_use_global*
+                                         *ale-options.python_bandit_use_global*
+                                               *g:ale_python_bandit_use_global*
                                                *b:ale_python_bandit_use_global*
+python_bandit_use_global
+g:ale_python_bandit_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_python_bandit_auto_pipenv               *g:ale_python_bandit_auto_pipenv*
+                                        *ale-options.python_bandit_auto_pipenv*
+                                              *g:ale_python_bandit_auto_pipenv*
                                               *b:ale_python_bandit_auto_pipenv*
+python_bandit_auto_pipenv
+g:ale_python_bandit_auto_pipenv
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a pipenv, and set the executable to `pipenv`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_bandit_auto_poetry               *g:ale_python_bandit_auto_poetry*
+                                        *ale-options.python_bandit_auto_poetry*
+                                              *g:ale_python_bandit_auto_poetry*
                                               *b:ale_python_bandit_auto_poetry*
+python_bandit_auto_poetry
+g:ale_python_bandit_auto_poetry
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a poetry, and set the executable to `poetry`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_bandit_auto_uv                       *g:ale_python_bandit_auto_uv*
+                                            *ale-options.python_bandit_auto_uv*
+                                                  *g:ale_python_bandit_auto_uv*
                                                   *b:ale_python_bandit_auto_uv*
+python_bandit_auto_uv
+g:ale_python_bandit_auto_uv
   Type: |Number|
   Default: `0`
 
@@ -312,59 +375,74 @@ g:ale_python_bandit_auto_uv                       *g:ale_python_bandit_auto_uv*
 ===============================================================================
 black                                                        *ale-python-black*
 
-g:ale_python_black_executable                   *g:ale_python_black_executable*
+                                          *ale-options.python_black_executable*
+                                                *g:ale_python_black_executable*
                                                 *b:ale_python_black_executable*
+python_black_executable
+g:ale_python_black_executable
   Type: |String|
   Default: `'black'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_python_black_options                         *g:ale_python_black_options*
+                                             *ale-options.python_black_options*
+                                                   *g:ale_python_black_options*
                                                    *b:ale_python_black_options*
+python_black_options
+g:ale_python_black_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass extra options to black.
 
-
-g:ale_python_black_use_global                   *g:ale_python_black_use_global*
+                                          *ale-options.python_black_use_global*
+                                                *g:ale_python_black_use_global*
                                                 *b:ale_python_black_use_global*
+python_black_use_global
+g:ale_python_black_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_python_black_auto_pipenv                 *g:ale_python_black_auto_pipenv*
+                                         *ale-options.python_black_auto_pipenv*
+                                               *g:ale_python_black_auto_pipenv*
                                                *b:ale_python_black_auto_pipenv*
+python_black_auto_pipenv
+g:ale_python_black_auto_pipenv
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a pipenv, and set the executable to `pipenv`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_black_auto_poetry                 *g:ale_python_black_auto_poetry*
+                                         *ale-options.python_black_auto_poetry*
+                                               *g:ale_python_black_auto_poetry*
                                                *b:ale_python_black_auto_poetry*
+python_black_auto_poetry
+g:ale_python_black_auto_poetry
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a poetry, and set the executable to `poetry`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_black_auto_uv                         *g:ale_python_black_auto_uv*
+                                             *ale-options.python_black_auto_uv*
+                                                   *g:ale_python_black_auto_uv*
                                                    *b:ale_python_black_auto_uv*
+python_black_auto_uv
+g:ale_python_black_auto_uv
   Type: |Number|
   Default: `0`
 
   Set the executable to `uv` if true. This is overridden by a manually-set
   executable.
 
-
-g:ale_python_black_change_directory       *g:ale_python_black_change_directory*
+                                    *ale-options.python_black_change_directory*
+                                          *g:ale_python_black_change_directory*
                                           *b:ale_python_black_change_directory*
+python_black_change_directory
+g:ale_python_black_change_directory
   Type: |Number|
   Default: `1`
 
@@ -383,8 +461,11 @@ See |ale-cspell-options|
 ===============================================================================
 flake8                                                      *ale-python-flake8*
 
-g:ale_python_flake8_change_directory     *g:ale_python_flake8_change_directory*
+                                   *ale-options.python_flake8_change_directory*
+                                         *g:ale_python_flake8_change_directory*
                                          *b:ale_python_flake8_change_directory*
+python_flake8_change_directory
+g:ale_python_flake8_change_directory
   Type: |String|
   Default: `'project'`
 
@@ -394,9 +475,11 @@ g:ale_python_flake8_change_directory     *g:ale_python_flake8_change_directory*
   You can turn it off with `off` option if you want to control the directory
   Python is executed from yourself.
 
-
-g:ale_python_flake8_executable                 *g:ale_python_flake8_executable*
+                                         *ale-options.python_flake8_executable*
+                                               *g:ale_python_flake8_executable*
                                                *b:ale_python_flake8_executable*
+python_flake8_executable
+g:ale_python_flake8_executable
   Type: |String|
   Default: `'flake8'`
 
@@ -404,9 +487,11 @@ g:ale_python_flake8_executable                 *g:ale_python_flake8_executable*
   this to `'pipenv'` to invoke `'pipenv` `run` `flake8'`. Set this to
   `'poetry'` to invoke `'poetry` `run` `flake8'`.
 
-
-g:ale_python_flake8_options                       *g:ale_python_flake8_options*
+                                            *ale-options.python_flake8_options*
+                                                  *g:ale_python_flake8_options*
                                                   *b:ale_python_flake8_options*
+python_flake8_options
+g:ale_python_flake8_options
   Type: |String|
   Default: `''`
 
@@ -422,9 +507,11 @@ g:ale_python_flake8_options                       *g:ale_python_flake8_options*
   after making sure it's installed for the appropriate Python versions (e.g.
   `python3 -m pip install --user flake8`).
 
-
-g:ale_python_flake8_use_global                 *g:ale_python_flake8_use_global*
+                                         *ale-options.python_flake8_use_global*
+                                               *g:ale_python_flake8_use_global*
                                                *b:ale_python_flake8_use_global*
+python_flake8_use_global
+g:ale_python_flake8_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
@@ -434,27 +521,33 @@ g:ale_python_flake8_use_global                 *g:ale_python_flake8_use_global*
 
   Both variables can be set with `b:` buffer variables instead.
 
-
-g:ale_python_flake8_auto_pipenv               *g:ale_python_flake8_auto_pipenv*
+                                        *ale-options.python_flake8_auto_pipenv*
+                                              *g:ale_python_flake8_auto_pipenv*
                                               *b:ale_python_flake8_auto_pipenv*
+python_flake8_auto_pipenv
+g:ale_python_flake8_auto_pipenv
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a pipenv, and set the executable to `pipenv`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_flake8_auto_poetry               *g:ale_python_flake8_auto_poetry*
+                                        *ale-options.python_flake8_auto_poetry*
+                                              *g:ale_python_flake8_auto_poetry*
                                               *b:ale_python_flake8_auto_poetry*
+python_flake8_auto_poetry
+g:ale_python_flake8_auto_poetry
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a poetry, and set the executable to `poetry`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_flake8_auto_uv                       *g:ale_python_flake8_auto_uv*
+                                            *ale-options.python_flake8_auto_uv*
+                                                  *g:ale_python_flake8_auto_uv*
                                                   *b:ale_python_flake8_auto_uv*
+python_flake8_auto_uv
+g:ale_python_flake8_auto_uv
   Type: |Number|
   Default: `0`
 
@@ -465,8 +558,11 @@ g:ale_python_flake8_auto_uv                       *g:ale_python_flake8_auto_uv*
 ===============================================================================
 flakehell                                                *ale-python-flakehell*
 
-g:ale_python_flakehell_change_directory*g:ale_python_flakehell_change_directory*
+                                *ale-options.python_flakehell_change_directory*
+                                      *g:ale_python_flakehell_change_directory*
                                       *b:ale_python_flakehell_change_directory*
+python_flakehell_change_directory
+g:ale_python_flakehell_change_directory
   Type: |String|
   Default: `project`
 
@@ -476,9 +572,11 @@ g:ale_python_flakehell_change_directory*g:ale_python_flakehell_change_directory*
   You can turn it off with `off` option if you want to control the directory
   Python is executed from yourself.
 
-
-g:ale_python_flakehell_executable           *g:ale_python_flakehell_executable*
+                                      *ale-options.python_flakehell_executable*
+                                            *g:ale_python_flakehell_executable*
                                             *b:ale_python_flakehell_executable*
+python_flakehell_executable
+g:ale_python_flakehell_executable
   Type: |String|
   Default: `'flakehell'`
 
@@ -487,18 +585,22 @@ g:ale_python_flakehell_executable           *g:ale_python_flakehell_executable*
   `'poetry'` to invoke `'poetry` `run` `flakehell'`. Set this to `'python'` to
   invoke `'python` `-m` `flakehell'`.
 
-
-g:ale_python_flakehell_options                 *g:ale_python_flakehell_options*
+                                         *ale-options.python_flakehell_options*
+                                               *g:ale_python_flakehell_options*
                                                *b:ale_python_flakehell_options*
+python_flakehell_options
+g:ale_python_flakehell_options
   Type: |String|
   Default: `''`
 
   This variable can be changed to add command-line arguments to the flakehell
   lint invocation.
 
-
-g:ale_python_flakehell_use_global           *g:ale_python_flakehell_use_global*
+                                      *ale-options.python_flakehell_use_global*
+                                            *g:ale_python_flakehell_use_global*
                                             *b:ale_python_flakehell_use_global*
+python_flakehell_use_global
+g:ale_python_flakehell_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
@@ -508,27 +610,33 @@ g:ale_python_flakehell_use_global           *g:ale_python_flakehell_use_global*
 
   Both variables can be set with `b:` buffer variables instead.
 
-
-g:ale_python_flakehell_auto_pipenv         *g:ale_python_flakehell_auto_pipenv*
+                                     *ale-options.python_flakehell_auto_pipenv*
+                                           *g:ale_python_flakehell_auto_pipenv*
                                            *b:ale_python_flakehell_auto_pipenv*
+python_flakehell_auto_pipenv
+g:ale_python_flakehell_auto_pipenv
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a pipenv, and set the executable to `pipenv`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_flakehell_auto_poetry         *g:ale_python_flakehell_auto_poetry*
+                                     *ale-options.python_flakehell_auto_poetry*
+                                           *g:ale_python_flakehell_auto_poetry*
                                            *b:ale_python_flakehell_auto_poetry*
+python_flakehell_auto_poetry
+g:ale_python_flakehell_auto_poetry
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a poetry, and set the executable to `poetry`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_flakehell_auto_uv                 *g:ale_python_flakehell_auto_uv*
+                                         *ale-options.python_flakehell_auto_uv*
+                                               *g:ale_python_flakehell_auto_uv*
                                                *b:ale_python_flakehell_auto_uv*
+python_flakehell_auto_uv
+g:ale_python_flakehell_auto_uv
   Type: |Number|
   Default: `0`
 
@@ -539,50 +647,63 @@ g:ale_python_flakehell_auto_uv                 *g:ale_python_flakehell_auto_uv*
 ===============================================================================
 isort                                                        *ale-python-isort*
 
-g:ale_python_isort_executable                   *g:ale_python_isort_executable*
+                                          *ale-options.python_isort_executable*
+                                                *g:ale_python_isort_executable*
                                                 *b:ale_python_isort_executable*
+python_isort_executable
+g:ale_python_isort_executable
   Type: |String|
   Default: `'isort'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_python_isort_options                         *g:ale_python_isort_options*
+                                             *ale-options.python_isort_options*
+                                                   *g:ale_python_isort_options*
                                                    *b:ale_python_isort_options*
+python_isort_options
+g:ale_python_isort_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass extra options to isort.
 
-
-g:ale_python_isort_use_global                   *g:ale_python_isort_use_global*
+                                          *ale-options.python_isort_use_global*
+                                                *g:ale_python_isort_use_global*
                                                 *b:ale_python_isort_use_global*
+python_isort_use_global
+g:ale_python_isort_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_python_isort_auto_pipenv                 *g:ale_python_isort_auto_pipenv*
+                                         *ale-options.python_isort_auto_pipenv*
+                                               *g:ale_python_isort_auto_pipenv*
                                                *b:ale_python_isort_auto_pipenv*
+python_isort_auto_pipenv
+g:ale_python_isort_auto_pipenv
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a pipenv, and set the executable to `pipenv`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_isort_auto_poetry                 *g:ale_python_isort_auto_poetry*
+                                         *ale-options.python_isort_auto_poetry*
+                                               *g:ale_python_isort_auto_poetry*
                                                *b:ale_python_isort_auto_poetry*
+python_isort_auto_poetry
+g:ale_python_isort_auto_poetry
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a poetry, and set the executable to `poetry`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_isort_auto_uv                         *g:ale_python_isort_auto_uv*
+                                             *ale-options.python_isort_auto_uv*
+                                                   *g:ale_python_isort_auto_uv*
                                                    *b:ale_python_isort_auto_uv*
+python_isort_auto_uv
+g:ale_python_isort_auto_uv
   Type: |Number|
   Default: `0`
 
@@ -599,36 +720,44 @@ to check for errors while you type.
 
 `mypy` will be run from a detected project root, per |ale-python-root|.
 
-
-g:ale_python_mypy_auto_pipenv                   *g:ale_python_mypy_auto_pipenv*
+                                          *ale-options.python_mypy_auto_pipenv*
+                                                *g:ale_python_mypy_auto_pipenv*
                                                 *b:ale_python_mypy_auto_pipenv*
+python_mypy_auto_pipenv
+g:ale_python_mypy_auto_pipenv
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a pipenv, and set the executable to `pipenv`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_mypy_auto_poetry                   *g:ale_python_mypy_auto_poetry*
+                                          *ale-options.python_mypy_auto_poetry*
+                                                *g:ale_python_mypy_auto_poetry*
                                                 *b:ale_python_mypy_auto_poetry*
+python_mypy_auto_poetry
+g:ale_python_mypy_auto_poetry
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a poetry, and set the executable to `poetry`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_mypy_auto_uv                           *g:ale_python_mypy_auto_uv*
+                                              *ale-options.python_mypy_auto_uv*
+                                                    *g:ale_python_mypy_auto_uv*
                                                     *b:ale_python_mypy_auto_uv*
+python_mypy_auto_uv
+g:ale_python_mypy_auto_uv
   Type: |Number|
   Default: `0`
 
   Set the executable to `uv` if true. This is overridden by a manually-set
   executable.
 
-
-g:ale_python_mypy_executable                     *g:ale_python_mypy_executable*
+                                           *ale-options.python_mypy_executable*
+                                                 *g:ale_python_mypy_executable*
                                                  *b:ale_python_mypy_executable*
+python_mypy_executable
+g:ale_python_mypy_executable
   Type: |String|
   Default: `'mypy'`
 
@@ -637,10 +766,11 @@ g:ale_python_mypy_executable                     *g:ale_python_mypy_executable*
   Set this to `'pipenv'` to invoke `'pipenv` `run` `mypy'`.
   Set this to `'poetry'` to invoke `'poetry` `run` `mypy'`.
 
-
-g:ale_python_mypy_ignore_invalid_syntax
+                                *ale-options.python_mypy_ignore_invalid_syntax*
                                       *g:ale_python_mypy_ignore_invalid_syntax*
                                       *b:ale_python_mypy_ignore_invalid_syntax*
+python_mypy_ignore_invalid_syntax
+g:ale_python_mypy_ignore_invalid_syntax
   Type: |Number|
   Default: `0`
 
@@ -648,26 +778,32 @@ g:ale_python_mypy_ignore_invalid_syntax
   can be used when running other Python linters which check for syntax errors,
   as mypy can take a while to finish executing.
 
-
-g:ale_python_mypy_options                           *g:ale_python_mypy_options*
+                                              *ale-options.python_mypy_options*
+                                                    *g:ale_python_mypy_options*
                                                     *b:ale_python_mypy_options*
+python_mypy_options
+g:ale_python_mypy_options
   Type: |String|
   Default: `''`
 
   This variable can be changed to add command-line arguments to the mypy
   invocation.
 
-
-g:ale_python_mypy_show_notes                     *g:ale_python_mypy_show_notes*
+                                           *ale-options.python_mypy_show_notes*
+                                                 *g:ale_python_mypy_show_notes*
                                                  *b:ale_python_mypy_show_notes*
+python_mypy_show_notes
+g:ale_python_mypy_show_notes
   Type: |Number|
   Default: `1`
 
   If enabled, notes on lines will be displayed as 'I' (info) messages.
 
-
-g:ale_python_mypy_use_global                     *g:ale_python_mypy_use_global*
+                                           *ale-options.python_mypy_use_global*
+                                                 *g:ale_python_mypy_use_global*
                                                  *b:ale_python_mypy_use_global*
+python_mypy_use_global
+g:ale_python_mypy_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
@@ -677,8 +813,11 @@ g:ale_python_mypy_use_global                     *g:ale_python_mypy_use_global*
 ===============================================================================
 prospector                                              *ale-python-prospector*
 
-g:ale_python_prospector_executable         *g:ale_python_prospector_executable*
+                                     *ale-options.python_prospector_executable*
+                                           *g:ale_python_prospector_executable*
                                            *b:ale_python_prospector_executable*
+python_prospector_executable
+g:ale_python_prospector_executable
   Type: |String|
   Default: `'prospector'`
 
@@ -687,9 +826,11 @@ g:ale_python_prospector_executable         *g:ale_python_prospector_executable*
   Set this to `'pipenv'` to invoke `'pipenv` `run` `prospector'`.
   Set this to `'poetry'` to invoke `'poetry` `run` `prospector'`.
 
-
-g:ale_python_prospector_options               *g:ale_python_prospector_options*
+                                        *ale-options.python_prospector_options*
+                                              *g:ale_python_prospector_options*
                                               *b:ale_python_prospector_options*
+python_prospector_options
+g:ale_python_prospector_options
   Type: |String|
   Default: `''`
 
@@ -707,36 +848,44 @@ g:ale_python_prospector_options               *g:ale_python_prospector_options*
 
   after making sure it's installed for the appropriate Python versions (e.g.
   `python3 -m pip install --user prospector`).
-
-
-g:ale_python_prospector_use_global         *g:ale_python_prospector_use_global*
+<
+                                     *ale-options.python_prospector_use_global*
+                                           *g:ale_python_prospector_use_global*
                                            *b:ale_python_prospector_use_global*
+python_prospector_use_global
+g:ale_python_prospector_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_python_prospector_auto_pipenv       *g:ale_python_prospector_auto_pipenv*
+                                    *ale-options.python_prospector_auto_pipenv*
+                                          *g:ale_python_prospector_auto_pipenv*
                                           *b:ale_python_prospector_auto_pipenv*
+python_prospector_auto_pipenv
+g:ale_python_prospector_auto_pipenv
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a pipenv, and set the executable to `pipenv`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_prospector_auto_poetry       *g:ale_python_prospector_auto_poetry*
+                                    *ale-options.python_prospector_auto_poetry*
+                                          *g:ale_python_prospector_auto_poetry*
                                           *b:ale_python_prospector_auto_poetry*
+python_prospector_auto_poetry
+g:ale_python_prospector_auto_poetry
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a poetry, and set the executable to `poetry`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_prospector_auto_uv               *g:ale_python_prospector_auto_uv*
+                                        *ale-options.python_prospector_auto_uv*
+                                              *g:ale_python_prospector_auto_uv*
                                               *b:ale_python_prospector_auto_uv*
+python_prospector_auto_uv
+g:ale_python_prospector_auto_uv
   Type: |Number|
   Default: `0`
 
@@ -747,8 +896,11 @@ g:ale_python_prospector_auto_uv               *g:ale_python_prospector_auto_uv*
 ===============================================================================
 pycln                                                        *ale-python-pycln*
 
-g:ale_python_pycln_change_directory       *g:ale_python_pycln_change_directory*
+                                    *ale-options.python_pycln_change_directory*
+                                          *g:ale_python_pycln_change_directory*
                                           *b:ale_python_pycln_change_directory*
+python_pycln_change_directory
+g:ale_python_pycln_change_directory
   Type: |Number|
   Default: `1`
 
@@ -756,9 +908,11 @@ g:ale_python_pycln_change_directory       *g:ale_python_pycln_change_directory*
   |ale-python-root|. if set to `0` or no project root detected,
   `pycln` will be run from the buffer's directory.
 
-
-g:ale_python_pycln_executable                   *g:ale_python_pycln_executable*
+                                          *ale-options.python_pycln_executable*
+                                                *g:ale_python_pycln_executable*
                                                 *b:ale_python_pycln_executable*
+python_pycln_executable
+g:ale_python_pycln_executable
   Type: |String|
   Default: `'pycln'`
 
@@ -767,9 +921,11 @@ g:ale_python_pycln_executable                   *g:ale_python_pycln_executable*
   Set this to `'pipenv'` to invoke `'pipenv` `run` `pycln'`.
   Set this to `'poetry'` to invoke `'poetry` `run` `pycln'`.
 
-
-g:ale_python_pycln_options                         *g:ale_python_pycln_options*
+                                             *ale-options.python_pycln_options*
+                                                   *g:ale_python_pycln_options*
                                                    *b:ale_python_pycln_options*
+python_pycln_options
+g:ale_python_pycln_options
   Type: |String|
   Default: `''`
 
@@ -777,12 +933,15 @@ g:ale_python_pycln_options                         *g:ale_python_pycln_options*
   invocation.
 
   For example, to select/enable and/or disable some error codes,
-  you may want to set >
+  you may want to set the following: >
+
   let g:ale_python_pycln_options = '--expand-stars'
-
-
-g:ale_python_pycln_config_file                 *g:ale_python_pycln_config_file*
+<
+                                         *ale-options.python_pycln_config_file*
+                                               *g:ale_python_pycln_config_file*
                                                *b:ale_python_pycln_config_file*
+python_pycln_config_file
+g:ale_python_pycln_config_file
   Type: |String|
   Default: `''`
 
@@ -790,34 +949,43 @@ g:ale_python_pycln_config_file                 *g:ale_python_pycln_config_file*
   If `'--config' ` is found in the |g:ale_python_pycln_options|, then that
   option value will override the value in this variable.
 
-g:ale_python_pycln_use_global                   *g:ale_python_pycln_use_global*
+                                          *ale-options.python_pycln_use_global*
+                                                *g:ale_python_pycln_use_global*
                                                 *b:ale_python_pycln_use_global*
+python_pycln_use_global
+g:ale_python_pycln_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_python_pycln_auto_pipenv                 *g:ale_python_pycln_auto_pipenv*
+                                         *ale-options.python_pycln_auto_pipenv*
+                                               *g:ale_python_pycln_auto_pipenv*
                                                *b:ale_python_pycln_auto_pipenv*
+python_pycln_auto_pipenv
+g:ale_python_pycln_auto_pipenv
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a pipenv, and set the executable to `pipenv`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_pycln_auto_poetry                 *g:ale_python_pycln_auto_poetry*
+                                         *ale-options.python_pycln_auto_poetry*
+                                               *g:ale_python_pycln_auto_poetry*
                                                *b:ale_python_pycln_auto_poetry*
+python_pycln_auto_poetry
+g:ale_python_pycln_auto_poetry
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a poetry, and set the executable to `poetry`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_pycln_auto_uv                         *g:ale_python_pycln_auto_uv*
+                                             *ale-options.python_pycln_auto_uv*
+                                                   *g:ale_python_pycln_auto_uv*
                                                    *b:ale_python_pycln_auto_uv*
+python_pycln_auto_uv
+g:ale_python_pycln_auto_uv
   Type: |Number|
   Default: `0`
 
@@ -828,8 +996,11 @@ g:ale_python_pycln_auto_uv                         *g:ale_python_pycln_auto_uv*
 ===============================================================================
 pycodestyle                                            *ale-python-pycodestyle*
 
-g:ale_python_pycodestyle_executable       *g:ale_python_pycodestyle_executable*
+                                    *ale-options.python_pycodestyle_executable*
+                                          *g:ale_python_pycodestyle_executable*
                                           *b:ale_python_pycodestyle_executable*
+python_pycodestyle_executable
+g:ale_python_pycodestyle_executable
   Type: |String|
   Default: `'pycodestyle'`
 
@@ -838,44 +1009,54 @@ g:ale_python_pycodestyle_executable       *g:ale_python_pycodestyle_executable*
   Set this to `'pipenv'` to invoke `'pipenv` `run` `pycodestyle'`.
   Set this to `'poetry'` to invoke `'poetry` `run` `pycodestyle'`.
 
-
-g:ale_python_pycodestyle_options             *g:ale_python_pycodestyle_options*
+                                       *ale-options.python_pycodestyle_options*
+                                             *g:ale_python_pycodestyle_options*
                                              *b:ale_python_pycodestyle_options*
+python_pycodestyle_options
+g:ale_python_pycodestyle_options
   Type: |String|
   Default: `''`
 
   This variable can be changed to add command-line arguments to the
   pycodestyle invocation.
 
-
-g:ale_python_pycodestyle_use_global       *g:ale_python_pycodestyle_use_global*
+                                    *ale-options.python_pycodestyle_use_global*
+                                          *g:ale_python_pycodestyle_use_global*
                                           *b:ale_python_pycodestyle_use_global*
+python_pycodestyle_use_global
+g:ale_python_pycodestyle_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_python_pycodestyle_auto_pipenv     *g:ale_python_pycodestyle_auto_pipenv*
+                                   *ale-options.python_pycodestyle_auto_pipenv*
+                                         *g:ale_python_pycodestyle_auto_pipenv*
                                          *b:ale_python_pycodestyle_auto_pipenv*
+python_pycodestyle_auto_pipenv
+g:ale_python_pycodestyle_auto_pipenv
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a pipenv, and set the executable to `pipenv`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_pycodestyle_auto_poetry     *g:ale_python_pycodestyle_auto_poetry*
+                                   *ale-options.python_pycodestyle_auto_poetry*
+                                         *g:ale_python_pycodestyle_auto_poetry*
                                          *b:ale_python_pycodestyle_auto_poetry*
+python_pycodestyle_auto_poetry
+g:ale_python_pycodestyle_auto_poetry
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a poetry, and set the executable to `poetry`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_pycodestyle_auto_uv             *g:ale_python_pycodestyle_auto_uv*
+                                       *ale-options.python_pycodestyle_auto_uv*
+                                             *g:ale_python_pycodestyle_auto_uv*
                                              *b:ale_python_pycodestyle_auto_uv*
+python_pycodestyle_auto_uv
+g:ale_python_pycodestyle_auto_uv
   Type: |Number|
   Default: `0`
 
@@ -886,8 +1067,11 @@ g:ale_python_pycodestyle_auto_uv             *g:ale_python_pycodestyle_auto_uv*
 ===============================================================================
 pydocstyle                                              *ale-python-pydocstyle*
 
-g:ale_python_pydocstyle_executable         *g:ale_python_pydocstyle_executable*
+                                     *ale-options.python_pydocstyle_executable*
+                                           *g:ale_python_pydocstyle_executable*
                                            *b:ale_python_pydocstyle_executable*
+python_pydocstyle_executable
+g:ale_python_pydocstyle_executable
   Type: |String|
   Default: `'pydocstyle'`
 
@@ -896,44 +1080,54 @@ g:ale_python_pydocstyle_executable         *g:ale_python_pydocstyle_executable*
   Set this to `'pipenv'` to invoke `'pipenv` `run` `pydocstyle'`.
   Set this to `'poetry'` to invoke `'poetry` `run` `pydocstyle'`.
 
-
-g:ale_python_pydocstyle_options               *g:ale_python_pydocstyle_options*
+                                        *ale-options.python_pydocstyle_options*
+                                              *g:ale_python_pydocstyle_options*
                                               *b:ale_python_pydocstyle_options*
+python_pydocstyle_options
+g:ale_python_pydocstyle_options
   Type: |String|
   Default: `''`
 
   This variable can be changed to add command-line arguments to the
   pydocstyle invocation.
 
-
-g:ale_python_pydocstyle_use_global         *g:ale_python_pydocstyle_use_global*
+                                     *ale-options.python_pydocstyle_use_global*
+                                           *g:ale_python_pydocstyle_use_global*
                                            *b:ale_python_pydocstyle_use_global*
+python_pydocstyle_use_global
+g:ale_python_pydocstyle_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_python_pydocstyle_auto_pipenv       *g:ale_python_pydocstyle_auto_pipenv*
+                                    *ale-options.python_pydocstyle_auto_pipenv*
+                                          *g:ale_python_pydocstyle_auto_pipenv*
                                           *b:ale_python_pydocstyle_auto_pipenv*
+python_pydocstyle_auto_pipenv
+g:ale_python_pydocstyle_auto_pipenv
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a pipenv, and set the executable to `pipenv`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_pydocstyle_auto_poetry       *g:ale_python_pydocstyle_auto_poetry*
+                                    *ale-options.python_pydocstyle_auto_poetry*
+                                          *g:ale_python_pydocstyle_auto_poetry*
                                           *b:ale_python_pydocstyle_auto_poetry*
+python_pydocstyle_auto_poetry
+g:ale_python_pydocstyle_auto_poetry
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a poetry, and set the executable to `poetry`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_pydocstyle_auto_uv               *g:ale_python_pydocstyle_auto_uv*
+                                        *ale-options.python_pydocstyle_auto_uv*
+                                              *g:ale_python_pydocstyle_auto_uv*
                                               *b:ale_python_pydocstyle_auto_uv*
+python_pydocstyle_auto_uv
+g:ale_python_pydocstyle_auto_uv
   Type: |Number|
   Default: `0`
 
@@ -944,8 +1138,11 @@ g:ale_python_pydocstyle_auto_uv               *g:ale_python_pydocstyle_auto_uv*
 ===============================================================================
 pyflakes                                                  *ale-python-pyflakes*
 
-g:ale_python_pyflakes_executable             *g:ale_python_pyflakes_executable*
+                                       *ale-options.python_pyflakes_executable*
+                                             *g:ale_python_pyflakes_executable*
                                              *b:ale_python_pyflakes_executable*
+python_pyflakes_executable
+g:ale_python_pyflakes_executable
   Type: |String|
   Default: `'pyflakes'`
 
@@ -954,27 +1151,33 @@ g:ale_python_pyflakes_executable             *g:ale_python_pyflakes_executable*
   Set this to `'pipenv'` to invoke `'pipenv` `run` `pyflakes'`.
   Set this to `'poetry'` to invoke `'poetry` `run` `pyflakes'`.
 
-
-g:ale_python_pyflakes_auto_pipenv           *g:ale_python_pyflakes_auto_pipenv*
+                                      *ale-options.python_pyflakes_auto_pipenv*
+                                            *g:ale_python_pyflakes_auto_pipenv*
                                             *b:ale_python_pyflakes_auto_pipenv*
+python_pyflakes_auto_pipenv
+g:ale_python_pyflakes_auto_pipenv
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a pipenv, and set the executable to `pipenv`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_pyflakes_auto_poetry           *g:ale_python_pyflakes_auto_poetry*
+                                      *ale-options.python_pyflakes_auto_poetry*
+                                            *g:ale_python_pyflakes_auto_poetry*
                                             *b:ale_python_pyflakes_auto_poetry*
+python_pyflakes_auto_poetry
+g:ale_python_pyflakes_auto_poetry
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a poetry, and set the executable to `poetry`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_pyflakes_auto_uv                   *g:ale_python_pyflakes_auto_uv*
+                                          *ale-options.python_pyflakes_auto_uv*
+                                                *g:ale_python_pyflakes_auto_uv*
                                                 *b:ale_python_pyflakes_auto_uv*
+python_pyflakes_auto_uv
+g:ale_python_pyflakes_auto_uv
   Type: |Number|
   Default: `0`
 
@@ -985,51 +1188,64 @@ g:ale_python_pyflakes_auto_uv                   *g:ale_python_pyflakes_auto_uv*
 ===============================================================================
 pyflyby                                                    *ale-python-pyflyby*
 
-g:ale_python_pyflyby_executable               *g:ale_python_pyflyby_executable*
+                                        *ale-options.python_pyflyby_executable*
+                                              *g:ale_python_pyflyby_executable*
                                               *b:ale_python_pyflyby_executable*
+python_pyflyby_executable
+g:ale_python_pyflyby_executable
   Type: |String|
   Default: `'tidy-imports'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_python_pyflyby_options                     *g:ale_python_pyflyby_options*
+                                           *ale-options.python_pyflyby_options*
+                                                 *g:ale_python_pyflyby_options*
                                                  *b:ale_python_pyflyby_options*
+python_pyflyby_options
+g:ale_python_pyflyby_options
   Type: |String|
   Default: `''`
 
   This variable can be changed to add command-line arguments to the pyflyby
   tidy-imports invocation.
 
-
-g:ale_python_pyflyby_use_global               *g:ale_python_pyflyby_use_global*
+                                        *ale-options.python_pyflyby_use_global*
+                                              *g:ale_python_pyflyby_use_global*
                                               *b:ale_python_pyflyby_use_global*
+python_pyflyby_use_global
+g:ale_python_pyflyby_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_python_pyflyby_auto_pipenv             *g:ale_python_pyflyby_auto_pipenv*
+                                       *ale-options.python_pyflyby_auto_pipenv*
+                                             *g:ale_python_pyflyby_auto_pipenv*
                                              *b:ale_python_pyflyby_auto_pipenv*
+python_pyflyby_auto_pipenv
+g:ale_python_pyflyby_auto_pipenv
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a pipenv, and set the executable to `pipenv`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_pyflyby_auto_poetry             *g:ale_python_pyflyby_auto_poetry*
+                                       *ale-options.python_pyflyby_auto_poetry*
+                                             *g:ale_python_pyflyby_auto_poetry*
                                              *b:ale_python_pyflyby_auto_poetry*
+python_pyflyby_auto_poetry
+g:ale_python_pyflyby_auto_poetry
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a poetry, and set the executable to `poetry`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_pyflyby_auto_uv                     *g:ale_python_pyflyby_auto_uv*
+                                           *ale-options.python_pyflyby_auto_uv*
+                                                 *g:ale_python_pyflyby_auto_uv*
                                                  *b:ale_python_pyflyby_auto_uv*
+python_pyflyby_auto_uv
+g:ale_python_pyflyby_auto_uv
   Type: |Number|
   Default: `0`
 
@@ -1040,8 +1256,11 @@ g:ale_python_pyflyby_auto_uv                     *g:ale_python_pyflyby_auto_uv*
 ===============================================================================
 pylama                                                      *ale-python-pylama*
 
-g:ale_python_pylama_change_directory     *g:ale_python_pylama_change_directory*
+                                   *ale-options.python_pylama_change_directory*
+                                         *g:ale_python_pylama_change_directory*
                                          *b:ale_python_pylama_change_directory*
+python_pylama_change_directory
+g:ale_python_pylama_change_directory
   Type: |Number|
   Default: `1`
 
@@ -1051,9 +1270,11 @@ g:ale_python_pylama_change_directory     *g:ale_python_pylama_change_directory*
   paths relative to its current directory.  This option can be turned off if
   you want to control the directory in which `pylama` is executed.
 
-
-g:ale_python_pylama_executable                 *g:ale_python_pylama_executable*
+                                         *ale-options.python_pylama_executable*
+                                               *g:ale_python_pylama_executable*
                                                *b:ale_python_pylama_executable*
+python_pylama_executable
+g:ale_python_pylama_executable
   Type: |String|
   Default: `'pylama'`
 
@@ -1061,18 +1282,22 @@ g:ale_python_pylama_executable                 *g:ale_python_pylama_executable*
   this to `'pipenv'` to invoke `'pipenv` `run` `pylama'`. Set this to
   `'poetry'` to invoke `'poetry` `run` `pylama'`.
 
-
-g:ale_python_pylama_options                       *g:ale_python_pylama_options*
+                                            *ale-options.python_pylama_options*
+                                                  *g:ale_python_pylama_options*
                                                   *b:ale_python_pylama_options*
+python_pylama_options
+g:ale_python_pylama_options
   Type: |String|
   Default: `''`
 
   This variable can be changed to add command-line arguments to the pylama
   invocation.
 
-
-g:ale_python_pylama_use_global                 *g:ale_python_pylama_use_global*
+                                         *ale-options.python_pylama_use_global*
+                                               *g:ale_python_pylama_use_global*
                                                *b:ale_python_pylama_use_global*
+python_pylama_use_global
+g:ale_python_pylama_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
@@ -1082,26 +1307,33 @@ g:ale_python_pylama_use_global                 *g:ale_python_pylama_use_global*
 
   Both variables can be set with `b:` buffer variables instead.
 
-
-g:ale_python_pylama_auto_pipenv               *g:ale_python_pylama_auto_pipenv*
+                                        *ale-options.python_pylama_auto_pipenv*
+                                              *g:ale_python_pylama_auto_pipenv*
                                               *b:ale_python_pylama_auto_pipenv*
+python_pylama_auto_pipenv
+g:ale_python_pylama_auto_pipenv
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a pipenv, and set the executable to `pipenv`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_pylama_auto_poetry               *g:ale_python_pylama_auto_poetry*
+                                        *ale-options.python_pylama_auto_poetry*
+                                              *g:ale_python_pylama_auto_poetry*
                                               *b:ale_python_pylama_auto_poetry*
+python_pylama_auto_poetry
+g:ale_python_pylama_auto_poetry
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a poetry, and set the executable to `poetry`
   if true. This is overridden by a manually-set executable.
 
-g:ale_python_pylama_auto_uv                       *g:ale_python_pylama_auto_uv*
+                                            *ale-options.python_pylama_auto_uv*
+                                                  *g:ale_python_pylama_auto_uv*
                                                   *b:ale_python_pylama_auto_uv*
+python_pylama_auto_uv
+g:ale_python_pylama_auto_uv
   Type: |Number|
   Default: `0`
 
@@ -1112,8 +1344,11 @@ g:ale_python_pylama_auto_uv                       *g:ale_python_pylama_auto_uv*
 ===============================================================================
 pylint                                                      *ale-python-pylint*
 
-g:ale_python_pylint_change_directory     *g:ale_python_pylint_change_directory*
+                                   *ale-options.python_pylint_change_directory*
+                                         *g:ale_python_pylint_change_directory*
                                          *b:ale_python_pylint_change_directory*
+python_pylint_change_directory
+g:ale_python_pylint_change_directory
   Type: |Number|
   Default: `1`
 
@@ -1124,9 +1359,11 @@ g:ale_python_pylint_change_directory     *g:ale_python_pylint_change_directory*
   present.  This option can be turned off if you want to control the directory
   Python is executed from yourself.
 
-
-g:ale_python_pylint_executable                 *g:ale_python_pylint_executable*
+                                         *ale-options.python_pylint_executable*
+                                               *g:ale_python_pylint_executable*
                                                *b:ale_python_pylint_executable*
+python_pylint_executable
+g:ale_python_pylint_executable
   Type: |String|
   Default: `'pylint'`
 
@@ -1135,9 +1372,11 @@ g:ale_python_pylint_executable                 *g:ale_python_pylint_executable*
   Set this to `'pipenv'` to invoke `'pipenv` `run` `pylint'`.
   Set this to `'poetry'` to invoke `'poetry` `run` `pylint'`.
 
-
-g:ale_python_pylint_options                       *g:ale_python_pylint_options*
+                                            *ale-options.python_pylint_options*
+                                                  *g:ale_python_pylint_options*
                                                   *b:ale_python_pylint_options*
+python_pylint_options
+g:ale_python_pylint_options
   Type: |String|
   Default: `''`
 
@@ -1154,45 +1393,55 @@ g:ale_python_pylint_options                       *g:ale_python_pylint_options*
 
   after making sure it's installed for the appropriate Python versions (e.g.
   `python3 -m pip install --user pylint`).
-
-
-g:ale_python_pylint_use_global                 *g:ale_python_pylint_use_global*
+<
+                                         *ale-options.python_pylint_use_global*
+                                               *g:ale_python_pylint_use_global*
                                                *b:ale_python_pylint_use_global*
+python_pylint_use_global
+g:ale_python_pylint_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_python_pylint_auto_pipenv               *g:ale_python_pylint_auto_pipenv*
+                                        *ale-options.python_pylint_auto_pipenv*
+                                              *g:ale_python_pylint_auto_pipenv*
                                               *b:ale_python_pylint_auto_pipenv*
+python_pylint_auto_pipenv
+g:ale_python_pylint_auto_pipenv
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a pipenv, and set the executable to `pipenv`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_pylint_auto_poetry               *g:ale_python_pylint_auto_poetry*
+                                        *ale-options.python_pylint_auto_poetry*
+                                              *g:ale_python_pylint_auto_poetry*
                                               *b:ale_python_pylint_auto_poetry*
+python_pylint_auto_poetry
+g:ale_python_pylint_auto_poetry
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a poetry, and set the executable to `poetry`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_pylint_auto_uv                       *g:ale_python_pylint_auto_uv*
+                                            *ale-options.python_pylint_auto_uv*
+                                                  *g:ale_python_pylint_auto_uv*
                                                   *b:ale_python_pylint_auto_uv*
+python_pylint_auto_uv
+g:ale_python_pylint_auto_uv
   Type: |Number|
   Default: `0`
 
   Set the executable to `uv` if true. This is overridden by a manually-set
   executable.
 
-
-g:ale_python_pylint_use_msg_id                 *g:ale_python_pylint_use_msg_id*
+                                         *ale-options.python_pylint_use_msg_id*
+                                               *g:ale_python_pylint_use_msg_id*
                                                *b:ale_python_pylint_use_msg_id*
+python_pylint_use_msg_id
+g:ale_python_pylint_use_msg_id
   Type: |Number|
   Default: `0`
 
@@ -1205,9 +1454,11 @@ pylsp                                                        *ale-python-pylsp*
 
 `pylsp` will be run from a detected project root, per |ale-python-root|.
 
-
-g:ale_python_pylsp_executable                   *g:ale_python_pylsp_executable*
+                                          *ale-options.python_pylsp_executable*
+                                                *g:ale_python_pylsp_executable*
                                                 *b:ale_python_pylsp_executable*
+python_pylsp_executable
+g:ale_python_pylsp_executable
   Type: |String|
   Default: `'pylsp'`
 
@@ -1216,62 +1467,75 @@ g:ale_python_pylsp_executable                   *g:ale_python_pylsp_executable*
   Set this to `'pipenv'` to invoke `'pipenv` `run` `pylsp'`.
   Set this to `'poetry'` to invoke `'poetry` `run` `pyls'`.
 
-
-g:ale_python_pylsp_use_global                   *g:ale_python_pylsp_use_global*
+                                          *ale-options.python_pylsp_use_global*
+                                                *g:ale_python_pylsp_use_global*
                                                 *b:ale_python_pylsp_use_global*
+python_pylsp_use_global
+g:ale_python_pylsp_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_python_pylsp_auto_pipenv                 *g:ale_python_pylsp_auto_pipenv*
+                                         *ale-options.python_pylsp_auto_pipenv*
+                                               *g:ale_python_pylsp_auto_pipenv*
                                                *b:ale_python_pylsp_auto_pipenv*
+python_pylsp_auto_pipenv
+g:ale_python_pylsp_auto_pipenv
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a pipenv, and set the executable to `pipenv`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_pylsp_auto_poetry                 *g:ale_python_pylsp_auto_poetry*
+                                         *ale-options.python_pylsp_auto_poetry*
+                                               *g:ale_python_pylsp_auto_poetry*
                                                *b:ale_python_pylsp_auto_poetry*
+python_pylsp_auto_poetry
+g:ale_python_pylsp_auto_poetry
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a poetry, and set the executable to `poetry`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_pylsp_auto_uv                         *g:ale_python_pylsp_auto_uv*
+                                             *ale-options.python_pylsp_auto_uv*
+                                                   *g:ale_python_pylsp_auto_uv*
                                                    *b:ale_python_pylsp_auto_uv*
+python_pylsp_auto_uv
+g:ale_python_pylsp_auto_uv
   Type: |Number|
   Default: `0`
 
   Set the executable to `uv` if true. This is overridden by a manually-set
   executable.
 
-
-g:ale_python_pylsp_config                           *g:ale_python_pylsp_config*
+                                              *ale-options.python_pylsp_config*
+                                                    *g:ale_python_pylsp_config*
                                                     *b:ale_python_pylsp_config*
+python_pylsp_config
+g:ale_python_pylsp_config
   Type: |Dictionary|
   Default: `{}`
 
   Dictionary with configuration settings for pylsp. For example, to disable
   the pycodestyle linter: >
-        {
-      \   'pylsp': {
-      \     'plugins': {
-      \       'pycodestyle': {
-      \         'enabled': v:false
-      \       }
-      \     }
-      \   },
-      \ }
-<
 
-g:ale_python_pylsp_options                         *g:ale_python_pylsp_options*
+  let g:ale_python_pylsp_config = {
+  \   'pylsp': {
+  \       'plugins': {
+  \           'pycodestyle': {
+  \               'enabled': v:false
+  \           }
+  \       }
+  \   },
+  \}
+<
+                                             *ale-options.python_pylsp_options*
+                                                   *g:ale_python_pylsp_options*
                                                    *b:ale_python_pylsp_options*
+python_pylsp_options
+g:ale_python_pylsp_options
   Type: |String|
   Default: `''`
 
@@ -1295,9 +1559,11 @@ pyre                                                          *ale-python-pyre*
 
 `pyre` will be run from a detected project root, per |ale-python-root|.
 
-
-g:ale_python_pyre_executable                     *g:ale_python_pyre_executable*
+                                           *ale-options.python_pyre_executable*
+                                                 *g:ale_python_pyre_executable*
                                                  *b:ale_python_pyre_executable*
+python_pyre_executable
+g:ale_python_pyre_executable
   Type: |String|
   Default: `'pyre'`
 
@@ -1306,35 +1572,43 @@ g:ale_python_pyre_executable                     *g:ale_python_pyre_executable*
   Set this to `'pipenv'` to invoke `'pipenv` `run` `pyre'`.
   Set this to `'poetry'` to invoke `'poetry` `run` `pyre'`.
 
-
-g:ale_python_pyre_use_global                     *g:ale_python_pyre_use_global*
+                                           *ale-options.python_pyre_use_global*
+                                                 *g:ale_python_pyre_use_global*
                                                  *b:ale_python_pyre_use_global*
+python_pyre_use_global
+g:ale_python_pyre_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_python_pyre_auto_pipenv                   *g:ale_python_pyre_auto_pipenv*
+                                          *ale-options.python_pyre_auto_pipenv*
+                                                *g:ale_python_pyre_auto_pipenv*
                                                 *b:ale_python_pyre_auto_pipenv*
+python_pyre_auto_pipenv
+g:ale_python_pyre_auto_pipenv
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a pipenv, and set the executable to `pipenv`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_pyre_auto_poetry                   *g:ale_python_pyre_auto_poetry*
+                                          *ale-options.python_pyre_auto_poetry*
+                                                *g:ale_python_pyre_auto_poetry*
                                                 *b:ale_python_pyre_auto_poetry*
+python_pyre_auto_poetry
+g:ale_python_pyre_auto_poetry
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a poetry, and set the executable to `poetry`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_pyre_auto_uv                           *g:ale_python_pyre_auto_uv*
+                                              *ale-options.python_pyre_auto_uv*
+                                                    *g:ale_python_pyre_auto_uv*
                                                     *b:ale_python_pyre_auto_uv*
+python_pyre_auto_uv
+g:ale_python_pyre_auto_uv
   Type: |Number|
   Default: `0`
 
@@ -1356,17 +1630,21 @@ https://github.com/Microsoft/pyright
 virtualenv to run. ALE will try to detect these automatically.
 See |g:ale_python_pyright_config|.
 
-
-g:ale_python_pyright_executable               *g:ale_python_pyright_executable*
+                                        *ale-options.python_pyright_executable*
+                                              *g:ale_python_pyright_executable*
                                               *b:ale_python_pyright_executable*
+python_pyright_executable
+g:ale_python_pyright_executable
   Type: |String|
   Default: `'pyright-langserver'`
 
   The executable for running `pyright`, which is typically installed globally.
 
-
-g:ale_python_pyright_config                       *g:ale_python_pyright_config*
+                                            *ale-options.python_pyright_config*
+                                                  *g:ale_python_pyright_config*
                                                   *b:ale_python_pyright_config*
+python_pyright_config
+g:ale_python_pyright_config
   Type: |Dictionary|
   Default: `{}`
 
@@ -1400,27 +1678,33 @@ g:ale_python_pyright_config                       *g:ale_python_pyright_config*
   \ },
   \}
 <
-
-g:ale_python_pyright_auto_pipenv             *g:ale_python_pyright_auto_pipenv*
+                                       *ale-options.python_pyright_auto_pipenv*
+                                             *g:ale_python_pyright_auto_pipenv*
                                              *b:ale_python_pyright_auto_pipenv*
+python_pyright_auto_pipenv
+g:ale_python_pyright_auto_pipenv
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a pipenv, and set the executable to `pipenv`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_pyright_auto_poetry             *g:ale_python_pyright_auto_poetry*
+                                       *ale-options.python_pyright_auto_poetry*
+                                             *g:ale_python_pyright_auto_poetry*
                                              *b:ale_python_pyright_auto_poetry*
+python_pyright_auto_poetry
+g:ale_python_pyright_auto_poetry
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a poetry, and set the executable to `poetry`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_pyright_auto_uv                     *g:ale_python_pyright_auto_uv*
+                                           *ale-options.python_pyright_auto_uv*
+                                                 *g:ale_python_pyright_auto_uv*
                                                  *b:ale_python_pyright_auto_uv*
+python_pyright_auto_uv
+g:ale_python_pyright_auto_uv
   Type: |Number|
   Default: `0`
 
@@ -1431,8 +1715,11 @@ g:ale_python_pyright_auto_uv                     *g:ale_python_pyright_auto_uv*
 ===============================================================================
 refurb                                                      *ale-python-refurb*
 
-g:ale_python_refurb_change_directory     *g:ale_python_refurb_change_directory*
+                                   *ale-options.python_refurb_change_directory*
+                                         *g:ale_python_refurb_change_directory*
                                          *b:ale_python_refurb_change_directory*
+python_refurb_change_directory
+g:ale_python_refurb_change_directory
   Type: |Number|
   Default: `1`
 
@@ -1440,9 +1727,11 @@ g:ale_python_refurb_change_directory     *g:ale_python_refurb_change_directory*
   |ale-python-root|. if set to `0` or no project root detected,
   `refurb` will be run from the buffer's directory.
 
-
-g:ale_python_refurb_executable                 *g:ale_python_refurb_executable*
+                                         *ale-options.python_refurb_executable*
+                                               *g:ale_python_refurb_executable*
                                                *b:ale_python_refurb_executable*
+python_refurb_executable
+g:ale_python_refurb_executable
   Type: |String|
   Default: `'refurb'`
 
@@ -1451,9 +1740,11 @@ g:ale_python_refurb_executable                 *g:ale_python_refurb_executable*
   Set this to `'pipenv'` to invoke `'pipenv` `run` `refurb'`.
   Set this to `'poetry'` to invoke `'poetry` `run` `refurb'`.
 
-
-g:ale_python_refurb_options                       *g:ale_python_refurb_options*
+                                            *ale-options.python_refurb_options*
+                                                  *g:ale_python_refurb_options*
                                                   *b:ale_python_refurb_options*
+python_refurb_options
+g:ale_python_refurb_options
   Type: |String|
   Default: `''`
 
@@ -1462,35 +1753,46 @@ g:ale_python_refurb_options                       *g:ale_python_refurb_options*
 
   For example, to select/enable and/or disable some error codes,
   you may want to set >
+
   let g:ale_python_refurb_options = '--ignore 100'
-g:ale_python_refurb_use_global                 *g:ale_python_refurb_use_global*
+<
+                                         *ale-options.python_refurb_use_global*
+                                               *g:ale_python_refurb_use_global*
                                                *b:ale_python_refurb_use_global*
+python_refurb_use_global
+g:ale_python_refurb_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_python_refurb_auto_pipenv               *g:ale_python_refurb_auto_pipenv*
+                                        *ale-options.python_refurb_auto_pipenv*
+                                              *g:ale_python_refurb_auto_pipenv*
                                               *b:ale_python_refurb_auto_pipenv*
+python_refurb_auto_pipenv
+g:ale_python_refurb_auto_pipenv
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a pipenv, and set the executable to `pipenv`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_refurb_auto_poetry               *g:ale_python_refurb_auto_poetry*
+                                        *ale-options.python_refurb_auto_poetry*
+                                              *g:ale_python_refurb_auto_poetry*
                                               *b:ale_python_refurb_auto_poetry*
+python_refurb_auto_poetry
+g:ale_python_refurb_auto_poetry
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a poetry, and set the executable to `poetry`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_refurb_auto_uv                       *g:ale_python_refurb_auto_uv*
+                                            *ale-options.python_refurb_auto_uv*
+                                                  *g:ale_python_refurb_auto_uv*
                                                   *b:ale_python_refurb_auto_uv*
+python_refurb_auto_uv
+g:ale_python_refurb_auto_uv
   Type: |Number|
   Default: `0`
 
@@ -1501,56 +1803,63 @@ g:ale_python_refurb_auto_uv                       *g:ale_python_refurb_auto_uv*
 ===============================================================================
 reorder-python-imports                      *ale-python-reorder_python_imports*
 
-g:ale_python_reorder_python_imports_executable
+                         *ale-options.python_reorder_python_imports_executable*
                                *g:ale_python_reorder_python_imports_executable*
                                *b:ale_python_reorder_python_imports_executable*
+python_reorder_python_imports_executable
+g:ale_python_reorder_python_imports_executable
   Type: |String|
   Default: `'reorder-python-imports'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_python_reorder_python_imports_options
+                            *ale-options.python_reorder_python_imports_options*
                                   *g:ale_python_reorder_python_imports_options*
                                   *b:ale_python_reorder_python_imports_options*
+python_reorder_python_imports_options
+g:ale_python_reorder_python_imports_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass extra options to reorder-python-imports.
 
-
-g:ale_python_reorder_python_imports_use_global
+                         *ale-options.python_reorder_python_imports_use_global*
                                *g:ale_python_reorder_python_imports_use_global*
                                *b:ale_python_reorder_python_imports_use_global*
+python_reorder_python_imports_use_global
+g:ale_python_reorder_python_imports_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_python_reorder_python_imports_auto_pipenv
+                        *ale-options.python_reorder_python_imports_auto_pipenv*
                               *g:ale_python_reorder_python_imports_auto_pipenv*
                               *b:ale_python_reorder_python_imports_auto_pipenv*
+python_reorder_python_imports_auto_pipenv
+g:ale_python_reorder_python_imports_auto_pipenv
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a pipenv, and set the executable to `pipenv`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_reorder_python_imports_auto_poetry
+                        *ale-options.python_reorder_python_imports_auto_poetry*
                               *g:ale_python_reorder_python_imports_auto_poetry*
                               *b:ale_python_reorder_python_imports_auto_poetry*
+python_reorder_python_imports_auto_poetry
+g:ale_python_reorder_python_imports_auto_poetry
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a poetry, and set the executable to `poetry`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_reorder_python_imports_auto_uv
+                            *ale-options.python_reorder_python_imports_auto_uv*
                                   *g:ale_python_reorder_python_imports_auto_uv*
                                   *b:ale_python_reorder_python_imports_auto_uv*
+python_reorder_python_imports_auto_uv
+g:ale_python_reorder_python_imports_auto_uv
   Type: |Number|
   Default: `0`
 
@@ -1561,8 +1870,11 @@ g:ale_python_reorder_python_imports_auto_uv
 ===============================================================================
 ruff                                                          *ale-python-ruff*
 
-g:ale_python_ruff_change_directory         *g:ale_python_ruff_change_directory*
+                                     *ale-options.python_ruff_change_directory*
+                                           *g:ale_python_ruff_change_directory*
                                            *b:ale_python_ruff_change_directory*
+python_ruff_change_directory
+g:ale_python_ruff_change_directory
   Type: |Number|
   Default: `1`
 
@@ -1570,9 +1882,11 @@ g:ale_python_ruff_change_directory         *g:ale_python_ruff_change_directory*
   |ale-python-root|. if set to `0` or no project root detected,
   `ruff` will be run from the buffer's directory.
 
-
-g:ale_python_ruff_executable                     *g:ale_python_ruff_executable*
+                                           *ale-options.python_ruff_executable*
+                                                 *g:ale_python_ruff_executable*
                                                  *b:ale_python_ruff_executable*
+python_ruff_executable
+g:ale_python_ruff_executable
   Type: |String|
   Default: `'ruff'`
 
@@ -1581,9 +1895,11 @@ g:ale_python_ruff_executable                     *g:ale_python_ruff_executable*
   Set this to `'pipenv'` to invoke `'pipenv` `run` `ruff'`.
   Set this to `'poetry'` to invoke `'poetry` `run` `ruff'`.
 
-
-g:ale_python_ruff_options                           *g:ale_python_ruff_options*
+                                              *ale-options.python_ruff_options*
+                                                    *g:ale_python_ruff_options*
                                                     *b:ale_python_ruff_options*
+python_ruff_options
+g:ale_python_ruff_options
   Type: |String|
   Default: `''`
 
@@ -1591,38 +1907,47 @@ g:ale_python_ruff_options                           *g:ale_python_ruff_options*
   invocation.
 
   For example, to select/enable and/or disable some error codes,
-  you may want to set >
+  you may want to set: >
+
   let g:ale_python_ruff_options = '--ignore F401'
-
-
-g:ale_python_ruff_use_global                     *g:ale_python_ruff_use_global*
+<
+                                           *ale-options.python_ruff_use_global*
+                                                 *g:ale_python_ruff_use_global*
                                                  *b:ale_python_ruff_use_global*
+python_ruff_use_global
+g:ale_python_ruff_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_python_ruff_auto_pipenv                   *g:ale_python_ruff_auto_pipenv*
+                                          *ale-options.python_ruff_auto_pipenv*
+                                                *g:ale_python_ruff_auto_pipenv*
                                                 *b:ale_python_ruff_auto_pipenv*
+python_ruff_auto_pipenv
+g:ale_python_ruff_auto_pipenv
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a pipenv, and set the executable to `pipenv`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_ruff_auto_poetry                   *g:ale_python_ruff_auto_poetry*
+                                          *ale-options.python_ruff_auto_poetry*
+                                                *g:ale_python_ruff_auto_poetry*
                                                 *b:ale_python_ruff_auto_poetry*
+python_ruff_auto_poetry
+g:ale_python_ruff_auto_poetry
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a poetry, and set the executable to `poetry`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_ruff_auto_uv                           *g:ale_python_ruff_auto_uv*
+                                              *ale-options.python_ruff_auto_uv*
+                                                    *g:ale_python_ruff_auto_uv*
                                                     *b:ale_python_ruff_auto_uv*
+python_ruff_auto_uv
+g:ale_python_ruff_auto_uv
   Type: |Number|
   Default: `0`
 
@@ -1633,9 +1958,11 @@ g:ale_python_ruff_auto_uv                           *g:ale_python_ruff_auto_uv*
 ===============================================================================
 ruff-format                                            *ale-python-ruff-format*
 
-g:ale_python_ruff_format_change_directory
+                              *ale-options.python_ruff_format_change_directory*
                                     *g:ale_python_ruff_format_change_directory*
                                     *b:ale_python_ruff_format_change_directory*
+python_ruff_format_change_directory
+g:ale_python_ruff_format_change_directory
   Type: |Number|
   Default: `1`
 
@@ -1643,9 +1970,11 @@ g:ale_python_ruff_format_change_directory
   |ale-python-root|. if set to `0` or no project root detected,
   `ruff` will be run from the buffer's directory.
 
-
-g:ale_python_ruff_format_executable       *g:ale_python_ruff_format_executable*
+                                    *ale-options.python_ruff_format_executable*
+                                          *g:ale_python_ruff_format_executable*
                                           *b:ale_python_ruff_format_executable*
+python_ruff_format_executable
+g:ale_python_ruff_format_executable
   Type: |String|
   Default: `'ruff'`
 
@@ -1654,9 +1983,11 @@ g:ale_python_ruff_format_executable       *g:ale_python_ruff_format_executable*
   Set this to `'pipenv'` to invoke `'pipenv` `run` `ruff'`.
   Set this to `'poetry'` to invoke `'poetry` `run` `ruff'`.
 
-
-g:ale_python_ruff_format_options             *g:ale_python_ruff_format_options*
+                                       *ale-options.python_ruff_format_options*
+                                             *g:ale_python_ruff_format_options*
                                              *b:ale_python_ruff_format_options*
+python_ruff_format_options
+g:ale_python_ruff_format_options
   Type: |String|
   Default: `''`
 
@@ -1665,37 +1996,46 @@ g:ale_python_ruff_format_options             *g:ale_python_ruff_format_options*
 
   For example, to select/enable and/or disable some error codes,
   you may want to set >
+
   let g:ale_python_ruff_format_options = '--ignore F401'
-
-
-g:ale_python_ruff_format_use_global       *g:ale_python_ruff_format_use_global*
+<
+                                    *ale-options.python_ruff_format_use_global*
+                                          *g:ale_python_ruff_format_use_global*
                                           *b:ale_python_ruff_format_use_global*
+python_ruff_format_use_global
+g:ale_python_ruff_format_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_python_ruff_format_auto_pipenv     *g:ale_python_ruff_format_auto_pipenv*
+                                   *ale-options.python_ruff_format_auto_pipenv*
+                                         *g:ale_python_ruff_format_auto_pipenv*
                                          *b:ale_python_ruff_format_auto_pipenv*
+python_ruff_format_auto_pipenv
+g:ale_python_ruff_format_auto_pipenv
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a pipenv, and set the executable to `pipenv`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_ruff_format_auto_poetry     *g:ale_python_ruff_format_auto_poetry*
+                                   *ale-options.python_ruff_format_auto_poetry*
+                                         *g:ale_python_ruff_format_auto_poetry*
                                          *b:ale_python_ruff_format_auto_poetry*
+python_ruff_format_auto_poetry
+g:ale_python_ruff_format_auto_poetry
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a poetry, and set the executable to `poetry`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_ruff_format_auto_uv             *g:ale_python_ruff_format_auto_uv*
+                                       *ale-options.python_ruff_format_auto_uv*
+                                             *g:ale_python_ruff_format_auto_uv*
                                              *b:ale_python_ruff_format_auto_uv*
+python_ruff_format_auto_uv
+g:ale_python_ruff_format_auto_uv
   Type: |Number|
   Default: `0`
 
@@ -1708,36 +2048,44 @@ unimport                                                  *ale-python-unimport*
 
 `unimport` will be run from a detected project root, per |ale-python-root|.
 
-
-g:ale_python_unimport_auto_pipenv           *g:ale_python_unimport_auto_pipenv*
+                                      *ale-options.python_unimport_auto_pipenv*
+                                            *g:ale_python_unimport_auto_pipenv*
                                             *b:ale_python_unimport_auto_pipenv*
+python_unimport_auto_pipenv
+g:ale_python_unimport_auto_pipenv
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a pipenv, and set the executable to `pipenv`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_unimport_auto_poetry           *g:ale_python_unimport_auto_poetry*
+                                      *ale-options.python_unimport_auto_poetry*
+                                            *g:ale_python_unimport_auto_poetry*
                                             *b:ale_python_unimport_auto_poetry*
+python_unimport_auto_poetry
+g:ale_python_unimport_auto_poetry
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a poetry, and set the executable to `poetry`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_unimport_auto_uv                   *g:ale_python_unimport_auto_uv*
+                                          *ale-options.python_unimport_auto_uv*
+                                                *g:ale_python_unimport_auto_uv*
                                                 *b:ale_python_unimport_auto_uv*
+python_unimport_auto_uv
+g:ale_python_unimport_auto_uv
   Type: |Number|
   Default: `0`
 
   Set the executable to `uv` if true. This is overridden by a manually-set
   executable.
 
-
-g:ale_python_unimport_executable             *g:ale_python_unimport_executable*
+                                       *ale-options.python_unimport_executable*
+                                             *g:ale_python_unimport_executable*
                                              *b:ale_python_unimport_executable*
+python_unimport_executable
+g:ale_python_unimport_executable
   Type: |String|
   Default: `'unimport'`
 
@@ -1746,18 +2094,22 @@ g:ale_python_unimport_executable             *g:ale_python_unimport_executable*
   Set this to `'pipenv'` to invoke `'pipenv` `run` `unimport'`.
   Set this to `'poetry'` to invoke `'poetry` `run` `unimport'`.
 
-
-g:ale_python_unimport_options                   *g:ale_python_unimport_options*
+                                          *ale-options.python_unimport_options*
+                                                *g:ale_python_unimport_options*
                                                 *b:ale_python_unimport_options*
+python_unimport_options
+g:ale_python_unimport_options
   Type: |String|
   Default: `''`
 
   This variable can be changed to add command-line arguments to the unimport
   invocation.
 
-
-g:ale_python_unimport_use_global             *g:ale_python_unimport_use_global*
+                                       *ale-options.python_unimport_use_global*
+                                             *g:ale_python_unimport_use_global*
                                              *b:ale_python_unimport_use_global*
+python_unimport_use_global
+g:ale_python_unimport_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
@@ -1767,8 +2119,11 @@ g:ale_python_unimport_use_global             *g:ale_python_unimport_use_global*
 ===============================================================================
 vulture                                                    *ale-python-vulture*
 
-g:ale_python_vulture_change_directory   *g:ale_python_vulture_change_directory*
+                                  *ale-options.python_vulture_change_directory*
+                                        *g:ale_python_vulture_change_directory*
                                         *b:ale_python_vulture_change_directory*
+python_vulture_change_directory
+g:ale_python_vulture_change_directory
   Type: |Number|
   Default: `1`
 
@@ -1777,51 +2132,64 @@ g:ale_python_vulture_change_directory   *g:ale_python_vulture_change_directory*
   directory instead of checking only the file opened in the current buffer.
   This helps `vulture` to know the context and avoid false-negative results.
 
-
-g:ale_python_vulture_executable               *g:ale_python_vulture_executable*
+                                        *ale-options.python_vulture_executable*
+                                              *g:ale_python_vulture_executable*
                                               *b:ale_python_vulture_executable*
+python_vulture_executable
+g:ale_python_vulture_executable
   Type: |String|
   Default: `'vulture'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_python_vulture_options                     *g:ale_python_vulture_options*
+                                           *ale-options.python_vulture_options*
+                                                 *g:ale_python_vulture_options*
                                                  *b:ale_python_vulture_options*
+python_vulture_options
+g:ale_python_vulture_options
   Type: |String|
   Default: `''`
 
   This variable can be changed to add command-line arguments to the vulture
   invocation.
 
-
-g:ale_python_vulture_use_global               *g:ale_python_vulture_use_global*
+                                        *ale-options.python_vulture_use_global*
+                                              *g:ale_python_vulture_use_global*
                                               *b:ale_python_vulture_use_global*
+python_vulture_use_global
+g:ale_python_vulture_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
   See |ale-integrations-local-executables|
 
-g:ale_python_vulture_auto_pipenv             *g:ale_python_vulture_auto_pipenv*
+                                       *ale-options.python_vulture_auto_pipenv*
+                                             *g:ale_python_vulture_auto_pipenv*
                                              *b:ale_python_vulture_auto_pipenv*
+python_vulture_auto_pipenv
+g:ale_python_vulture_auto_pipenv
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a pipenv, and set the executable to `pipenv`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_vulture_auto_poetry             *g:ale_python_vulture_auto_poetry*
+                                       *ale-options.python_vulture_auto_poetry*
+                                             *g:ale_python_vulture_auto_poetry*
                                              *b:ale_python_vulture_auto_poetry*
+python_vulture_auto_poetry
+g:ale_python_vulture_auto_poetry
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a poetry, and set the executable to `poetry`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_vulture_auto_uv                     *g:ale_python_vulture_auto_uv*
+                                           *ale-options.python_vulture_auto_uv*
+                                                 *g:ale_python_vulture_auto_uv*
                                                  *b:ale_python_vulture_auto_uv*
+python_vulture_auto_uv
+g:ale_python_vulture_auto_uv
   Type: |Number|
   Default: `0`
 
@@ -1832,42 +2200,53 @@ g:ale_python_vulture_auto_uv                     *g:ale_python_vulture_auto_uv*
 ===============================================================================
 yapf                                                          *ale-python-yapf*
 
-g:ale_python_yapf_executable                     *g:ale_python_yapf_executable*
+                                           *ale-options.python_yapf_executable*
+                                                 *g:ale_python_yapf_executable*
                                                  *b:ale_python_yapf_executable*
+python_yapf_executable
+g:ale_python_yapf_executable
   Type: |String|
   Default: `'yapf'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_python_yapf_use_global                     *g:ale_python_yapf_use_global*
+                                           *ale-options.python_yapf_use_global*
+                                                 *g:ale_python_yapf_use_global*
                                                  *b:ale_python_yapf_use_global*
+python_yapf_use_global
+g:ale_python_yapf_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_python_yapf_auto_pipenv                   *g:ale_python_yapf_auto_pipenv*
+                                          *ale-options.python_yapf_auto_pipenv*
+                                                *g:ale_python_yapf_auto_pipenv*
                                                 *b:ale_python_yapf_auto_pipenv*
+python_yapf_auto_pipenv
+g:ale_python_yapf_auto_pipenv
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a pipenv, and set the executable to `pipenv`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_yapf_auto_poetry                   *g:ale_python_yapf_auto_poetry*
+                                          *ale-options.python_yapf_auto_poetry*
+                                                *g:ale_python_yapf_auto_poetry*
                                                 *b:ale_python_yapf_auto_poetry*
+python_yapf_auto_poetry
+g:ale_python_yapf_auto_poetry
   Type: |Number|
   Default: `0`
 
   Detect whether the file is inside a poetry, and set the executable to `poetry`
   if true. This is overridden by a manually-set executable.
 
-
-g:ale_python_yapf_auto_uv                           *g:ale_python_yapf_auto_uv*
+                                              *ale-options.python_yapf_auto_uv*
+                                                    *g:ale_python_yapf_auto_uv*
                                                     *b:ale_python_yapf_auto_uv*
+python_yapf_auto_uv
+g:ale_python_yapf_auto_uv
   Type: |Number|
   Default: `0`
 

--- a/doc/ale-qml.txt
+++ b/doc/ale-qml.txt
@@ -5,8 +5,11 @@ ALE QML Integration                                           *ale-qml-options*
 ===============================================================================
 qmlfmt                                                         *ale-qml-qmlfmt*
 
-g:ale_qml_qmlfmt_executable                       *g:ale_qml_qmlfmt_executable*
+                                            *ale-options.qml_qmlfmt_executable*
+                                                  *g:ale_qml_qmlfmt_executable*
                                                   *b:ale_qml_qmlfmt_executable*
+qml_qmlfmt_executable
+g:ale_qml_qmlfmt_executable
   Type: |String|
   Default: `'qmlfmt'`
 
@@ -15,4 +18,3 @@ g:ale_qml_qmlfmt_executable                       *g:ale_qml_qmlfmt_executable*
 
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:
-

--- a/doc/ale-r.txt
+++ b/doc/ale-r.txt
@@ -5,8 +5,11 @@ ALE R Integration                                               *ale-r-options*
 ===============================================================================
 languageserver                                           *ale-r-languageserver*
 
-g:ale_r_languageserver_cmd                         *g:ale_r_languageserver_cmd*
+                                             *ale-options.r_languageserver_cmd*
+                                                   *g:ale_r_languageserver_cmd*
                                                    *b:ale_r_languageserver_cmd*
+r_languageserver_cmd
+g:ale_r_languageserver_cmd
   Type: |String|
   Default: `'languageserver::run()'`
 
@@ -15,9 +18,11 @@ g:ale_r_languageserver_cmd                         *g:ale_r_languageserver_cmd*
 
   See the languageserver documentation for more options.
 
-
-g:ale_r_languageserver_config                   *g:ale_r_languageserver_config*
+                                          *ale-options.r_languageserver_config*
+                                                *g:ale_r_languageserver_config*
                                                 *b:ale_r_languageserver_config*
+r_languageserver_config
+g:ale_r_languageserver_config
   Type: |Dictionary|
   Default: `{}`
 
@@ -28,8 +33,11 @@ g:ale_r_languageserver_config                   *g:ale_r_languageserver_config*
 ===============================================================================
 lintr                                                             *ale-r-lintr*
 
-g:ale_r_lintr_options                                   *g:ale_r_lintr_options*
+                                                  *ale-options.r_lintr_options*
+                                                        *g:ale_r_lintr_options*
                                                         *b:ale_r_lintr_options*
+r_lintr_options
+g:ale_r_lintr_options
   Type: |String|
   Default: `'lintr::with_defaults()'`
 
@@ -38,9 +46,11 @@ g:ale_r_lintr_options                                   *g:ale_r_lintr_options*
   The value of this option will be run with `eval` for the `lintr::lint`
   options. Consult the lintr documentation for more information.
 
-
-g:ale_r_lintr_lint_package                         *g:ale_r_lintr_lint_package*
+                                             *ale-options.r_lintr_lint_package*
+                                                   *g:ale_r_lintr_lint_package*
                                                    *b:ale_r_lintr_lint_package*
+r_lintr_lint_package
+g:ale_r_lintr_lint_package
   Type: |Number|
   Default: `0`
 
@@ -52,8 +62,11 @@ g:ale_r_lintr_lint_package                         *g:ale_r_lintr_lint_package*
 ===============================================================================
 styler                                                           *ale-r-styler*
 
-g:ale_r_styler_options                                 *g:ale_r_styler_options*
+                                                 *ale-options.r_styler_options*
+                                                       *g:ale_r_styler_options*
                                                        *b:ale_r_styler_options*
+r_styler_options
+g:ale_r_styler_options
   Type: |String|
   Default: `'styler::tidyverse_style'`
 

--- a/doc/ale-racket.txt
+++ b/doc/ale-racket.txt
@@ -1,6 +1,7 @@
 ===============================================================================
 ALE Racket Integration                                       *ale-racket-options*
 
+
 ===============================================================================
 racket_langserver                                         *ale-racket-langserver*
 
@@ -14,11 +15,15 @@ racket_langserver                                         *ale-racket-langserver
 You should be able to see linter results and use LSP features of `ALE` like
 `ALEGoToDefinition` with `racket-langserver`.
 
+
 ===============================================================================
 raco_fmt                                                    *ale-racket-raco-fmt*
 
-g:ale_racket_raco_fmt_executable               *g:ale_racket_raco_fmt_executable*
+                                       *ale-options.racket_raco_fmt_executable*
+                                             *g:ale_racket_raco_fmt_executable*
                                                *b:ale_racket_raco_fmt_executable*
+racket_raco_fmt_executable
+g:ale_racket_raco_fmt_executable
   Type: |String|
   Default: `'raco'`
 
@@ -26,8 +31,11 @@ g:ale_racket_raco_fmt_executable               *g:ale_racket_raco_fmt_executable
   prefer to use one installed in a custom location, set this option to the
   path to the specific `raco` executable.
 
-g:ale_racket_raco_fmt_options                     *g:ale_racket_raco_fmt_options*
+                                          *ale-options.racket_raco_fmt_options*
+                                                *g:ale_racket_raco_fmt_options*
                                                   *b:ale_racket_raco_fmt_options*
+racket_raco_fmt_options
+g:ale_racket_raco_fmt_options
   Type: |String|
   Default: `''`
 

--- a/doc/ale-reasonml.txt
+++ b/doc/ale-reasonml.txt
@@ -19,16 +19,23 @@ instructions:
 https://github.com/freebroccolo/ocaml-language-server#installation
 
 
-g:ale_reason_ols_executable                       *g:ale_reason_ols_executable*
+-------------------------------------------------------------------------------
+Options
+                                            *ale-options.reason_ols_executable*
+                                                  *g:ale_reason_ols_executable*
                                                   *b:ale_reason_ols_executable*
+reason_ols_executable
+g:ale_reason_ols_executable
   Type: |String|
   Default: `'ocaml-language-server'`
 
   This variable can be set to change the executable path for `ols`.
 
-
-g:ale_reason_ols_use_global                       *g:ale_reason_ols_use_global*
+                                            *ale-options.reason_ols_use_global*
+                                                  *g:ale_reason_ols_use_global*
                                                   *b:ale_reason_ols_use_global*
+reason_ols_use_global
+g:ale_reason_ols_use_global
   Type: |String|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
@@ -44,9 +51,11 @@ Go to https://github.com/jaredly/reason-language-server and download the
 latest release. You can place it anywhere, but ensure you set the executable
 path.
 
-
-g:ale_reason_ls_executable                         *g:ale_reason_ls_executable*
+                                             *ale-options.reason_ls_executable*
+                                                   *g:ale_reason_ls_executable*
                                                    *b:ale_reason_ls_executable*
+reason_ls_executable
+g:ale_reason_ls_executable
   Type: |String|
 
   This variable defines the standard location of the language server
@@ -56,16 +65,21 @@ g:ale_reason_ls_executable                         *g:ale_reason_ls_executable*
 ===============================================================================
 refmt                                                      *ale-reasonml-refmt*
 
-g:ale_reasonml_refmt_executable               *g:ale_reasonml_refmt_executable*
+                                        *ale-options.reasonml_refmt_executable*
+                                              *g:ale_reasonml_refmt_executable*
                                               *b:ale_reasonml_refmt_executable*
+reasonml_refmt_executable
+g:ale_reasonml_refmt_executable
   Type: |String|
   Default: `'refmt'`
 
   This variable can be set to pass the path of the refmt fixer.
 
-
-g:ale_reasonml_refmt_options                     *g:ale_reasonml_refmt_options*
+                                           *ale-options.reasonml_refmt_options*
+                                                 *g:ale_reasonml_refmt_options*
                                                  *b:ale_reasonml_refmt_options*
+reasonml_refmt_options
+g:ale_reasonml_refmt_options
   Type: |String|
   Default: `''`
 

--- a/doc/ale-rego.txt
+++ b/doc/ale-rego.txt
@@ -11,17 +11,21 @@ See |ale-cspell-options|
 ===============================================================================
 opacheck                                                   *ale-rego-opa-check*
 
-g:ale_rego_opacheck_executable                     *g:rego_opacheck_executable*
-                                                   *b:rego_opacheck_executable*
-
+                                         *ale-options.rego_opacheck_executable*
+                                               *g:ale_rego_opacheck_executable*
+                                               *b:ale_rego_opacheck_executable*
+rego_opacheck_executable
+g:ale_rego_opacheck_executable
   Type: |String|
   Default: `'opa'`
 
   This variable can be changed to use a different executable for opa.
 
-
-g:rego_opacheck_options                               *g:rego_opacheck_options*
+                                            *ale-options.rego_opacheck_options*
+                                                      *g:rego_opacheck_options*
                                                       *b:rego_opacheck_options*
+rego_opacheck_options
+g:ale_rego_opacheck_options
   Type: |String|
   Default: `''`
 
@@ -31,17 +35,21 @@ g:rego_opacheck_options                               *g:rego_opacheck_options*
 ===============================================================================
 opafmt                                                 *ale-rego-opa-fmt-fixer*
 
-g:ale_opa_fmt_executable                             *g:ale_opa_fmt_executable*
+                                               *ale-options.opa_fmt_executable*
+                                                     *g:ale_opa_fmt_executable*
                                                      *b:ale_opa_fmt_executable*
-
+opa_fmt_executable
+g:ale_opa_fmt_executable
   Type: |String|
   Default: `'opa'`
 
   This variable can be changed to use a different executable for opa.
 
-
-g:ale_opa_fmt_options                                   *g:ale_opa_fmt_options*
+                                                  *ale-options.opa_fmt_options*
+                                                        *g:ale_opa_fmt_options*
                                                         *b:ale_opa_fmt_options*
+opa_fmt_options
+g:ale_opa_fmt_options
   Type: |String|
   Default: `''`
 

--- a/doc/ale-rest.txt
+++ b/doc/ale-rest.txt
@@ -7,5 +7,6 @@ kulala_fmt                                                *ale-rest-kulala_fmt*
 
 See |ale-http-kulala_fmt|
 
+
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-robot.txt
+++ b/doc/ale-robot.txt
@@ -5,12 +5,14 @@ ALE Robot Integration                                       *ale-robot-options*
 ===============================================================================
 rflint                                                       *ale-robot-rflint*
 
-g:ale_robot_rflint_executable                   *g:ale_robot_rflint_executable*
+                                          *ale-options.robot_rflint_executable*
+                                                *g:ale_robot_rflint_executable*
                                                 *b:ale_robot_rflint_executable*
+robot_rflint_executable
+g:ale_robot_rflint_executable
   Type: |String|
   Default: `'rflint'`
 
 
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:
-

--- a/doc/ale-ruby.txt
+++ b/doc/ale-ruby.txt
@@ -5,17 +5,22 @@ ALE Ruby Integration                                         *ale-ruby-options*
 ===============================================================================
 brakeman                                                    *ale-ruby-brakeman*
 
-g:ale_ruby_brakeman_executable                 *g:ale_ruby_brakeman_executable*
+                                         *ale-options.ruby_brakeman_executable*
+                                               *g:ale_ruby_brakeman_executable*
                                                *b:ale_ruby_brakeman_executable*
+ruby_brakeman_executable
+g:ale_ruby_brakeman_executable
   Type: |String|
   Default: `'brakeman'`
 
   Override the invoked brakeman binary. Set this to `'bundle'` to invoke
   `'bundle` `exec` brakeman'.
 
-
-g:ale_ruby_brakeman_options                       *g:ale_ruby_brakeman_options*
+                                            *ale-options.ruby_brakeman_options*
+                                                  *g:ale_ruby_brakeman_options*
                                                   *b:ale_ruby_brakeman_options*
+ruby_brakeman_options
+g:ale_ruby_brakeman_options
   Type: |String|
   Default: `''`
 
@@ -31,17 +36,22 @@ See |ale-cspell-options|
 ===============================================================================
 debride                                                      *ale-ruby-debride*
 
-g:ale_ruby_debride_executable                   *g:ale_ruby_debride_executable*
+                                          *ale-options.ruby_debride_executable*
+                                                *g:ale_ruby_debride_executable*
                                                 *b:ale_ruby_debride_executable*
+ruby_debride_executable
+g:ale_ruby_debride_executable
   Type: |String|
   Default: `'debride'`
 
   Override the invoked debride binary. Set this to `'bundle'` to invoke
   `'bundle` `exec` debride'.
 
-
-g:ale_ruby_debride_options                         *g:ale_ruby_debride_options*
+                                             *ale-options.ruby_debride_options*
+                                                   *g:ale_ruby_debride_options*
                                                    *b:ale_ruby_debride_options*
+ruby_debride_options
+g:ale_ruby_debride_options
   Type: |String|
   Default: `''`
 
@@ -51,17 +61,22 @@ g:ale_ruby_debride_options                         *g:ale_ruby_debride_options*
 ===============================================================================
 packwerk                                                    *ale-ruby-packwerk*
 
-g:ale_ruby_packwerk_executable                 *g:ale_ruby_packwerk_executable*
+                                         *ale-options.ruby_packwerk_executable*
+                                               *g:ale_ruby_packwerk_executable*
                                                *b:ale_ruby_packwerk_executable*
+ruby_packwerk_executable
+g:ale_ruby_packwerk_executable
   Type: |String|
   Default: `'packwerk'`
 
   Override the invoked packwerk binary. Set this to `'bundle'` to invoke
   `'bundle` `exec` packwerk'.
 
-
-g:ale_ruby_packwerk_options                       *g:ale_ruby_packwerk_options*
+                                            *ale-options.ruby_packwerk_options*
+                                                  *g:ale_ruby_packwerk_options*
                                                   *b:ale_ruby_packwerk_options*
+ruby_packwerk_options
+g:ale_ruby_packwerk_options
   Type: |String|
   Default: `''`
 
@@ -77,9 +92,11 @@ See |ale-javascript-prettier| for information about the available options.
 ===============================================================================
 rails_best_practices                            *ale-ruby-rails_best_practices*
 
-g:ale_ruby_rails_best_practices_executable
+                             *ale-options.ruby_rails_best_practices_executable*
                                    *g:ale_ruby_rails_best_practices_executable*
                                    *b:ale_ruby_rails_best_practices_executable*
+ruby_rails_best_practices_executable
+g:ale_ruby_rails_best_practices_executable
   Type: |String|
   Default: `'rails_best_practices'`
 
@@ -87,9 +104,11 @@ g:ale_ruby_rails_best_practices_executable
   invoke `'bundle` `exec` rails_best_practices'.
 
 
-g:ale_ruby_rails_best_practices_options
+                                *ale-options.ruby_rails_best_practices_options*
                                       *g:ale_ruby_rails_best_practices_options*
                                       *b:ale_ruby_rails_best_practices_options*
+ruby_rails_best_practices_options
+g:ale_ruby_rails_best_practices_options
   Type: |String|
   Default: `''`
 
@@ -99,26 +118,33 @@ g:ale_ruby_rails_best_practices_options
 ===============================================================================
 reek                                                            *ale-ruby-reek*
 
-g:ale_ruby_reek_executable                         *g:ale_ruby_reek_executable*
+                                             *ale-options.ruby_reek_executable*
+                                                   *g:ale_ruby_reek_executable*
                                                    *b:ale_ruby_reek_executable*
+ruby_reek_executable
+g:ale_ruby_reek_executable
   Type: |String|
   Default: `'reek'`
 
   Override the invoked reek binary. Set this to `'bundle'` to invoke
   `'bundle` `exec` reek'.
 
-
-g:ale_ruby_reek_show_context                     *g:ale_ruby_reek_show_context*
+                                           *ale-options.ruby_reek_show_context*
+                                                 *g:ale_ruby_reek_show_context*
                                                  *b:ale_ruby_reek_show_context*
+ruby_reek_show_context
+g:ale_ruby_reek_show_context
   Type: |Number|
   Default: `0`
 
   Controls whether context is included in the linter message. Defaults to off
   because context is usually obvious while viewing a file.
 
-
-g:ale_ruby_reek_show_wiki_link                 *g:ale_ruby_reek_show_wiki_link*
+                                         *ale-options.ruby_reek_show_wiki_link*
+                                               *g:ale_ruby_reek_show_wiki_link*
                                                *b:ale_ruby_reek_show_wiki_link*
+ruby_reek_show_wiki_link
+g:ale_ruby_reek_show_wiki_link
   Type: |Number|
   Default: `0`
 
@@ -129,25 +155,32 @@ g:ale_ruby_reek_show_wiki_link                 *g:ale_ruby_reek_show_wiki_link*
 ===============================================================================
 rubocop                                                      *ale-ruby-rubocop*
 
-g:ale_ruby_rubocop_executable                   *g:ale_ruby_rubocop_executable*
+                                          *ale-options.ruby_rubocop_executable*
+                                                *g:ale_ruby_rubocop_executable*
                                                 *b:ale_ruby_rubocop_executable*
+ruby_rubocop_executable
+g:ale_ruby_rubocop_executable
   Type: |String|
   Default: `'rubocop'`
 
   Override the invoked rubocop binary. Set this to `'bundle'` to invoke
   `'bundle` `exec` rubocop'.
 
-
-g:ale_ruby_rubocop_options                         *g:ale_ruby_rubocop_options*
+                                             *ale-options.ruby_rubocop_options*
+                                                   *g:ale_ruby_rubocop_options*
                                                    *b:ale_ruby_rubocop_options*
+ruby_rubocop_options
+g:ale_ruby_rubocop_options
   Type: |String|
   Default: `''`
 
   This variable can be changed to modify flags given to rubocop.
 
-
-g:ale_ruby_rubocop_auto_correct_all       *g:ale_ruby_rubocop_auto_correct_all*
+                                    *ale-options.ruby_rubocop_auto_correct_all*
+                                          *g:ale_ruby_rubocop_auto_correct_all*
                                           *b:ale_ruby_rubocop_auto_correct_all*
+ruby_rubocop_auto_correct_all
+g:ale_ruby_rubocop_auto_correct_all
   Type: |Number|
   Default: `0`
 
@@ -157,8 +190,11 @@ g:ale_ruby_rubocop_auto_correct_all       *g:ale_ruby_rubocop_auto_correct_all*
 ===============================================================================
 ruby                                                            *ale-ruby-ruby*
 
-g:ale_ruby_ruby_executable                         *g:ale_ruby_ruby_executable*
+                                             *ale-options.ruby_ruby_executable*
+                                                   *g:ale_ruby_ruby_executable*
                                                    *b:ale_ruby_ruby_executable*
+ruby_ruby_executable
+g:ale_ruby_ruby_executable
   Type: |String|
   Default: `'ruby'`
 
@@ -168,8 +204,11 @@ g:ale_ruby_ruby_executable                         *g:ale_ruby_ruby_executable*
 ===============================================================================
 rufo                                                            *ale-ruby-rufo*
 
-g:ale_ruby_rufo_executable                         *g:ale_ruby_rufo_executable*
+                                             *ale-options.ruby_rufo_executable*
+                                                   *g:ale_ruby_rufo_executable*
                                                    *b:ale_ruby_rufo_executable*
+ruby_rufo_executable
+g:ale_ruby_rufo_executable
   Type: |String|
   Default: `'rufo'`
 
@@ -180,8 +219,11 @@ g:ale_ruby_rufo_executable                         *g:ale_ruby_rufo_executable*
 ===============================================================================
 solargraph                                                *ale-ruby-solargraph*
 
-g:ale_ruby_solargraph_executable             *g:ale_ruby_solargraph_executable*
+                                       *ale-options.ruby_solargraph_executable*
+                                             *g:ale_ruby_solargraph_executable*
                                              *b:ale_ruby_solargraph_executable*
+ruby_solargraph_executable
+g:ale_ruby_solargraph_executable
   Type: |String|
   Default: `'solargraph'`
 
@@ -192,25 +234,32 @@ g:ale_ruby_solargraph_executable             *g:ale_ruby_solargraph_executable*
 ===============================================================================
 sorbet                                                        *ale-ruby-sorbet*
 
-g:ale_ruby_sorbet_executable                     *g:ale_ruby_sorbet_executable*
+                                           *ale-options.ruby_sorbet_executable*
+                                                 *g:ale_ruby_sorbet_executable*
                                                  *b:ale_ruby_sorbet_executable*
+ruby_sorbet_executable
+g:ale_ruby_sorbet_executable
   Type: |String|
   Default: `'srb'`
 
   Override the invoked sorbet binary. Set this to `'bundle'` to invoke
   `'bundle` `exec` srb'.
 
-
-g:ale_ruby_sorbet_options                           *g:ale_ruby_sorbet_options*
+                                              *ale-options.ruby_sorbet_options*
+                                                    *g:ale_ruby_sorbet_options*
                                                     *b:ale_ruby_sorbet_options*
+ruby_sorbet_options
+g:ale_ruby_sorbet_options
   Type: |String|
   Default: `''`
 
   This variable can be changed to modify flags given to sorbet.
 
-
-g:ale_ruby_sorbet_enable_watchman           *g:ale_ruby_sorbet_enable_watchman*
+                                      *ale-options.ruby_sorbet_enable_watchman*
+                                            *g:ale_ruby_sorbet_enable_watchman*
                                             *b:ale_ruby_sorbet_enable_watchman*
+ruby_sorbet_enable_watchman
+g:ale_ruby_sorbet_enable_watchman
   Type: |Number|
   Default: `0`
 
@@ -222,17 +271,22 @@ g:ale_ruby_sorbet_enable_watchman           *g:ale_ruby_sorbet_enable_watchman*
 ===============================================================================
 standardrb                                                *ale-ruby-standardrb*
 
-g:ale_ruby_standardrb_executable             *g:ale_ruby_standardrb_executable*
+                                       *ale-options.ruby_standardrb_executable*
+                                             *g:ale_ruby_standardrb_executable*
                                              *b:ale_ruby_standardrb_executable*
+ruby_standardrb_executable
+g:ale_ruby_standardrb_executable
   Type: |String|
   Default: `'standardrb'`
 
   Override the invoked standardrb binary. Set this to `'bundle'` to invoke
   `'bundle` `exec` standardrb'.
 
-
-g:ale_ruby_standardrb_options                   *g:ale_ruby_standardrb_options*
+                                          *ale-options.ruby_standardrb_options*
+                                                *g:ale_ruby_standardrb_options*
                                                 *b:ale_ruby_standardrb_options*
+ruby_standardrb_options
+g:ale_ruby_standardrb_options
   Type: |String|
   Default: `''`
 
@@ -242,35 +296,46 @@ g:ale_ruby_standardrb_options                   *g:ale_ruby_standardrb_options*
 ===============================================================================
 syntax_tree                                              *ale-ruby-syntax_tree*
 
-g:ale_ruby_syntax_tree_executable           *g:ale_ruby_syntax_tree_executable*
+                                      *ale-options.ruby_syntax_tree_executable*
+                                            *g:ale_ruby_syntax_tree_executable*
                                             *b:ale_ruby_syntax_tree_executable*
+ruby_syntax_tree_executable
+g:ale_ruby_syntax_tree_executable
   Type: |String|
   Default: `'stree'`
 
   Override the invoked SyntaxTree binary. Set this to `'bundle'` to invoke
   `'bundle` `exec` stree'.
 
-
-g:ale_ruby_syntax_tree_options                 *g:ale_ruby_syntax_tree_options*
+                                         *ale-options.ruby_syntax_tree_options*
+                                               *g:ale_ruby_syntax_tree_options*
                                                *b:ale_ruby_syntax_tree_options*
+ruby_syntax_tree_options
+g:ale_ruby_syntax_tree_options
   Type: |String|
   Default: `''`
 
   This variable can be changed to modify flags given to SyntaxTree.
 
+
 ===============================================================================
 rubyfmt                                                       *ale-ruby-rubyfmt*
 
-g:ale_ruby_rubyfmt_executable                    *g:ale_ruby_rubyfmt_executable*
+                                          *ale-options.ruby_rubyfmt_executable*
+                                                *g:ale_ruby_rubyfmt_executable*
                                                  *b:ale_ruby_rubyfmt_executable*
+ruby_rubyfmt_executable
+g:ale_ruby_rubyfmt_executable
   Type: |String|
   Default: `'rubyfmt'`
 
   This option can be changed to change the path for `rubyfmt`.
 
-
-g:ale_ruby_rubyfmt_options                          *g:ale_ruby_rubyfmt_options*
+                                             *ale-options.ruby_rubyfmt_options*
+                                                   *g:ale_ruby_rubyfmt_options*
                                                     *b:ale_ruby_rubyfmt_options*
+ruby_rubyfmt_options
+g:ale_ruby_rubyfmt_options
   Type: |String|
   Default: `''`
 

--- a/doc/ale-rust.txt
+++ b/doc/ale-rust.txt
@@ -40,35 +40,43 @@ Integration Information
   " See the help text for the option for more information.
   let b:ale_linters = ['analyzer', 'rustc']
 <
+  Or in Lua: >
 
+  require("ale").setup.buffer({linters = {"analyzer", "rustc"}})
+<
   Also note that rustc 1.18. or later is needed.
 
 
 ===============================================================================
 analyzer                                                    *ale-rust-analyzer*
 
-g:ale_rust_analyzer_executable                 *g:ale_rust_analyzer_executable*
+                                         *ale-options.rust_analyzer_executable*
+                                               *g:ale_rust_analyzer_executable*
                                                *b:ale_rust_analyzer_executable*
+rust_analyzer_executable
+g:ale_rust_analyzer_executable
   Type: |String|
   Default: `'rust-analyzer'`
 
   This variable can be modified to change the executable path for
   `rust-analyzer`.
 
-
-g:ale_rust_analyzer_config                         *g:ale_rust_analyzer_config*
+                                             *ale-options.rust_analyzer_config*
+                                                   *g:ale_rust_analyzer_config*
                                                    *b:ale_rust_analyzer_config*
+rust_analyzer_config
+g:ale_rust_analyzer_config
   Type: |Dictionary|
   Default: `{}`
 
   Dictionary with configuration settings for rust-analyzer. Keys of the
-  dictionary are components of configuration keys. For example:
->
-    let g:ale_rust_analyzer_config = {
-    \  'server': {
-    \    'extraEnv': { 'RUSTUP_TOOLCHAIN': 'stable' },
-    \  }
-    \}
+  dictionary are components of configuration keys. For example: >
+
+  let g:ale_rust_analyzer_config = {
+  \  'server': {
+  \    'extraEnv': { 'RUSTUP_TOOLCHAIN': 'stable' },
+  \  }
+  \}
 <
   corresponds to `rust-analyzer.server.extraEnv = { 'RUSTUP_TOOLCHAIN': 'stable' }`
 
@@ -76,11 +84,15 @@ g:ale_rust_analyzer_config                         *g:ale_rust_analyzer_config*
 
   https://rust-analyzer.github.io/manual.html#configuration
 
+
 ===============================================================================
 cargo                                                          *ale-rust-cargo*
 
-g:ale_rust_cargo_use_check                         *g:ale_rust_cargo_use_check*
+                                             *ale-options.rust_cargo_use_check*
+                                                   *g:ale_rust_cargo_use_check*
                                                    *b:ale_rust_cargo_use_check*
+rust_cargo_use_check
+g:ale_rust_cargo_use_check
   Type: |Number|
   Default: `1`
 
@@ -90,18 +102,22 @@ g:ale_rust_cargo_use_check                         *g:ale_rust_cargo_use_check*
   ALE will never use `cargo check` when the version of `cargo` is less than
   0.17.0.
 
-
-g:ale_rust_cargo_check_all_targets         *g:ale_rust_cargo_check_all_targets*
+                                     *ale-options.rust_cargo_check_all_targets*
+                                           *g:ale_rust_cargo_check_all_targets*
                                            *b:ale_rust_cargo_check_all_targets*
+rust_cargo_check_all_targets
+g:ale_rust_cargo_check_all_targets
   Type: |Number|
   Default: `0`
 
   When set to `1`, ALE will set the `--all-targets` option when `cargo check`
   is used. See |g:ale_rust_cargo_use_check|,
 
-
-g:ale_rust_cargo_check_tests                     *g:ale_rust_cargo_check_tests*
+                                           *ale-options.rust_cargo_check_tests*
+                                                 *g:ale_rust_cargo_check_tests*
                                                  *b:ale_rust_cargo_check_tests*
+rust_cargo_check_tests
+g:ale_rust_cargo_check_tests
   Type: |Number|
   Default: `0`
 
@@ -109,9 +125,11 @@ g:ale_rust_cargo_check_tests                     *g:ale_rust_cargo_check_tests*
   is used. This allows for linting of tests which are normally excluded.
   See |g:ale_rust_cargo_use_check|,
 
-
-g:ale_rust_cargo_check_examples               *g:ale_rust_cargo_check_examples*
+                                        *ale-options.rust_cargo_check_examples*
+                                              *g:ale_rust_cargo_check_examples*
                                               *b:ale_rust_cargo_check_examples*
+rust_cargo_check_examples
+g:ale_rust_cargo_check_examples
   Type: |Number|
   Default: `0`
 
@@ -119,10 +137,11 @@ g:ale_rust_cargo_check_examples               *g:ale_rust_cargo_check_examples*
   is used. This allows for linting of examples which are normally excluded.
   See |g:ale_rust_cargo_use_check|,
 
-
-g:ale_rust_cargo_default_feature_behavior
+                              *ale-options.rust_cargo_default_feature_behavior*
                                     *g:ale_rust_cargo_default_feature_behavior*
                                     *b:ale_rust_cargo_default_feature_behavior*
+rust_cargo_default_feature_behavior
+g:ale_rust_cargo_default_feature_behavior
   Type: |String|
   Default: `default`
 
@@ -140,18 +159,22 @@ g:ale_rust_cargo_default_feature_behavior
   invoking `cargo`, which will include all features defined in the project's
   `Cargo.toml` file when performing the lint check.
 
-
-g:ale_rust_cargo_include_features           *g:ale_rust_cargo_include_features*
+                                      *ale-options.rust_cargo_include_features*
+                                            *g:ale_rust_cargo_include_features*
                                             *b:ale_rust_cargo_include_features*
+rust_cargo_include_features
+g:ale_rust_cargo_include_features
   Type: |String|
   Default: `''`
 
   When defined, ALE will set the `--features` option when invoking `cargo` to
   perform the lint check. See |g:ale_rust_cargo_default_feature_behavior|.
 
-
-g:ale_rust_cargo_avoid_whole_workspace *g:ale_rust_cargo_avoid_whole_workspace*
+                                 *ale-options.rust_cargo_avoid_whole_workspace*
+                                       *g:ale_rust_cargo_avoid_whole_workspace*
                                        *b:ale_rust_cargo_avoid_whole_workspace*
+rust_cargo_avoid_whole_workspace
+g:ale_rust_cargo_avoid_whole_workspace
   Type: |Number|
   Default: `1`
 
@@ -159,9 +182,11 @@ g:ale_rust_cargo_avoid_whole_workspace *g:ale_rust_cargo_avoid_whole_workspace*
   workspace, avoid building the entire workspace by invoking `cargo` directly
   in the crate's directory. Otherwise, behave as usual.
 
-
-g:ale_rust_cargo_use_clippy                       *g:ale_rust_cargo_use_clippy*
+                                            *ale-options.rust_cargo_use_clippy*
+                                                  *g:ale_rust_cargo_use_clippy*
                                                   *b:ale_rust_cargo_use_clippy*
+rust_cargo_use_clippy
+g:ale_rust_cargo_use_clippy
   Type: |Number|
   Default: `0`
 
@@ -176,10 +201,11 @@ g:ale_rust_cargo_use_clippy                       *g:ale_rust_cargo_use_clippy*
 >
     let g:ale_rust_cargo_use_clippy = executable('cargo-clippy')
 <
-
-g:ale_rust_cargo_clippy_options               *g:ale_rust_cargo_clippy_options*
+                                        *ale-options.rust_cargo_clippy_options*
+                                              *g:ale_rust_cargo_clippy_options*
                                               *b:ale_rust_cargo_clippy_options*
-
+rust_cargo_clippy_options
+g:ale_rust_cargo_clippy_options
   Type: |String|
   Default: `''`
 
@@ -187,10 +213,11 @@ g:ale_rust_cargo_clippy_options               *g:ale_rust_cargo_clippy_options*
   it. This variable is useful when you want to add some extra options which
   only `cargo clippy` supports (e.g. `--deny`).
 
-
-g:ale_rust_cargo_target_dir                       *g:ale_rust_cargo_target_dir*
+                                            *ale-options.rust_cargo_target_dir*
+                                                  *g:ale_rust_cargo_target_dir*
                                                   *b:ale_rust_cargo_target_dir*
-
+rust_cargo_target_dir
+g:ale_rust_cargo_target_dir
   Type: |String|
   Default: `''`
 
@@ -208,16 +235,21 @@ See |ale-cspell-options|
 ===============================================================================
 rls                                                              *ale-rust-rls*
 
-g:ale_rust_rls_executable                           *g:ale_rust_rls_executable*
+                                              *ale-options.rust_rls_executable*
+                                                    *g:ale_rust_rls_executable*
                                                     *b:ale_rust_rls_executable*
+rust_rls_executable
+g:ale_rust_rls_executable
   Type: |String|
   Default: `'rls'`
 
   This variable can be modified to change the executable path for `rls`.
 
-
-g:ale_rust_rls_toolchain                             *g:ale_rust_rls_toolchain*
+                                               *ale-options.rust_rls_toolchain*
+                                                     *g:ale_rust_rls_toolchain*
                                                      *b:ale_rust_rls_toolchain*
+rust_rls_toolchain
+g:ale_rust_rls_toolchain
   Type: |String|
   Default: `''`
 
@@ -230,27 +262,42 @@ g:ale_rust_rls_toolchain                             *g:ale_rust_rls_toolchain*
 
   The `rls` server will only be started once per executable.
 
-
-g:ale_rust_rls_config                                   *g:ale_rust_rls_config*
+                                                  *ale-options.rust_rls_config*
+                                                        *g:ale_rust_rls_config*
                                                         *b:ale_rust_rls_config*
+rust_rls_config
+g:ale_rust_rls_config
   Type: |Dictionary|
   Default: `{}`
 
   Dictionary with configuration settings for rls. For example, to force
-  using clippy as linter: >
-        {
-      \   'rust': {
-      \     'clippy_preference': 'on'
-      \   }
-      \ }
+  using clippy as linter in your ftplugin file: >
 
+  let b:ale_rust_rls_config = {
+  \   'rust': {
+  \       'clippy_preference': 'on'
+  \   },
+  \}
+<
+  Or in Lua: >
+
+  require("ale").setup.buffer({
+      rust_rls_config = {
+          rust = {
+              clippy_preference = "on",
+          },
+      },
+  })
+<
 
 ===============================================================================
 rustc                                                          *ale-rust-rustc*
 
-
-g:ale_rust_rustc_options                             *g:ale_rust_rustc_options*
+                                               *ale-options.rust_rustc_options*
+                                                     *g:ale_rust_rustc_options*
                                                      *b:ale_rust_rustc_options*
+rust_rustc_options
+g:ale_rust_rustc_options
   Type: |String|
   Default: `'--emit=mir -o /dev/null'`
 
@@ -260,20 +307,24 @@ g:ale_rust_rustc_options                             *g:ale_rust_rustc_options*
   Be careful when setting the options, as running `rustc` could execute code
   or generate binary files.
 
-
-g:ale_rust_ignore_error_codes                   *g:ale_rust_ignore_error_codes*
+                                          *ale-options.rust_ignore_error_codes*
+                                                *g:ale_rust_ignore_error_codes*
                                                 *b:ale_rust_ignore_error_codes*
+rust_ignore_error_codes
+g:ale_rust_ignore_error_codes
   Type: |List| of |String|s
   Default: `[]`
 
   This variable can contain error codes which will be ignored. For example, to
-  ignore most errors regarding failed imports, put this in your .vimrc
-  >
+  ignore most errors regarding failed imports, put this in your .vimrc >
+
   let g:ale_rust_ignore_error_codes = ['E0432', 'E0433']
-
-
-g:ale_rust_ignore_secondary_spans           *g:ale_rust_ignore_secondary_spans*
+<
+                                      *ale-options.rust_ignore_secondary_spans*
+                                            *g:ale_rust_ignore_secondary_spans*
                                             *b:ale_rust_ignore_secondary_spans*
+rust_ignore_secondary_spans
+g:ale_rust_ignore_secondary_spans
   Type: |Number|
   Default: `0`
 
@@ -293,16 +344,21 @@ g:ale_rust_ignore_secondary_spans           *g:ale_rust_ignore_secondary_spans*
 ===============================================================================
 rustfmt                                                      *ale-rust-rustfmt*
 
-g:ale_rust_rustfmt_options                         *g:ale_rust_rustfmt_options*
+                                             *ale-options.rust_rustfmt_options*
+                                                   *g:ale_rust_rustfmt_options*
                                                    *b:ale_rust_rustfmt_options*
+rust_rustfmt_options
+g:ale_rust_rustfmt_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass additional options to the rustfmt fixer.
 
-
-g:ale_rust_rustfmt_executable                   *g:ale_rust_rustfmt_executable*
+                                          *ale-options.rust_rustfmt_executable*
+                                                *g:ale_rust_rustfmt_executable*
                                                 *b:ale_rust_rustfmt_executable*
+rust_rustfmt_executable
+g:ale_rust_rustfmt_executable
   Type: |String|
   Default: `'rustfmt'`
 

--- a/doc/ale-salt.tmt
+++ b/doc/ale-salt.tmt
@@ -7,32 +7,36 @@ salt-lint                                                  *ale-salt-salt-lint*
 Website: https://github.com/warpnet/salt-lint
 
 
-Installation
 -------------------------------------------------------------------------------
+Installation
 
 Install salt-lint in your a virtualenv directory, locally, or globally: >
 
   pip install salt-lint # After activating virtualenv
   pip install --user salt-lint # Install to ~/.local/bin
   sudo pip install salt-lint # Install globally
-
+<
 See |g:ale_virtualenv_dir_names| for configuring how ALE searches for
 virtualenv directories.
 
 
-Options
 -------------------------------------------------------------------------------
-
-g:ale_salt_salt_lint_executable                *g:ale_salt_salt_lint_executable*
-                                               *b:ale_salt_salt_lint_executable*
+Options
+                                        *ale-options.salt_salt_lint_executable*
+                                              *g:ale_salt_salt_lint_executable*
+                                              *b:ale_salt_salt_lint_executable*
+salt_salt_lint_executable
+g:ale_salt_salt_lint_executable
   Type: |String|
   Default: `'salt-lint'`
 
   This variable can be set to change the path to salt-lint.
 
-
-g:ale_salt_salt_lint_options                      *g:ale_salt_salt_lint_options*
-                                                  *b:ale_salt_salt_lint_options*
+                                           *ale-options.salt_salt_lint_options*
+                                                 *g:ale_salt_salt_lint_options*
+                                                 *b:ale_salt_salt_lint_options*
+salt_salt_lint_options
+g:ale_salt_salt_lint_options
   Type: |String|
   Default: `''`
 

--- a/doc/ale-sass.txt
+++ b/doc/ale-sass.txt
@@ -11,16 +11,21 @@ See |ale-scss-sasslint| for information about the available options.
 ===============================================================================
 stylelint                                                  *ale-sass-stylelint*
 
-g:ale_sass_stylelint_executable               *g:ale_sass_stylelint_executable*
+                                        *ale-options.sass_stylelint_executable*
+                                              *g:ale_sass_stylelint_executable*
                                               *b:ale_sass_stylelint_executable*
+sass_stylelint_executable
+g:ale_sass_stylelint_executable
   Type: |String|
   Default: `'stylelint'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_sass_stylelint_use_global               *g:ale_sass_stylelint_use_global*
+                                        *ale-options.sass_stylelint_use_global*
+                                              *g:ale_sass_stylelint_use_global*
                                               *b:ale_sass_stylelint_use_global*
+sass_stylelint_use_global
+g:ale_sass_stylelint_use_global
   Type: |String|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 

--- a/doc/ale-scala.txt
+++ b/doc/ale-scala.txt
@@ -14,24 +14,27 @@ metals                                                       *ale-scala-metals*
 `metals` requires either an SBT project, a Mill project, or a running Bloop
 server.
 
-
-g:ale_scala_metals_executable                    *g:ale_scala_metals_executable*
+                                          *ale-options.scala_metals_executable*
+                                                *g:ale_scala_metals_executable*
                                                  *b:ale_scala_metals_executable*
+scala_metals_executable
+g:ale_scala_metals_executable
   Type: |String|
   Default: `'metals-vim'`
 
   Override the invoked `metals` binary.
 
-
-g:ale_scala_metals_project_root                *g:ale_scala_metals_project_root*
+                                        *ale-options.scala_metals_project_root*
+                                              *g:ale_scala_metals_project_root*
                                                *b:ale_scala_metals_project_root*
+scala_metals_project_root
+g:ale_scala_metals_project_root
   Type: |String|
   Default: `''`
 
   By default the project root is found by searching upwards for `build.sbt`,
-  `build.sc`, `.bloop` or `.metals`.
-  If the project root is elsewhere, you can override the project root
-  directory.
+  `build.sc`, `.bloop` or `.metals`. If the project root is elsewhere, you
+  can override the project root directory.
 
 
 ===============================================================================
@@ -45,9 +48,11 @@ to the right socket:
 
 `serverConnectionType := ConnectionType.Tcp` and `serverPort := 4273`
 
-
-g:ale_scala_sbtserver_address                   *g:ale_scala_sbtserver_address*
+                                          *ale-options.scala_sbtserver_address*
+                                                *g:ale_scala_sbtserver_address*
                                                 *b:ale_scala_sbtserver_address*
+scala_sbtserver_address
+g:ale_scala_sbtserver_address
   Type: |String|
   Default: `'127.0.0.1:4273'`
 
@@ -56,9 +61,11 @@ g:ale_scala_sbtserver_address                   *g:ale_scala_sbtserver_address*
   around this is to configure sbt to always connect to the same port, which
   the instructions above describe.
 
-
-g:ale_scala_sbtserver_project_root         *g:ale_scala_sbtserver_project_root*
+                                     *ale-options.scala_sbtserver_project_root*
+                                           *g:ale_scala_sbtserver_project_root*
                                            *b:ale_scala_sbtserver_project_root*
+scala_sbtserver_project_root
+g:ale_scala_sbtserver_project_root
   Type: |String|
   Default: `''`
 
@@ -71,20 +78,25 @@ g:ale_scala_sbtserver_project_root         *g:ale_scala_sbtserver_project_root*
 scalafmt                                                   *ale-scala-scalafmt*
 
 If Nailgun is used, override `g:ale_scala_scalafmt_executable` like so: >
+
   let g:ale_scala_scalafmt_executable = 'ng'
-
-
-g:ale_scala_scalafmt_executable               *g:ale_scala_scalafmt_executable*
+<
+                                        *ale-options.scala_scalafmt_executable*
+                                              *g:ale_scala_scalafmt_executable*
                                               *b:ale_scala_scalafmt_executable*
+scala_scalafmt_executable
+g:ale_scala_scalafmt_executable
   Type: |String|
   Default: `'scalafmt'`
 
   Override the invoked `scalafmt` binary. This is useful for running `scalafmt`
   with Nailgun.
 
-
-g:ale_scala_scalafmt_options                     *g:ale_scala_scalafmt_options*
+                                           *ale-options.scala_scalafmt_options*
+                                                 *g:ale_scala_scalafmt_options*
                                                  *b:ale_scala_scalafmt_options*
+scala_scalafmt_options
+g:ale_scala_scalafmt_options
   Type: |String|
   Default: `''`
 
@@ -100,14 +112,16 @@ configuration file can be found, ALE will report a problem saying that a
 configuration file is required at line 1.
 
 To disable `scalastyle` globally, use |g:ale_linters| like so: >
+
   let g:ale_linters = {'scala': ['scalac']} " Enable only scalac instead
 <
-
 See |g:ale_linters| for more information on disabling linters.
 
-
-g:ale_scala_scalastyle_config                   *g:ale_scala_scalastyle_config*
+                                          *ale-options.scala_scalastyle_config*
+                                                *g:ale_scala_scalastyle_config*
                                                 *b:ale_scala_scalastyle_config*
+scala_scalastyle_config
+g:ale_scala_scalastyle_config
   Type: |String|
   Default: `''`
 
@@ -117,9 +131,11 @@ g:ale_scala_scalastyle_config                   *g:ale_scala_scalastyle_config*
   `scalastyle_config.xml` or `scalastyle-config.xml` in the current file's
   directory or parent directories.
 
-
-g:ale_scala_scalastyle_options                 *g:ale_scala_scalastyle_options*
+                                         *ale-options.scala_scalastyle_options*
+                                               *g:ale_scala_scalastyle_options*
                                                *b:ale_scala_scalastyle_options*
+scala_scalastyle_options
+g:ale_scala_scalastyle_options
   Type: |String|
   Default: `''`
 

--- a/doc/ale-scss.txt
+++ b/doc/ale-scss.txt
@@ -11,24 +11,31 @@ See |ale-javascript-prettier| for information about the available options.
 ===============================================================================
 sasslint                                                    *ale-scss-sasslint*
 
-g:ale_scss_sasslint_executable                 *g:ale_scss_sasslint_executable*
+                                         *ale-options.scss_sasslint_executable*
+                                               *g:ale_scss_sasslint_executable*
                                                *b:ale_scss_sasslint_executable*
+scss_sasslint_executable
+g:ale_scss_sasslint_executable
   Type: |String|
   Default: `'sass-lint'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_scss_sasslint_options                       *g:ale_scss_sasslint_options*
+                                            *ale-options.scss_sasslint_options*
+                                                  *g:ale_scss_sasslint_options*
                                                   *b:ale_scss_sasslint_options*
+scss_sasslint_options
+g:ale_scss_sasslint_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass additional options to sass-lint.
 
-
-g:ale_scss_sasslint_use_global                 *g:ale_scss_sasslint_use_global*
+                                         *ale-options.scss_sasslint_use_global*
+                                               *g:ale_scss_sasslint_use_global*
                                                *b:ale_scss_sasslint_use_global*
+scss_sasslint_use_global
+g:ale_scss_sasslint_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
@@ -38,22 +45,31 @@ g:ale_scss_sasslint_use_global                 *g:ale_scss_sasslint_use_global*
 ===============================================================================
 stylelint                                                  *ale-scss-stylelint*
 
-g:ale_scss_stylelint_executable               *g:ale_scss_stylelint_executable*
+                                        *ale-options.scss_stylelint_executable*
+                                              *g:ale_scss_stylelint_executable*
                                               *b:ale_scss_stylelint_executable*
+scss_stylelint_executable
+g:ale_scss_stylelint_executable
   Type: |String|
   Default: `'stylelint'`
 
   See |ale-integrations-local-executables|
 
-g:ale_scss_stylelint_options                     *g:ale_scss_stylelint_options*
+                                           *ale-options.scss_stylelint_options*
+                                                 *g:ale_scss_stylelint_options*
                                                  *b:ale_scss_stylelint_options*
+scss_stylelint_options
+g:ale_scss_stylelint_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass additional options to stylelint.
 
-g:ale_scss_stylelint_use_global               *g:ale_scss_stylelint_use_global*
+                                        *ale-options.scss_stylelint_use_global*
+                                              *g:ale_scss_stylelint_use_global*
                                               *b:ale_scss_stylelint_use_global*
+scss_stylelint_use_global
+g:ale_scss_stylelint_use_global
   Type: |String|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 

--- a/doc/ale-sh.txt
+++ b/doc/ale-sh.txt
@@ -5,23 +5,27 @@ ALE Shell Integration                                          *ale-sh-options*
 ===============================================================================
 bashate                                                        *ale-sh-bashate*
 
-g:ale_sh_bashate_executable                       *g:ale_sh_bashate_executable*
+                                            *ale-options.sh_bashate_executable*
+                                                  *g:ale_sh_bashate_executable*
                                                   *b:ale_sh_bashate_executable*
+sh_bashate_executable
+g:ale_sh_bashate_executable
   Type: |String|
   Default: `'bashate'`
 
   This variable sets executable used for bashate.
 
-
-g:ale_sh_bashate_options                             *g:ale_sh_bashate_options*
+                                               *ale-options.sh_bashate_options*
+                                                     *g:ale_sh_bashate_options*
                                                      *b:ale_sh_bashate_options*
+sh_bashate_options
+g:ale_sh_bashate_options
   Type: |String|
   Default: `''`
 
   With this variable we are able to pass extra arguments for bashate. For
-  example to ignore the indentation rule:
+  example to ignore the indentation rule: >
 
->
   let g:ale_sh_bashate_options = '-i E003'
 <
 
@@ -34,16 +38,21 @@ See |ale-cspell-options|
 ===============================================================================
 sh-language-server                                     *ale-sh-language-server*
 
-g:ale_sh_language_server_executable        *g:ale_sh_language_server_executable*
+                                    *ale-options.sh_language_server_executable*
+                                          *g:ale_sh_language_server_executable*
                                            *b:ale_sh_language_server_executable*
+sh_language_server_executable
+g:ale_sh_language_server_executable
   Type: |String|
   Default: `'bash-language-server'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_sh_language_server_use_global        *g:ale_sh_language_server_use_global*
+                                    *ale-options.sh_language_server_use_global*
+                                          *g:ale_sh_language_server_use_global*
                                            *b:ale_sh_language_server_use_global*
+sh_language_server_use_global
+g:ale_sh_language_server_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
@@ -53,8 +62,11 @@ g:ale_sh_language_server_use_global        *g:ale_sh_language_server_use_global*
 ===============================================================================
 shell                                                            *ale-sh-shell*
 
-g:ale_sh_shell_default_shell                     *g:ale_sh_shell_default_shell*
+                                           *ale-options.sh_shell_default_shell*
+                                                 *g:ale_sh_shell_default_shell*
                                                  *b:ale_sh_shell_default_shell*
+sh_shell_default_shell
+g:ale_sh_shell_default_shell
   Type: |String|
   Default: The current shell (`$SHELL`). Falls back to `'bash'` if that cannot be
   read or if the current shell is `'fish'`.
@@ -68,16 +80,21 @@ g:ale_sh_shell_default_shell                     *g:ale_sh_shell_default_shell*
 ===============================================================================
 shellcheck                                                  *ale-sh-shellcheck*
 
-g:ale_sh_shellcheck_executable                 *g:ale_sh_shellcheck_executable*
+                                         *ale-options.sh_shellcheck_executable*
+                                               *g:ale_sh_shellcheck_executable*
                                                *b:ale_sh_shellcheck_executable*
+sh_shellcheck_executable
+g:ale_sh_shellcheck_executable
   Type: |String|
   Default: `'shellcheck'`
 
   This variable sets executable used for shellcheck.
 
-
-g:ale_sh_shellcheck_options                       *g:ale_sh_shellcheck_options*
+                                            *ale-options.sh_shellcheck_options*
+                                                  *g:ale_sh_shellcheck_options*
                                                   *b:ale_sh_shellcheck_options*
+sh_shellcheck_options
+g:ale_sh_shellcheck_options
   Type: |String|
   Default: `''`
 
@@ -85,14 +102,15 @@ g:ale_sh_shellcheck_options                       *g:ale_sh_shellcheck_options*
   for shellcheck invocation.
 
   For example, if we want shellcheck to follow external sources (`see SC1091`)
-  we can set the variable as such:
->
+  we can set the variable as such: >
+
   let g:ale_sh_shellcheck_options = '-x'
 <
-
-
-g:ale_sh_shellcheck_change_directory     *g:ale_sh_shellcheck_change_directory*
+                                   *ale-options.sh_shellcheck_change_directory*
+                                         *g:ale_sh_shellcheck_change_directory*
                                          *b:ale_sh_shellcheck_change_directory*
+sh_shellcheck_change_directory
+g:ale_sh_shellcheck_change_directory
   Type: |Number|
   Default: `1`
 
@@ -102,9 +120,11 @@ g:ale_sh_shellcheck_change_directory     *g:ale_sh_shellcheck_change_directory*
   off if you want to control the directory `shellcheck` is executed from
   yourself.
 
-
-g:ale_sh_shellcheck_dialect                       *g:ale_sh_shellcheck_dialect*
+                                            *ale-options.sh_shellcheck_dialect*
+                                                  *g:ale_sh_shellcheck_dialect*
                                                   *b:ale_sh_shellcheck_dialect*
+sh_shellcheck_dialect
+g:ale_sh_shellcheck_dialect
   Type: |String|
   Default: `'auto'`
 
@@ -113,9 +133,11 @@ g:ale_sh_shellcheck_dialect                       *g:ale_sh_shellcheck_dialect*
   line (if present) or the value of `b:is_bash`, `b:is_sh`, or `b:is_kornshell`
   (set and used by |sh.vim|).
 
-
-g:ale_sh_shellcheck_exclusions                 *g:ale_sh_shellcheck_exclusions*
+                                         *ale-options.sh_shellcheck_exclusions*
+                                               *g:ale_sh_shellcheck_exclusions*
                                                *b:ale_sh_shellcheck_exclusions*
+sh_shellcheck_exclusions
+g:ale_sh_shellcheck_exclusions
   Type: |String|
   Default: `''`
 
@@ -123,8 +145,8 @@ g:ale_sh_shellcheck_exclusions                 *g:ale_sh_shellcheck_exclusions*
   To exclude more than one option, separate them with commas.
 
   For example, to ignore some warnings that aren't applicable to files that
-  will be sourced by other scripts, use the buffer-local variant:
->
+  will be sourced by other scripts, use the buffer-local variant: >
+
     autocmd BufEnter PKGBUILD,.env
     \   let b:ale_sh_shellcheck_exclusions = 'SC2034,SC2154,SC2164'
 <
@@ -132,8 +154,11 @@ g:ale_sh_shellcheck_exclusions                 *g:ale_sh_shellcheck_exclusions*
 ===============================================================================
 shfmt                                                            *ale-sh-shfmt*
 
-g:ale_sh_shfmt_options                                 *g:ale_sh_shfmt_options*
+                                                 *ale-options.sh_shfmt_options*
+                                                       *g:ale_sh_shfmt_options*
                                                        *b:ale_sh_shfmt_options*
+sh_shfmt_options
+g:ale_sh_shfmt_options
   Type: |String|
   Default: `''`
 

--- a/doc/ale-sml.txt
+++ b/doc/ale-sml.txt
@@ -17,9 +17,12 @@ or above the directory of the file being checked. Only one checker (`smlnj`,
 `smlnj-cm`) will be enabled at a time.
 
 -------------------------------------------------------------------------------
-
-g:ale_sml_smlnj_cm_file                               *g:ale_sml_smlnj_cm_file*
+Options
+                                                *ale-options.sml_smlnj_cm_file*
+                                                      *g:ale_sml_smlnj_cm_file*
                                                       *b:ale_sml_smlnj_cm_file*
+sml_smlnj_cm_file
+g:ale_sml_smlnj_cm_file
   Type: |String|
   Default: `'*.cm'`
 
@@ -28,9 +31,9 @@ g:ale_sml_smlnj_cm_file                               *g:ale_sml_smlnj_cm_file*
   the first file if there are more than one).
 
   Change this option (in the buffer or global scope) to control how ALE finds
-  CM files. For example, to always search for a CM file named `sandbox.cm`:
->
-      let g:ale_sml_smlnj_cm_file = 'sandbox.cm'
+  CM files. For example, to always search for a CM file named `sandbox.cm`: >
 
+  let g:ale_sml_smlnj_cm_file = 'sandbox.cm'
+<
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-solidity.txt
+++ b/doc/ale-solidity.txt
@@ -5,15 +5,21 @@ ALE Solidity Integration                                 *ale-solidity-options*
 ===============================================================================
 solc                                                        *ale-solidity-solc*
 
-g:ale_solidity_solc_executable                  *g:ale_solidity_solc_executable*
+                                         *ale-options.solidity_solc_executable*
+                                               *g:ale_solidity_solc_executable*
                                                 *b:ale_solidity_solc_executable*
+solidity_solc_executable
+g:ale_solidity_solc_executable
   Type: |String|
   Default: `'solc'`
 
   Override the invoked solc binary. For truffle/hardhat binaries.
 
-g:ale_solidity_solc_options                       *g:ale_solidity_solc_options*
+                                            *ale-options.solidity_solc_options*
+                                                  *g:ale_solidity_solc_options*
                                                   *b:ale_solidity_solc_options*
+solidity_solc_options
+g:ale_solidity_solc_options
   Type: |String|
   Default: `''`
 
@@ -36,6 +42,7 @@ solium                                                    *ale-solidity-solium*
   See the corresponding solium usage for detailed instructions
   (https://github.com/duaraghav8/Solium#usage).
 
+
 ===============================================================================
 forge                                                      *ale-solidity-forge*
 
@@ -45,6 +52,7 @@ forge                                                      *ale-solidity-forge*
   `forge fmt` should work out-of-the-box. You can further configure it using
   `foundry.toml`. See the corresponding documentation for detailed
   instructions (https://book.getfoundry.sh/reference/config/formatter).
+
 
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-spec.txt
+++ b/doc/ale-spec.txt
@@ -19,16 +19,21 @@ Integration Information
 ===============================================================================
 rpmlint                                                      *ale-spec-rpmlint*
 
-g:ale_spec_rpmlint_executable                   *g:ale_spec_rpmlint_executable*
+                                          *ale-options.spec_rpmlint_executable*
+                                                *g:ale_spec_rpmlint_executable*
                                                 *b:ale_spec_rpmlint_executable*
+spec_rpmlint_executable
+g:ale_spec_rpmlint_executable
   Type: |String|
   Default: `'rpmlint'`
 
   This variable sets executable used for rpmlint.
 
-
-g:ale_spec_rpmlint_options                         *g:ale_spec_rpmlint_options*
+                                             *ale-options.spec_rpmlint_options*
+                                                   *g:ale_spec_rpmlint_options*
                                                    *b:ale_spec_rpmlint_options*
+spec_rpmlint_options
+g:ale_spec_rpmlint_options
   Type: |String|
   Default: `''`
 

--- a/doc/ale-sql.txt
+++ b/doc/ale-sql.txt
@@ -12,15 +12,21 @@ and https://github.com/dprint/dprint-plugin-sql/releases
 ===============================================================================
 pgformatter                                               *ale-sql-pgformatter*
 
-g:ale_sql_pgformatter_executable             *g:ale_sql_pgformatter_executable*
+                                       *ale-options.sql_pgformatter_executable*
+                                             *g:ale_sql_pgformatter_executable*
                                              *b:ale_sql_pgformatter_executable*
+sql_pgformatter_executable
+g:ale_sql_pgformatter_executable
   Type: |String|
   Default: `'pg_format'`
 
   This variable sets executable used for pgformatter.
 
-g:ale_sql_pgformatter_options                   *g:ale_sql_pgformatter_options*
+                                          *ale-options.sql_pgformatter_options*
+                                                *g:ale_sql_pgformatter_options*
                                                 *b:ale_sql_pgformatter_options*
+sql_pgformatter_options
+g:ale_sql_pgformatter_options
   Type: |String|
   Default: `''`
 
@@ -30,36 +36,44 @@ g:ale_sql_pgformatter_options                   *g:ale_sql_pgformatter_options*
 ===============================================================================
 sqlfluff                                                     *ale-sql-sqlfluff*
 
-g:ale_sql_sqlfluff_executable                   *g:ale_sql_sqlfluff_executable*
+                                          *ale-options.sql_sqlfluff_executable*
+                                                *g:ale_sql_sqlfluff_executable*
                                                 *b:ale_sql_sqlfluff_executable*
+sql_sqlfluff_executable
+g:ale_sql_sqlfluff_executable
   Type: |String|
   Default: `'sqlfluff'`
 
   This variable sets executable used for sqlfluff.
 
-g:ale_sql_sqlfluff_options                         *g:ale_sql_sqlfluff_options*
+                                             *ale-options.sql_sqlfluff_options*
+                                                   *g:ale_sql_sqlfluff_options*
                                                    *b:ale_sql_sqlfluff_options*
+sql_sqlfluff_options
+g:ale_sql_sqlfluff_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass additional options to the sqlfluff linter.
 
-
-===============================================================================
-
-
 ===============================================================================
 sqlfmt                                                         *ale-sql-sqlfmt*
 
-g:ale_sql_sqlfmt_executable                       *g:ale_sql_sqlfmt_executable*
+                                            *ale-options.sql_sqlfmt_executable*
+                                                  *g:ale_sql_sqlfmt_executable*
                                                   *b:ale_sql_sqlfmt_executable*
+sql_sqlfmt_executable
+g:ale_sql_sqlfmt_executable
   Type: |String|
   Default: `'sqlfmt'`
 
   This variable sets executable used for sqlfmt.
 
-g:ale_sql_sqlfmt_options                             *g:ale_sql_sqlfmt_options*
+                                               *ale-options.sql_sqlfmt_options*
+                                                     *g:ale_sql_sqlfmt_options*
                                                      *b:ale_sql_sqlfmt_options*
+sql_sqlfmt_options
+g:ale_sql_sqlfmt_options
   Type: |String|
   Default: `''`
 
@@ -70,15 +84,21 @@ g:ale_sql_sqlfmt_options                             *g:ale_sql_sqlfmt_options*
 ===============================================================================
 sqlformat                                                   *ale-sql-sqlformat*
 
-g:ale_sql_sqlformat_executable                 *g:ale_sql_sqlformat_executable*
+                                         *ale-options.sql_sqlformat_executable*
+                                               *g:ale_sql_sqlformat_executable*
                                                *b:ale_sql_sqlformat_executable*
+sql_sqlformat_executable
+g:ale_sql_sqlformat_executable
   Type: |String|
   Default: `'sqlformat'`
 
   This variable sets executable used for sqlformat.
 
-g:ale_sql_sqlformat_options                       *g:ale_sql_sqlformat_options*
+                                            *ale-options.sql_sqlformat_options*
+                                                  *g:ale_sql_sqlformat_options*
                                                   *b:ale_sql_sqlformat_options*
+sql_sqlformat_options
+g:ale_sql_sqlformat_options
   Type: |String|
   Default: `''`
 

--- a/doc/ale-stylus.txt
+++ b/doc/ale-stylus.txt
@@ -5,24 +5,31 @@ ALE Stylus Integration                                     *ale-stylus-options*
 ===============================================================================
 stylelint                                                *ale-stylus-stylelint*
 
-g:ale_stylus_stylelint_executable           *g:ale_stylus_stylelint_executable*
+                                      *ale-options.stylus_stylelint_executable*
+                                            *g:ale_stylus_stylelint_executable*
                                             *b:ale_stylus_stylelint_executable*
+stylus_stylelint_executable
+g:ale_stylus_stylelint_executable
   Type: |String|
   Default: `'stylelint'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_stylus_stylelint_options                 *g:ale_stylus_stylelint_options*
+                                         *ale-options.stylus_stylelint_options*
+                                               *g:ale_stylus_stylelint_options*
                                                *b:ale_stylus_stylelint_options*
+stylus_stylelint_options
+g:ale_stylus_stylelint_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass additional options to stylelint.
 
-
-g:ale_stylus_stylelint_use_global           *g:ale_stylus_stylelint_use_global*
+                                      *ale-options.stylus_stylelint_use_global*
+                                            *g:ale_stylus_stylelint_use_global*
                                             *b:ale_stylus_stylelint_use_global*
+stylus_stylelint_use_global
+g:ale_stylus_stylelint_use_global
   Type: |String|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 

--- a/doc/ale-sugarss.txt
+++ b/doc/ale-sugarss.txt
@@ -1,26 +1,35 @@
 ===============================================================================
-ALE SugarSS Integration                                    *ale-sugarss-options*
+ALE SugarSS Integration                                   *ale-sugarss-options*
 
 
 ===============================================================================
-stylelint                                                  *ale-sugarss-stylelint*
+stylelint                                               *ale-sugarss-stylelint*
 
-g:ale_sugarss_stylelint_executable            *g:ale_sugarss_stylelint_executable*
-                                              *b:ale_sugarss_stylelint_executable*
+                                     *ale-options.sugarss_stylelint_executable*
+                                           *g:ale_sugarss_stylelint_executable*
+                                           *b:ale_sugarss_stylelint_executable*
+sugarss_stylelint_executable
+g:ale_sugarss_stylelint_executable
   Type: |String|
   Default: `'stylelint'`
 
   See |ale-integrations-local-executables|
 
-g:ale_sugarss_stylelint_options                  *g:ale_sugarss_stylelint_options*
-                                                 *b:ale_sugarss_stylelint_options*
+                                        *ale-options.sugarss_stylelint_options*
+                                              *g:ale_sugarss_stylelint_options*
+                                              *b:ale_sugarss_stylelint_options*
+sugarss_stylelint_options
+g:ale_sugarss_stylelint_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass additional options to stylelint.
 
-g:ale_sugarss_stylelint_use_global            *g:ale_sugarss_stylelint_use_global*
-                                              *b:ale_sugarss_stylelint_use_global*
+                                     *ale-options.sugarss_stylelint_use_global*
+                                           *g:ale_sugarss_stylelint_use_global*
+                                           *b:ale_sugarss_stylelint_use_global*
+sugarss_stylelint_use_global
+g:ale_sugarss_stylelint_use_global
   Type: |String|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 

--- a/doc/ale-svelte.txt
+++ b/doc/ale-svelte.txt
@@ -11,16 +11,21 @@ See |ale-javascript-prettier| for information about the available options.
 ===============================================================================
 svelteserver                                          *ale-svelte-svelteserver*
 
-g:ale_svelte_svelteserver_executable     *g:ale_svelte_svelteserver_executable*
+                                   *ale-options.svelte_svelteserver_executable*
+                                         *g:ale_svelte_svelteserver_executable*
                                          *b:ale_svelte_svelteserver_executable*
+svelte_svelteserver_executable
+g:ale_svelte_svelteserver_executable
   Type: |String|
   Default: `'svelteserver'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_svelte_svelteserver_use_global      *g:ale_svelte_svelteserver_use_global*
-                                          *b:ale_svelte_svelteserver_use_global*
+                                   *ale-options.svelte_svelteserver_use_global*
+                                         *g:ale_svelte_svelteserver_use_global*
+                                         *b:ale_svelte_svelteserver_use_global*
+svelte_svelteserver_use_global
+g:ale_svelte_svelteserver_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 

--- a/doc/ale-swift.txt
+++ b/doc/ale-swift.txt
@@ -18,20 +18,22 @@ There are 3 options to enable linting and fixing with Apple's swift-format:
 Additionally, ALE tries to locate and use the nearest existing `.swift-format`
 configuration file.
 
-
-g:ale_swift_appleswiftformat_executable
+                                *ale-options.swift_appleswiftformat_executable*
                                       *g:ale_swift_appleswiftformat_executable*
                                       *b:ale_swift_appleswiftformat_executable*
+swift_appleswiftformat_executable
+g:ale_swift_appleswiftformat_executable
   Type: |String|
   Default: `'swift-format'`
 
   This variable can be modified to change the executable path for
   `swift-format`.
 
-
-g:ale_swift_appleswiftformat_use_swiftpm
+                               *ale-options.swift_appleswiftformat_use_swiftpm*
                                      *g:ale_swift_appleswiftformat_use_swiftpm*
                                      *b:ale_swift_appleswiftformat_use_swiftpm*
+swift_appleswiftformat_use_swiftpm
+g:ale_swift_appleswiftformat_use_swiftpm
   Type: |Number|
   Default: `0`
 
@@ -54,9 +56,11 @@ sourcekitlsp                                           *ale-swift-sourcekitlsp*
 To enable the SourceKit-LSP you need to install and build the executable as
 described here: https://github.com/apple/sourcekit-lsp#building-sourcekit-lsp
 
-
-g:ale_sourcekit_lsp_executable                 *g:ale_sourcekit_lsp_executable*
+                                         *ale-options.sourcekit_lsp_executable*
+                                               *g:ale_sourcekit_lsp_executable*
                                                *b:ale_sourcekit_lsp_executable*
+sourcekit_lsp_executable
+g:ale_sourcekit_lsp_executable
   Type: |String|
   Default: `'sourcekit-lsp'`
 

--- a/doc/ale-tcl.txt
+++ b/doc/ale-tcl.txt
@@ -5,16 +5,21 @@ ALE Tcl Integration                                           *ale-tcl-options*
 ===============================================================================
 nagelfar                                                     *ale-tcl-nagelfar*
 
-g:ale_tcl_nagelfar_executable                   *g:ale_tcl_nagelfar_executable*
+                                          *ale-options.tcl_nagelfar_executable*
+                                                *g:ale_tcl_nagelfar_executable*
                                                 *b:ale_tcl_nagelfar_executable*
+tcl_nagelfar_executable
+g:ale_tcl_nagelfar_executable
   Type: |String|
   Default: `'nagelfar.tcl'`
 
   This variable can be changed to change the path to nagelfar.
 
-
-g:ale_tcl_nagelfar_options                         *g:ale_tcl_nagelfar_options*
+                                             *ale-options.tcl_nagelfar_options*
+                                                   *g:ale_tcl_nagelfar_options*
                                                    *b:ale_tcl_nagelfar_options*
+tcl_nagelfar_options
+g:ale_tcl_nagelfar_options
   Type: |String|
   Default: `''`
 

--- a/doc/ale-terraform.txt
+++ b/doc/ale-terraform.txt
@@ -5,36 +5,45 @@ ALE Terraform Integration                               *ale-terraform-options*
 ===============================================================================
 checkov                                                 *ale-terraform-checkov*
 
-g:ale_terraform_checkov_executable         *g:ale_terraform_checkov_executable*
+                                     *ale-options.terraform_checkov_executable*
+                                           *g:ale_terraform_checkov_executable*
                                            *b:ale_terraform_checkov_executable*
-
+terraform_checkov_executable
+g:ale_terraform_checkov_executable
   Type: |String|
   Default: `'checkov'`
 
   This variable can be changed to use a different executable for checkov.
 
-
-g:ale_terraform_checkov_options               *g:ale_terraform_checkov_options*
+                                        *ale-options.terraform_checkov_options*
+                                              *g:ale_terraform_checkov_options*
                                               *b:ale_terraform_checkov_options*
+terraform_checkov_options
+g:ale_terraform_checkov_options
   Type: |String|
   Default: `''`
 
   This variable can be changed to set additional options for checkov.
 
+
 ===============================================================================
 terraform-fmt-fixer                                   *ale-terraform-fmt-fixer*
 
-g:ale_terraform_fmt_executable                 *g:ale_terraform_fmt_executable*
+                                         *ale-options.terraform_fmt_executable*
+                                               *g:ale_terraform_fmt_executable*
                                                *b:ale_terraform_fmt_executable*
-
+terraform_fmt_executable
+g:ale_terraform_fmt_executable
   Type: |String|
   Default: `'terraform'`
 
   This variable can be changed to use a different executable for terraform.
 
-
-g:ale_terraform_fmt_options                       *g:ale_terraform_fmt_options*
+                                            *ale-options.terraform_fmt_options*
+                                                  *g:ale_terraform_fmt_options*
                                                   *b:ale_terraform_fmt_options*
+terraform_fmt_options
+g:ale_terraform_fmt_options
   Type: |String|
   Default: `''`
 
@@ -42,9 +51,11 @@ g:ale_terraform_fmt_options                       *g:ale_terraform_fmt_options*
 ===============================================================================
 terraform                                             *ale-terraform-terraform*
 
-g:ale_terraform_terraform_executable     *g:ale_terraform_terraform_executable*
+                                   *ale-options.terraform_terraform_executable*
+                                         *g:ale_terraform_terraform_executable*
                                          *b:ale_terraform_terraform_executable*
-
+terraform_terraform_executable
+g:ale_terraform_terraform_executable
   Type: |String|
   Default: `'terraform'`
 
@@ -57,16 +68,21 @@ terraform-ls                                       *ale-terraform-terraform-ls*
 Official terraform language server. More stable than *terraform-lsp* but
 currently has less features.
 
-g:ale_terraform_ls_executable                   *g:ale_terraform_ls_executable*
+                                          *ale-options.terraform_ls_executable*
+                                                *g:ale_terraform_ls_executable*
                                                 *b:ale_terraform_ls_executable*
+terraform_ls_executable
+g:ale_terraform_ls_executable
   Type: |String|
   Default: `'terraform-ls'`
 
   This variable can be changed to use a different executable for terraform-ls.
 
-
-g:ale_terraform_ls_options                         *g:ale_terraform_ls_options*
+                                             *ale-options.terraform_ls_options*
+                                                   *g:ale_terraform_ls_options*
                                                    *b:ale_terraform_ls_options*
+terraform_ls_options
+g:ale_terraform_ls_options
   Type: |String|
   Default: `''`
 
@@ -76,16 +92,21 @@ g:ale_terraform_ls_options                         *g:ale_terraform_ls_options*
 ===============================================================================
 terraform-lsp                                     *ale-terraform-terraform-lsp*
 
-g:ale_terraform_langserver_executable   *g:ale_terraform_langserver_executable*
+                                  *ale-options.terraform_langserver_executable*
+                                        *g:ale_terraform_langserver_executable*
                                         *b:ale_terraform_langserver_executable*
+terraform_langserver_executable
+g:ale_terraform_langserver_executable
   Type: |String|
   Default: `'terraform-lsp'`
 
   This variable can be changed to use a different executable for terraform-lsp.
 
-
-g:ale_terraform_langserver_options         *g:ale_terraform_langserver_options*
+                                     *ale-options.terraform_langserver_options*
+                                           *g:ale_terraform_langserver_options*
                                            *b:ale_terraform_langserver_options*
+terraform_langserver_options
+g:ale_terraform_langserver_options
   Type: |String|
   Default: `''`
 
@@ -95,17 +116,21 @@ g:ale_terraform_langserver_options         *g:ale_terraform_langserver_options*
 ===============================================================================
 tflint                                                   *ale-terraform-tflint*
 
-g:ale_terraform_tflint_executable           *g:ale_terraform_tflint_executable*
+                                      *ale-options.terraform_tflint_executable*
+                                            *g:ale_terraform_tflint_executable*
                                             *b:ale_terraform_tflint_executable*
-
+terraform_tflint_executable
+g:ale_terraform_tflint_executable
   Type: |String|
   Default: `'tflint'`
 
   This variable can be changed to use a different executable for tflint.
 
-
-g:ale_terraform_tflint_options                 *g:ale_terraform_tflint_options*
+                                         *ale-options.terraform_tflint_options*
+                                               *g:ale_terraform_tflint_options*
                                                *b:ale_terraform_tflint_options*
+terraform_tflint_options
+g:ale_terraform_tflint_options
   Type: |String|
   Default: `'-f json'`
 
@@ -117,22 +142,26 @@ g:ale_terraform_tflint_options                 *g:ale_terraform_tflint_options*
 ===============================================================================
 tfsec                                                     *ale-terraform-tfsec*
 
-g:ale_terraform_tfsec_executable             *g:ale_terraform_tfsec_executable*
+                                       *ale-options.terraform_tfsec_executable*
+                                             *g:ale_terraform_tfsec_executable*
                                              *b:ale_terraform_tfsec_executable*
-
+terraform_tfsec_executable
+g:ale_terraform_tfsec_executable
   Type: |String|
   Default: `'tfsec'`
 
   This variable can be changed to use a different executable for tfsec.
 
-g:ale_terraform_tfsec_options                   *g:ale_terraform_tfsec_options*
+                                          *ale-options.terraform_tfsec_options*
+                                                *g:ale_terraform_tfsec_options*
                                                 *b:ale_terraform_tfsec_options*
-
+terraform_tfsec_options
+g:ale_terraform_tfsec_options
   Type: |String|
   Default: `''`
 
   This variable can be changed to pass custom CLI flags to tfsec.
 
+
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:
-

--- a/doc/ale-tex.txt
+++ b/doc/ale-tex.txt
@@ -5,16 +5,21 @@ ALE TeX Integration                                           *ale-tex-options*
 ===============================================================================
 chktex                                                         *ale-tex-chktex*
 
-g:ale_tex_chktex_executable                       *g:ale_tex_chktex_executable*
+                                            *ale-options.tex_chktex_executable*
+                                                  *g:ale_tex_chktex_executable*
                                                   *b:ale_tex_chktex_executable*
+tex_chktex_executable
+g:ale_tex_chktex_executable
   Type: |String|
   Default: `'chktex'`
 
   This variable can be changed to change the path to chktex.
 
-
-g:ale_tex_chktex_options                             *g:ale_tex_chktex_options*
+                                               *ale-options.tex_chktex_options*
+                                                     *g:ale_tex_chktex_options*
                                                      *b:ale_tex_chktex_options*
+tex_chktex_options
+g:ale_tex_chktex_options
   Type: |String|
   Default: `'-I'`
 
@@ -30,8 +35,11 @@ See |ale-cspell-options|
 ===============================================================================
 lacheck                                                       *ale-tex-lacheck*
 
-g:ale_lacheck_executable                             *g:ale_lacheck_executable*
+                                               *ale-options.lacheck_executable*
+                                                     *g:ale_lacheck_executable*
                                                      *b:ale_lacheck_executable*
+lacheck_executable
+g:ale_lacheck_executable
   Type: |String|
   Default: `'lacheck'`
 
@@ -41,16 +49,21 @@ g:ale_lacheck_executable                             *g:ale_lacheck_executable*
 ===============================================================================
 latexindent                                               *ale-tex-latexindent*
 
-g:ale_tex_latexindent_executable             *g:ale_tex_latexindent_executable*
+                                       *ale-options.tex_latexindent_executable*
+                                             *g:ale_tex_latexindent_executable*
                                              *b:ale_tex_latexindent_executable*
+tex_latexindent_executable
+g:ale_tex_latexindent_executable
   Type: |String|
   Default: `'latexindent'`
 
   This variable can be changed to change the path to latexindent.
 
-
-g:ale_tex_latexindent_options                   *g:ale_tex_latexindent_options*
+                                          *ale-options.tex_latexindent_options*
+                                                *g:ale_tex_latexindent_options*
                                                 *b:ale_tex_latexindent_options*
+tex_latexindent_options
+g:ale_tex_latexindent_options
   Type: |String|
   Default: `''`
 
@@ -60,34 +73,41 @@ g:ale_tex_latexindent_options                   *g:ale_tex_latexindent_options*
 ===============================================================================
 texlab                                                         *ale-tex-texlab*
 
-g:ale_tex_texlab_executable                       *g:ale_tex_texlab_executable*
+                                            *ale-options.tex_texlab_executable*
+                                                  *g:ale_tex_texlab_executable*
                                                   *b:ale_tex_texlab_executable*
+tex_texlab_executable
+g:ale_tex_texlab_executable
   Type: |String|
   Default: `'texlab'`
 
   This variable can be changed to change the path to texlab.
 
-
-g:ale_tex_texlab_options                             *g:ale_tex_texlab_options*
+                                               *ale-options.tex_texlab_options*
+                                                     *g:ale_tex_texlab_options*
                                                      *b:ale_tex_texlab_options*
+tex_texlab_options
+g:ale_tex_texlab_options
   Type: |String|
   Default: `''`
 
   This variable can be changed to modify flags given to texlab command.
 
-g:ale_tex_texlab_config                               *g:ale_tex_texlab_config*
+                                                *ale-options.tex_texlab_config*
+                                                      *g:ale_tex_texlab_config*
                                                       *b:ale_tex_texlab_config*
+tex_texlab_config
+g:ale_tex_texlab_config
   Type: |Dictionary|
   Default: `{}`
 
   Dictionary containing LSP configuration settings used to initialize texlab
   language server. Refer to texlab documentation for possible settings:
 
-    https://github.com/latex-lsp/texlab/blob/master/docs/options.md
+  https://github.com/latex-lsp/texlab/blob/master/docs/options.md
 
-  For example to set build onSave initialization setting:
+  For example to set build onSave initialization setting: >
 
->
   let g:ale_tex_texlab_config = {"build":{"onSave":v:true}}
 <
 

--- a/doc/ale-text.txt
+++ b/doc/ale-text.txt
@@ -14,24 +14,31 @@ textlint                                                    *ale-text-textlint*
 The options for the textlint linter are global because it does not make
 sense to have them specified on a per-language basis.
 
-g:ale_textlint_executable                           *g:ale_textlint_executable*
+                                              *ale-options.textlint_executable*
+                                                    *g:ale_textlint_executable*
                                                     *b:ale_textlint_executable*
+textlint_executable
+g:ale_textlint_executable
   Type: |String|
   Default: `'textlint'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_textlint_options                                 *g:ale_textlint_options*
+                                                 *ale-options.textlint_options*
+                                                       *g:ale_textlint_options*
                                                        *b:ale_textlint_options*
+textlint_options
+g:ale_textlint_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass additional options to textlint.
 
-
-g:ale_textlint_use_global                           *g:ale_textlint_use_global*
+                                              *ale-options.textlint_use_global*
+                                                    *g:ale_textlint_use_global*
                                                     *b:ale_textlint_use_global*
+textlint_use_global
+g:ale_textlint_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 

--- a/doc/ale-thrift.txt
+++ b/doc/ale-thrift.txt
@@ -8,58 +8,77 @@ thrift                                                      *ale-thrift-thrift*
 The `thrift` linter works by compiling the buffer's contents and reporting any
 errors reported by the parser and the configured code generator(s).
 
-g:ale_thrift_thrift_executable                 *g:ale_thrift_thrift_executable*
+
+-------------------------------------------------------------------------------
+Options
+                                         *ale-options.thrift_thrift_executable*
+                                               *g:ale_thrift_thrift_executable*
                                                *b:ale_thrift_thrift_executable*
+thrift_thrift_executable
+g:ale_thrift_thrift_executable
   Type: |String|
   Default: `'thrift'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_thrift_thrift_generators                 *g:ale_thrift_thrift_generators*
+                                         *ale-options.thrift_thrift_generators*
+                                               *g:ale_thrift_thrift_generators*
                                                *b:ale_thrift_thrift_generators*
-  Type: |List| of |String|s
+thrift_thrift_generators
+g:ale_thrift_thrift_generators
+  Type: |List|
   Default: `['cpp']`
 
   This list must contain one or more named code generators. Generator options
   can be included as part of each string, e.g. `['py:dynamic']`.
 
-
-g:ale_thrift_thrift_includes                     *g:ale_thrift_thrift_includes*
+                                           *ale-options.thrift_thrift_includes*
+                                                 *g:ale_thrift_thrift_includes*
                                                  *b:ale_thrift_thrift_includes*
-  Type: |List| of |String|s
+thrift_thrift_includes
+g:ale_thrift_thrift_includes
+  Type: |List|
   Default: `['.']`
 
   This list contains paths that will be searched for thrift `include`
   directives.
 
-
-g:ale_thrift_thrift_options                       *g:ale_thrift_thrift_options*
+                                            *ale-options.thrift_thrift_options*
+                                                  *g:ale_thrift_thrift_options*
                                                   *b:ale_thrift_thrift_options*
+thrift_thrift_options
+g:ale_thrift_thrift_options
   Type: |String|
   Default: `'-strict'`
 
   This variable can be changed to customize the additional command-line
   arguments that are passed to the thrift compiler.
 
+
 ===============================================================================
 thriftcheck                                            *ale-thrift-thriftcheck*
 
-g:ale_thrift_thriftcheck_executable       *g:ale_thrift_thriftcheck_executable*
+                                    *ale-options.thrift_thriftcheck_executable*
+                                          *g:ale_thrift_thriftcheck_executable*
                                           *b:ale_thrift_thriftcheck_executable*
+thrift_thriftcheck_executable
+g:ale_thrift_thriftcheck_executable
   Type: |String|
   Default: `'thriftcheck'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_thrift_thriftcheck_options             *g:ale_thrift_thriftcheck_options*
+                                       *ale-options.thrift_thriftcheck_options*
+                                             *g:ale_thrift_thriftcheck_options*
                                              *b:ale_thrift_thriftcheck_options*
+thrift_thriftcheck_options
+g:ale_thrift_thriftcheck_options
   Type: |String|
   Default: `''`
 
   This variable can be changed to customize the additional command-line
   arguments that are passed to thriftcheck.
+
 
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-typescript.txt
+++ b/doc/ale-typescript.txt
@@ -5,39 +5,50 @@ ALE TypeScript Integration                             *ale-typescript-options*
 ===============================================================================
 biome                                                    *ale-typescript-biome*
 
-g:ale_biome_executable                                 *g:ale_biome_executable*
+                                                 *ale-options.biome_executable*
+                                                       *g:ale_biome_executable*
                                                        *b:ale_biome_executable*
+biome_executable
+g:ale_biome_executable
   Type: |String|
   Default: `'biome'`
 
-
-g:ale_biome_options                                       *g:ale_biome_options*
+                                                    *ale-options.biome_options*
+                                                          *g:ale_biome_options*
                                                           *b:ale_biome_options*
+biome_options
+g:ale_biome_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass additional options to `biome check` when
   applying fixes.
 
-
-g:ale_biome_use_global                                 *g:ale_biome_use_global*
+                                                 *ale-options.biome_use_global*
+                                                       *g:ale_biome_use_global*
                                                        *b:ale_biome_use_global*
+biome_use_global
+g:ale_biome_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_biome_fixer_apply_unsafe                 *g:ale_biome_fixer_apply_unsafe*
+                                         *ale-options.biome_fixer_apply_unsafe*
+                                               *g:ale_biome_fixer_apply_unsafe*
                                                *b:ale_biome_fixer_apply_unsafe*
+biome_fixer_apply_unsafe
+g:ale_biome_fixer_apply_unsafe
   Type: |Number|
   Default: `0`
 
   If set to `1`, biome will apply unsafe fixes along with safe fixes.
 
-
-g:ale_biome_lsp_project_root                     *g:ale_biome_lsp_project_root*
+                                           *ale-options.biome_lsp_project_root*
+                                                 *g:ale_biome_lsp_project_root*
                                                  *b:ale_biome_lsp_project_root*
+biome_lsp_project_root
+g:ale_biome_lsp_project_root
   Type: |String|
   Default: `''`
 
@@ -64,14 +75,22 @@ deno                                                      *ale-typescript-deno*
 Starting from version 1.6.0, Deno comes with its own language server. Earlier
 versions are not supported.
 
-g:ale_deno_executable                                   *g:ale_deno_executable*
+
+-------------------------------------------------------------------------------
+Options
+                                                  *ale-options.deno_executable*
+                                                        *g:ale_deno_executable*
                                                         *b:ale_deno_executable*
+deno_executable
+g:ale_deno_executable
   Type: |String|
   Default: `'deno'`
 
-
-g:ale_deno_lsp_project_root                       *g:ale_deno_lsp_project_root*
+                                            *ale-options.deno_lsp_project_root*
+                                                  *g:ale_deno_lsp_project_root*
                                                   *b:ale_deno_lsp_project_root*
+deno_lsp_project_root
+g:ale_deno_lsp_project_root
   Type: |String|
   Default: `''`
 
@@ -83,17 +102,21 @@ g:ale_deno_lsp_project_root                       *g:ale_deno_lsp_project_root*
   3. Use the directory of the current buffer (if the buffer was opened from
      a file).
 
-
-g:ale_deno_unstable                                       *g:ale_deno_unstable*
+                                                    *ale-options.deno_unstable*
+                                                          *g:ale_deno_unstable*
                                                           *b:ale_deno_unstable*
+deno_unstable
+g:ale_deno_unstable
   Type: |Number|
   Default: `0`
 
   Enable or disable unstable Deno features and APIs.
 
-
-g:ale_deno_import_map                                   *g:ale_deno_import_map*
+                                                  *ale-options.deno_import_map*
+                                                        *g:ale_deno_import_map*
                                                         *b:ale_deno_import_map*
+deno_import_map
+g:ale_deno_import_map
   Type: |String|
   Default: `'import_map.json'`
 
@@ -123,24 +146,31 @@ See |ale-javascript-prettier| for information about the available options.
 ===============================================================================
 standard                                              *ale-typescript-standard*
 
-g:ale_typescript_standard_executable     *g:ale_typescript_standard_executable*
+                                   *ale-options.typescript_standard_executable*
+                                         *g:ale_typescript_standard_executable*
                                          *b:ale_typescript_standard_executable*
+typescript_standard_executable
+g:ale_typescript_standard_executable
   Type: |String|
   Default: `'standard'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_typescript_standard_options           *g:ale_typescript_standard_options*
+                                      *ale-options.typescript_standard_options*
+                                            *g:ale_typescript_standard_options*
                                             *b:ale_typescript_standard_options*
+typescript_standard_options
+g:ale_typescript_standard_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass additional options to standard.
 
-
-g:ale_typescript_standard_use_global     *g:ale_typescript_standard_use_global*
+                                   *ale-options.typescript_standard_use_global*
+                                         *g:ale_typescript_standard_use_global*
                                          *b:ale_typescript_standard_use_global*
+typescript_standard_use_global
+g:ale_typescript_standard_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
@@ -158,30 +188,41 @@ https://github.com/Microsoft/TypeScript/wiki/Writing-a-Language-Service-Plugin
 Follow the instructions on the plugin website for installing it:
 https://github.com/Microsoft/typescript-tslint-plugin
 
-Then disable TSLint in vimrc or any other Vim configuration file. >
-  let g:ale_linters_ignore = {'typescript': ['tslint']}
+Then disable TSLint in your typescript ftplugin file. >
+  let b:ale_linters_ignore = ['tslint']
+<
+Or in Lua: >
+  require("ale").setup.buffer({linters_ignore={"tslint"}})
 <
 
-g:ale_typescript_tslint_executable         *g:ale_typescript_tslint_executable*
+-------------------------------------------------------------------------------
+Options
+                                     *ale-options.typescript_tslint_executable*
+                                           *g:ale_typescript_tslint_executable*
                                            *b:ale_typescript_tslint_executable*
+typescript_tslint_executable
+g:ale_typescript_tslint_executable
   Type: |String|
   Default: `'tslint'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_typescript_tslint_config_path       *g:ale_typescript_tslint_config_path*
+                                    *ale-options.typescript_tslint_config_path*
+                                          *g:ale_typescript_tslint_config_path*
                                           *b:ale_typescript_tslint_config_path*
+typescript_tslint_config_path
+g:ale_typescript_tslint_config_path
   Type: |String|
   Default: `''`
 
   ALE will first discover the tslint.json path in an ancestor directory. If no
   such path exists, this variable will be used instead.
 
-
-g:ale_typescript_tslint_ignore_empty_files
+                             *ale-options.typescript_tslint_ignore_empty_files*
                                    *g:ale_typescript_tslint_ignore_empty_files*
                                    *b:ale_typescript_tslint_ignore_empty_files*
+typescript_tslint_ignore_empty_files
+g:ale_typescript_tslint_ignore_empty_files
   Type: |Number|
   Default: `0`
 
@@ -190,17 +231,21 @@ g:ale_typescript_tslint_ignore_empty_files
   reported. This stops ALE from complaining about newly created files,
   and files where lines have been added and then removed.
 
-
-g:ale_typescript_tslint_rules_dir           *g:ale_typescript_tslint_rules_dir*
+                                      *ale-options.typescript_tslint_rules_dir*
+                                            *g:ale_typescript_tslint_rules_dir*
                                             *b:ale_typescript_tslint_rules_dir*
+typescript_tslint_rules_dir
+g:ale_typescript_tslint_rules_dir
   Type: |String|
   Default: `''`
 
   If this variable is set, ALE will use it as the rules directory for tslint.
 
-
-g:ale_typescript_tslint_use_global         *g:ale_typescript_tslint_use_global*
+                                     *ale-options.typescript_tslint_use_global*
+                                           *g:ale_typescript_tslint_use_global*
                                            *b:ale_typescript_tslint_use_global*
+typescript_tslint_use_global
+g:ale_typescript_tslint_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
@@ -210,8 +255,11 @@ g:ale_typescript_tslint_use_global         *g:ale_typescript_tslint_use_global*
 ===============================================================================
 tsserver                                              *ale-typescript-tsserver*
 
-g:ale_typescript_tsserver_executable     *g:ale_typescript_tsserver_executable*
+                                   *ale-options.typescript_tsserver_executable*
+                                         *g:ale_typescript_tsserver_executable*
                                          *b:ale_typescript_tsserver_executable*
+typescript_tsserver_executable
+g:ale_typescript_tsserver_executable
   Type: |String|
   Default: `'tsserver'`
 
@@ -221,18 +269,22 @@ g:ale_typescript_tsserver_executable     *g:ale_typescript_tsserver_executable*
   If you wish to use only a globally installed version of tsserver, set
   |g:ale_typescript_tsserver_use_global| to `1`.
 
-
-g:ale_typescript_tsserver_config_path   *g:ale_typescript_tsserver_config_path*
+                                  *ale-options.typescript_tsserver_config_path*
+                                        *g:ale_typescript_tsserver_config_path*
                                         *b:ale_typescript_tsserver_config_path*
+typescript_tsserver_config_path
+g:ale_typescript_tsserver_config_path
   Type: |String|
   Default: `''`
 
   ALE will first discover the tsserver.json path in an ancestor directory. If
   no such path exists, this variable will be used instead.
 
-
-g:ale_typescript_tsserver_use_global     *g:ale_typescript_tsserver_use_global*
+                                   *ale-options.typescript_tsserver_use_global*
+                                         *g:ale_typescript_tsserver_use_global*
                                          *b:ale_typescript_tsserver_use_global*
+typescript_tsserver_use_global
+g:ale_typescript_tsserver_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
@@ -245,24 +297,31 @@ g:ale_typescript_tsserver_use_global     *g:ale_typescript_tsserver_use_global*
 ===============================================================================
 xo                                                          *ale-typescript-xo*
 
-g:ale_typescript_xo_executable                 *g:ale_typescript_xo_executable*
+                                         *ale-options.typescript_xo_executable*
+                                               *g:ale_typescript_xo_executable*
                                                *b:ale_typescript_xo_executable*
+typescript_xo_executable
+g:ale_typescript_xo_executable
   Type: |String|
   Default: `'xo'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_typescript_xo_options                       *g:ale_typescript_xo_options*
+                                            *ale-options.typescript_xo_options*
+                                                  *g:ale_typescript_xo_options*
                                                   *b:ale_typescript_xo_options*
+typescript_xo_options
+g:ale_typescript_xo_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass additional options to xo.
 
-
-g:ale_typescript_xo_use_global                 *g:ale_typescript_xo_use_global*
+                                         *ale-options.typescript_xo_use_global*
+                                               *g:ale_typescript_xo_use_global*
                                                *b:ale_typescript_xo_use_global*
+typescript_xo_use_global
+g:ale_typescript_xo_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 

--- a/doc/ale-typst.html
+++ b/doc/ale-typst.html
@@ -1,19 +1,24 @@
 ===============================================================================
-ALE Typst Integration                                         *ale-typst-options*
+ALE Typst Integration                                       *ale-typst-options*
 
 ===============================================================================
-typstyle                                                     *ale-typst-typstyle*
+typstyle                                                   *ale-typst-typstyle*
 
-g:ale_typst_typstyle_executable                 *g:ale_typst_typstyle_executable*
-                                                *b:ale_typst_typstyle_executable*
+                                        *ale-options.typst_typstyle_executable*
+                                              *g:ale_typst_typstyle_executable*
+                                              *b:ale_typst_typstyle_executable*
+typst_typstyle_executable
+g:ale_typst_typstyle_executable
   Type: |String|
   Default: `'typstyle'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_typst_typstyle_options                       *g:ale_typst_typstyle_options*
-                                                   *b:ale_typst_typstyle_options*
+                                           *ale-options.typst_typstyle_options*
+                                                 *g:ale_typst_typstyle_options*
+                                                 *b:ale_typst_typstyle_options*
+typst_typstyle_options
+g:ale_typst_typstyle_options
   Type: |String|
   Default: `''`
 

--- a/doc/ale-v.txt
+++ b/doc/ale-v.txt
@@ -8,9 +8,11 @@ Integration Information
 `v` is V's build tool. `vfmt` (called as `v fmt` from the same
 executable that does the builds) is the autoformatter/fixer.
 
-g:ale_v_v_executable                                     *g:ale_v_v_executable*
+                                                   *ale-options.v_v_executable*
+                                                         *g:ale_v_v_executable*
                                                          *b:ale_v_v_executable*
-
+v_v_executable
+g:ale_v_v_executable
   Type: |String|
   Default: `'v'`
 
@@ -20,8 +22,11 @@ g:ale_v_v_executable                                     *g:ale_v_v_executable*
 ===============================================================================
 v                                                                     *ale-v-v*
 
-g:ale_v_v_options                                           *g:ale_v_v_options*
+                                                      *ale-options.v_v_options*
+                                                            *g:ale_v_v_options*
                                                             *b:ale_v_v_options*
+v_v_options
+g:ale_v_v_options
   Type: |String|
   Default: `''`
 
@@ -32,8 +37,11 @@ g:ale_v_v_options                                           *g:ale_v_v_options*
 ===============================================================================
 vfmt                                                               *ale-v-vfmt*
 
-g:ale_v_vfmt_options                                     *g:ale_v_vfmt_options*
+                                                   *ale-options.v_vfmt_options*
+                                                         *g:ale_v_vfmt_options*
                                                          *b:ale_v_vfmt_options*
+v_vfmt_options
+g:ale_v_vfmt_options
   Type: |String|
   Default: `''`
 

--- a/doc/ale-vala.txt
+++ b/doc/ale-vala.txt
@@ -11,16 +11,19 @@ See |ale-c-uncrustify| for information about the available options.
 ===============================================================================
 Vala-Lint                                                  *ale-vala-vala-lint*
 
-g:vala_vala_lint_executable                       *g:vala_vala_lint_executable*
-                                                  *b:vala_vala_lint_executable*
+                                        *ale-options.vala_vala_lint_executable*
+                                              *g:ale_vala_vala_lint_executable*
+                                              *b:ale_vala_vala_lint_executable*
+g:ale_vala_vala_lint_executable
   Type: |String|
   Default: `'io.elementary.vala-lint'`
 
   This variable can be set to specify a Vala-Lint executable file.
 
-
-g:vala_vala_lint_config_filename             *g:vala_vala_lint_config_filename*
-                                             *b:vala_vala_lint_config_filename*
+                                   *ale-options.vala_vala_lint_config_filename*
+                                         *g:ale_vala_vala_lint_config_filename*
+                                         *b:ale_vala_vala_lint_config_filename*
+g:ale_vala_vala_lint_config_filename
   Type: |String|
   Default: `'vala-lint.conf'`
 

--- a/doc/ale-verilog.txt
+++ b/doc/ale-verilog.txt
@@ -29,8 +29,8 @@ ALE can use seven different linters for Verilog HDL:
 By default, both 'verilog' and 'systemverilog' filetypes are checked.
 
 You can limit 'systemverilog' files to be checked using only 'verilator' by
-defining 'g:ale_linters' variable:
->
+defining 'g:ale_linters' variable: >
+
     au FileType systemverilog
     \ let g:ale_linters = {'systemverilog' : ['verilator'],}
 <
@@ -70,18 +70,25 @@ iverilog                                                 *ale-verilog-iverilog*
 ===============================================================================
 slang                                                       *ale-verilog-slang*
 
-g:ale_verilog_slang_option                        *g:ale_verilog_slang_options*
+                                             *ale-options.verilog_slang_option*
+                                                   *g:ale_verilog_slang_option*
                                                   *b:ale_verilog_slang_options*
-  Type: String
-  Default: ''
+verilog_slang_option
+g:ale_verilog_slang_option
+  Type: |String|
+  Default: `''`
 
   This variable can be changed to modify 'slang' command arguments.
+
 
 ===============================================================================
 verilator                                               *ale-verilog-verilator*
 
-g:ale_verilog_verilator_options               *g:ale_verilog_verilator_options*
+                                        *ale-options.verilog_verilator_options*
+                                              *g:ale_verilog_verilator_options*
                                               *b:ale_verilog_verilator_options*
+verilog_verilator_options
+g:ale_verilog_verilator_options
   Type: |String|
   Default: `''`
 
@@ -94,16 +101,21 @@ g:ale_verilog_verilator_options               *g:ale_verilog_verilator_options*
 ===============================================================================
 vlog                                                         *ale-verilog-vlog*
 
-g:ale_verilog_vlog_executable                   *g:ale_verilog_vlog_executable*
+                                          *ale-options.verilog_vlog_executable*
+                                                *g:ale_verilog_vlog_executable*
                                                 *b:ale_verilog_vlog_executable*
+verilog_vlog_executable
+g:ale_verilog_vlog_executable
   Type: |String|
   Default: `'vlog'`
 
   This variable can be changed to the path to the 'vlog' executable.
 
-
-g:ale_verilog_vlog_options                         *g:ale_verilog_vlog_options*
+                                             *ale-options.verilog_vlog_options*
+                                                   *g:ale_verilog_vlog_options*
                                                    *b:ale_verilog_vlog_options*
+verilog_vlog_options
+g:ale_verilog_vlog_options
   Type: |String|
   Default: `'-quiet -lint'`
 
@@ -113,16 +125,21 @@ g:ale_verilog_vlog_options                         *g:ale_verilog_vlog_options*
 ===============================================================================
 xvlog                                                       *ale-verilog-xvlog*
 
-g:ale_verilog_xvlog_executable                 *g:ale_verilog_xvlog_executable*
+                                         *ale-options.verilog_xvlog_executable*
+                                               *g:ale_verilog_xvlog_executable*
                                                *b:ale_verilog_xvlog_executable*
+verilog_xvlog_executable
+g:ale_verilog_xvlog_executable
   Type: |String|
   Default: `'xvlog'`
 
   This variable can be changed to the path to the 'xvlog' executable.
 
-
-g:ale_verilog_xvlog_options                       *g:ale_verilog_xvlog_options*
+                                            *ale-options.verilog_xvlog_options*
+                                                  *g:ale_verilog_xvlog_options*
                                                   *b:ale_verilog_xvlog_options*
+verilog_xvlog_options
+g:ale_verilog_xvlog_options
   Type: |String|
   Default: `''`
 
@@ -132,16 +149,21 @@ g:ale_verilog_xvlog_options                       *g:ale_verilog_xvlog_options*
 ===============================================================================
 yosys                                                       *ale-verilog-yosys*
 
-g:ale_verilog_yosys_executable                 *g:ale_verilog_yosys_executable*
+                                         *ale-options.verilog_yosys_executable*
+                                               *g:ale_verilog_yosys_executable*
                                                *b:ale_verilog_yosys_executable*
+verilog_yosys_executable
+g:ale_verilog_yosys_executable
   Type: |String|
   Default: `'yosys'`
 
   This variable can be changed to the path to the 'yosys' executable.
 
-
-g:ale_verilog_yosys_options                       *g:ale_verilog_yosys_options*
+                                            *ale-options.verilog_yosys_options*
+                                                  *g:ale_verilog_yosys_options*
                                                   *b:ale_verilog_yosys_options*
+verilog_yosys_options
+g:ale_verilog_yosys_options
   Type: |String|
   Default: `'-Q -T -p ''read_verilog %s'''`
 

--- a/doc/ale-vhdl.txt
+++ b/doc/ale-vhdl.txt
@@ -45,16 +45,21 @@ handle mixed language (VHDL, Verilog, SystemVerilog) designs.
 ===============================================================================
 ghdl                                                            *ale-vhdl-ghdl*
 
-g:ale_vhdl_ghdl_executable                         *g:ale_vhdl_ghdl_executable*
+                                             *ale-options.vhdl_ghdl_executable*
+                                                   *g:ale_vhdl_ghdl_executable*
                                                    *b:ale_vhdl_ghdl_executable*
+vhdl_ghdl_executable
+g:ale_vhdl_ghdl_executable
   Type: |String|
   Default: `'ghdl'`
 
   This variable can be changed to the path to the 'ghdl' executable.
 
-
-g:ale_vhdl_ghdl_options                               *g:ale_vhdl_ghdl_options*
+                                                *ale-options.vhdl_ghdl_options*
+                                                      *g:ale_vhdl_ghdl_options*
                                                       *b:ale_vhdl_ghdl_options*
+vhdl_ghdl_options
+g:ale_vhdl_ghdl_options
   Type: |String|
   Default: `'--std=08'`
 
@@ -82,27 +87,32 @@ following methods, in order:
    a folder named `'.git'
 3. If no such folder is found, use the directory of the current buffer
 
-
-g:ale_hdl_checker_executable
+                                           *ale-options.hdl_checker_executable*
                                                  *g:ale_hdl_checker_executable*
                                                  *b:ale_hdl_checker_executable*
+hdl_checker_executable
+g:ale_hdl_checker_executable
   Type: |String|
   Default: `'hdl_checker'`
 
   This variable can be changed to the path to the 'hdl_checker' executable.
 
-
-g:ale_hdl_checker_options                           *g:ale_hdl_checker_options*
+                                              *ale-options.hdl_checker_options*
+                                                    *g:ale_hdl_checker_options*
                                                     *b:ale_hdl_checker_options*
+hdl_checker_options
+g:ale_hdl_checker_options
   Type: |String|
   Default: `''`
 
   This variable can be changed to modify the flags/options passed to the
   'hdl_checker' server startup command.
 
-
-g:ale_hdl_checker_config_file                   *g:ale_hdl_checker_config_file*
+                                          *ale-options.hdl_checker_config_file*
+                                                *g:ale_hdl_checker_config_file*
                                                 *b:ale_hdl_checker_config_file*
+hdl_checker_config_file
+g:ale_hdl_checker_config_file
   Type: |String|
   Default: `'.hdl_checker.config'` (Unix),
            `'_hdl_checker.config'` (Windows)
@@ -118,16 +128,21 @@ g:ale_hdl_checker_config_file                   *g:ale_hdl_checker_config_file*
 ===============================================================================
 vcom                                                            *ale-vhdl-vcom*
 
-g:ale_vhdl_vcom_executable                         *g:ale_vhdl_vcom_executable*
+                                             *ale-options.vhdl_vcom_executable*
+                                                   *g:ale_vhdl_vcom_executable*
                                                    *b:ale_vhdl_vcom_executable*
+vhdl_vcom_executable
+g:ale_vhdl_vcom_executable
   Type: |String|
   Default: `'vcom'`
 
   This variable can be changed to the path to the 'vcom' executable.
 
-
-g:ale_vhdl_vcom_options                               *g:ale_vhdl_vcom_options*
+                                                *ale-options.vhdl_vcom_options*
+                                                      *g:ale_vhdl_vcom_options*
                                                       *b:ale_vhdl_vcom_options*
+vhdl_vcom_options
+g:ale_vhdl_vcom_options
   Type: |String|
   Default: `'-2008 -quiet -lint'`
 
@@ -137,16 +152,21 @@ g:ale_vhdl_vcom_options                               *g:ale_vhdl_vcom_options*
 ===============================================================================
 xvhdl                                                          *ale-vhdl-xvhdl*
 
-g:ale_vhdl_xvhdl_executable                       *g:ale_vhdl_xvhdl_executable*
+                                            *ale-options.vhdl_xvhdl_executable*
+                                                  *g:ale_vhdl_xvhdl_executable*
                                                   *b:ale_vhdl_xvhdl_executable*
+vhdl_xvhdl_executable
+g:ale_vhdl_xvhdl_executable
   Type: |String|
   Default: `'xvhdl'`
 
   This variable can be changed to the path to the 'xvhdl' executable.
 
-
-g:ale_vhdl_xvhdl_options                             *g:ale_vhdl_xvhdl_options*
+                                               *ale-options.vhdl_xvhdl_options*
+                                                     *g:ale_vhdl_xvhdl_options*
                                                      *b:ale_vhdl_xvhdl_options*
+vhdl_xvhdl_options
+g:ale_vhdl_xvhdl_options
   Type: |String|
   Default: `'--2008'`
 

--- a/doc/ale-vim.txt
+++ b/doc/ale-vim.txt
@@ -9,48 +9,54 @@ vimls                                                           *ale-vim-vimls*
   using the Language Server Protocol.  See the installation instructions:
   https://github.com/iamcco/vim-language-server#install
 
-g:ale_vim_vimls_executable                         *g:ale_vim_vimls_executable*
+                                             *ale-options.vim_vimls_executable*
+                                                   *g:ale_vim_vimls_executable*
                                                    *b:ale_vim_vimls_executable*
+vim_vimls_executable
+g:ale_vim_vimls_executable
   Type: |String|
   Default: `'vim-language-server'`
 
   This option can be set to change the executable path for vimls.
 
-
-g:ale_vim_vimls_config                                 *g:ale_vim_vimls_config*
+                                                 *ale-options.vim_vimls_config*
+                                                       *g:ale_vim_vimls_config*
                                                        *b:ale_vim_vimls_config*
+vim_vimls_config
+g:ale_vim_vimls_config
   Type: |Dictionary|
   Default: `{}`
 
   Dictionary containing configuration settings that will be passed to the
   language server. For example: >
-    {
-    \  'vim': {
-    \    'iskeyword': '@,48-57,_,192-255,-#',
-    \    'vimruntime': '',
-    \    'runtimepath': '',
-    \    'diagnostic': {
-    \      'enable': v:true
-    \    },
-    \    'indexes': {
-    \      'runtimepath': v:true,
-    \      'gap': 100,
-    \      'count': 3,
-    \      'projectRootPatterns' : ['.git', 'autoload', 'plugin']
-    \    },
-    \    'suggest': {
-    \      'fromVimruntime': v:true,
-    \      'fromRuntimepath': v:false
-    \    },
-    \  }
-    \}
+
+  let g:ale_vim_vimls_config = {
+  \   'vim': {
+  \       'iskeyword': '@,48-57,_,192-255,-#',
+  \       'vimruntime': '',
+  \       'runtimepath': '',
+  \       'diagnostic': {'enable': v:true},
+  \       'indexes': {
+  \           'runtimepath': v:true,
+  \           'gap': 100,
+  \           'count': 3,
+  \           'projectRootPatterns': ['.git', 'autoload', 'plugin'],
+  \       },
+  \       'suggest': {
+  \           'fromVimruntime': v:true,
+  \           'fromRuntimepath': v:false,
+  \       },
+  \   },
+  \}
 <
   Consult the vim-language-server documentation for more information about
   settings.
 
-
-g:ale_vim_vimls_use_global                         *g:ale_vim_vimls_use_global*
+                                             *ale-options.vim_vimls_use_global*
+                                                   *g:ale_vim_vimls_use_global*
                                                    *b:ale_vim_vimls_use_global*
+vim_vimls_use_global
+g:ale_vim_vimls_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
@@ -60,16 +66,21 @@ g:ale_vim_vimls_use_global                         *g:ale_vim_vimls_use_global*
 ===============================================================================
 vint                                                             *ale-vim-vint*
 
-g:ale_vim_vint_executable                           *g:ale_vim_vint_executable*
+                                              *ale-options.vim_vint_executable*
+                                                    *g:ale_vim_vint_executable*
                                                     *b:ale_vim_vint_executable*
+vim_vint_executable
+g:ale_vim_vint_executable
   Type: |String|
   Default: `'vint'`
 
   This option can be set to change the executable path for Vint.
 
-
-g:ale_vim_vint_show_style_issues             *g:ale_vim_vint_show_style_issues*
+                                       *ale-options.vim_vint_show_style_issues*
+                                             *g:ale_vim_vint_show_style_issues*
                                              *b:ale_vim_vint_show_style_issues*
+vim_vint_show_style_issues
+g:ale_vim_vint_show_style_issues
   Type: |Number|
   Default: `1`
 

--- a/doc/ale-vue.txt
+++ b/doc/ale-vue.txt
@@ -17,16 +17,21 @@ See |ale-javascript-prettier| for information about the available options.
 ===============================================================================
 vls                                                               *ale-vue-vls*
 
-g:ale_vue_vls_executable                             *g:ale_vue_vls_executable*
+                                               *ale-options.vue_vls_executable*
+                                                     *g:ale_vue_vls_executable*
                                                      *b:ale_vue_vls_executable*
+vue_vls_executable
+g:ale_vue_vls_executable
   Type: |String|
   Default: `'vls'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_vue_vls_use_global                             *g:ale_vue_vls_use_global*
+                                               *ale-options.vue_vls_use_global*
+                                                     *g:ale_vue_vls_use_global*
                                                      *b:ale_vue_vls_use_global*
+vue_vls_use_global
+g:ale_vue_vls_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
@@ -39,29 +44,38 @@ volar                                                           *ale-vue-volar*
   It is required to have typescript installed in your project as your dev
   dependency: `npm i -D typescript`
 
-g:ale_vue_volar_executable                         *g:ale_vue_volar_executable*
+                                             *ale-options.vue_volar_executable*
+                                                   *g:ale_vue_volar_executable*
                                                    *b:ale_vue_volar_executable*
+vue_volar_executable
+g:ale_vue_volar_executable
   Type: |String|
   Default: `'vue-language-server'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_vue_volar_use_global                         *g:ale_vue_volar_use_global*
+                                             *ale-options.vue_volar_use_global*
+                                                   *g:ale_vue_volar_use_global*
                                                    *b:ale_vue_volar_use_global*
+vue_volar_use_global
+g:ale_vue_volar_use_global
   Type: |Number|
   Default: `1`
 
   See |ale-integrations-local-executables|
 
-
-g:vue_volar_init_options                         *g:ale_vue_volar_init_options*
+                                           *ale-options.vue_volar_init_options*
+                                                 *g:ale_vue_volar_init_options*
                                                  *b:ale_vue_volar_init_options*
+vue_volar_init_options
+g:ale_vue_volar_init_options
   Type: |Dictionary|
-  Default: `{ 'typescript': 'tsdk': '' }`
+  Default: `{'typescript': 'tsdk': ''}`
 
-  Default is too long to show here, take a look at it over
-  `ale_linters/vue/volar.vim`
+  This option can be configured to set the initialization options for volar.
+
+  ALE will automatically replace `tsdk` with local detected path to the
+  typescript library.
 
 
 ===============================================================================

--- a/doc/ale-wgsl.txt
+++ b/doc/ale-wgsl.txt
@@ -5,8 +5,11 @@ ALE WGSL Integration                                         *ale-wgsl-options*
 ===============================================================================
 naga                                                            *ale-wgsl-naga*
 
-g:ale_wgsl_naga_executable                         *g:ale_wgsl_naga_executable*
+                                             *ale-options.wgsl_naga_executable*
+                                                   *g:ale_wgsl_naga_executable*
                                                    *b:ale_wgsl_naga_executable*
+wgsl_naga_executable
+g:ale_wgsl_naga_executable
   Type: |String|
   Default: `'naga'`
 

--- a/doc/ale-xml.txt
+++ b/doc/ale-xml.txt
@@ -5,24 +5,31 @@ ALE XML Integration                                           *ale-xml-options*
 ===============================================================================
 xmllint                                                       *ale-xml-xmllint*
 
-g:ale_xml_xmllint_executable                     *g:ale_xml_xmllint_executable*
+                                           *ale-options.xml_xmllint_executable*
+                                                 *g:ale_xml_xmllint_executable*
                                                  *b:ale_xml_xmllint_executable*
+xml_xmllint_executable
+g:ale_xml_xmllint_executable
   Type: |String|
   Default: `'xmllint'`
 
   This variable can be set to change the path to xmllint.
 
-
-g:ale_xml_xmllint_options                           *g:ale_xml_xmllint_options*
+                                              *ale-options.xml_xmllint_options*
+                                                    *g:ale_xml_xmllint_options*
                                                     *b:ale_xml_xmllint_options*
+xml_xmllint_options
+g:ale_xml_xmllint_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass additional options to xmllint.
 
-
-g:ale_xml_xmllint_indentsize                     *g:ale_xml_xmllint_indentsize*
+                                           *ale-options.xml_xmllint_indentsize*
+                                                 *g:ale_xml_xmllint_indentsize*
                                                  *b:ale_xml_xmllint_indentsize*
+xml_xmllint_indentsize
+g:ale_xml_xmllint_indentsize
   Type: |Number|
   Default: `2`
 
@@ -31,4 +38,3 @@ g:ale_xml_xmllint_indentsize                     *g:ale_xml_xmllint_indentsize*
 
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:
-

--- a/doc/ale-yaml.txt
+++ b/doc/ale-yaml.txt
@@ -22,19 +22,23 @@ better:
                                 \ let b:ale_linters = {'yaml': ['actionlint']}
 <
 
-Options
 -------------------------------------------------------------------------------
-
-g:ale_yaml_actionlint_executable             *g:ale_yaml_actionlint_executable*
+Options
+                                       *ale-options.yaml_actionlint_executable*
+                                             *g:ale_yaml_actionlint_executable*
                                              *b:ale_yaml_actionlint_executable*
+yaml_actionlint_executable
+g:ale_yaml_actionlint_executable
   Type: |String|
   Default: `'actionlint'`
 
   This variable can be set to change the path to actionlint.
 
-g:ale_yaml_actionlint_options                   *g:ale_yaml_actionlint_options*
+                                          *ale-options.yaml_actionlint_options*
+                                                *g:ale_yaml_actionlint_options*
                                                 *b:ale_yaml_actionlint_options*
-
+yaml_actionlint_options
+g:ale_yaml_actionlint_options
   Type: |String|
   Default: `''`
 
@@ -99,18 +103,23 @@ Install spectral either globally or locally: >
   npm install @stoplight/spectral     # local
 <
 
-Options
 -------------------------------------------------------------------------------
-
-g:ale_yaml_spectral_executable                 *g:ale_yaml_spectral_executable*
+Options
+                                         *ale-options.yaml_spectral_executable*
+                                               *g:ale_yaml_spectral_executable*
                                                *b:ale_yaml_spectral_executable*
+yaml_spectral_executable
+g:ale_yaml_spectral_executable
   Type: |String|
   Default: `'spectral'`
 
   This variable can be set to change the path to spectral.
 
-g:ale_yaml_spectral_use_global                 *g:ale_yaml_spectral_use_global*
+                                         *ale-options.yaml_spectral_use_global*
+                                               *g:ale_yaml_spectral_use_global*
                                                *b:ale_yaml_spectral_use_global*
+yaml_spectral_use_global
+g:ale_yaml_spectral_use_global
   Type: |String|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
@@ -132,19 +141,23 @@ Install swaglint either globally or locally: >
   npm install swaglint     # local
 <
 
-Options
 -------------------------------------------------------------------------------
-
-g:ale_yaml_swaglint_executable                 *g:ale_yaml_swaglint_executable*
+Options
+                                         *ale-options.yaml_swaglint_executable*
+                                               *g:ale_yaml_swaglint_executable*
                                                *b:ale_yaml_swaglint_executable*
+yaml_swaglint_executable
+g:ale_yaml_swaglint_executable
   Type: |String|
   Default: `'swaglint'`
 
   This variable can be set to change the path to swaglint.
 
-
-g:ale_yaml_swaglint_use_global                 *g:ale_yaml_swaglint_use_global*
+                                         *ale-options.yaml_swaglint_use_global*
+                                               *g:ale_yaml_swaglint_use_global*
                                                *b:ale_yaml_swaglint_use_global*
+yaml_swaglint_use_global
+g:ale_yaml_swaglint_use_global
   Type: |String|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
@@ -166,38 +179,58 @@ Install yaml-language-server either globally or locally: >
   npm install yaml-language-server     # local
 
 
-Options
 -------------------------------------------------------------------------------
-
-g:ale_yaml_ls_executable                             *g:ale_yaml_ls_executable*
+Options
+                                               *ale-options.yaml_ls_executable*
+                                                     *g:ale_yaml_ls_executable*
                                                      *b:ale_yaml_ls_executable*
+yaml_ls_executable
+g:ale_yaml_ls_executable
   Type: |String|
   Default: `'yaml-language-server'`
 
   This variable can be set to change the path to yaml-language-server.
 
-
-g:ale_yaml_ls_config                                     *g:ale_yaml_ls_config*
+                                                   *ale-options.yaml_ls_config*
+                                                         *g:ale_yaml_ls_config*
                                                          *b:ale_yaml_ls_config*
+yaml_ls_config
+g:ale_yaml_ls_config
   Type: |Dictionary|
   Default: `{}`
 
-  Dictionary containing configuration settings that will be passed to the
-  language server.  For example, to enable schema store: >
-      {
-    \   'yaml': {
-    \     'schemaStore': {
-    \         'enable': v:true,
-    \     },
-    \   },
-    \ }
+  A Dictionary for settings to pass to the language server. For example, to
+  enable the schema store, you can do use the following in your yaml ftplugin
+  file: >
+
+  let b:ale_yaml_ls_config = {
+  \   'yaml': {
+  \       'schemaStore': {
+  \           'enable': v:true,
+  \       },
+  \   },
+  \}
+<
+  Or in Lua: >
+
+  require("ale").setup.buffer({
+      yaml_ls_config = {
+          yaml = {
+              schemaStore = {
+                  enable = true,
+              },
+          },
+      },
+  })
 <
   Consult the yaml-language-server documentation for more information about
   settings.
 
-
-g:ale_yaml_ls_use_global                             *g:ale_yaml_ls_use_global*
+                                               *ale-options.yaml_ls_use_global*
+                                                     *g:ale_yaml_ls_use_global*
                                                      *b:ale_yaml_ls_use_global*
+yaml_ls_use_global
+g:ale_yaml_ls_use_global
   Type: |String|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
@@ -218,25 +251,33 @@ Install yamlfix: >
   pip install yamlfix
 <
 
-Options
 -------------------------------------------------------------------------------
-g:ale_yaml_yamlfix_executable                   *g:ale_yaml_yamlfix_executable*
+Options
+                                          *ale-options.yaml_yamlfix_executable*
+                                                *g:ale_yaml_yamlfix_executable*
                                                 *b:ale_yaml_yamlfix_executable*
+yaml_yamlfix_executable
+g:ale_yaml_yamlfix_executable
   Type: |String|
   Default: `'yamlfix'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_yaml_yamlfix_options                         *g:ale_yaml_yamlfix_options*
+                                             *ale-options.yaml_yamlfix_options*
+                                                   *g:ale_yaml_yamlfix_options*
                                                    *b:ale_yaml_yamlfix_options*
+yaml_yamlfix_options
+g:ale_yaml_yamlfix_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass extra options to yamlfix.
 
-g:ale_yaml_yamlfix_use_global                   *g:ale_yaml_yamlfix_use_global*
+                                          *ale-options.yaml_yamlfix_use_global*
+                                                *g:ale_yaml_yamlfix_use_global*
                                                 *b:ale_yaml_yamlfix_use_global*
+yaml_yamlfix_use_global
+g:ale_yaml_yamlfix_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
@@ -249,32 +290,41 @@ yamlfmt                                                      *ale-yaml-yamlfmt*
 Website: https://github.com/google/yamlfmt
 
 
-Installation
 -------------------------------------------------------------------------------
+Installation
 
 Install yamlfmt:
 
   See the website.
 
-Options
+
 -------------------------------------------------------------------------------
-g:ale_yaml_yamlfmt_executable                   *g:ale_yaml_yamlfmt_executable*
+Options
+                                          *ale-options.yaml_yamlfmt_executable*
+                                                *g:ale_yaml_yamlfmt_executable*
                                                 *b:ale_yaml_yamlfmt_executable*
+yaml_yamlfmt_executable
+g:ale_yaml_yamlfmt_executable
   Type: |String|
   Default: `'yamlfmt'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_yaml_yamlfmt_options                         *g:ale_yaml_yamlfmt_options*
+                                             *ale-options.yaml_yamlfmt_options*
+                                                   *g:ale_yaml_yamlfmt_options*
                                                    *b:ale_yaml_yamlfmt_options*
+yaml_yamlfmt_options
+g:ale_yaml_yamlfmt_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass extra options to yamlfmt.
 
-g:ale_yaml_yamlfmt_use_global                   *g:ale_yaml_yamlfmt_use_global*
+                                          *ale-options.yaml_yamlfmt_use_global*
+                                                *g:ale_yaml_yamlfmt_use_global*
                                                 *b:ale_yaml_yamlfmt_use_global*
+yaml_yamlfmt_use_global
+g:ale_yaml_yamlfmt_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
@@ -287,8 +337,8 @@ yamllint                                                    *ale-yaml-yamllint*
 Website: https://github.com/adrienverge/yamllint
 
 
-Installation
 -------------------------------------------------------------------------------
+Installation
 
 Install yamllint in your a virtualenv directory, locally, or globally: >
 
@@ -300,19 +350,23 @@ See |g:ale_virtualenv_dir_names| for configuring how ALE searches for
 virtualenv directories.
 
 
-Options
 -------------------------------------------------------------------------------
-
-g:ale_yaml_yamllint_executable                 *g:ale_yaml_yamllint_executable*
+Options
+                                         *ale-options.yaml_yamllint_executable*
+                                               *g:ale_yaml_yamllint_executable*
                                                *b:ale_yaml_yamllint_executable*
+yaml_yamllint_executable
+g:ale_yaml_yamllint_executable
   Type: |String|
   Default: `'yamllint'`
 
   This variable can be set to change the path to yamllint.
 
-
-g:ale_yaml_yamllint_options                       *g:ale_yaml_yamllint_options*
+                                            *ale-options.yaml_yamllint_options*
+                                                  *g:ale_yaml_yamllint_options*
                                                   *b:ale_yaml_yamllint_options*
+yaml_yamllint_options
+g:ale_yaml_yamllint_options
   Type: |String|
   Default: `''`
 
@@ -325,8 +379,8 @@ gitlablint                                                  *ale-yaml-gitlablint
 Website: https://github.com/elijah-roberts/gitlab-lint
 
 
-Installation
 -------------------------------------------------------------------------------
+Installation
 
 Install yamllint in your a virtualenv directory, locally, or globally: >
 
@@ -347,19 +401,23 @@ applies to 'gitlab-ci.yml' files and not all yaml files:
   \}
 <
 
-Options
 -------------------------------------------------------------------------------
-
-g:ale_yaml_gitlablint_executable               *g:ale_yaml_gitlablint_executable*
+Options
+                                       *ale-options.yaml_gitlablint_executable*
+                                             *g:ale_yaml_gitlablint_executable*
                                                *b:ale_yaml_gitlablint_executable*
+yaml_gitlablint_executable
+g:ale_yaml_gitlablint_executable
   Type: |String|
   Default: `'gll'`
 
   This variable can be set to change the path to gll.
 
-
-g:ale_yaml_gitlablint_options                     *g:ale_yaml_gitlablint_options*
+                                          *ale-options.yaml_gitlablint_options*
+                                                *g:ale_yaml_gitlablint_options*
                                                   *b:ale_yaml_gitlablint_options*
+yaml_gitlablint_options
+g:ale_yaml_gitlablint_options
   Type: |String|
   Default: `''`
 
@@ -372,33 +430,41 @@ yq                                                                  *ale-yaml-yq
 Website: https://github.com/mikefarah/yq
 
 
-Installation
 -------------------------------------------------------------------------------
+Installation
 
 Install yq: >
 
   wget https://github.com/mikefarah/yq/releases/download/${VERSION}/${BINARY}.tar.gz -O - | tar xz && mv ${BINARY} /usr/bin/yq
 
-Options
--------------------------------------------------------------------------------
 
-g:ale_yaml_yq_executable                               *g:ale_yaml_yq_executable*
+-------------------------------------------------------------------------------
+Options
+                                               *ale-options.yaml_yq_executable*
+                                                     *g:ale_yaml_yq_executable*
                                                        *b:ale_yaml_yq_executable*
+yaml_yq_executable
+g:ale_yaml_yq_executable
   Type: |String|
   Default: `'yq'`
 
   This variable can be set to change the path to yq.
 
-
-g:ale_yaml_yq_options                                     *g:ale_yaml_yq_options*
+                                                  *ale-options.yaml_yq_options*
+                                                        *g:ale_yaml_yq_options*
                                                           *b:ale_yaml_yq_options*
+yaml_yq_options
+g:ale_yaml_yq_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass additional options to yq.
 
-g:ale_yaml_yq_filters                                     *g:ale_yaml_yq_filters
+                                                  *ale-options.yaml_yq_filters*
+                                                        *g:ale_yaml_yq_filters*
                                                           *b:ale_yaml_yq_filters*
+yaml_yq_filters
+g:ale_yaml_yq_filters
   Type: |String|
   Default: `'.'`
 

--- a/doc/ale-yang.txt
+++ b/doc/ale-yang.txt
@@ -5,8 +5,11 @@ ALE YANG Integration                                         *ale-yang-options*
 ===============================================================================
 yang-lsp                                                         *ale-yang-lsp*
 
-g:ale_yang_lsp_executable                           *g:ale_yang_lsp_executable*
+                                              *ale-options.yang_lsp_executable*
+                                                    *g:ale_yang_lsp_executable*
                                                     *b:ale_yang_lsp_executable*
+yang_lsp_executable
+g:ale_yang_lsp_executable
   Type: |String|
   Default: `'yang-language-server'`
 

--- a/doc/ale-yara.txt
+++ b/doc/ale-yara.txt
@@ -11,8 +11,11 @@ Integration Information
 ===============================================================================
 yls                                                              *ale-yara-yls*
 
-g:ale_yara_yls_executable                           *g:ale_yara_yls_executable*
+                                              *ale-options.yara_yls_executable*
+                                                    *g:ale_yara_yls_executable*
                                                     *b:ale_yara_yls_executable*
+yara_yls_executable
+g:ale_yara_yls_executable
   Type: |String|
   Default: `'yls'`
 

--- a/doc/ale-zeek.txt
+++ b/doc/ale-zeek.txt
@@ -10,8 +10,11 @@ Integration Information
 ===============================================================================
 zeek                                                            *ale-zeek-zeek*
 
-g:ale_zeek_zeek_executable                         *g:ale_zeek_zeek_executable*
+                                             *ale-options.zeek_zeek_executable*
+                                                   *g:ale_zeek_zeek_executable*
                                                    *b:ale_zeek_zeek_executable*
+zeek_zeek_executable
+g:ale_zeek_zeek_executable
   Type: |String|
   Default: `'zeek'`
 

--- a/doc/ale-zig.txt
+++ b/doc/ale-zig.txt
@@ -14,8 +14,11 @@ Integration Information
 ===============================================================================
 zigfmt                                                         *ale-zig-zigfmt*
 
-g:ale_zig_zigfmt_executable                       *g:ale_zig_zigfmt_executable*
+                                            *ale-options.zig_zigfmt_executable*
+                                                  *g:ale_zig_zigfmt_executable*
                                                   *b:ale_zig_zigfmt_executable*
+zig_zigfmt_executable
+g:ale_zig_zigfmt_executable
   Type: |String|
   Default: `'zig'`
 
@@ -25,26 +28,35 @@ g:ale_zig_zigfmt_executable                       *g:ale_zig_zigfmt_executable*
 ===============================================================================
 zlint                                                           *ale-zig-zlint*
 
-g:ale_zig_zlint_executable                         *g:ale_zig_zlint_executable*
+                                             *ale-options.zig_zlint_executable*
+                                                   *g:ale_zig_zlint_executable*
                                                    *b:ale_zig_zlint_executable*
+zig_zlint_executable
+g:ale_zig_zlint_executable
   Type: |String|
   Default: `'zlint'`
 
   This variable can be modified to change the executable path for `zlint`.
 
+
 ===============================================================================
 zls                                                               *ale-zig-zls*
 
-g:ale_zig_zls_executable                             *g:ale_zig_zls_executable*
+                                               *ale-options.zig_zls_executable*
+                                                     *g:ale_zig_zls_executable*
                                                      *b:ale_zig_zls_executable*
+zig_zls_executable
+g:ale_zig_zls_executable
   Type: |String|
   Default: `'zls'`
 
   This variable can be modified to change the executable path for `zls`.
 
-
-g:ale_zig_zls_config                                     *g:ale_zig_zls_config*
+                                                   *ale-options.zig_zls_config*
+                                                         *g:ale_zig_zls_config*
                                                          *b:ale_zig_zls_config*
+zig_zls_config
+g:ale_zig_zls_config
   Type: |Dictionary|
   Default: `{}`
 

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -14,14 +14,15 @@ CONTENTS                                                         *ale-contents*
     3.3 Other Sources.....................|ale-lint-other-sources|
   4. Fixing Problems......................|ale-fix|
   5. Language Server Protocol Support.....|ale-lsp|
-    5.1 Completion........................|ale-completion|
-    5.2 Go To Definition..................|ale-go-to-definition|
-    5.3 Go To Type Definition.............|ale-go-to-type-definition|
-    5.4 Go To Implementation..............|ale-go-to-implementation|
-    5.5 Find References...................|ale-find-references|
-    5.6 Hovering..........................|ale-hover|
-    5.7 Symbol Search.....................|ale-symbol-search|
-    5.8 Refactoring: Rename, Actions......|ale-refactor|
+    5.1 LSP Neovim Integration............|ale-lsp-neovim|
+    5.2 Completion........................|ale-completion|
+    5.3 Go To Definition..................|ale-go-to-definition|
+    5.4 Go To Type Definition.............|ale-go-to-type-definition|
+    5.5 Go To Implementation..............|ale-go-to-implementation|
+    5.6 Find References...................|ale-find-references|
+    5.7 Hovering..........................|ale-hover|
+    5.8 Symbol Search.....................|ale-symbol-search|
+    5.9 Refactoring: Rename, Actions......|ale-refactor|
   6. Global Options.......................|ale-options|
     6.1 Highlights........................|ale-highlights|
   7. Linter/Fixer Options.................|ale-integration-options|
@@ -446,14 +447,20 @@ server, etc. See |ale-lint-other-machines|.
 ===============================================================================
 5. Language Server Protocol Support                                   *ale-lsp*
 
-ALE offers some support for integrating with Language Server Protocol (LSP)
-servers. LSP linters can be used in combination with any other linter, and
-will automatically connect to LSP servers when needed. ALE also supports
-`tsserver` for TypeScript, which uses a different but very similar protocol.
+ALE integrates with Language Server Protocol (LSP) servers. LSP linters can be
+used in combination with any other linter, and will automatically connect to
+LSP servers when needed. ALE also supports `tsserver` for TypeScript, which
+uses a different but very similar protocol.
 
 If you want to use another plugin for LSP features and tsserver, you can use
 the |g:ale_disable_lsp| setting to disable ALE's own LSP integrations, or
-ignore particular linters with |g:ale_linters_ignore|.
+ignore particular linters with |g:ale_linters_ignore|. In ALE's default
+configuration ALE will attempt to avoid conflicting with `nvim-lspconfig`.
+
+ALE will integrate with Neovim's LSP client by default in Neovim 0.8+. This
+functionality can be controlled with the |g:ale_use_neovim_lsp_api| setting.
+See |ale-lsp-neovim| below for information about ALE's integration with
+Neovim's LSP client.
 
 If for any reason you want to stop a language server ALE starts, such as when
 a project configuration has significantly changed, or new files have been
@@ -461,7 +468,111 @@ added the language server isn't aware of, use either `:ALEStopLSP` or
 `:ALEStopAllLSPs` to stop the server until ALE automatically starts it again.
 
 -------------------------------------------------------------------------------
-5.1 Completion                                                 *ale-completion*
+5.1 LSP Neovim Integration                                     *ale-lsp-neovim*
+
+In Neovim 0.8+ ALE will integrate with Neovim's native LSP client by default,
+unless disabled by setting |g:ale_use_neovim_lsp_api| to `0`. All built in
+functionality for Neovim's LSP client should work as expected, and this
+ensures ALE integrates well with other plugins that rely on Neovim's LSP
+client.
+
+See |lsp| for information on Neovim's built in LSP client.
+
+For diagnostics, for computing problems to show via ALE, ALE overrides the
+diagnostics handler for the LSP client launched by ALE, so all of the
+functionality in ALE will work as expected. By default ALE will send
+diagnostics back to Neovim's diagnostics API, which can be configured with the
+|g:ale_use_neovim_diagnostics_api| setting. This ensures that all of the
+functionality ALE adds on top for diagnostics will function, and that problems
+from linters that don't use LSP can be combined with LSP servers. See the
+diagram below. >
+
+  +-------------------+
+  |  Language Server  |  (Sends diagnostics)
+  +-------------------+
+           |
+  +-------------------+
+  | Neovim LSP Client |  (Receives diagnostics)
+  +-------------------+
+           |
+  +-------------------+
+  |  ALE Processing   |  (Intercepts and processes diagnostics)
+  +-------------------+
+           |
+  +-------------------+
+  | Diagnostic engine |  (Either Neovim's diagnostics or ALE's custom code)
+  +-------------------+
+           |
+  +-------------------+
+  |      Neovim       |  (User sees formatted diagnostics)
+  +-------------------+
+<
+For LSP functionality executed via ALE's own functions, commands, and
+keybinds, ALE will intercept requests and handle them in an entirely custom
+way, ensuring ALE functionality should work largely the same between
+different Vim versions. See the diagram below. >
+
+  +-------------------+
+  |      Neovim       |  (User triggers LSP request via ALE)
+  +-------------------+
+           |
+  +-------------------+
+  |       ALE         |  (ALE sends request to Neovim client)
+  +-------------------+
+           |
+  +-------------------+
+  | Neovim LSP Client |  (Forwards request to language server)
+  +-------------------+
+           |
+  +-------------------+
+  | Language Server   |  (Processes request and sends response)
+  +-------------------+
+           |
+  +-------------------+
+  | Neovim LSP Client |  (Receives response)
+  +-------------------+
+           |
+  +-------------------+
+  |       ALE         |  (ALE Handles "raw" LSP response)
+  +-------------------+
+           |
+  +-------------------+
+  |      Neovim       |  (User sees result)
+  +-------------------+
+<
+For LSP functionality built-in to Neovim, such as the |gd| keybind for jumping
+to a definition, Neovim will bypass ALE entirely, ensuring that ALE does not
+interfere with LSP functionality as expected by built-in Neovim tools or other
+plugins. See the diagram below. >
+
+  +-------------------+
+  |      Neovim       |  (User triggers LSP request)
+  +-------------------+
+           |
+  +-------------------+
+  | Neovim LSP Client |  (Directly handles the request)
+  +-------------------+
+           |
+  +-------------------+
+  | Language Server   |  (Processes request and sends response)
+  +-------------------+
+           |
+  +-------------------+
+  | Neovim LSP Client |  (Receives response and shows result)
+  +-------------------+
+           |
+  +-------------------+
+  |      Neovim       |  (User sees result)
+  +-------------------+
+<
+
+-------------------------------------------------------------------------------
+5.2 Completion                                                 *ale-completion*
+
+In Neovim 0.8+ ALE's integration with its native LSP client will make it
+possible to use other plugins that rely on Neovim's LSP client as a basis.
+`nvim-cmp` is recommended as a completion plugin worth trying in Neovim.
+See: https://github.com/hrsh7th/nvim-cmp
 
 ALE offers support for automatic completion of code while you type.
 Completion is only supported while at least one LSP linter is enabled. ALE
@@ -622,7 +733,7 @@ would like to use. An example here shows the available options for symbols  >
   \ }
 <
 -------------------------------------------------------------------------------
-5.2 Go To Definition                                     *ale-go-to-definition*
+5.3 Go To Definition                                     *ale-go-to-definition*
 
 ALE supports jumping to the files and locations where symbols are defined
 through any enabled LSP linters. The locations ALE will jump to depend on the
@@ -634,7 +745,7 @@ ALE will update Vim's |tagstack| automatically unless |g:ale_update_tagstack| is
 set to `0`.
 
 -------------------------------------------------------------------------------
-5.3 Go To Type Definition                           *ale-go-to-type-definition*
+5.4 Go To Type Definition                           *ale-go-to-type-definition*
 
 ALE supports jumping to the files and locations where symbols' types are
 defined through any enabled LSP linters. The locations ALE will jump to depend
@@ -644,7 +755,7 @@ documentation for the command for configuring how the location will be
 displayed.
 
 -------------------------------------------------------------------------------
-5.4 Go To Implementation                             *ale-go-to-implementation*
+5.5 Go To Implementation                             *ale-go-to-implementation*
 
 ALE supports jumping to the files and locations where symbols are implemented
 through any enabled LSP linters. The locations ALE will jump to depend on the
@@ -653,14 +764,14 @@ jump to the implementation of symbols under the cursor. See the documentation
 for the command for configuring how the location will be displayed.
 
 -------------------------------------------------------------------------------
-5.5 Find References                                       *ale-find-references*
+5.6 Find References                                       *ale-find-references*
 
 ALE supports finding references for symbols though any enabled LSP linters
 with the `:ALEFindReferences` command. See the documentation for the command
 for a full list of options.
 
 -------------------------------------------------------------------------------
-5.6 Hovering                                                        *ale-hover*
+5.7 Hovering                                                        *ale-hover*
 
 ALE supports "hover" information for printing brief information about symbols
 at the cursor taken from LSP linters. The following commands are supported:
@@ -703,14 +814,14 @@ Documentation for symbols at the cursor can be retrieved using the
 `:ALEDocumentation` command. This command is only available for `tsserver`.
 
 -------------------------------------------------------------------------------
-5.7 Symbol Search                                           *ale-symbol-search*
+5.8 Symbol Search                                           *ale-symbol-search*
 
 ALE supports searching for workspace symbols via LSP linters with the
 `:ALESymbolSearch` command. See the documentation for the command
 for a full list of options.
 
 -------------------------------------------------------------------------------
-5.8 Refactoring: Rename, Actions                                 *ale-refactor*
+5.9 Refactoring: Rename, Actions                                 *ale-refactor*
 
 ALE supports renaming symbols in code such as variables or class names with
 the `:ALERename` command.
@@ -1011,7 +1122,7 @@ g:ale_disable_lsp                                           *g:ale_disable_lsp*
   Default: `'auto'`
 
   When this option is set to `'auto'`, ALE will automatically disable linters
-  that it detects as having already been configured with the nvim-lspconfig
+  that it detects as having already been configured with the `nvim-lspconfig`
   plugin. When this option is set to `1`, ALE ignores all linters powered by
   LSP, and also `tsserver`.
 
@@ -2356,6 +2467,22 @@ g:ale_use_neovim_diagnostics_api             *g:ale_use_neovim_diagnostics_api*
   API.
 
 
+g:ale_use_neovim_lsp_api                             *g:ale_use_neovim_lsp_api*
+
+  Type: |Number|
+  Default: `has('nvim-0.8')`
+
+  If enabled, ALE will use Neovim's native LSP client API for LSP
+  functionality. This makes it possible to use Neovim's built in LSP commands
+  and keybinds, and improves integration with other Neovim plugins that
+  integrate with Neovim's LSP client.
+
+  See |ale-lsp-neovim| for more information about ALE's integration with
+  Neovim's LSP client.
+
+  This option requires Neovim 0.8+.
+
+
 g:ale_virtualtext_cursor                             *g:ale_virtualtext_cursor*
 
   Type: |Number|
@@ -3632,7 +3759,7 @@ documented in additional help files.
   See |ale-fix| for more information.
 
 
-:ALEGoToDefinition [options]                                *:ALEGoToDefinition*
+:ALEGoToDefinition [options]                               *:ALEGoToDefinition*
 
   Jump to the definition of a symbol under the cursor using the enabled LSP
   linters for the buffer. ALE will jump to a definition if an LSP server

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -4506,19 +4506,21 @@ ale#Pad(str)                                                        *ale#Pad()*
   parts of a command from variables.
 
 
-ale#Queue(delay, [linting_flag, buffer_number])                   *ale#Queue()*
+ale.queue(delay, [linting_flag, buffer])                          *ale.queue()*
+ale#Queue(delay, [linting_flag, buffer])                          *ale#Queue()*
 
   Run linters for the current buffer, based on the filetype of the buffer,
   with a given `delay`. A `delay` of `0` will run the linters immediately.
   The linters will always be run in the background. Calling this function
-  again from the same buffer
+  several times will reset an internal timer so ALE doesn't check buffers too
+  often.
 
   An optional `linting_flag` argument can be given. If `linting_flag` is
   `'lint_file'`, then linters where the `lint_file` option evaluates to `1`
   will be run. Otherwise, those linters will not be run.
 
-  An optional `buffer_number` argument can be given for specifying the buffer
-  to check. The active buffer (`bufnr('')`) will be checked by default.
+  An optional `buffer` argument can be given for specifying the buffer to
+  check. The active buffer (`bufnr('')`) will be checked by default.
 
                                                                 *ale-cool-down*
   If an exception is thrown when queuing/running ALE linters, ALE will enter

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -476,6 +476,11 @@ functionality for Neovim's LSP client should work as expected, and this
 ensures ALE integrates well with other plugins that rely on Neovim's LSP
 client.
 
+NOTE: Neovim versions below `0.11.0` do not support socket connections to
+language servers when the `address` defined in ALE uses a hostname instead of
+an IP address. To work around this, configure language clients with an IP
+address instead of a hostname, or revert back to ALE's custom LSP client.
+
 See |lsp| for information on Neovim's built in LSP client.
 
 For diagnostics, for computing problems to show via ALE, ALE overrides the

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -4498,7 +4498,8 @@ ale#Has(feature)                                                    *ale#Has()*
   `ale#Has('ale-x.y.z')`, such as `ale#Has('ale-2.4.0')`.
 
 
-ale#Pad(string)                                                     *ale#Pad()*
+ale.pad(str)                                                        *ale.pad()*
+ale#Pad(str)                                                        *ale#Pad()*
 
   Given a string or any |empty()| value, return either the string prefixed
   with a single space, or an empty string. This function can be used to build

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -4486,9 +4486,12 @@ ale#GetFilenameMappings(buffer, name)               *ale#GetFilenameMappings()*
   See |g:ale_filename_mappings| for details on filename mapping.
 
 
+ale.has(feature)                                                    *ale.has()*
 ale#Has(feature)                                                    *ale#Has()*
 
-  Return `1` if ALE supports a given feature, like |has()| for Vim features.
+  In Vim, `ale#Has` returns `1` if ALE supports a given feature, like |has()|
+  for Vim features. In Lua `ale.has` returns `true` instead, and `false` if a
+  feature is not supported.
 
   ALE versions can be checked with version strings in the format
   `ale#Has('ale-x.y.z')`, such as `ale#Has('ale-2.4.0')`.

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -4477,6 +4477,7 @@ ale#Escape(str)                                                  *ale#Escape()*
   In all other cases, ALE will call |shellescape|.
 
 
+ale.get_filename_mappings(buffer, name)           *ale.get_filename_mappings()*
 ale#GetFilenameMappings(buffer, name)               *ale#GetFilenameMappings()*
 
   Given a `buffer` and the `name` of either a linter for fixer, return a

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -4453,6 +4453,7 @@ Vim autocmd names `ale#Foo` are available in the Vim context, and functions
 documented with dot names `ale.foo` are available in Lua scripts.
 
 
+ale.env(variable_name, value)                                       *ale.env()*
 ale#Env(variable_name, value)                                       *ale#Env()*
 
   Given a variable name and a string value, produce a string for including in
@@ -4462,6 +4463,18 @@ ale#Env(variable_name, value)                                       *ale#Env()*
     :echo string(ale#Env('VAR', 'some value') . 'command')
     'VAR=''some value'' command'      # On Linux or Mac OSX
     'set VAR="some value" && command' # On Windows
+
+
+ale.escape(str)                                                  *ale.escape()*
+ale#Escape(str)                                                  *ale#Escape()*
+
+  Given a string, escape that string so it is ready for shell execution.
+
+  If the shell is detected to be `cmd.exe`, ALE will apply its own escaping
+  that tries to avoid escaping strings unless absolutely necessary to avoid
+  issues with Windows programs that do not properly handle quoted arguments.
+
+  In all other cases, ALE will call |shellescape|.
 
 
 ale#GetFilenameMappings(buffer, name)               *ale#GetFilenameMappings()*
@@ -4509,7 +4522,7 @@ ale#Queue(delay, [linting_flag, buffer_number])                   *ale#Queue()*
   is broken, or when developing ALE itself.
 
 
-ale.setup(config)                                                   *ale.setup*
+ale.setup(config)                                                 *ale.setup()*
 
   Configure ALE global settings, which are documented in |ale-options|. For
   example: >
@@ -4524,7 +4537,7 @@ ale.setup(config)                                                   *ale.setup*
   ALE is being configured in less ambiguous if you like.
 
 
-ale.setup.buffer(config)                                     *ale.setup.buffer*
+ale.setup.buffer(config)                                   *ale.setup.buffer()*
 
   Configure ALE buffer-local settings, which are documented in |ale-options|.
   For example: >
@@ -4533,6 +4546,18 @@ ale.setup.buffer(config)                                     *ale.setup.buffer*
       fixers = {"ruff"}
     })
 <
+
+ale.var(buffer, variable_name)                                      *ale.var()*
+ale#Var(buffer, variable_name)                                      *ale#Var()*
+
+  Given a buffer number and an ALE variable name return the value of that
+  if defined in the buffer, and if not defined in the buffer return the
+  global value. The `ale_` prefix will be added to the Vim variable name.
+
+  The `ale#Var` Vim function will return errors if the variable is not defined
+  in either the buffer or globally. The `ale.var` Lua function will return
+  `nil` if the variable is not defined in either the buffer or globally.
+
 
 ale#command#CreateDirectory(buffer)             *ale#command#CreateDirectory()*
 

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -36,6 +36,7 @@ CONTENTS                                                         *ale-contents*
   10. Special Thanks......................|ale-special-thanks|
   11. Contact.............................|ale-contact|
 
+
 ===============================================================================
 1. Introduction                                              *ale-introduction*
 
@@ -63,11 +64,33 @@ for the current buffer.
 If you are interested in contributing to the development of ALE, read the
 developer documentation. See |ale-development|
 
+For configuring ALE in Neovim, you can use the |ale.setup| function to
+configure ALE globally in `init.vim`. >
+
+  require("ale").setup({
+    completion_enabled = true,
+    maximum_file_size = 1024 * 1024,
+    warn_about_trailing_whitespace = false,
+  })
+<
+In |ftplugin| files you can customise behavior for different filetypes by
+using the |ale.setup.buffer| function. >
+
+  -- In ftplugin/python.lua in &runtimepath
+  require("ale").setup.buffer({
+    linters = {"ruff", "pyright"},
+    fixers = {"ruff"}
+  })
+<
+Buffer local settings override global settings for that buffer.
+
+
 ===============================================================================
 2. Supported Languages & Tools                                    *ale-support*
 
 ALE supports a wide variety of languages and tools. See |ale-supported-list|
 for the full list.
+
 
 ===============================================================================
 3. Linting                                                           *ale-lint*
@@ -89,12 +112,12 @@ of the file on disk. This allows you to check your code for errors before you
 have even saved your changes. ALE will check your code in the following
 circumstances, which can be configured with the associated options.
 
-* When you modify a buffer.                - |g:ale_lint_on_text_changed|
-* On leaving insert mode.                  - |g:ale_lint_on_insert_leave|
-* When you open a new or modified buffer.  - |g:ale_lint_on_enter|
-* When you save a buffer.                  - |g:ale_lint_on_save|
-* When the filetype changes for a buffer.  - |g:ale_lint_on_filetype_changed|
-* If ALE is used to check code manually.   - |:ALELint|
+* When you modify a buffer                   - |g:ale_lint_on_text_changed|
+* On leaving insert mode                     - |g:ale_lint_on_insert_leave|
+* When you open a new or modified buffer     - |g:ale_lint_on_enter|
+* When you save a buffer                     - |g:ale_lint_on_save|
+* When the filetype changes for a buffer     - |g:ale_lint_on_filetype_changed|
+* If ALE is used to check code manually      - |:ALELint|
 
                                                  *ale-lint-settings-on-startup*
 
@@ -114,23 +137,23 @@ which behave this way are documented in the lists and tables of supported
 programs. ALE will only lint files with these programs in the following
 circumstances.
 
-* When you open a new or modified buffer.  - |g:ale_lint_on_enter|
-* When you save a buffer.                  - |g:ale_lint_on_save|
-* When the filetype changes for a buffer.  - |g:ale_lint_on_filetype_changed|
-* If ALE is used to check code manually.   - |:ALELint|
+* When you open a new or modified buffer     - |g:ale_lint_on_enter|
+* When you save a buffer                     - |g:ale_lint_on_save|
+* When the filetype changes for a buffer     - |g:ale_lint_on_filetype_changed|
+* If ALE is used to check code manually      - |:ALELint|
 
 ALE will report problems with your code in the following ways, listed with
 their relevant options.
 
-* Via Neovim diagnostics (On in Neovim 0.7+)       - |g:ale_use_neovim_diagnostics_api|
-* By updating loclist. (On by default)             - |g:ale_set_loclist|
-* By updating quickfix. (Off by default)           - |g:ale_set_quickfix|
-* By setting error highlights.                     - |g:ale_set_highlights|
-* By creating signs in the sign column.            - |g:ale_set_signs|
-* By echoing messages based on your cursor.        - |g:ale_echo_cursor|
-* By inline text based on your cursor.             - |g:ale_virtualtext_cursor|
-* By displaying the preview based on your cursor.  - |g:ale_cursor_detail|
-* By showing balloons for your mouse cursor        - |g:ale_set_balloons|
+* Via Neovim diagnostics (On in Neovim 0.7+) - |g:ale_use_neovim_diagnostics_api|
+* By updating loclist (On by default)        - |g:ale_set_loclist|
+* By updating quickfix (Off by default)      - |g:ale_set_quickfix|
+* By setting error highlights                - |g:ale_set_highlights|
+* By creating signs in the sign column       - |g:ale_set_signs|
+* By echoing messages based on your cursor   - |g:ale_echo_cursor|
+* By showing virtual text at your cursor     - |g:ale_virtualtext_cursor|
+* By previewing details at your cursor       - |g:ale_cursor_detail|
+* By showing balloons for your mouse cursor  - |g:ale_set_balloons|
 
 Please consult the documentation for each option, which can reveal some other
 ways of tweaking the behavior of each way of displaying problems. You can
@@ -154,6 +177,7 @@ ALE offers several options for controlling which linters are run.
 
 You can stop ALE any currently running linters with the `:ALELintStop` command.
 Any existing problems will be kept.
+
 
 -------------------------------------------------------------------------------
 3.1 Linting On Other Machines                         *ale-lint-other-machines*
@@ -186,7 +210,6 @@ script like so. >
 
   exec docker run -i --rm -v "$(pwd):/data" cytopia/pylint "$@"
 <
-
 You will want to run Docker commands with `-i` in order to read from stdin.
 
 With the above script in mind, you might configure ALE to lint your Python
@@ -207,7 +230,6 @@ mappings which describe how to change between the two file systems in your
     \}
   endif
 <
-
 You might consider using a Vim plugin for loading Vim configuration files
 specific to each project, if you have a lot of projects to manage.
 
@@ -242,15 +264,15 @@ should define the address to connect to instead. >
   \   'project_root': '/path/to/root_of_project',
   \})
 <
-  Most of the options for a language server can be replaced with a |Funcref|
-  for a function accepting a buffer number for dynamically computing values
-  such as the executable path, the project path, the server address, etc,
-  most of which can also be determined based on executing some other
-  asynchronous task. See |ale#command#Run()| for computing linter options
-  based on asynchronous results.
+Most of the options for a language server can be replaced with a |Funcref| for
+a function accepting a buffer number for dynamically computing values such as
+the executable path, the project path, the server address, etc, most of which
+can also be determined based on executing some other asynchronous task. See
+|ale#command#Run()| for computing linter options based on asynchronous
+results.
 
-  See |ale#linter#Define()| for a detailed explanation of all of the options
-  for configuring linters.
+See |ale#linter#Define()| for a detailed explanation of all of the options for
+configuring linters.
 
 
 -------------------------------------------------------------------------------
@@ -274,7 +296,6 @@ ALE's loclist format. (See |ale-loclist-format|) For example: >
   \ {'text': 'Something went wrong', 'lnum': 13},
   \])
 <
-
 Other sources should use a unique name for identifying themselves. A single
 linter name can be used for all problems from another source, or a series of
 unique linter names can be used. Results can be cleared for that source by
@@ -467,6 +488,7 @@ a project configuration has significantly changed, or new files have been
 added the language server isn't aware of, use either `:ALEStopLSP` or
 `:ALEStopAllLSPs` to stop the server until ALE automatically starts it again.
 
+
 -------------------------------------------------------------------------------
 5.1 LSP Neovim Integration                                     *ale-lsp-neovim*
 
@@ -593,21 +615,24 @@ integration should not be combined with ALE's own implementation.
                                                  *ale-asyncomplete-integration*
 
 ALE additionally integrates with asyncomplete.vim for offering automatic
-completion data. ALE's asyncomplete source requires registration and should
-use the defaults provided by the |asyncomplete#sources#ale#get_source_options| function >
+completion data. ALE's asyncomplete source requires registration with
+defaults provided by the |asyncomplete#sources#ale#get_source_options| function >
 
   " Use ALE's function for asyncomplete defaults
-  au User asyncomplete_setup call asyncomplete#register_source(asyncomplete#sources#ale#get_source_options({
-      \ 'priority': 10, " Provide your own overrides here
-      \ }))
+  " Provide your own overrides here.
+  au User asyncomplete_setup call asyncomplete#register_source(
+  \   asyncomplete#sources#ale#get_source_options({
+  \       'priority': 10,
+  \   })
+  \)
 >
 ALE also offers its own completion implementation, which does not require any
 other plugins. Suggestions will be made while you type after completion is
 enabled. ALE's own completion implementation can be enabled by setting
-|g:ale_completion_enabled| to `1`. This setting must be set to `1` before ALE
-is loaded. The delay for completion can be configured with
-|g:ale_completion_delay|. This setting should not be enabled if you wish to
-use ALE as a completion source for other plugins.
+|g:ale_completion_enabled| to `true` or `1`. This setting must be set to
+`true` or `1` before ALE is loaded. The delay for completion can be configured
+with |g:ale_completion_delay|. This setting should not be enabled if you wish
+to use ALE as a completion source for other plugins.
 
 ALE automatic completion will not work when 'paste' is active. Only set
 'paste' when you are copy and pasting text into your buffers.
@@ -737,6 +762,7 @@ would like to use. An example here shows the available options for symbols  >
   \ '<default>': 'v'
   \ }
 <
+
 -------------------------------------------------------------------------------
 5.3 Go To Definition                                     *ale-go-to-definition*
 
@@ -749,6 +775,7 @@ command for configuring how the location will be displayed.
 ALE will update Vim's |tagstack| automatically unless |g:ale_update_tagstack| is
 set to `0`.
 
+
 -------------------------------------------------------------------------------
 5.4 Go To Type Definition                           *ale-go-to-type-definition*
 
@@ -759,6 +786,7 @@ command will jump to the definition of symbols under the cursor. See the
 documentation for the command for configuring how the location will be
 displayed.
 
+
 -------------------------------------------------------------------------------
 5.5 Go To Implementation                             *ale-go-to-implementation*
 
@@ -768,12 +796,14 @@ information returned by LSP servers. The `:ALEGoToImplementation` command will
 jump to the implementation of symbols under the cursor. See the documentation
 for the command for configuring how the location will be displayed.
 
+
 -------------------------------------------------------------------------------
 5.6 Find References                                       *ale-find-references*
 
 ALE supports finding references for symbols though any enabled LSP linters
 with the `:ALEFindReferences` command. See the documentation for the command
 for a full list of options.
+
 
 -------------------------------------------------------------------------------
 5.7 Hovering                                                        *ale-hover*
@@ -787,24 +817,25 @@ Truncated information will be displayed when the cursor rests on a symbol by
 default, as long as there are no problems on the same line. You can disable
 this behavior by setting |g:ale_hover_cursor| to `0`.
 
-If |g:ale_set_balloons| is set to `1` and your version of Vim supports the
-|balloon_show()| function, then "hover" information also show up when you move
-the mouse over a symbol in a buffer. Diagnostic information will take priority
-over hover information for balloons. If a line contains a problem, that
-problem will be displayed in a balloon instead of hover information.
+If |g:ale_set_balloons| is set to `true` or `1` and your version of Vim
+supports the |balloon_show()| function, then "hover" information also show up
+when you move the mouse over a symbol in a buffer. Diagnostic information will
+take priority over hover information for balloons. If a line contains a
+problem, that problem will be displayed in a balloon instead of hover
+information.
 
 Hover information can be displayed in the preview window instead by setting
-|g:ale_hover_to_preview| to `1`.
+|g:ale_hover_to_preview| to `true` or `1`.
 
 When using Neovim or Vim with |popupwin|, if |g:ale_hover_to_floating_preview|
-or |g:ale_floating_preview| is set to 1, the hover information will show in a
-floating window. The borders of the floating preview window can be customized
-by setting |g:ale_floating_window_border|.
+or |g:ale_floating_preview| is set to `true` or `1`, the hover information
+will show in a floating window. The borders of the floating preview window can
+be customized by setting |g:ale_floating_window_border|.
 
 For Vim 8.1+ terminals, mouse hovering is disabled by default. Enabling
 |balloonexpr| commands in terminals can cause scrolling issues in terminals,
 so ALE will not attempt to show balloons unless |g:ale_set_balloons| is set to
-`1` before ALE is loaded.
+`true` or `1` before ALE is loaded.
 
 For enabling mouse support in terminals, you may have to change your mouse
 settings. For example: >
@@ -818,12 +849,14 @@ settings. For example: >
 Documentation for symbols at the cursor can be retrieved using the
 `:ALEDocumentation` command. This command is only available for `tsserver`.
 
+
 -------------------------------------------------------------------------------
 5.8 Symbol Search                                           *ale-symbol-search*
 
 ALE supports searching for workspace symbols via LSP linters with the
 `:ALESymbolSearch` command. See the documentation for the command
 for a full list of options.
+
 
 -------------------------------------------------------------------------------
 5.9 Refactoring: Rename, Actions                                 *ale-refactor*
@@ -855,12 +888,24 @@ You may wish to remove some other menu items you don't want to see: >
   silent! aunmenu PopUp.Select\ Blockwise
   silent! aunmenu PopUp.Select\ All
 <
+
 ===============================================================================
 6. Global Options                                                 *ale-options*
 
+Options documented here can be configured either Vim variables, or via the
+|ale.setup| and |ale.setup.buffer| functions in Lua. When configuring via
+the Lua functions in Lua scripts, ALE will bridge types to Vim script in the
+following ways.
 
-g:airline#extensions#ale#enabled             *g:airline#extensions#ale#enabled*
+1. Strings, numbers, booleans, and `nil` will be represented exactly.
+2. Tables with no or only number keys will become a |List| in Vim.
+3. Keys other than strings and numbers in tables cannot be represented.
+4. Tables with special |metatable| properties cannot be represented.
+5. Options accepting functions as values will automatically have Vim functions
+   created that bridge the function calls to and from Lua code.
 
+                                             *g:airline#extensions#ale#enabled*
+g:airline#extensions#ale#enabled
   Type: |Number|
   Default: `1`
 
@@ -869,27 +914,29 @@ g:airline#extensions#ale#enabled             *g:airline#extensions#ale#enabled*
   |airline#extensions#ale#error_symbol| and
   |airline#extensions#ale#warning_symbol|.
 
+                                  *ale-options.cache_executable_check_failures*
+                                        *g:ale_cache_executable_check_failures*
+cache_executable_check_failures
+g:ale_cache_executable_check_failures
+  Type: |Boolean| or |Number|
+  Default: `nil`
 
-g:ale_cache_executable_check_failures   *g:ale_cache_executable_check_failures*
+  When set to `true` or `1`, ALE will cache failing executable checks for
+  linters. By default, only executable checks which succeed will be cached.
 
-  Type: |Number|
-  Default: not set
+  When this option is set to `true` or `1`, Vim will have to be restarted
+  after new executables are installed for ALE to be able to run linters for
+  those executables.
 
-  When set to `1`, ALE will cache failing executable checks for linters. By
-  default, only executable checks which succeed will be cached.
+                                         *ale-options.change_sign_column_color*
+                                               *g:ale_change_sign_column_color*
+change_sign_column_color
+g:ale_change_sign_column_color
+  Type: |Boolean| or |Number|
+  Default: `false`
 
-  When this option is set to `1`, Vim will have to be restarted after new
-  executables are installed for ALE to be able to run linters for those
-  executables.
-
-
-g:ale_change_sign_column_color                 *g:ale_change_sign_column_color*
-
-  Type: |Number|
-  Default: `0`
-
-  When set to `1`, this option will set different highlights for the sign
-  column itself when ALE reports problems with a file. This option can be
+  When set to `true` or `1`, this option will set different highlights for the
+  sign column itself when ALE reports problems with a file. This option can be
   combined with |g:ale_sign_column_always|.
 
   ALE uses the following highlight groups for highlighting the sign column:
@@ -901,23 +948,27 @@ g:ale_change_sign_column_color                 *g:ale_change_sign_column_color*
   might produce unexpected results if editing different files in split
   windows.
 
+                                          *ale-options.close_preview_on_insert*
+                                                *g:ale_close_preview_on_insert*
+close_preview_on_insert
+g:ale_close_preview_on_insert
+  Type: |Boolean| or |Number|
+  Default: `false`
 
-g:ale_close_preview_on_insert                   *g:ale_close_preview_on_insert*
+  When this option is set to `true` or `1`, ALE's |preview-window| will be
+  automatically closed upon entering Insert Mode. This option can be used in
+  combination with |g:ale_cursor_detail| for automatically displaying the
+  preview window on problem lines, and automatically closing it again when
+  editing text.
 
-  Type: |Number|
-  Default: `0`
+  This setting must be set to `true` or `1` before ALE is loaded for this
+  behavior to be enabled. See |ale-lint-settings-on-startup|.
 
-  When this option is set to `1`, ALE's |preview-window| will be automatically
-  closed upon entering Insert Mode. This option can be used in combination
-  with |g:ale_cursor_detail| for automatically displaying the preview window
-  on problem lines, and automatically closing it again when editing text.
-
-  This setting must be set to `1` before ALE is loaded for this behavior
-  to be enabled. See |ale-lint-settings-on-startup|.
-
-
-g:ale_command_wrapper                                   *g:ale_command_wrapper*
+                                                  *ale-options.command_wrapper*
+                                                        *g:ale_command_wrapper*
                                                         *b:ale_command_wrapper*
+command_wrapper
+g:ale_command_wrapper
   Type: |String|
   Default: `''`
 
@@ -947,9 +998,10 @@ g:ale_command_wrapper                                   *g:ale_command_wrapper*
   be passed to the wrapper. `&&` is most commonly used in ALE to change the
   working directory before running a command.
 
-
-g:ale_completion_delay                                 *g:ale_completion_delay*
-
+                                                 *ale-options.completion_delay*
+                                                       *g:ale_completion_delay*
+completion_delay
+g:ale_completion_delay
   Type: |Number|
   Default: `100`
 
@@ -958,15 +1010,17 @@ g:ale_completion_delay                                 *g:ale_completion_delay*
 
   See |ale-completion|
 
-
-g:ale_completion_enabled                             *g:ale_completion_enabled*
+                                               *ale-options.completion_enabled*
+                                                     *g:ale_completion_enabled*
                                                      *b:ale_completion_enabled*
-  Type: |Number|
-  Default: `0`
+completion_enabled
+g:ale_completion_enabled
+  Type: |Boolean| or |Number|
+  Default: `false`
 
-  When this option is set to `1`, completion support will be enabled.
+  When this option is set to `true` or `1`, completion support will be enabled.
 
-  This setting must be set to `1` before ALE is loaded for this behavior
+  This setting must be set to `true` or `1` before ALE is loaded for this behavior
   to be enabled.
 
   This setting should not be enabled if you wish to use ALE as a completion
@@ -981,22 +1035,24 @@ g:ale_completion_enabled                             *g:ale_completion_enabled*
 
   See |ale-completion|
 
-
+                              *ale-options.completion_tsserver_remove_warnings*
                                     *g:ale_completion_tsserver_remove_warnings*
+completion_tsserver_remove_warnings
 g:ale_completion_tsserver_remove_warnings
+  Type: |Boolean| or |Number|
+  Default: `false`
 
-  Type: |Number|
-  Default: `0`
+  When this option is set to `false` or `0`, ALE will return all completion
+  items from its built in completion engine, including those that are a
+  warning. Warnings can be excluded from completed items by setting it to
+  `true` or `1`.
 
-  When this option is set to `0`, ALE will return all completion items,
-  including those that are a warning. Warnings can be excluded from completed
-  items by setting it to `1`.
-
-
-g:ale_completion_autoimport                       *g:ale_completion_autoimport*
-
-  Type: |Number|
-  Default: `1`
+                                            *ale-options.completion_autoimport*
+                                                  *g:ale_completion_autoimport*
+completion_autoimport
+g:ale_completion_autoimport
+  Type: |Boolean| or |Number|
+  Default: `true`
 
   When this option is set to `1`, ALE will try to automatically import
   completion results from external modules. It can be disabled by setting it
@@ -1004,9 +1060,11 @@ g:ale_completion_autoimport                       *g:ale_completion_autoimport*
   disabling automatic imports may drop some or all completion items returned
   by it (e.g. eclipselsp).
 
-
-g:ale_completion_excluded_words               *g:ale_completion_excluded_words*
+                                        *ale-options.completion_excluded_words*
+                                              *g:ale_completion_excluded_words*
                                               *b:ale_completion_excluded_words*
+completion_excluded_words
+g:ale_completion_excluded_words
   Type: |List|
   Default: `[]`
 
@@ -1022,9 +1080,10 @@ g:ale_completion_excluded_words               *g:ale_completion_excluded_words*
   " Don't suggest `it` or `describe` so we can use snippets for those words.
   let b:ale_completion_excluded_words = ['it', 'describe']
 <
-
-g:ale_completion_symbols                             *g:ale_completion_symbols*
-
+                                               *ale-options.completion_symbols*
+                                                     *g:ale_completion_symbols*
+completion_symbols
+g:ale_completion_symbols
   Type: |Dictionary|
   Default: See `autoload/ale/completion.vim`
 
@@ -1032,7 +1091,7 @@ g:ale_completion_symbols                             *g:ale_completion_symbols*
   |ale-symbols| for more information.
 
   By default, this mapping only uses built in Vim completion kinds, but it can
-  be updated to use any unicode character for the completion kind. For
+  be updated to use any Unicode character for the completion kind. For
   example: >
     let g:ale_completion_symbols = {
     \ 'text': '',
@@ -1063,9 +1122,10 @@ g:ale_completion_symbols                             *g:ale_completion_symbols*
     \ '<default>': 'v'
     \ })
 <
-
-g:ale_completion_max_suggestions             *g:ale_completion_max_suggestions*
-
+                                       *ale-options.completion_max_suggestions*
+                                             *g:ale_completion_max_suggestions*
+completion_max_suggestions
+g:ale_completion_max_suggestions
   Type: |Number|
   Default: `50`
 
@@ -1080,16 +1140,18 @@ g:ale_completion_max_suggestions             *g:ale_completion_max_suggestions*
   Adjust this option as needed, depending on the complexity of your codebase
   and your available processing power.
 
-
-g:ale_cursor_detail                                       *g:ale_cursor_detail*
-
+                                                    *ale-options.cursor_detail*
+                                                          *g:ale_cursor_detail*
+cursor_detail
+g:ale_cursor_detail
   Type: |Number|
-  Default: `0`
+  Default: `false`
 
-  When this option is set to `1`, ALE's |preview-window| will be automatically
-  opened when the cursor moves onto lines with problems. ALE will search for
-  problems using the same logic that |g:ale_echo_cursor| uses. The preview
-  window will be closed automatically when you move away from the line.
+  When this option is set to `true` or `1`, ALE's |preview-window| will be
+  automatically opened when the cursor moves onto lines with problems. ALE
+  will search for problems using the same logic that |g:ale_echo_cursor| uses.
+  The preview window will be closed automatically when you move away from the
+  line.
 
   Messages are only displayed after a short delay. See |g:ale_echo_delay|.
 
@@ -1097,32 +1159,39 @@ g:ale_cursor_detail                                       *g:ale_cursor_detail*
   will stay in the same buffer as it currently is.
 
   The preview window can be closed automatically upon entering Insert mode
-  by setting |g:ale_close_preview_on_insert| to `1`.
+  by setting |g:ale_close_preview_on_insert| to `true` or `1`.
 
-  Either this setting or |g:ale_echo_cursor| must be set to `1` before ALE is
-  loaded for messages to be displayed. See |ale-lint-settings-on-startup|.
+  Either this setting or |g:ale_echo_cursor| must be set to `true` or  `1`
+  before ALE is loaded for messages to be displayed.
+  See |ale-lint-settings-on-startup|.
 
-
-g:ale_default_navigation                             *g:ale_default_navigation*
+                                               *ale-options.default_navigation*
+                                                     *g:ale_default_navigation*
                                                      *b:ale_default_navigation*
+default_navigation
+g:ale_default_navigation
   Type: |String|
   Default: `'buffer'`
 
   The default method for navigating away from the current buffer to another
   buffer, such as for `:ALEFindReferences` or `:ALEGoToDefinition`.
 
-
-g:ale_detail_to_floating_preview             *g:ale_detail_to_floating_preview*
+                                       *ale-options.detail_to_floating_preview*
+                                             *g:ale_detail_to_floating_preview*
                                              *b:ale_detail_to_floating_preview*
+detail_to_floating_preview
+g:ale_detail_to_floating_preview
   Type: |Number|
   Default: `0`
 
   When this option is set to `1`, Neovim or Vim with |popupwin| will use a
   floating window for ALEDetail output.
 
-
-g:ale_disable_lsp                                           *g:ale_disable_lsp*
+                                                      *ale-options.disable_lsp*
+                                                            *g:ale_disable_lsp*
                                                             *b:ale_disable_lsp*
+disable_lsp
+g:ale_disable_lsp
   Type: |Number| OR |String|
   Default: `'auto'`
 
@@ -1136,9 +1205,10 @@ g:ale_disable_lsp                                           *g:ale_disable_lsp*
 
   Please see also |ale-lsp|.
 
-
-g:ale_echo_cursor                                           *g:ale_echo_cursor*
-
+                                                      *ale-options.echo_cursor*
+                                                            *g:ale_echo_cursor*
+echo_cursor
+g:ale_echo_cursor
   Type: |Number|
   Default: `1`
 
@@ -1152,12 +1222,15 @@ g:ale_echo_cursor                                           *g:ale_echo_cursor*
 
   The format of the message can be customized with |g:ale_echo_msg_format|.
 
-  Either this setting or |g:ale_cursor_detail| must be set to `1` before ALE
-  is loaded for messages to be displayed. See |ale-lint-settings-on-startup|.
+  Either this setting or |g:ale_cursor_detail| must be set to `true` or  `1`
+  before ALE is loaded for messages to be displayed. See
+  |ale-lint-settings-on-startup|.
 
-
-g:ale_echo_delay                                             *g:ale_echo_delay*
+                                                       *ale-options.echo_delay*
+                                                             *g:ale_echo_delay*
                                                              *b:ale_echo_delay*
+echo_delay
+g:ale_echo_delay
   Type: |Number|
   Default: `10`
 
@@ -1167,17 +1240,20 @@ g:ale_echo_delay                                             *g:ale_echo_delay*
   The value can be increased to decrease the amount of processing ALE will do
   for files displaying a large number of problems.
 
-
-g:ale_echo_msg_error_str                             *g:ale_echo_msg_error_str*
-
+                                               *ale-options.echo_msg_error_str*
+                                                     *g:ale_echo_msg_error_str*
+echo_msg_error_str
+g:ale_echo_msg_error_str
   Type: |String|
   Default: `'Error'`
 
   The string used for `%severity%` for errors. See |g:ale_echo_msg_format|
 
-
-g:ale_echo_msg_format                                   *g:ale_echo_msg_format*
+                                                  *ale-options.echo_msg_format*
+                                                        *g:ale_echo_msg_format*
                                                         *b:ale_echo_msg_format*
+echo_msg_format
+g:ale_echo_msg_format
   Type: |String|
   Default: `'%code: %%s'`
 
@@ -1208,34 +1284,39 @@ g:ale_echo_msg_format                                   *g:ale_echo_msg_format*
   so different formats can be used for different languages. (Say in ftplugin
   files.)
 
-
-g:ale_echo_msg_info_str                               *g:ale_echo_msg_info_str*
-
+                                                *ale-options.echo_msg_info_str*
+                                                      *g:ale_echo_msg_info_str*
+echo_msg_info_str
+g:ale_echo_msg_info_str
   Type: |String|
   Default: `'Info'`
 
   The string used for `%severity%` for info. See |g:ale_echo_msg_format|
 
-
-g:ale_echo_msg_log_str                                 *g:ale_echo_msg_log_str*
-
+                                                 *ale-options.echo_msg_log_str*
+                                                       *g:ale_echo_msg_log_str*
+echo_msg_log_str
+g:ale_echo_msg_log_str
   Type: |String|
   Default: `'Log'`
 
   The string used for `%severity%` for log, used only for handling LSP show
   message requests. See |g:ale_lsp_show_message_format|
 
-
-g:ale_echo_msg_warning_str                         *g:ale_echo_msg_warning_str*
-
+                                             *ale-options.echo_msg_warning_str*
+                                                   *g:ale_echo_msg_warning_str*
+echo_msg_warning_str
+g:ale_echo_msg_warning_str
   Type: |String|
   Default: `'Warning'`
 
   The string used for `%severity%` for warnings. See |g:ale_echo_msg_format|
 
-
-g:ale_enabled                                                   *g:ale_enabled*
+                                                          *ale-options.enabled*
+                                                                *g:ale_enabled*
                                                                 *b:ale_enabled*
+enabled
+g:ale_enabled
   Type: |Number|
   Default: `1`
 
@@ -1252,13 +1333,15 @@ g:ale_enabled                                                   *g:ale_enabled*
 <
   See |g:ale_pattern_options| for more information on that option.
 
-
-g:ale_exclude_highlights                             *g:ale_exclude_highlights*
+                                               *ale-options.exclude_highlights*
+                                                     *g:ale_exclude_highlights*
                                                      *b:ale_exclude_highlights*
+exclude_highlights
+g:ale_exclude_highlights
   Type: |List|
   Default: `[]`
 
-  This setting has no effect when |g:ale_use_neovim_diagnostics_api| is `1`.
+  This has no effect when |g:ale_use_neovim_diagnostics_api| is `true` or `1`.
 
   A list of regular expressions for matching against highlight messages to
   remove. For example: >
@@ -1268,9 +1351,11 @@ g:ale_exclude_highlights                             *g:ale_exclude_highlights*
 <
   See also: |g:ale_set_highlights|
 
-
-g:ale_fixers                                                     *g:ale_fixers*
+                                                           *ale-options.fixers*
+                                                                 *g:ale_fixers*
                                                                  *b:ale_fixers*
+fixers
+g:ale_fixers
   Type: |Dictionary|
   Default: `{}`
 
@@ -1289,9 +1374,11 @@ g:ale_fixers                                                     *g:ale_fixers*
     " Fix everything else with 'foo'.
     let g:ale_fixers = {'python': ['bar'], 'html': [], '*': ['foo']}
 <
-
-g:ale_fix_on_save                                           *g:ale_fix_on_save*
+                                                      *ale-options.fix_on_save*
+                                                            *g:ale_fix_on_save*
                                                             *b:ale_fix_on_save*
+fix_on_save
+g:ale_fix_on_save
   Type: |Number|
   Default: `0`
 
@@ -1310,9 +1397,11 @@ g:ale_fix_on_save                                           *g:ale_fix_on_save*
   Some fixers can be excluded from being run automatically when you save files
   with the |g:ale_fix_on_save_ignore| setting.
 
-
-g:ale_fix_on_save_ignore                             *g:ale_fix_on_save_ignore*
+                                               *ale-options.fix_on_save_ignore*
+                                                     *g:ale_fix_on_save_ignore*
                                                      *b:ale_fix_on_save_ignore*
+fix_on_save_ignore
+g:ale_fix_on_save_ignore
   Type: |Dictionary| or |List|
   Default: `{}`
 
@@ -1343,9 +1432,10 @@ g:ale_fix_on_save_ignore                             *g:ale_fix_on_save_ignore*
   " The lambda fixer will be ignored, as it will be found in the ignore list.
   let g:ale_fix_on_save_ignore = [g:AddBar]
 <
-
-g:ale_floating_preview                                 *g:ale_floating_preview*
-
+                                                 *ale-options.floating_preview*
+                                                       *g:ale_floating_preview*
+floating_preview
+g:ale_floating_preview
   Type: |Number|
   Default: `0`
 
@@ -1354,9 +1444,10 @@ g:ale_floating_preview                                 *g:ale_floating_preview*
   This is equivalent to setting |g:ale_hover_to_floating_preview| and
   |g:ale_detail_to_floating_preview| to `1`.
 
-
-g:ale_floating_preview_popup_opts           *g:ale_floating_preview_popup_opts*
-
+                                      *ale-options.floating_preview_popup_opts*
+                                            *g:ale_floating_preview_popup_opts*
+floating_preview_popup_opts
+g:ale_floating_preview_popup_opts
   Type: |String| or |Dictionary|
   Default: `''`
 
@@ -1379,9 +1470,10 @@ g:ale_floating_preview_popup_opts           *g:ale_floating_preview_popup_opts*
 
   let g:ale_floating_preview_popup_opts = 'g:CustomOpts'
 <
-
-g:ale_floating_window_border                     *g:ale_floating_window_border*
-
+                                           *ale-options.floating_window_border*
+                                                 *g:ale_floating_window_border*
+floating_window_border
+g:ale_floating_window_border
   Type: |List|
   Default: `['|', '-', '+', '+', '+', '+', '|', '-']`
 
@@ -1397,9 +1489,10 @@ g:ale_floating_window_border                     *g:ale_floating_window_border*
   elements for the right side and bottom, the left side and top will be used
   instead.
 
-
-g:ale_history_enabled                                   *g:ale_history_enabled*
-
+                                                  *ale-options.history_enabled*
+                                                        *g:ale_history_enabled*
+history_enabled
+g:ale_history_enabled
   Type: |Number|
   Default: `1`
 
@@ -1410,9 +1503,10 @@ g:ale_history_enabled                                   *g:ale_history_enabled*
 
   This option can be disabled if storing a command history is not desired.
 
-
-g:ale_history_log_output                             *g:ale_history_log_output*
-
+                                               *ale-options.history_log_output*
+                                                     *g:ale_history_log_output*
+history_log_output
+g:ale_history_log_output
   Type: |Number|
   Default: `1`
 
@@ -1427,9 +1521,10 @@ g:ale_history_log_output                             *g:ale_history_log_output*
   out what went wrong with linters, and for bug reports. Turn this option off
   if you want to save on some memory usage.
 
-
-g:ale_hover_cursor                                         *g:ale_hover_cursor*
-
+                                                     *ale-options.hover_cursor*
+                                                           *g:ale_hover_cursor*
+hover_cursor
+g:ale_hover_cursor
   Type: |Number|
   Default: `1`
 
@@ -1446,36 +1541,44 @@ g:ale_hover_cursor                                         *g:ale_hover_cursor*
   This setting must be set to `1` before ALE is loaded for this behavior
   to be enabled. See |ale-lint-settings-on-startup|.
 
-
-g:ale_hover_to_preview                                 *g:ale_hover_to_preview*
+                                                 *ale-options.hover_to_preview*
+                                                       *g:ale_hover_to_preview*
                                                        *b:ale_hover_to_preview*
+hover_to_preview
+g:ale_hover_to_preview
   Type: |Number|
   Default: `0`
 
   If set to `1`, hover messages will be displayed in the preview window,
   instead of in balloons or the message line.
 
-
-g:ale_hover_to_floating_preview               *g:ale_hover_to_floating_preview*
+                                        *ale-options.hover_to_floating_preview*
+                                              *g:ale_hover_to_floating_preview*
                                               *b:ale_hover_to_floating_preview*
+hover_to_floating_preview
+g:ale_hover_to_floating_preview
   Type: |Number|
   Default: `0`
 
   If set to `1`, Neovim or Vim with |popupwin| will use floating windows for
   hover messages.
 
-
-g:ale_info_default_mode                               *g:ale_info_default_mode*
+                                                *ale-options.info_default_mode*
+                                                      *g:ale_info_default_mode*
                                                       *b:ale_info_default_mode*
+info_default_mode
+g:ale_info_default_mode
   Type: |String|
   Default: `'preview'`
 
   Changes the default mode used for `:ALEInfo`. See documentation for `:ALEInfo`
   for more information.
 
-
-g:ale_keep_list_window_open                       *g:ale_keep_list_window_open*
+                                            *ale-options.keep_list_window_open*
+                                                  *g:ale_keep_list_window_open*
                                                   *b:ale_keep_list_window_open*
+keep_list_window_open
+g:ale_keep_list_window_open
   Type: |Number|
   Default: `0`
 
@@ -1486,9 +1589,11 @@ g:ale_keep_list_window_open                       *g:ale_keep_list_window_open*
 
   See |g:ale_open_list|
 
-
-g:ale_list_window_size                                 *g:ale_list_window_size*
+                                                 *ale-options.list_window_size*
+                                                       *g:ale_list_window_size*
                                                        *b:ale_list_window_size*
+list_window_size
+g:ale_list_window_size
   Type: |Number|
   Default: `10`
 
@@ -1499,9 +1604,11 @@ g:ale_list_window_size                                 *g:ale_list_window_size*
   See |g:ale_open_list| for information on automatically opening windows
   for quickfix or the loclist.
 
-
-g:ale_lint_delay                                             *g:ale_lint_delay*
+                                                       *ale-options.lint_delay*
+                                                             *g:ale_lint_delay*
                                                              *b:ale_lint_delay*
+lint_delay
+g:ale_lint_delay
   Type: |Number|
   Default: `200`
 
@@ -1512,9 +1619,10 @@ g:ale_lint_delay                                             *g:ale_lint_delay*
   A buffer-local option, `b:ale_lint_delay`, can be set to change the delay
   for different buffers, such as in |ftplugin| files.
 
-
-g:ale_lint_on_enter                                       *g:ale_lint_on_enter*
-
+                                                    *ale-options.lint_on_enter*
+                                                          *g:ale_lint_on_enter*
+lint_on_enter
+g:ale_lint_on_enter
   Type: |Number|
   Default: `1`
 
@@ -1529,9 +1637,10 @@ g:ale_lint_on_enter                                       *g:ale_lint_on_enter*
   You should set this setting once before ALE is loaded, and restart Vim if
   you want to change your preferences. See |ale-lint-settings-on-startup|.
 
-
-g:ale_lint_on_filetype_changed                 *g:ale_lint_on_filetype_changed*
-
+                                         *ale-options.lint_on_filetype_changed*
+                                               *g:ale_lint_on_filetype_changed*
+lint_on_filetype_changed
+g:ale_lint_on_filetype_changed
   Type: |Number|
   Default: `1`
 
@@ -1543,9 +1652,10 @@ g:ale_lint_on_filetype_changed                 *g:ale_lint_on_filetype_changed*
   You should set this setting once before ALE is loaded, and restart Vim if
   you want to change your preferences. See |ale-lint-settings-on-startup|.
 
-
-g:ale_lint_on_save                                         *g:ale_lint_on_save*
-
+                                                     *ale-options.lint_on_save*
+                                                           *g:ale_lint_on_save*
+lint_on_save
+g:ale_lint_on_save
   Type: |Number|
   Default: `1`
 
@@ -1555,19 +1665,20 @@ g:ale_lint_on_save                                         *g:ale_lint_on_save*
   make ALE only check files after that have been saved, if that is what is
   desired.
 
-
-g:ale_lint_on_text_changed                         *g:ale_lint_on_text_changed*
-
-  Type: |String|
+                                             *ale-options.lint_on_text_changed*
+                                                   *g:ale_lint_on_text_changed*
+lint_on_text_changed
+g:ale_lint_on_text_changed
+  Type: |Boolean| or |Number| or |String|
   Default: `'normal'`
 
   This option controls how ALE will check your files as you make changes.
   The following values can be used.
 
-  `'always'`, `'1'`, or `1` - Check buffers on |TextChanged| or |TextChangedI|.
-  `'normal'`            - Check buffers only on |TextChanged|.
-  `'insert'`            - Check buffers only on |TextChangedI|.
-  `'never'`, `'0'`, or `0`  - Never check buffers on changes.
+  `'always'`, `'1'`, `true`, or `1`  - Check buffers on |TextChanged| or |TextChangedI|.
+  `'normal'`                   - Check buffers only on |TextChanged|.
+  `'insert'`                   - Check buffers only on |TextChangedI|.
+  `'never'`, `'0'`, `false`, or `0`  - Never check buffers on changes.
 
   ALE will check buffers after a short delay, with a timer which resets on
   each change. The delay can be configured by adjusting the |g:ale_lint_delay|
@@ -1582,11 +1693,13 @@ g:ale_lint_on_text_changed                         *g:ale_lint_on_text_changed*
   You should set this setting once before ALE is loaded, and restart Vim if
   you want to change your preferences. See |ale-lint-settings-on-startup|.
 
-
-g:ale_lint_on_insert_leave                         *g:ale_lint_on_insert_leave*
+                                             *ale-options.lint_on_insert_leave*
+                                                   *g:ale_lint_on_insert_leave*
                                                    *b:ale_lint_on_insert_leave*
-  Type: |Number|
-  Default: `1`
+lint_on_insert_leave
+g:ale_lint_on_insert_leave
+  Type: |Boolean| or |Number|
+  Default: `true`
 
   When set to `1` in your vimrc file, this option will cause ALE to run
   linters when you leave insert mode.
@@ -1605,10 +1718,12 @@ g:ale_lint_on_insert_leave                         *g:ale_lint_on_insert_leave*
   You should set this setting once before ALE is loaded, and restart Vim if
   you want to change your preferences. See |ale-lint-settings-on-startup|.
 
-
-g:ale_linter_aliases                                     *g:ale_linter_aliases*
+                                                   *ale-options.linter_aliases*
+                                                         *g:ale_linter_aliases*
                                                          *b:ale_linter_aliases*
-  Type: |Dictionary|
+linter_aliases
+g:ale_linter_aliases
+  Type: |Dictionary| or |List| or |String|
   Default: `{}`
 
   The |g:ale_linter_aliases| option can be used to set aliases from one
@@ -1642,6 +1757,10 @@ g:ale_linter_aliases                                     *g:ale_linter_aliases*
 
   let g:ale_linter_aliases = {'foobar': 'php'}
 <
+  Or in Lua: >
+
+  require("ale").setup({linter_aliases = {foobar = "php"}})
+<
   When combined with the |g:ale_linters| option, the original filetype
   (`'foobar'`) will be used for determining which linters to run,
   not the aliased type (`'php'`). This allows an aliased type to run a
@@ -1649,10 +1768,14 @@ g:ale_linter_aliases                                     *g:ale_linter_aliases*
 
   Passing a list of filetypes is also supported. Say you want to lint
   javascript and css embedded in HTML (using linters that support that).
-  You could alias `html` like so:
+  You could alias `html` like so: >
 
   `let g:ale_linter_aliases = {'html': ['html', 'javascript', 'css']}`
+<
+  Or in Lua: >
 
+  require("ale").setup({linter_aliases = {html = {"html", "javascript", "css"}})
+<
   Note that `html` itself was included as an alias. That is because aliases
   will override the original linters for the aliased filetype.
 
@@ -1667,11 +1790,19 @@ g:ale_linter_aliases                                     *g:ale_linter_aliases*
   " OR, Alias a filetype to only a single filetype with a String.
   let b:ale_linter_aliases = 'javascript'
 <
+  Or in Lua: >
+
+  require("ale").setup.buffer({linter_aliases = {"html", "javascript", "css"}})
+  -- OR, Alias a filetype to only a single filetype with a String.
+  require("ale").setup.buffer({linter_aliases = "javascript"})
+<
   No linters will be loaded when the buffer's filetype is empty.
 
-
-g:ale_filename_mappings                               *g:ale_filename_mappings*
+                                                *ale-options.filename_mappings*
+                                                      *g:ale_filename_mappings*
                                                       *b:ale_filename_mappings*
+filename_mappings
+g:ale_filename_mappings
   Type: |Dictionary| or |List|
   Default: `{}`
 
@@ -1689,6 +1820,16 @@ g:ale_filename_mappings                               *g:ale_filename_mappings*
   \       ['/home/john/proj', '/data'],
   \   ],
   \}
+<
+  Or in Lua: >
+
+  require("ale").setup({
+      filename_mappings = {
+        pylint = {
+            {"/home/john/proj", "/data"},
+        },
+      },
+  })
 <
   With the above configuration, a filename such as `/home/john/proj/foo.py`
   will be provided to the linter/fixer as `/data/foo.py`, and paths parsed
@@ -1716,6 +1857,14 @@ g:ale_filename_mappings                               *g:ale_filename_mappings*
   let g:ale_filename_mappings = [
   \   ['/home/john/proj', '/data'],
   \]
+<
+  Or in Lua: >
+
+  require("ale").setup({
+      filename_mappings = {
+          {"/home/john/proj", "/data"},
+      },
+  })
 <
   You can provide many such filename paths for multiple projects. Paths are
   matched by checking if the start of a file path matches the given strings,
@@ -1751,10 +1900,12 @@ g:ale_filename_mappings                               *g:ale_filename_mappings*
   You can inspect the filename mappings ALE will use with the
   |ale#GetFilenameMappings()| function.
 
-
-g:ale_linters                                                   *g:ale_linters*
+                                                          *ale-options.linters*
+                                                                *g:ale_linters*
                                                                 *b:ale_linters*
-  Type: |Dictionary|
+linters
+g:ale_linters
+  Type: |Dictionary| or |List|
   Default: `{}`
 
   The |g:ale_linters| option sets a |Dictionary| mapping a filetype to a
@@ -1794,16 +1945,28 @@ g:ale_linters                                                   *g:ale_linters*
 
   let g:ale_linters = {'javascript': ['eslint']}
 <
+  Or in Lua: >
+
+  require("ale").setup({linters = {javascript = {"eslint"}}})
+<
   If you want to disable all linters for a particular filetype, you can pass
   an empty list of linters as the value: >
 
   let g:ale_linters = {'javascript': []}
+<
+  Or in Lua: >
+
+  require("ale").setup({linters = {javascript = {}}})
 <
   All linters will be run for unspecified filetypes. All available linters can
   be enabled explicitly for a given filetype by passing the string `'all'`,
   instead of a List. >
 
   let g:ale_linters = {'c': 'all'}
+<
+  Or in Lua: >
+
+  require("ale").setup({linters = {c = "all"}})
 <
   Linters can be configured in each buffer with buffer-local variables. ALE
   will first look for linters for filetypes in the `b:ale_linters` variable,
@@ -1823,22 +1986,34 @@ g:ale_linters                                                   *g:ale_linters*
   " Explicitly enable all available linters for the filetype.
   let b:ale_linters = 'all'
 <
+  In Lua: >
+
+  require("ale").setup.buffer({
+    linters = {javascript = {"eslint"}, html = {"tidy"}},
+  })
+  require("ale").setup.buffer({linters = {"eslint", "tidy"}})
+  require("ale").setup.buffer({linters = {}})
+  require("ale").setup.buffer({linters = "all"})
+<
   ALE can be configured to disable all linters unless otherwise specified with
   `g:ale_enabled` or `b:ale_enabled` with the option |g:ale_linters_explicit|.
 
+                                                 *ale-options.linters_explicit*
+                                                       *g:ale_linters_explicit*
+linters_explicit
+g:ale_linters_explicit
+  Type: |Boolean| or |Number|
+  Default: `false`
 
-g:ale_linters_explicit                                 *g:ale_linters_explicit*
+  When set to `true` or `1`, only the linters from |g:ale_linters| and
+  |b:ale_linters| will be enabled. The default behavior for ALE is to enable
+  as many linters as possible, unless otherwise specified.
 
-  Type: |Number|
-  Default: `0`
-
-  When set to `1`, only the linters from |g:ale_linters| and |b:ale_linters|
-  will be enabled. The default behavior for ALE is to enable as many linters
-  as possible, unless otherwise specified.
-
-
-g:ale_linters_ignore                                     *g:ale_linters_ignore*
+                                                   *ale-options.linters_ignore*
+                                                         *g:ale_linters_ignore*
                                                          *b:ale_linters_ignore*
+linters_ignore
+g:ale_linters_ignore
   Type: |Dictionary| or |List|
   Default: `{}`
 
@@ -1853,6 +2028,13 @@ g:ale_linters_ignore                                     *g:ale_linters_ignore*
   let g:ale_linters = {'python': ['flake8', 'pylint']}
   let g:ale_linters_ignore = {'python': ['pylint']}
 <
+  Or in Lua: >
+
+  require("ale").setup({
+    linters = {"python": {"flake8", "pylint"}},
+    linters_ignore = {"python": {"pylint"}},
+  })
+<
   This setting can be set to simply a |List| of linter names, which is
   especially more convenient when using the setting in ftplugin files for
   particular buffers. >
@@ -1861,30 +2043,42 @@ g:ale_linters_ignore                                     *g:ale_linters_ignore*
   let b:ale_linters = ['flake8', 'pylint']
   let b:ale_linters_ignore = ['pylint']
 <
+  Or in Lua: >
 
-g:ale_list_vertical                                       *g:ale_list_vertical*
+  require("ale").setup.buffer({
+    linters = {"flake8", "pylint"},
+    linters_ignore = {"pylint"},
+  })
+<
+                                                    *ale-options.list_vertical*
+                                                          *g:ale_list_vertical*
                                                           *b:ale_list_vertical*
-  Type: |Number|
-  Default: `0`
+list_vertical
+g:ale_list_vertical
+  Type: |Boolean| or |Number|
+  Default: `false`
 
-  When set to `1`, this will cause ALE to open any windows (loclist or
-  quickfix) vertically instead of horizontally (|vert| |lopen|) or (|vert|
+  When set to `true` or `1`, this will cause ALE to open any windows (loclist
+  or quickfix) vertically instead of horizontally (|vert| |lopen|) or (|vert|
   |copen|)
 
-
-g:ale_loclist_msg_format                             *g:ale_loclist_msg_format*
+                                               *ale-options.loclist_msg_format*
+                                                     *g:ale_loclist_msg_format*
                                                      *b:ale_loclist_msg_format*
+loclist_msg_format
+g:ale_loclist_msg_format
   Type: |String|
-  Default: `g:ale_echo_msg_format`
+  Default: `g:ale_echo_msg_format` (`echo_msg_format`)
 
   This option is the same as |g:ale_echo_msg_format|, but for formatting the
   message used for the loclist and the quickfix list.
 
   The strings for configuring `%severity%` are also used for this option.
 
-
-g:ale_lsp_show_message_format                   *g:ale_lsp_show_message_format*
-
+                                          *ale-options.lsp_show_message_format*
+                                                *g:ale_lsp_show_message_format*
+lsp_show_message_format
+g:ale_lsp_show_message_format
   Type: |String|
   Default: `'%severity%:%linter%: %s'`
 
@@ -1904,9 +2098,10 @@ g:ale_lsp_show_message_format                   *g:ale_lsp_show_message_format*
   Please note that |g:ale_lsp_show_message_format| *can not* be configured
   separately for each buffer like |g:ale_echo_msg_format| can.
 
-
-g:ale_lsp_show_message_severity               *g:ale_lsp_show_message_severity*
-
+                                        *ale-options.lsp_show_message_severity*
+                                              *g:ale_lsp_show_message_severity*
+lsp_show_message_severity
+g:ale_lsp_show_message_severity
   Type: |String|
   Default: `'error'`
 
@@ -1922,18 +2117,20 @@ g:ale_lsp_show_message_severity               *g:ale_lsp_show_message_severity*
   `'log'`         - Same as `'information'`
   `'disabled'`    - Doesn't display any information at all.
 
+                                                  *ale-options.lsp_suggestions*
+                                                        *g:ale_lsp_suggestions*
+lsp_suggestions
+g:ale_lsp_suggestions
+  Type: |Boolean| or |Number|
+  Default: `false`
 
-g:ale_lsp_suggestions                                   *g:ale_lsp_suggestions*
-
-  Type: |Number|
-  Default: `0`
-
-  If set to `1`, show hints/suggestions from LSP servers or tsserver, in
+  If set to `true` or ``1`, show suggestions from LSP servers or tsserver, in
   addition to warnings and errors.
 
-
-g:ale_max_buffer_history_size                   *g:ale_max_buffer_history_size*
-
+                                          *ale-options.max_buffer_history_size*
+                                                *g:ale_max_buffer_history_size*
+max_buffer_history_size
+g:ale_max_buffer_history_size
   Type: |Number|
   Default: `20`
 
@@ -1944,13 +2141,15 @@ g:ale_max_buffer_history_size                   *g:ale_max_buffer_history_size*
 
   History can be disabled completely with |g:ale_history_enabled|.
 
-
-g:ale_max_signs                                               *g:ale_max_signs*
+                                                        *ale-options.max_signs*
+                                                              *g:ale_max_signs*
                                                               *b:ale_max_signs*
+max_signs
+g:ale_max_signs
   Type: |Number|
   Default: `-1`
 
-  This setting has no effect when |g:ale_use_neovim_diagnostics_api| is `1`.
+  This has no effect when |g:ale_use_neovim_diagnostics_api| is `true` or `1`.
 
   When set to any positive integer, ALE will not render any more than the
   given number of signs for any one buffer.
@@ -1963,26 +2162,30 @@ g:ale_max_signs                                               *g:ale_max_signs*
 
   For disabling sign processing, see |g:ale_set_signs|.
 
-
-g:ale_maximum_file_size                               *g:ale_maximum_file_size*
+                                                *ale-options.maximum_file_size*
+                                                      *g:ale_maximum_file_size*
                                                       *b:ale_maximum_file_size*
+maximum_file_size
+g:ale_maximum_file_size
   Type: |Number|
-  Default: not set
+  Default: `nil`
 
   A maximum file size in bytes for ALE to check. If set to any positive
   number, ALE will skip checking files larger than the given size.
 
-
-g:ale_open_list                                               *g:ale_open_list*
+                                                        *ale-options.open_list*
+                                                              *g:ale_open_list*
                                                               *b:ale_open_list*
-  Type: |Number| or |String|
-  Default: `0`
+open_list
+g:ale_open_list
+  Type: |Boolean| |Number| or |String|
+  Default: `false`
 
-  When set to `1`, this will cause ALE to automatically open a window for the
-  loclist (|lopen|) or for the quickfix list instead if |g:ale_set_quickfix|
-  is `1`. (|copen|)
+  When set to `true` or `1`, this will cause ALE to automatically open a
+  window for the loclist (|lopen|) or for the quickfix list instead if
+  |g:ale_set_quickfix| is `true` or `1`. (|copen|)
 
-  When set to any higher numberical value, ALE will only open the window when
+  When set to any higher numerical value, ALE will only open the window when
   the number of warnings or errors are at least that many.
 
   When set to `'on_save'`, ALE will only open the loclist after buffers have
@@ -1991,8 +2194,8 @@ g:ale_open_list                                               *g:ale_open_list*
 
   The window will be kept open until all warnings or errors are cleared,
   including those not set by ALE, unless |g:ale_keep_list_window_open| is set
-  to `1`, in which case the window will be kept open when no problems are
-  found.
+  to `true` or `1`, in which case the window will be kept open when no
+  problems are found.
 
   The window size can be configured with |g:ale_list_window_size|.
 
@@ -2005,12 +2208,16 @@ g:ale_open_list                                               *g:ale_open_list*
     autocmd!
     autocmd QuitPre * if empty(&buftype) | lclose | endif
   augroup END
-
 <
-g:ale_pattern_options                                   *g:ale_pattern_options*
-
+                                                        *g:ale_pattern_options*
+g:ale_pattern_options
   Type: |Dictionary|
-  Default: not set
+  Default: `nil`
+
+  NOTE: This option is not available through |ale.setup| in Lua as the options
+  named here would require separate translation to the equivalent Vim options.
+  You should instead use conditions in ftplugin files to configure options
+  based on filename patterns.
 
   This option maps regular expression patterns to |Dictionary| values for
   buffer variables. This option can be set to automatically configure
@@ -2035,53 +2242,57 @@ g:ale_pattern_options                                   *g:ale_pattern_options*
   pattern keys sorted in alphabetical order. Options for `'zebra'` will
   override the options for `'alpha'` for a filename `alpha-zebra`.
 
-
-g:ale_pattern_options_enabled                   *g:ale_pattern_options_enabled*
-
-  Type: |Number|
-  Default: not set
+                                          *ale-options.pattern_options_enabled*
+                                                *g:ale_pattern_options_enabled*
+pattern_options_enabled
+g:ale_pattern_options_enabled
+  Type: |Boolean| or |Number|
+  Default: `nil`
 
   This option can be used for disabling pattern options. If set to `0`, ALE
   will not set buffer variables per |g:ale_pattern_options|.
 
-
-g:ale_popup_menu_enabled                             *g:ale_popup_menu_enabled*
-
-  Type: |Number|
+                                               *ale-options.popup_menu_enabled*
+                                                     *g:ale_popup_menu_enabled*
+popup_menu_enabled
+g:ale_popup_menu_enabled
+  Type: |Boolean| or |Number|
   Default: `has('gui_running')`
 
-  When this option is set to `1`, ALE will show code actions and rename
-  capabilities in the right click mouse menu when there's a LSP server or
-  tsserver available. See |ale-refactor|.
+  When this option is set to `true` or `1`, ALE will show code actions and
+  rename capabilities in the right click mouse menu when there's a LSP server
+  or tsserver available. See |ale-refactor|.
 
   This feature is only supported in GUI versions of Vim.
 
-  This setting must be set to `1` before ALE is loaded for this behavior
-  to be enabled. See |ale-lint-settings-on-startup|.
+  This setting must be set to `true` or `1` before ALE is loaded for this
+  behavior to be enabled. See |ale-lint-settings-on-startup|.
 
+                                 *ale-options.rename_tsserver_find_in_comments*
+                                       *g:ale_rename_tsserver_find_in_comments*
+rename_tsserver_find_in_comments
+g:ale_rename_tsserver_find_in_comments
+  Type: |Boolean| or |Number|
+  Default: `false`
 
-g:ale_rename_tsserver_find_in_comments *g:ale_rename_tsserver_find_in_comments*
+  If set to `true` or `1`, this option will tell tsserver to find and replace
+  text in comments when calling `:ALERename`.
 
-  Type: |Number|
-  Default: `0`
+                                  *ale-options.rename_tsserver_find_in_strings*
+                                        *g:ale_rename_tsserver_find_in_strings*
+rename_tsserver_find_in_strings
+g:ale_rename_tsserver_find_in_strings
+  Type: |Boolean| or |Number|
+  Default: `false`
 
-  If enabled, this option will tell tsserver to find and replace text in
-  comments when calling `:ALERename`. It can be enabled by settings the value
-  to `1`.
+  If set to `true` or `1`, this option will tell tsserver to find and replace
+  text in strings when calling `:ALERename`.
 
-
-g:ale_rename_tsserver_find_in_strings   *g:ale_rename_tsserver_find_in_strings*
-
-  Type: |Number|
-  Default: `0`
-
-  If enabled, this option will tell tsserver to find and replace text in
-  strings when calling `:ALERename`. It can be enabled by settings the value to
-  `1`.
-
-
-g:ale_root                                                         *g:ale_root*
+                                                             *ale-options.root*
+                                                                   *g:ale_root*
                                                                    *b:ale_root*
+root
+g:ale_root
   Type: |Dictionary| or |String|
   Default: `{}`
 
@@ -2097,24 +2308,27 @@ g:ale_root                                                         *g:ale_root*
   detect a project root. If this, too, yields no result, and the linter is an
   LSP linter, it will not run.
 
+                                                      *ale-options.save_hidden*
+                                                            *g:ale_save_hidden*
+save_hidden
+g:ale_save_hidden
+  Type: |Boolean| or |Number|
+  Default: `false`
 
-g:ale_save_hidden                                           *g:ale_save_hidden*
-
-  Type: |Number|
-  Default: `0`
-
-  When set to `1`, save buffers when 'hidden' is set when applying code
-  actions or rename operations, such as through `:ALERename` or
+  When set to `true` or `1`, save buffers when 'hidden' is set when applying
+  code actions or rename operations, such as through `:ALERename` or
   `:ALEOrganizeImports`.
 
-
-g:ale_set_balloons                                         *g:ale_set_balloons*
+                                                     *ale-options.set_balloons*
+                                                           *g:ale_set_balloons*
                                                            *b:ale_set_balloons*
-  Type: |Number| or |String|
+set_balloons
+g:ale_set_balloons
+  Type: |Boolean| or |Number| or |String|
   Default: `has('balloon_eval') && has('gui_running')`
 
-  When this option is set to `1`, balloon messages will be displayed for
-  problems or hover information if available.
+  When this option is set to `true` or `1`, balloon messages will be displayed
+  for problems or hover information if available.
 
   Problems nearest to the line the mouse cursor is over will be displayed. If
   there are no problems to show, and one of the linters is an LSP linter
@@ -2137,35 +2351,40 @@ g:ale_set_balloons                                         *g:ale_set_balloons*
   Balloons cannot be enabled for a specific buffer when not initially enabled
   globally.
 
-  Balloons will not be shown when |g:ale_enabled| or |b:ale_enabled| is `0`.
+  Balloons will not be shown when |g:ale_enabled| or |b:ale_enabled| is not
+  `true` or `1`.
 
-
-g:ale_set_balloons_legacy_echo                 *g:ale_set_balloons_legacy_echo*
+                                         *ale-options.set_balloons_legacy_echo*
+                                               *g:ale_set_balloons_legacy_echo*
                                                *b:ale_set_balloons_legacy_echo*
-  Type: |Number|
-  Default: not set
+set_balloons_legacy_echo
+g:ale_set_balloons_legacy_echo
+  Type: |Boolean| or |Number|
+  Default: `nil`
 
-  If set to `1`, moving your mouse over documents in Vim will make ALE ask
-  `tsserver` or `LSP` servers for information about the symbol where the mouse
-  cursor is, and print that information into Vim's echo line. This is an
-  option for supporting older versions of Vim which do not properly support
-  balloons in an asynchronous manner.
+  If set to `true` or `1`, moving your mouse over documents in Vim will make
+  ALE ask `tsserver` or `LSP` servers for information about the symbol where
+  the mouse cursor is, and print that information into Vim's echo line. This
+  is an option for supporting older versions of Vim which do not properly
+  support balloons in an asynchronous manner.
 
   If your version of Vim supports the |balloon_show| function, then this
   option does nothing meaningful.
 
-
-g:ale_set_highlights                                     *g:ale_set_highlights*
-
-  Type: |Number|
+                                                   *ale-options.set_highlights*
+                                                         *g:ale_set_highlights*
+set_highlights
+g:ale_set_highlights
+  Type: |Boolean| or |Number|
   Default: `has('syntax')`
 
-  This setting has no effect when |g:ale_use_neovim_diagnostics_api| is `1`.
-  In addition, ALE's highlight groups will not be used when setting
-  highlights through Neovim's diagnostics API. See |diagnostic-highlights| for
-  how to configure Neovim diagnostic highlighting.
+  This has no effect when |g:ale_use_neovim_diagnostics_api| is `true` or `1`.
 
-  When this option is set to `1`, highlights will be set for problems.
+  ALE's highlight groups will not be used when setting highlights through
+  Neovim's diagnostics API. See |diagnostic-highlights| for how to configure
+  Neovim diagnostic highlighting.
+
+  When this option is set to `true` or `1`, highlights will be presented.
 
   ALE will use the following highlight groups for problems:
 
@@ -2177,8 +2396,8 @@ g:ale_set_highlights                                     *g:ale_set_highlights*
   ALEStyleWarning  items with `'type': 'W'` and
                               `'sub_type': 'style'`    |hl-ALEStyleWarning|
 
-  When |g:ale_set_signs| is set to `0`, the following highlights for entire
-  lines will be set.
+  When |g:ale_set_signs| is not set to `true` or `1`, the following highlights
+  for entire lines will be set.
 
   ALEErrorLine     all items with `'type': 'E'`        |hl-ALEErrorLine|
   ALEWarningLine   all items with `'type': 'W'`        |hl-ALEWarningLine|
@@ -2190,25 +2409,29 @@ g:ale_set_highlights                                     *g:ale_set_highlights*
 
   Highlights can be excluded with the |g:ale_exclude_highlights| option.
 
+                                                      *ale-options.set_loclist*
+                                                            *g:ale_set_loclist*
+set_loclist
+g:ale_set_loclist
+  Type: |Boolean| or |Number|
+  Default: `true`
 
-g:ale_set_loclist                                           *g:ale_set_loclist*
+  When this option is set to `true` or `1`, the |location-list| will be
+  populated with any warnings and errors which are found by ALE. This feature
+  can be used to implement jumping between errors through typical use of
+  `:lnext` and `:lprev`.
 
-  Type: |Number|
-  Default: `1`
+                                                     *ale-options.set_quickfix*
+                                                           *g:ale_set_quickfix*
+set_quickfix
+g:ale_set_quickfix
+  Type: |Boolean| or |Number|
+  Default: `false`
 
-  When this option is set to `1`, the |location-list| will be populated with
-  any warnings and errors which are found by ALE. This feature can be used to
-  implement jumping between errors through typical use of `:lnext` and `:lprev`.
-
-
-g:ale_set_quickfix                                         *g:ale_set_quickfix*
-
-  Type: |Number|
-  Default: `0`
-
-  When this option is set to `1`, the |quickfix| list will be populated with
-  any problems which are found by ALE, instead of the |location-list|. The
-  loclist will never be populated when this option is on.
+  When this option is set to `true` or `1`, the |quickfix| list will be
+  populated with any problems which are found by ALE, instead of the
+  |location-list|. The loclist will never be populated when this option is
+  enabled.
 
   Problems from every buffer ALE has checked will be included in the quickfix
   list, which can be checked with `:copen`. Problems will be de-duplicated.
@@ -2218,14 +2441,15 @@ g:ale_set_quickfix                                         *g:ale_set_quickfix*
   pretty frequently. If you wish to use such tools, you should populate the
   loclist or use `:ALEPopulateQuickfix` instead.
 
-
-g:ale_set_signs                                               *g:ale_set_signs*
-
-  Type: |Number|
+                                                        *ale-options.set_signs*
+                                                              *g:ale_set_signs*
+set_signs
+g:ale_set_signs
+  Type: |Boolean| or |Number|
   Default: `has('signs')`
 
-  When this option is set to `1`, the |sign| column will be populated with
-  signs marking where problems appear in the file.
+  When this option is set to `true` or `1`, the |sign| column will be
+  populated with signs marking where problems appear in the file.
 
   When |g:ale_use_neovim_diagnostics_api| is `1`, the only other setting that
   will be respected for signs is |g:ale_sign_priority|. ALE's highlight groups
@@ -2262,7 +2486,7 @@ g:ale_set_signs                                               *g:ale_set_signs*
                              `'sub_type': 'style'`   |hl-ALEStyleWarningSignLineNr|
 
   To enable line number highlighting |g:ale_sign_highlight_linenrs| must be
-  set to `1` before ALE is loaded.
+  set to `true` or `1` before ALE is loaded.
 
   The markers for the highlights can be customized with the following options:
 
@@ -2277,9 +2501,10 @@ g:ale_set_signs                                               *g:ale_set_signs*
 
   To limit the number of signs ALE will set, see |g:ale_max_signs|.
 
-
-g:ale_sign_priority                                       *g:ale_sign_priority*
-
+                                                    *ale-options.sign_priority*
+                                                          *g:ale_sign_priority*
+sign_priority
+g:ale_sign_priority
   Type: |Number|
   Default: `30`
 
@@ -2287,11 +2512,13 @@ g:ale_sign_priority                                       *g:ale_sign_priority*
   larger this value is, the higher priority ALE signs have over other plugin
   signs. See |sign-priority| for further details on how priority works.
 
-
-g:ale_shell                                                       *g:ale_shell*
+                                                            *ale-options.shell*
+                                                                  *g:ale_shell*
                                                                   *b:ale_shell*
+shell
+g:ale_shell
   Type: |String|
-  Default: not set
+  Default: `nil`
 
   Override the shell used by ALE for executing commands. ALE uses 'shell' by
   default, but falls back in `/bin/sh` if the default shell looks like `fish`
@@ -2304,76 +2531,84 @@ g:ale_shell                                                       *g:ale_shell*
 
   NOTE: Consider setting |g:ale_shell_arguments| if this option is defined.
 
-
-g:ale_shell_arguments                                   *g:ale_shell_arguments*
+                                                  *ale-options.shell_arguments*
+                                                        *g:ale_shell_arguments*
                                                         *b:ale_shell_arguments*
+shell_arguments
+g:ale_shell_arguments
   Type: |String|
-  Default: not set
+  Default: `nil`
 
   This option specifies the arguments to use for executing a command with a
   custom shell, per |g:ale_shell|. If this option is not set, 'shellcmdflag'
   will be used instead.
 
+                                               *ale-options.sign_column_always*
+                                                     *g:ale_sign_column_always*
+sign_column_always
+g:ale_sign_column_always
+  Type: |Boolean| or |Number|
+  Default: `v:false`
 
-g:ale_sign_column_always                             *g:ale_sign_column_always*
-
-  Type: |Number|
-  Default: `0`
-
-  This setting has no effect when |g:ale_use_neovim_diagnostics_api| is `1`.
+  This has no effect when |g:ale_use_neovim_diagnostics_api| is `true` or `1`.
 
   By default, the sign gutter will disappear when all warnings and errors have
   been fixed for a file. When this option is set to `1`, the sign column will
   remain open. This can be preferable if you don't want the text in your file
   to move around as you edit a file.
 
-
-g:ale_sign_error                                             *g:ale_sign_error*
-
+                                                       *ale-options.sign_error*
+                                                             *g:ale_sign_error*
+sign_error
+g:ale_sign_error
   Type: |String|
   Default: `'E'`
 
-  This setting has no effect when |g:ale_use_neovim_diagnostics_api| is `1`.
+  This has no effect when |g:ale_use_neovim_diagnostics_api| is `true` or `1`.
 
   The sign for errors in the sign gutter.
 
-
-g:ale_sign_info                                               *g:ale_sign_info*
-
+                                                        *ale-options.sign_info*
+                                                              *g:ale_sign_info*
+sign_info
+g:ale_sign_info
   Type: |String|
   Default: `'I'`
 
-  This setting has no effect when |g:ale_use_neovim_diagnostics_api| is `1`.
+  This has no effect when |g:ale_use_neovim_diagnostics_api| is `true` or `1`.
 
   The sign for "info" markers in the sign gutter.
 
-
-g:ale_sign_style_error                                 *g:ale_sign_style_error*
-
+                                                 *ale-options.sign_style_error*
+                                                       *g:ale_sign_style_error*
+sign_style_error
+g:ale_sign_style_error
   Type: |String|
   Default: `g:ale_sign_error`
 
-  This setting has no effect when |g:ale_use_neovim_diagnostics_api| is `1`.
+  This has no effect when |g:ale_use_neovim_diagnostics_api| is `true` or `1`.
 
   The sign for style errors in the sign gutter.
 
-
-g:ale_sign_style_warning                             *g:ale_sign_style_warning*
-
+                                               *ale-options.sign_style_warning*
+                                                     *g:ale_sign_style_warning*
+sign_style_warning
+g:ale_sign_style_warning
   Type: |String|
   Default: `g:ale_sign_warning`
 
-  This setting has no effect when |g:ale_use_neovim_diagnostics_api| is `1`.
+  This has no effect when |g:ale_use_neovim_diagnostics_api| is `true` or `1`.
 
   The sign for style warnings in the sign gutter.
 
-
-g:ale_sign_offset                                           *g:ale_sign_offset*
-
+                                                      *ale-options.sign_offset*
+                                                            *g:ale_sign_offset*
+sign_offset
+g:ale_sign_offset
   Type: |Number|
   Default: `1000000`
 
-  This setting has no effect when |g:ale_use_neovim_diagnostics_api| is `1`.
+  This has no effect when |g:ale_use_neovim_diagnostics_api| is `true` or `1`.
 
   This variable controls offset from which numeric IDs will be generated for
   new signs. Signs cannot share the same ID values, so when two Vim plugins
@@ -2383,39 +2618,46 @@ g:ale_sign_offset                                           *g:ale_sign_offset*
   plugins will work together. See |sign-place| for more information on how
   signs are set.
 
-
-g:ale_sign_warning                                         *g:ale_sign_warning*
-
+                                                     *ale-options.sign_warning*
+                                                           *g:ale_sign_warning*
+sign_warning
+g:ale_sign_warning
   Type: |String|
   Default: `'W'`
 
-  This setting has no effect when |g:ale_use_neovim_diagnostics_api| is `1`.
+  This has no effect when |g:ale_use_neovim_diagnostics_api| is `true` or `1`.
 
   The sign for warnings in the sign gutter.
 
+                                           *ale-options.sign_highlight_linenrs*
+                                                 *g:ale_sign_highlight_linenrs*
+sign_highlight_linenrs
+g:ale_sign_highlight_linenrs
+  Type: |Boolean| or |Number|
+  Default: `false`
 
-g:ale_sign_highlight_linenrs                     *g:ale_sign_highlight_linenrs*
+  This has no effect when |g:ale_use_neovim_diagnostics_api| is `true` or `1`.
 
-  Type: |Number|
-  Default: `0`
+  When set to `true` or `1`, this option enables highlighting problems on the
+  'number' column in Vim versions that support `numhl` highlights. This option
+  must be configured before ALE is loaded.
 
-  This setting has no effect when |g:ale_use_neovim_diagnostics_api| is `1`.
-
-  When set to `1`, this option enables highlighting problems on the 'number'
-  column in Vim versions that support `numhl` highlights. This option must be
-  configured before ALE is loaded.
-
-
-g:ale_update_tagstack                                   *g:ale_update_tagstack*
+                                                  *ale-options.update_tagstack*
+                                                        *g:ale_update_tagstack*
                                                         *b:ale_update_tagstack*
-  Type: |Number|
-  Default: `1`
+update_tagstack
+g:ale_update_tagstack
+  Type: |Boolean| or |Number|
+  Default: `v:true`
 
-  This option can be set to disable updating Vim's |tagstack| automatically.
-
-
-g:ale_type_map                                                 *g:ale_type_map*
+  When set to `true` or `1`, ALE will update Vims |tagstack| automatically
+  when jumping to a location through ALE's commands, so users can jump back to
+  where they came from.
+                                                         *ale-options.type_map*
+                                                               *g:ale_type_map*
                                                                *b:ale_type_map*
+type_map
+g:ale_type_map
   Type: |Dictionary|
   Default: `{}`
 
@@ -2435,18 +2677,28 @@ g:ale_type_map                                                 *g:ale_type_map*
 
   let g:ale_type_map = {'flake8': {'ES': 'WS', 'E': 'W'}}
 <
+  Or in Lua: >
+
+  require("ale").setup(type_map = {flake8 = {ES = "WS", E = "W"}})
+<
   If you wanted to turn style errors and warnings into regular errors and
   warnings, you can write the following: >
 
   let g:ale_type_map = {'flake8': {'ES': 'E', 'WS': 'W'}}
 <
-  Type maps can be set per-buffer with `b:ale_type_map`.
+  Or in Lua: >
 
+  require("ale").setup(type_map = {flake8 = {ES = "E", WS = "W"}})
+<
+  Type maps can be set per-buffer with `b:ale_type_map`, or in Lua with
+  |ale.setup.buffer|.
 
-g:ale_use_global_executables                     *g:ale_use_global_executables*
-
+                                           *ale-options.use_global_executables*
+                                                 *g:ale_use_global_executables*
+use_global_executables
+g:ale_use_global_executables
   Type: |Number|
-  Default: not set
+  Default: `nil`
 
   This option can be set to change the default for all `_use_global` options.
   This option must be set before ALE is loaded, preferably in a vimrc file.
@@ -2454,30 +2706,30 @@ g:ale_use_global_executables                     *g:ale_use_global_executables*
   See |ale-integrations-local-executables| for more information on those
   options.
 
-
-g:ale_use_neovim_diagnostics_api             *g:ale_use_neovim_diagnostics_api*
-
-  Type: |Number|
+                                       *ale-options.use_neovim_diagnostics_api*
+                                             *g:ale_use_neovim_diagnostics_api*
+use_neovim_diagnostics_api
+g:ale_use_neovim_diagnostics_api
+  Type: |Boolean| or |Number|
   Default: `has('nvim-0.7')`
 
-  If enabled, this option will disable ALE's standard UI, and instead send
-  all linter output to Neovim's diagnostics API. This allows you to collect
-  errors from nvim-lsp, ALE, and anything else that uses diagnostics all in
-  one place. Many options for configuring how problems appear on the screen
-  will not apply when the API is enabled.
-
-  To enable this option, set the value to `1`.
+  If set to `true` or `1`, disable ALE's standard UI, and instead send all
+  linter output to Neovim's diagnostics API. This allows you to collect
+  problems using ALE and other plugins together all in one place. Many
+  options for configuring how problems appear on the screen will not apply
+  when the API is enabled.
 
   This option requires Neovim 0.7+, as that version introduces the diagnostics
   API.
 
-
-g:ale_use_neovim_lsp_api                             *g:ale_use_neovim_lsp_api*
-
-  Type: |Number|
+                                               *ale-options.use_neovim_lsp_api*
+                                                     *g:ale_use_neovim_lsp_api*
+use_neovim_lsp_api
+g:ale_use_neovim_lsp_api
+  Type: |Boolean| or |Number|
   Default: `has('nvim-0.8')`
 
-  If enabled, ALE will use Neovim's native LSP client API for LSP
+  If set to `true` or `1`, ALE will use Neovim's native LSP client API for LSP
   functionality. This makes it possible to use Neovim's built in LSP commands
   and keybinds, and improves integration with other Neovim plugins that
   integrate with Neovim's LSP client.
@@ -2487,10 +2739,11 @@ g:ale_use_neovim_lsp_api                             *g:ale_use_neovim_lsp_api*
 
   This option requires Neovim 0.8+.
 
-
-g:ale_virtualtext_cursor                             *g:ale_virtualtext_cursor*
-
-  Type: |Number|
+                                               *ale-options.virtualtext_cursor*
+                                                     *g:ale_virtualtext_cursor*
+virtualtext_cursor
+g:ale_virtualtext_cursor
+  Type: |Number| or |String|
   Default: `'all'` (if supported, otherwise `'disabled'`)
 
   This option controls how ALE will display problems using |virtual-text|.
@@ -2520,13 +2773,15 @@ g:ale_virtualtext_cursor                             *g:ale_virtualtext_cursor*
   ALEVirtualTextStyleWarning items with `'type': 'W'` and
                              `'sub_type': 'style'`     |hl-ALEVirtualTextStyleWarning|
 
-
-g:ale_virtualtext_delay                               *g:ale_virtualtext_delay*
+                                                *ale-options.virtualtext_delay*
+                                                      *g:ale_virtualtext_delay*
                                                       *b:ale_virtualtext_delay*
+virtualtext_delay
+g:ale_virtualtext_delay
   Type: |Number|
   Default: `10`
 
-  This setting has no effect when |g:ale_use_neovim_diagnostics_api| is `1`.
+  This has no effect when |g:ale_use_neovim_diagnostics_api| is `true` or `1`.
 
   Given any integer, this option controls the number of milliseconds before
   ALE will show a message for a problem near the cursor.
@@ -2534,13 +2789,15 @@ g:ale_virtualtext_delay                               *g:ale_virtualtext_delay*
   The value can be increased to decrease the amount of processing ALE will do
   for files displaying a large number of problems.
 
-
-g:ale_virtualtext_prefix                             *g:ale_virtualtext_prefix*
+                                               *ale-options.virtualtext_prefix*
+                                                     *g:ale_virtualtext_prefix*
                                                      *b:ale_virtualtext_prefix*
+virtualtext_prefix
+g:ale_virtualtext_prefix
   Type: |String|
   Default: `'%comment% %type%: '`
 
-  This setting has no effect when |g:ale_use_neovim_diagnostics_api| is `1`.
+  This has no effect when |g:ale_use_neovim_diagnostics_api| is `true` or `1`.
 
   Prefix to be used with |g:ale_virtualtext_cursor|.
 
@@ -2555,15 +2812,20 @@ g:ale_virtualtext_prefix                             *g:ale_virtualtext_prefix*
   part before `%s`, with whitespace trimmed. If comment syntax cannot be
   pulled from 'commentstring', ALE will default to `'#'`.
 
-
-g:ale_virtualtext_column                             *g:ale_virtualtext_column*
+                                               *ale-options.virtualtext_column*
+                                                     *g:ale_virtualtext_column*
                                                      *b:ale_virtualtext_column*
-g:ale_virtualtext_maxcolumn                       *g:ale_virtualtext_maxcolumn*
+                                            *ale-options.virtualtext_maxcolumn*
+                                                  *g:ale_virtualtext_maxcolumn*
                                                   *b:ale_virtualtext_maxcolumn*
+virtualtext_column
+virtualtext_maxcolumn
+g:ale_virtualtext_column
+g:ale_virtualtext_maxcolumn
   Type: |String| or |Number|
   Default: `0`
 
-  This setting has no effect when |g:ale_use_neovim_diagnostics_api| is `1`.
+  This has no effect when |g:ale_use_neovim_diagnostics_api| is `true` or `1`.
 
   Virtualtext column range, from `column` to `maxcolumn`.  If a line is
   `column` or less characters long, the virtualtext message is shifted right
@@ -2580,13 +2842,15 @@ g:ale_virtualtext_maxcolumn                       *g:ale_virtualtext_maxcolumn*
   When `column` is set to zero, column positioning is disabled, when `maxcolumn`
   is set to zero, no maximum line length is enforced.
 
-
-g:ale_virtualtext_single                             *g:ale_virtualtext_single*
+                                               *ale-options.virtualtext_single*
+                                                     *g:ale_virtualtext_single*
                                                      *b:ale_virtualtext_single*
-  Type: |Number|
-  Default: `1`
+virtualtext_single
+g:ale_virtualtext_single
+  Type: |Boolean| or |Number|
+  Default: `true`
 
-  This setting has no effect when |g:ale_use_neovim_diagnostics_api| is `1`.
+  This has no effect when |g:ale_use_neovim_diagnostics_api| is `true` or `1`.
 
   Enable or disable concatenation of multiple virtual text messages on a single
   line. By default, if a line has multiple errors or warnings, each will be
@@ -2597,9 +2861,11 @@ g:ale_virtualtext_single                             *g:ale_virtualtext_single*
   printed. If two problems exist on a line of equal severity, the problem at
   the left-most position will be printed.
 
-
-g:ale_virtualenv_dir_names                         *g:ale_virtualenv_dir_names*
+                                             *ale-options.virtualenv_dir_names*
+                                                   *g:ale_virtualenv_dir_names*
                                                    *b:ale_virtualenv_dir_names*
+virtualenv_dir_names
+g:ale_virtualenv_dir_names
   Type: |List|
   Default: `['.venv', 'env', 've', 'venv', 'virtualenv', '.env']`
 
@@ -2610,9 +2876,11 @@ g:ale_virtualenv_dir_names                         *g:ale_virtualenv_dir_names*
   (`foo\Scripts\activate\` on Windows) in all directories on and above the
   directory containing the Python file to find virtualenv paths.
 
-
-g:ale_warn_about_trailing_blank_lines   *g:ale_warn_about_trailing_blank_lines*
+                                  *ale-options.warn_about_trailing_blank_lines*
+                                        *g:ale_warn_about_trailing_blank_lines*
                                         *b:ale_warn_about_trailing_blank_lines*
+warn_about_trailing_blank_lines
+g:ale_warn_about_trailing_blank_lines
   Type: |Number|
   Default: `1`
 
@@ -2621,9 +2889,11 @@ g:ale_warn_about_trailing_blank_lines   *g:ale_warn_about_trailing_blank_lines*
 
   This option behaves similarly to |g:ale_warn_about_trailing_whitespace|.
 
-
-g:ale_warn_about_trailing_whitespace     *g:ale_warn_about_trailing_whitespace*
+                                   *ale-options.warn_about_trailing_whitespace*
+                                         *g:ale_warn_about_trailing_whitespace*
                                          *b:ale_warn_about_trailing_whitespace*
+warn_about_trailing_whitespace
+g:ale_warn_about_trailing_whitespace
   Type: |Number|
   Default: `1`
 
@@ -2637,9 +2907,11 @@ g:ale_warn_about_trailing_whitespace     *g:ale_warn_about_trailing_whitespace*
 
   This option may be configured on a per buffer basis.
 
-
-g:ale_windows_node_executable_path         *g:ale_windows_node_executable_path*
+                                     *ale-options.windows_node_executable_path*
+                                           *g:ale_windows_node_executable_path*
                                            *b:ale_windows_node_executable_path*
+windows_node_executable_path
+g:ale_windows_node_executable_path
   Type: |String|
   Default: `'node.exe'`
 
@@ -2863,8 +3135,8 @@ If you prefer to use global executables for those tools, set the relevant
   let g:ale_python_flake8_executable = '/foo/bar/flake8'
   let g:ale_python_flake8_use_global = 1
 <
-|g:ale_use_global_executables| can be set to `1` in your vimrc file to make
-ALE use global executables for all linters by default.
+|g:ale_use_global_executables| can be set to `true` or  `1` in your init or
+vimrc file to make ALE use global executables for all linters by default.
 
 The option |g:ale_virtualenv_dir_names| controls the local virtualenv paths
 ALE will use to search for Python executables.
@@ -2876,16 +3148,21 @@ ALE will use to search for Python executables.
 The options for `alex` are shared between all filetypes, so options can be
 configured once.
 
-g:ale_alex_executable                                   *g:ale_alex_executable*
+                                                  *ale-options.alex_executable*
+                                                        *g:ale_alex_executable*
                                                         *b:ale_alex_executable*
+alex_executable
+g:ale_alex_executable
   Type: |String|
   Default: `'alex'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_alex_use_global                                   *g:ale_alex_use_global*
+                                                  *ale-options.alex_use_global*
+                                                        *g:ale_alex_use_global*
                                                         *b:ale_alex_use_global*
+alex_use_global
+g:ale_alex_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
@@ -2898,24 +3175,31 @@ g:ale_alex_use_global                                   *g:ale_alex_use_global*
 The options for `cspell` are shared between all filetypes, so options can be
 configured only once.
 
-g:ale_cspell_executable                               *g:ale_cspell_executable*
+                                                *ale-options.cspell_executable*
+                                                      *g:ale_cspell_executable*
                                                       *b:ale_cspell_executable*
+cspell_executable
+g:ale_cspell_executable
   Type: |String|
   Default: `'cspell'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_cspell_options                                     *g:ale_cspell_options*
+                                                   *ale-options.cspell_options*
+                                                         *g:ale_cspell_options*
                                                          *b:ale_cspell_options*
+cspell_options
+g:ale_cspell_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass additional options to `cspell`.
 
-
-g:ale_cspell_use_global                               *g:ale_cspell_use_global*
+                                                *ale-options.cspell_use_global*
+                                                      *g:ale_cspell_use_global*
                                                       *b:ale_cspell_use_global*
+cspell_use_global
+g:ale_cspell_use_global
   Type: |Number|
   Default: `get(g: 'ale_use_global_executables', 0)`
 
@@ -2929,16 +3213,21 @@ g:ale_cspell_use_global                               *g:ale_cspell_use_global*
 json(c?), markdown, and more. See https://dprint.dev/plugins for an up-to-date
 list of supported plugins and their configuration options.
 
-g:ale_dprint_executable                               *g:ale_dprint_executable*
+                                                *ale-options.dprint_executable*
+                                                      *g:ale_dprint_executable*
                                                       *b:ale_dprint_executable*
+dprint_executable
+g:ale_dprint_executable
   Type: |String|
   Default: `'dprint'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_dprint_config                                       *g:ale_dprint_config*
+                                                    *ale-options.dprint_config*
+                                                          *g:ale_dprint_config*
                                                           *b:ale_dprint_config*
+dprint_config
+g:ale_dprint_config
   Type: |String|
   Default: `'dprint.json'`
 
@@ -2948,17 +3237,21 @@ g:ale_dprint_config                                       *g:ale_dprint_config*
 
   See https://dprint.dev/config and https://plugins.dprint.dev
 
-
-g:ale_dprint_options                                     *g:ale_dprint_options*
+                                                   *ale-options.dprint_options*
+                                                         *g:ale_dprint_options*
                                                          *b:ale_dprint_options*
+dprint_options
+g:ale_dprint_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass additional options to `dprint`.
 
-
-g:ale_dprint_use_global                               *g:ale_dprint_use_global*
+                                                *ale-options.dprint_use_global*
+                                                      *g:ale_dprint_use_global*
                                                       *b:ale_dprint_use_global*
+dprint_use_global
+g:ale_dprint_use_global
   Type: |Number|
   Default: `get(g: 'ale_use_global_executables', 0)`
 
@@ -2968,17 +3261,21 @@ g:ale_dprint_use_global                               *g:ale_dprint_use_global*
 -------------------------------------------------------------------------------
 7.4. Options for languagetool                        *ale-languagetool-options*
 
-g:ale_languagetool_executable                   *g:ale_languagetool_executable*
+                                          *ale-options.languagetool_executable*
+                                                *g:ale_languagetool_executable*
                                                 *b:ale_languagetool_executable*
-
+languagetool_executable
+g:ale_languagetool_executable
   Type: |String|
   Default: `'languagetool'`
 
   The executable to run for languagetool.
 
-
-g:ale_languagetool_options                         *g:ale_languagetool_options*
+                                             *ale-options.languagetool_options*
+                                                   *g:ale_languagetool_options*
                                                    *b:ale_languagetool_options*
+languagetool_options
+g:ale_languagetool_options
   Type: |String|
   Default: `'--autoDetect'`
 
@@ -2991,24 +3288,31 @@ g:ale_languagetool_options                         *g:ale_languagetool_options*
 The options for `write-good` are shared between all filetypes, so options can
 be configured once.
 
-g:ale_writegood_executable                         *g:ale_writegood_executable*
+                                             *ale-options.writegood_executable*
+                                                   *g:ale_writegood_executable*
                                                    *b:ale_writegood_executable*
+writegood_executable
+g:ale_writegood_executable
   Type: |String|
   Default: `'writegood'`
 
   See |ale-integrations-local-executables|
 
-
-g:ale_writegood_options                               *g:ale_writegood_options*
+                                                *ale-options.writegood_options*
+                                                      *g:ale_writegood_options*
                                                       *b:ale_writegood_options*
+writegood_options
+g:ale_writegood_options
   Type: |String|
   Default: `''`
 
   This variable can be set to pass additional options to writegood.
 
-
-g:ale_writegood_use_global                         *g:ale_writegood_use_global*
+                                             *ale-options.writegood_use_global*
+                                                   *g:ale_writegood_use_global*
                                                    *b:ale_writegood_use_global*
+writegood_use_global
+g:ale_writegood_use_global
   Type: |Number|
   Default: `get(g:, 'ale_use_global_executables', 0)`
 
@@ -3700,6 +4004,7 @@ documented in additional help files.
 
     imap <C-Space> <Plug>(ale_complete)
 <
+
 :ALEDocumentation                                           *:ALEDocumentation*
 
   Similar to the `:ALEHover` command, retrieve documentation information for
@@ -3893,7 +4198,7 @@ documented in additional help files.
   prompt will open to request a new name.
 
   The rename operation will not save modified buffers when 'hidden' is on
-  unless |g:ale_save_hidden| is 1.
+  unless |g:ale_save_hidden| is `true` or `1`.
 
 
 :ALEFileRename                                                 *:ALEFileRename*
@@ -4143,7 +4448,9 @@ documented in additional help files.
 
 ALE offers a number of functions for running linters or fixers, or defining
 them. The following functions are part of the publicly documented part of that
-API, and should be expected to continue to work.
+API, and should be expected to continue to work. Functions documented with
+Vim autocmd names `ale#Foo` are available in the Vim context, and functions
+documented with dot names `ale.foo` are available in Lua scripts.
 
 
 ale#Env(variable_name, value)                                       *ale#Env()*
@@ -4201,6 +4508,31 @@ ale#Queue(delay, [linting_flag, buffer_number])                   *ale#Queue()*
   of time. This is to prevent ALE from seriously annoying users if a linter
   is broken, or when developing ALE itself.
 
+
+ale.setup(config)                                                   *ale.setup*
+
+  Configure ALE global settings, which are documented in |ale-options|. For
+  example: >
+
+    require("ale").setup({
+      completion_enabled = true,
+      maximum_file_size = 1024 * 1024,
+      warn_about_trailing_whitespace = false,
+    })
+<
+  You can also call this function with `ale.setup.global` to make what context
+  ALE is being configured in less ambiguous if you like.
+
+
+ale.setup.buffer(config)                                     *ale.setup.buffer*
+
+  Configure ALE buffer-local settings, which are documented in |ale-options|.
+  For example: >
+    require("ale").setup.buffer({
+      linters = {"ruff", "pyright"},
+      fixers = {"ruff"}
+    })
+<
 
 ale#command#CreateDirectory(buffer)             *ale#command#CreateDirectory()*
 
@@ -4317,7 +4649,6 @@ ale#command#Run(buffer, command, callback, [options])       *ale#command#Run()*
                         The default is `[]`.
 
 
-
 ale#command#EscapeCommandPart(command_part)   *ale#command#EscapeCommandPart()*
 
   Given a |String|, return a |String| with all `%` characters replaced with
@@ -4378,9 +4709,8 @@ ale#engine#IsCheckingBuffer(buffer)             *ale#engine#IsCheckingBuffer()*
 
   This function can be used for status lines, tab names, etc.
 
-
-ale#fix#registry#Add(name, func, filetypes, desc, [aliases])
                                                        *ale#fix#registry#Add()*
+ale#fix#registry#Add(name, func, filetypes, desc, [aliases])
 
   Given a |String| `name` for a name to add to the registry, a |String| `func`
   for a function name, a |List| `filetypes` for a list of filetypes to
@@ -4796,9 +5126,8 @@ ale#linter#PreventLoading(filetype)               *ale#linter#PreventLoading()*
   |runtimepath| for that filetype. This function can be called from vimrc or
   similar to prevent ALE from loading linters.
 
-
-ale#lsp_linter#SendRequest(buffer, linter_name, message, [Handler])
                                                  *ale#lsp_linter#SendRequest()*
+ale#lsp_linter#SendRequest(buffer, linter_name, message, [Handler])
 
   Send a custom request to an LSP linter. The arguments are defined as
   follows:
@@ -4822,9 +5151,8 @@ ale#lsp_linter#SendRequest(buffer, linter_name, message, [Handler])
                  received, and takes as unique argument a dictionary
                  representing the response obtained from the server.
 
-
-ale#other_source#ShowResults(buffer, linter_name, loclist)
                                                *ale#other_source#ShowResults()*
+ale#other_source#ShowResults(buffer, linter_name, loclist)
 
   Show results from another source of information.
 
@@ -4833,9 +5161,8 @@ ale#other_source#ShowResults(buffer, linter_name, loclist)
   where the problems in a buffer are, and should be provided in the format ALE
   uses for regular linter results. See |ale-loclist-format|.
 
-
-ale#other_source#StartChecking(buffer, linter_name)
                                              *ale#other_source#StartChecking()*
+ale#other_source#StartChecking(buffer, linter_name)
 
   Tell ALE that another source of information has started checking a buffer.
 
@@ -4889,11 +5216,11 @@ g:ale_want_results_buffer                           *g:ale_want_results_buffer*
 
   `g:ale_want_results_buffer` is set to the number of the buffer being checked
   when the |ALEWantResults| event is signaled. This variable should be read to
-  figure out which buffer other sources should lint.
+  figure out which buffer other sources should lint. This variable can be read
+  in Lua scripts in the usual way via `vim.g.ale_want_results_buffer`.
 
-
-ALECompletePost                                       *ALECompletePost-autocmd*
-                                                              *ALECompletePost*
+                                                      *ALECompletePost-autocmd*
+ALECompletePost                                               *ALECompletePost*
 
   This |User| autocmd is triggered after ALE inserts an item on
   |CompleteDone|. This event can be used to run commands after a buffer
@@ -4908,15 +5235,14 @@ ALECompletePost                                       *ALECompletePost-autocmd*
       autocmd User ALEFixPre ALELintStop
   augroup END
 <
-
-ALELintPre                                                 *ALELintPre-autocmd*
-                                                                   *ALELintPre*
-ALELintPost                                               *ALELintPost-autocmd*
-                                                                  *ALELintPost*
-ALEFixPre                                                   *ALEFixPre-autocmd*
-                                                                    *ALEFixPre*
-ALEFixPost                                                 *ALEFixPost-autocmd*
-                                                                   *ALEFixPost*
+                                                           *ALELintPre-autocmd*
+ALELintPre                                                         *ALELintPre*
+                                                          *ALELintPost-autocmd*
+ALELintPost                                                       *ALELintPost*
+                                                            *ALEFixPre-autocmd*
+ALEFixPre                                                           *ALEFixPre*
+                                                           *ALEFixPost-autocmd*
+ALEFixPost                                                         *ALEFixPost*
 
   These |User| autocommands are triggered before and after every lint or fix
   cycle. They can be used to update statuslines, send notifications, etc.
@@ -4924,43 +5250,41 @@ ALEFixPost                                                 *ALEFixPost-autocmd*
   echoing messages.
 
   For example to change the color of the statusline while the linter is
-  running:
->
-    augroup ALEProgress
-        autocmd!
-        autocmd User ALELintPre  hi Statusline ctermfg=darkgrey
-        autocmd User ALELintPost hi Statusline ctermfg=NONE
-    augroup END
-<
-  Or to display the progress in the statusline:
->
-    let s:ale_running = 0
-    let l:stl .= '%{s:ale_running ? "[linting]" : ""}'
-    augroup ALEProgress
-        autocmd!
-        autocmd User ALELintPre  let s:ale_running = 1 | redrawstatus
-        autocmd User ALELintPost let s:ale_running = 0 | redrawstatus
-    augroup END
+  running: >
 
+  augroup ALEProgress
+      autocmd!
+      autocmd User ALELintPre  hi Statusline ctermfg=darkgrey
+      autocmd User ALELintPost hi Statusline ctermfg=NONE
+  augroup END
 <
-ALEJobStarted                                           *ALEJobStarted-autocmd*
-                                                                *ALEJobStarted*
+  Or to display the progress in the statusline: >
+
+  let s:ale_running = 0
+  let l:stl .= '%{s:ale_running ? "[linting]" : ""}'
+  augroup ALEProgress
+      autocmd!
+      autocmd User ALELintPre  let s:ale_running = 1 | redrawstatus
+      autocmd User ALELintPost let s:ale_running = 0 | redrawstatus
+  augroup END
+<
+                                                        *ALEJobStarted-autocmd*
+ALEJobStarted                                                   *ALEJobStarted*
 
   This |User| autocommand is triggered immediately after a job is successfully
   run. This provides better accuracy for checking linter status with
   |ale#engine#IsCheckingBuffer()| over |ALELintPre-autocmd|, which is actually
   triggered before any linters are executed.
 
-ALELSPStarted                                           *ALELSPStarted-autocmd*
-                                                                *ALELSPStarted*
+                                                        *ALELSPStarted-autocmd*
+ALELSPStarted                                                   *ALELSPStarted*
 
   This |User| autocommand is triggered immediately after an LSP connection is
   successfully initialized. This provides a way to perform any additional
   initialization work, such as setting up buffer-level mappings.
 
-
-ALEWantResults                                         *ALEWantResults-autocmd*
-                                                               *ALEWantResults*
+                                                       *ALEWantResults-autocmd*
+ALEWantResults                                                 *ALEWantResults*
 
   This |User| autocommand is triggered before ALE begins a lint cycle. Another
   source can respond by calling |ale#other_source#StartChecking()|, and
@@ -4981,6 +5305,7 @@ ALEWantResults                                         *ALEWantResults-autocmd*
 Special thanks to Mark Grealish (https://www.bhalash.com/) for providing ALE's
 snazzy looking ale glass logo. Cheers, Mark!
 
+
 ===============================================================================
 11. Contact                                                       *ale-contact*
 
@@ -4992,6 +5317,7 @@ free to send an email to devw0rp@gmail.com.
 
 Please drink responsibly, or not at all, which is ironically the preference
 of w0rp, who is teetotal.
+
 
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/lua/ale/diagnostics.lua
+++ b/lua/ale/diagnostics.lua
@@ -1,96 +1,95 @@
+local ale = require("ale")
+
 local module = {}
 
-local ale_type_to_diagnostic_severity = {
-  E = vim.diagnostic.severity.ERROR,
-  W = vim.diagnostic.severity.WARN,
-  I = vim.diagnostic.severity.INFO
+local diagnostic_severity_map = {
+    E = vim.diagnostic.severity.ERROR,
+    W = vim.diagnostic.severity.WARN,
+    I = vim.diagnostic.severity.INFO
 }
 
--- Equivalent to ale#Var, only we can't error on missing global keys.
-module.aleVar = function(buffer, key)
-  key = "ale_" .. key
-  local exists, value = pcall(vim.api.nvim_buf_get_var, buffer, key)
-
-  if exists then
-    return value
-  end
-
-  return vim.g[key]
-end
-
-module.sendAleResultsToDiagnostics = function(buffer, loclist)
-  local diagnostics = {}
-
-  -- Convert all the ALE loclist items to the shape that Neovim's diagnostic
-  -- API is expecting.
-  for _, location in ipairs(loclist) do
-    if location.bufnr == buffer then
-      table.insert(
-        diagnostics,
-        -- All line numbers from ALE are 1-indexed, but all line numbers
-        -- in the diagnostics API are 0-indexed, so we have to subtract 1
-        -- to make this work.
-        {
-          lnum = location.lnum - 1,
-          -- Ending line number, or if we don't have one, just make it the same
-          -- as the starting line number
-          end_lnum = (location.end_lnum or location.lnum) - 1,
-          -- Which column does the error start on?
-          col = math.max((location.col or 1) - 1, 0),
-          -- end_col does *not* appear to need 1 subtracted, so we don't.
-          end_col = location.end_col,
-          -- Which severity: error, warning, or info?
-          severity = ale_type_to_diagnostic_severity[location.type] or "E",
-          -- An error code
-          code = location.code,
-          -- The error message
-          message = location.text,
-          -- e.g. "rubocop"
-          source = location.linter_name,
-        }
-      )
-    end
-  end
-
-  local virtualtext_enabled_set = {
-    ['all'] = true,
-    ['2'] = true,
+-- A map of all possible values that we can consider virtualtext enabled for
+-- from ALE's setting.
+local virtualtext_enabled_set = {
+    ["all"] = true,
+    ["2"] = true,
     [2] = true,
-    ['current'] = true,
-    ['1'] = true,
+    ["current"] = true,
+    ["1"] = true,
     [1] = true,
-  }
+    [true] = true,
+}
 
-  local set_signs = module.aleVar(buffer, 'set_signs')
-  local sign_priority = module.aleVar(buffer, 'sign_priority')
-  local signs
+---Send diagnostics to the Neovim diagnostics API
+---@param buffer number The buffer number to retreive the variable for.
+---@param loclist table The loclist array to report as diagnostics.
+---@return nil
+module.send = function(buffer, loclist)
+    local diagnostics = {}
 
-  if set_signs == 1 and sign_priority then
-    -- If signs are enabled, set the priority for them.
-    local local_cfg = { priority = sign_priority }
-    local global_cfg = vim.diagnostic.config().signs
-
-    if type(global_cfg) == 'boolean' then
-      signs = local_cfg
-    elseif type(global_cfg) == 'table' then
-      signs = vim.tbl_extend('force', global_cfg, local_cfg)
-    else
-      signs = function(...)
-        local calculated = global_cfg(...)
-        return vim.tbl_extend('force', calculated, local_cfg)
-      end
+    -- Convert all the ALE loclist items to the shape that Neovim's diagnostic
+    -- API is expecting.
+    for _, location in ipairs(loclist) do
+        if location.bufnr == buffer then
+            table.insert(
+                diagnostics,
+                -- All line numbers from ALE are 1-indexed, but all line
+                -- numbers in the diagnostics API are 0-indexed, so we have to
+                -- subtract 1 to make this work.
+                {
+                    lnum = location.lnum - 1,
+                    -- Ending line number, or if we don't have one, just make
+                    -- it the same as the starting line number
+                    end_lnum = (location.end_lnum or location.lnum) - 1,
+                    -- Which column does the error start on?
+                    col = math.max((location.col or 1) - 1, 0),
+                    -- end_col does not appear to need 1 subtracted.
+                    end_col = location.end_col,
+                    -- Which severity: error, warning, or info?
+                    severity = diagnostic_severity_map[location.type] or "E",
+                    -- An error code
+                    code = location.code,
+                    -- The error message
+                    message = location.text,
+                    -- e.g. "rubocop"
+                    source = location.linter_name,
+                }
+            )
+        end
     end
-  end
 
-  vim.diagnostic.set(
-    vim.api.nvim_create_namespace('ale'),
-    buffer,
-    diagnostics,
-    {
-      virtual_text = virtualtext_enabled_set[vim.g.ale_virtualtext_cursor] ~= nil,
-      signs = signs,
-    }
-  )
+    local set_signs = ale.var(buffer, "set_signs")
+    local sign_priority = ale.var(buffer, "sign_priority")
+    local signs
+
+    if (set_signs == 1 or set_signs == true) and sign_priority then
+        -- If signs are enabled, set the priority for them.
+        local local_cfg = { priority = sign_priority }
+        local global_cfg = vim.diagnostic.config().signs
+
+        if type(global_cfg) == "boolean" then
+            signs = local_cfg
+        elseif type(global_cfg) == "table" then
+            signs = vim.tbl_extend("force", global_cfg, local_cfg)
+        else
+            -- If a global function is defined, then define a function
+            -- that calls that function when Neovim calls our function.
+            signs = function(...)
+                return vim.tbl_extend("force", global_cfg(...), local_cfg)
+            end
+        end
+    end
+
+    vim.diagnostic.set(
+        vim.api.nvim_create_namespace("ale"),
+        buffer,
+        diagnostics,
+        {
+            virtual_text =
+                virtualtext_enabled_set[vim.g.ale_virtualtext_cursor] ~= nil,
+            signs = signs,
+        }
+    )
 end
 
 return module

--- a/lua/ale/init.lua
+++ b/lua/ale/init.lua
@@ -1,19 +1,19 @@
 local ale = {}
 
 local global_settings = setmetatable({}, {
-    __index = function (_, key)
+    __index = function(_, key)
         return vim.g['ale_' .. key]
     end,
-    __newindex = function (_, key, value)
+    __newindex = function(_, key, value)
         vim.g['ale_' .. key] = value
     end
 })
 
 local buffer_settings = setmetatable({}, {
-    __index = function (_, key)
+    __index = function(_, key)
         return vim.b['ale_' .. key]
     end,
-    __newindex = function (_, key, value)
+    __newindex = function(_, key, value)
         vim.b['ale_' .. key] = value
     end
 })
@@ -30,17 +30,79 @@ ale.set_buffer = function(c)
     end
 end
 
+---(when called) Set global ALE settings, just like ale.setup.global.
+---@class ALESetup
+---@field global fun(c: table): nil  -- Set global ALE settings.
+---@field buffer fun(c: table): nil  -- Set buffer-local ALE settings.
+---@overload fun(c: table): nil
+---@type ALESetup
 ale.setup = setmetatable({
-  global = function(c)
-    ale.set_global(c)
-  end,
-  buffer = function(c)
-    ale.set_buffer(c)
-  end,
+    ---Set global ALE settings.
+    ---@param c table The table of ALE settings to set.
+    ---@return nil
+    global = function(c)
+        ale.set_global(c)
+    end,
+    ---Set buffer-local ALE settings.
+    ---@param c table The table of ALE settings to set.
+    ---@return nil
+    buffer = function(c)
+        ale.set_buffer(c)
+    end,
 }, {
-  __call = function(self, c)
-    self.global(c)
-  end,
+    __call = function(self, c)
+        self.global(c)
+    end,
 })
+
+---Get an ALE variable for a buffer (first) or globally (second)
+---@param buffer number The buffer number to retreive the variable for.
+---@param variable_name string The variable to retrieve.
+---@return any value The value for the ALE variable
+ale.var = function(buffer, variable_name)
+    variable_name = "ale_" .. variable_name
+    local exists, value = pcall(vim.api.nvim_buf_get_var, buffer, variable_name)
+
+    if exists then
+        return value
+    end
+
+    return vim.g[variable_name]
+end
+
+---Escape a string for use in a shell command
+---@param str string The string to escape.
+---@return string escaped The escaped string.
+ale.escape = function(str)
+    local shell = vim.fn.fnamemodify(vim.o.shell, ":t")
+
+    if shell:lower() == "cmd.exe" then
+        local step1
+
+        if str:find(" ") then
+            step1 = '"' .. str:gsub('"', '""') .. '"'
+        else
+            step1 = str:gsub("([&|<>^])", "^%1")
+        end
+
+        local percent_subbed = step1:gsub("%%", "%%%%")
+
+        return percent_subbed
+    end
+
+    return vim.fn.shellescape(str)
+end
+
+---Create a prefix for a shell command for adding environment variables.
+---@param variable_name string The environment variable name.
+---@param value string The value to set for the environment variable.
+---@return string prefix The shell code for prefixing a command.
+ale.env = function(variable_name, value)
+    if vim.fn.has("win32") then
+        return "set " .. ale.escape(variable_name .. "=" .. value) .. " && "
+    end
+
+    return variable_name .. "=" .. ale.escape(value) .. " "
+end
 
 return ale

--- a/lua/ale/init.lua
+++ b/lua/ale/init.lua
@@ -64,6 +64,21 @@ ale.has = function(feature)
     return vim.fn["ale#Has"](feature) == 1
 end
 
+---Prefix a string with a single space if it is not empty.
+---nil will be treated the same as an empty string.
+---
+---This function is a convenience for chaining options for commands together
+---without adding redundant whitespace.
+---@param str string|nil A value to pad with whitespace.
+---@return string padded A value padded with whitespace.
+ale.pad = function(str)
+    if str == nil or str == "" then
+        return ""
+    end
+
+    return " " .. str
+end
+
 ---Get an ALE variable for a buffer (first) or globally (second)
 ---@param buffer number The buffer number to retreive the variable for.
 ---@param variable_name string The variable to retrieve.

--- a/lua/ale/init.lua
+++ b/lua/ale/init.lua
@@ -55,6 +55,15 @@ ale.setup = setmetatable({
     end,
 })
 
+---Check if ALE supports a given feature.
+---
+---The ALE version can be checked with ale.has("ale-1.0.0"), etc.
+---@param feature string The feature to test for.
+---@return boolean supported If the feature is supported.
+ale.has = function(feature)
+    return vim.fn["ale#Has"](feature) == 1
+end
+
 ---Get an ALE variable for a buffer (first) or globally (second)
 ---@param buffer number The buffer number to retreive the variable for.
 ---@param variable_name string The variable to retrieve.

--- a/lua/ale/init.lua
+++ b/lua/ale/init.lua
@@ -1,0 +1,46 @@
+local ale = {}
+
+local global_settings = setmetatable({}, {
+    __index = function (_, key)
+        return vim.g['ale_' .. key]
+    end,
+    __newindex = function (_, key, value)
+        vim.g['ale_' .. key] = value
+    end
+})
+
+local buffer_settings = setmetatable({}, {
+    __index = function (_, key)
+        return vim.b['ale_' .. key]
+    end,
+    __newindex = function (_, key, value)
+        vim.b['ale_' .. key] = value
+    end
+})
+
+ale.set_global = function(c)
+    for key, value in pairs(c) do
+        global_settings[key] = value
+    end
+end
+
+ale.set_buffer = function(c)
+    for key, value in pairs(c) do
+        buffer_settings[key] = value
+    end
+end
+
+ale.setup = setmetatable({
+  global = function(c)
+    ale.set_global(c)
+  end,
+  buffer = function(c)
+    ale.set_buffer(c)
+  end,
+}, {
+  __call = function(self, c)
+    self.global(c)
+  end,
+})
+
+return ale

--- a/lua/ale/init.lua
+++ b/lua/ale/init.lua
@@ -114,4 +114,25 @@ ale.env = function(variable_name, value)
     return variable_name .. "=" .. ale.escape(value) .. " "
 end
 
+---Get an array of arrays for mapping paths to and from filesystems for an ALE
+---linter, as configured in the `filename_mappings` setting.
+---
+---The result can be used to instruct ALE how to map between filesystems.
+---@param buffer number The buffer number.
+---@param name string The linter name.
+---@return table mappings An array of arrays for mapping filenames.
+ale.get_filename_mappings = function(buffer, name)
+    local linter_mappings = ale.var(buffer, "filename_mappings")
+
+    if linter_mappings[1] ~= nil then
+        return linter_mappings
+    end
+
+    if linter_mappings[name] == nil then
+        name = "*"
+    end
+
+    return linter_mappings[name] or {}
+end
+
 return ale

--- a/lua/ale/init.lua
+++ b/lua/ale/init.lua
@@ -55,6 +55,21 @@ ale.setup = setmetatable({
     end,
 })
 
+---Run ALE linters on a buffer after a delay.
+---
+---If a delay in milliseconds multiple times, the internal timer used by ALE
+---will be reset, so ALE doesn't lint too often.
+---
+---If the `linting_flag` is not 'lint_file' then linters that require files to
+---be saved will no be run.
+---@param delay number Milliseconds to wait for. A delay of 0 lints immediately.
+---@param linting_flag string|nil If set to 'lint_file', run all linters.
+---@param buffer number|nil The buffer to check. Defaults to the current buffer.
+---@return nil
+ale.queue = function(delay, linting_flag, buffer)
+    vim.fn["ale#Queue"](delay, linting_flag, buffer)
+end
+
 ---Check if ALE supports a given feature.
 ---
 ---The ALE version can be checked with ale.has("ale-1.0.0"), etc.

--- a/lua/ale/lsp.lua
+++ b/lua/ale/lsp.lua
@@ -2,7 +2,9 @@ local module = {}
 
 module.start = function(config)
     -- Neovim's luaeval sometimes adds a Boolean key to table we need to remove.
-    if config.init_options[true] ~= nil then
+    if type(config.init_options) == "table"
+    and config.init_options[true] ~= nil
+    then
         config.init_options[true] = nil
     end
 

--- a/lua/ale/lsp.lua
+++ b/lua/ale/lsp.lua
@@ -1,0 +1,62 @@
+local module = {}
+
+vim.lsp.set_log_level("debug")
+
+module.start = function(config)
+    -- Neovim's luaeval sometimes adds a Boolean key to table we need to remove.
+    if config.init_options[true] ~= nil then
+        config.init_options[true] = nil
+    end
+
+    config.on_init = function(_, _)
+        vim.defer_fn(function()
+            vim.fn["ale#lsp#CallInitCallbacks"](config.name)
+        end, 0)
+    end
+
+    return vim.lsp.start(config, {
+        attach = false,
+        silent = true,
+    })
+end
+
+module.buf_attach = function(args)
+    return vim.lsp.buf_attach_client(args.bufnr, args.client_id)
+end
+
+module.buf_detach = function(args)
+    return vim.lsp.buf_detach_client(args.bufnr, args.client_id)
+end
+
+-- Send a message to an LSP server.
+-- Notifications do not need to be handled.
+--
+-- Returns -1 when a message is sent, but no response is expected
+--         0 when the message is not sent and
+--         >= 1 with the message ID when a response is expected.
+module.send_message = function(args)
+    local client = vim.lsp.get_client_by_id(args.client_id)
+
+    if args.is_notification then
+        local success = client.notify(args.method, args.params)
+
+        if success then
+            return -1
+        end
+
+        return 0
+    end
+
+    -- NOTE: We aren't yet handling reponses to requests properly!
+    -- NOTE: There is a fourth argument for a bufnr here, and it's not
+    --       clear what that argument is for or why we need it.
+    local success, request_id = client.request(args.method, args.params)
+
+    if success then
+        return request_id
+    end
+
+    return 0
+end
+
+return module

--- a/lua/ale/lsp.lua
+++ b/lua/ale/lsp.lua
@@ -1,7 +1,5 @@
 local module = {}
 
-vim.lsp.set_log_level("debug")
-
 module.start = function(config)
     -- Neovim's luaeval sometimes adds a Boolean key to table we need to remove.
     if config.init_options[true] ~= nil then

--- a/lua/ale/lsp.lua
+++ b/lua/ale/lsp.lua
@@ -39,6 +39,10 @@ module.start = function(config)
         end, 0)
     end
 
+    config.get_language_id = function(bufnr, _)
+        return vim.fn["ale#lsp#GetLanguage"](config.name, bufnr)
+    end
+
     return vim.lsp.start(config, {
         attach = false,
         silent = true,

--- a/plugin/ale.vim
+++ b/plugin/ale.vim
@@ -59,7 +59,7 @@ let g:ale_filetype_blacklist = [
 " This Dictionary configures which linters are enabled for which languages.
 let g:ale_linters = get(g:, 'ale_linters', {})
 " This option can be changed to only enable explicitly selected linters.
-let g:ale_linters_explicit = get(g:, 'ale_linters_explicit', 0)
+let g:ale_linters_explicit = get(g:, 'ale_linters_explicit', v:false)
 " Ignoring linters, for disabling some, or ignoring LSP diagnostics.
 let g:ale_linters_ignore = get(g:, 'ale_linters_ignore', {})
 " Disabling all language server functionality.
@@ -82,26 +82,26 @@ let g:ale_lint_delay = get(g:, 'ale_lint_delay', 200)
 " changed in both normal and insert mode, or only in insert mode respectively.
 let g:ale_lint_on_text_changed = get(g:, 'ale_lint_on_text_changed', 'normal')
 
-" This flag can be set to 1 to enable linting when leaving insert mode.
-let g:ale_lint_on_insert_leave = get(g:, 'ale_lint_on_insert_leave', 1)
+" This flag can be set to true or 1 to enable linting when leaving insert mode.
+let g:ale_lint_on_insert_leave = get(g:, 'ale_lint_on_insert_leave', v:true)
 
-" This flag can be set to 0 to disable linting when the buffer is entered.
-let g:ale_lint_on_enter = get(g:, 'ale_lint_on_enter', 1)
+" When true or 1 linting is done when a buffer is entered.
+let g:ale_lint_on_enter = get(g:, 'ale_lint_on_enter', v:true)
 
-" This flag can be set to 1 to enable linting when a buffer is written.
-let g:ale_lint_on_save = get(g:, 'ale_lint_on_save', 1)
+" When true or 1 linting is done when a buffer is written.
+let g:ale_lint_on_save = get(g:, 'ale_lint_on_save', v:true)
 
-" This flag can be set to 1 to enable linting when the filetype is changed.
-let g:ale_lint_on_filetype_changed = get(g:, 'ale_lint_on_filetype_changed', 1)
+" When true or 1 linting is done when the filetype changes.
+let g:ale_lint_on_filetype_changed = get(g:, 'ale_lint_on_filetype_changed', v:true)
 
-" If set to 1, hints and suggestion from LSP servers and tsserver will be shown.
-let g:ale_lsp_suggestions = get(g:, 'ale_lsp_suggestions', 0)
+" If set to true or 1, suggestions from LSP servers and tsserver will be shown.
+let g:ale_lsp_suggestions = get(g:, 'ale_lsp_suggestions', v:false)
 
-" This flag can be set to 1 to enable automatically fixing files on save.
-let g:ale_fix_on_save = get(g:, 'ale_fix_on_save', 0)
+" When true or 1 files are automatically fixed on save.
+let g:ale_fix_on_save = get(g:, 'ale_fix_on_save', v:false)
 
-" This flag may be set to 0 to disable ale. After ale is loaded, :ALEToggle
-" should be used instead.
+" When true or 1 ALE linting is enabled.
+" Disabling ALE linting does not disable fixing of files.
 let g:ale_enabled = get(g:, 'ale_enabled', 1)
 
 " A Dictionary mapping linter or fixer names to Arrays of two-item Arrays
@@ -113,117 +113,120 @@ let g:ale_root = get(g:, 'ale_root', {})
 
 " These flags dictates if ale uses the quickfix or the loclist (loclist is the
 " default, quickfix overrides loclist).
-let g:ale_set_loclist = get(g:, 'ale_set_loclist', 1)
-let g:ale_set_quickfix = get(g:, 'ale_set_quickfix', 0)
+let g:ale_set_loclist = get(g:, 'ale_set_loclist', v:true)
+let g:ale_set_quickfix = get(g:, 'ale_set_quickfix', v:false)
 
 " This flag can be set to 0 to disable setting signs.
 " This is enabled by default only if the 'signs' feature exists.
-let g:ale_set_signs = get(g:, 'ale_set_signs', has('signs'))
+let g:ale_set_signs = get(g:, 'ale_set_signs', has('signs') ? v:true : v:false)
 
 " This flag can be set to 0 to disable setting error highlights.
-let g:ale_set_highlights = get(g:, 'ale_set_highlights', has('syntax'))
+let g:ale_set_highlights = get(g:, 'ale_set_highlights', has('syntax') ? v:true : v:false)
 
 " This List can be configured to exclude particular highlights.
 let g:ale_exclude_highlights = get(g:, 'ale_exclude_highlights', [])
 
-" This flag can be set to 0 to disable echoing when the cursor moves.
-let g:ale_echo_cursor = get(g:, 'ale_echo_cursor', 1)
+" When set to true or 1 problems on lines are echoed when the cursor moves.
+let g:ale_echo_cursor = get(g:, 'ale_echo_cursor', v:true)
 
-" This flag can be set to 1 to automatically show errors in the preview window.
-let g:ale_cursor_detail = get(g:, 'ale_cursor_detail', 0)
+" If set to true or 1 automatically show errors in the preview window.
+let g:ale_cursor_detail = get(g:, 'ale_cursor_detail', v:false)
 
 " This flag can be changed to disable/enable virtual text.
 let g:ale_virtualtext_cursor = get(g:, 'ale_virtualtext_cursor', (has('nvim-0.3.2') || has('patch-9.0.0297') && has('textprop') && has('popupwin')) ? 'all' : 'disabled')
 
-" This flag can be set to 1 to enable LSP hover messages at the cursor.
-let g:ale_hover_cursor = get(g:, 'ale_hover_cursor', 1)
+" When set to true or 1 LSP hover messages are shown at the cursor.
+let g:ale_hover_cursor = get(g:, 'ale_hover_cursor', v:true)
 
-" This flag can be set to 1 to automatically close the preview window upon
-" entering Insert Mode.
-let g:ale_close_preview_on_insert = get(g:, 'ale_close_preview_on_insert', 0)
+" When true or 1 to close the preview window on entering Insert Mode.
+let g:ale_close_preview_on_insert = get(g:, 'ale_close_preview_on_insert', v:false)
 
-" This flag can be set to 0 to disable balloon support.
-let g:ale_set_balloons = get(g:, 'ale_set_balloons', has('balloon_eval') && has('gui_running'))
+" When set to true or 1 balloon support is enabled.
+let g:ale_set_balloons = get(g:, 'ale_set_balloons', (has('balloon_eval') && has('gui_running')) ? v:true : v:false)
 
-" Use preview window for hover messages.
-let g:ale_hover_to_preview = get(g:, 'ale_hover_to_preview', 0)
+" When set to true or 1 use the preview window for showing hover messages.
+let g:ale_hover_to_preview = get(g:, 'ale_hover_to_preview', v:false)
 
-" Float preview windows in Neovim
-let g:ale_floating_preview = get(g:, 'ale_floating_preview', 0)
+" When set to true or 1 use floating preview windows in Neovim.
+let g:ale_floating_preview = get(g:, 'ale_floating_preview', v:false)
 
-" Hovers use floating windows in Neovim
-let g:ale_hover_to_floating_preview = get(g:, 'ale_hover_to_floating_preview', 0)
+" When set to true or 1 show hove messages in floating windows in Neovim.
+let g:ale_hover_to_floating_preview = get(g:, 'ale_hover_to_floating_preview', v:false)
 
-" Detail uses floating windows in Neovim
-let g:ale_detail_to_floating_preview = get(g:, 'ale_detail_to_floating_preview', 0)
+" When set to true or 1 details are shown in floating windows in Neovim.
+let g:ale_detail_to_floating_preview = get(g:, 'ale_detail_to_floating_preview', v:false)
 
 " Border setting for floating preview windows
+"
 " The elements in the list set the characters for the left, top, top-left,
 " top-right, bottom-right, bottom-left, right, and bottom of the border
 " respectively
 let g:ale_floating_window_border = get(g:, 'ale_floating_window_border', ['|', '-', '+', '+', '+', '+', '|', '-'])
 
-" This flag can be set to 0 to disable warnings for trailing whitespace
-let g:ale_warn_about_trailing_whitespace = get(g:, 'ale_warn_about_trailing_whitespace', 1)
-" This flag can be set to 0 to disable warnings for trailing blank lines
-let g:ale_warn_about_trailing_blank_lines = get(g:, 'ale_warn_about_trailing_blank_lines', 1)
+" When set to true or 1 warnings for trailing whitespace are shown.
+let g:ale_warn_about_trailing_whitespace = get(g:, 'ale_warn_about_trailing_whitespace', v:true)
+" When set to true or 1 warnings for trailing blank lines are shown.
+let g:ale_warn_about_trailing_blank_lines = get(g:, 'ale_warn_about_trailing_blank_lines', v:true)
 
-" A flag for enabling or disabling the command history.
-let g:ale_history_enabled = get(g:, 'ale_history_enabled', 1)
+" When set to true or 1 the command history is logged.
+let g:ale_history_enabled = get(g:, 'ale_history_enabled', v:true)
 
-" A flag for storing the full output of commands in the history.
-let g:ale_history_log_output = get(g:, 'ale_history_log_output', 1)
+" When set to true or 1 the full output of commands is logged.
+let g:ale_history_log_output = get(g:, 'ale_history_log_output', v:true)
 
-" Enable automatic completion with LSP servers and tsserver
-let g:ale_completion_enabled = get(g:, 'ale_completion_enabled', 0)
+" When set to true or 1 enable ALE's built-in autocompletion functionality.
+let g:ale_completion_enabled = get(g:, 'ale_completion_enabled', v:false)
 
-" Enable automatic detection of pipenv for Python linters.
-let g:ale_python_auto_pipenv = get(g:, 'ale_python_auto_pipenv', 0)
+" When set to true or 1 enable automatic detection of pipenv for Python.
+let g:ale_python_auto_pipenv = get(g:, 'ale_python_auto_pipenv', v:false)
 
-" Enable automatic detection of poetry for Python linters.
-let g:ale_python_auto_poetry = get(g:, 'ale_python_auto_poetry', 0)
+" When set to true or 1 enable automatic detection of poetry for Python.
+let g:ale_python_auto_poetry = get(g:, 'ale_python_auto_poetry', v:false)
 
-" Enable automatic detection of uv for Python linters.
-let g:ale_python_auto_uv = get(g:, 'ale_python_auto_uv', 0)
+" When set to true or 1 enable automatic detection of uv for Python.
+let g:ale_python_auto_uv = get(g:, 'ale_python_auto_uv', v:false)
 
-" Enable automatic adjustment of environment variables for Python linters.
+" When set to true or 1 enable automatically updating environment variables
+" for running Python linters from virtualenv directories.
+"
 " The variables are set based on ALE's virtualenv detection.
-let g:ale_python_auto_virtualenv = get(g:, 'ale_python_auto_virtualenv', 0)
+let g:ale_python_auto_virtualenv = get(g:, 'ale_python_auto_virtualenv', v:false)
 
 " This variable can be overridden to set the GO111MODULE environment variable.
 let g:ale_go_go111module = get(g:, 'ale_go_go111module', '')
 
-" Default executable for deno, needed set before plugin start
+" The default executable for deno. Must be set before ALE lints any buffers.
 let g:ale_deno_executable = get(g:, 'ale_deno_executable', 'deno')
 
-" If 1, enable a popup menu for commands.
-let g:ale_popup_menu_enabled = get(g:, 'ale_popup_menu_enabled', has('gui_running'))
+" If true or 1, enable a popup menu for commands.
+let g:ale_popup_menu_enabled = get(g:, 'ale_popup_menu_enabled', has('gui_running') ? v:true : v:false)
 
-" If 0, save hidden files when code actions are applied.
-let g:ale_save_hidden = get(g:, 'ale_save_hidden', 0)
+" If true or 1, save hidden files when code actions are applied.
+let g:ale_save_hidden = get(g:, 'ale_save_hidden', v:false)
 
-" If 1, disables ALE's built in error display. Instead, all errors are piped
-" to the diagnostics API.
-let g:ale_use_neovim_diagnostics_api = get(g:, 'ale_use_neovim_diagnostics_api', has('nvim-0.7'))
+" If true or 1, disables ALE's built in error display.
+"
+" Instead, all errors are piped to the Neovim diagnostics API.
+let g:ale_use_neovim_diagnostics_api = get(g:, 'ale_use_neovim_diagnostics_api', has('nvim-0.7') ? v:true : v:false)
 
 if g:ale_use_neovim_diagnostics_api && !has('nvim-0.7')
     " no-custom-checks
-    echoerr('Setting g:ale_use_neovim_diagnostics_api to 1 requires Neovim 0.7+.')
+    echoerr('Setting g:ale_use_neovim_diagnostics_api to true or 1 requires Neovim 0.7+.')
 endif
 
-" If 1, uses Neovim's built-in LSP client to integrate with LSP, which
+" If true or 1, uses Neovim's built-in LSP client to integrate with LSP, which
 " improves ALE's integration with built-in Neovim tools and other plugins.
-let g:ale_use_neovim_lsp_api = get(g:, 'ale_use_neovim_lsp_api', has('nvim-0.8'))
+let g:ale_use_neovim_lsp_api = get(g:, 'ale_use_neovim_lsp_api', has('nvim-0.8') ? v:true : v:false)
 
 " If 1, replaces ALE's use of jobs and channels to connect to language
 " servers, plus the custom code, and instead hooks ALE into Neovim's built-in
 " language server tools.
 if g:ale_use_neovim_lsp_api && !has('nvim-0.8')
     " no-custom-checks
-    echoerr('Setting g:ale_use_neovim_lsp_api to 1 requires Neovim 0.8+.')
+    echoerr('Setting g:ale_use_neovim_lsp_api to true or 1 requires Neovim 0.8+.')
 endif
 
-if g:ale_set_balloons is 1 || g:ale_set_balloons is# 'hover'
+if g:ale_set_balloons || g:ale_set_balloons is# 'hover'
     call ale#balloon#Enable()
 endif
 

--- a/plugin/ale.vim
+++ b/plugin/ale.vim
@@ -211,6 +211,16 @@ if g:ale_use_neovim_diagnostics_api && !has('nvim-0.7')
     echoerr('Setting g:ale_use_neovim_diagnostics_api to 1 requires Neovim 0.7+.')
 endif
 
+let g:ale_use_neovim_lsp_api = get(g:, 'ale_use_neovim_lsp_api', has('nvim-0.8'))
+
+" If 1, replaces ALE's use of jobs and channels to connect to language
+" servers, plus the custom code, and instead hooks ALE into Neovim's built-in
+" language server tools.
+if g:ale_use_neovim_lsp_api && !has('nvim-0.8')
+    " no-custom-checks
+    echoerr('Setting g:ale_use_neovim_lsp_api to 1 requires Neovim 0.8+.')
+endif
+
 if g:ale_set_balloons is 1 || g:ale_set_balloons is# 'hover'
     call ale#balloon#Enable()
 endif

--- a/plugin/ale.vim
+++ b/plugin/ale.vim
@@ -211,6 +211,8 @@ if g:ale_use_neovim_diagnostics_api && !has('nvim-0.7')
     echoerr('Setting g:ale_use_neovim_diagnostics_api to 1 requires Neovim 0.7+.')
 endif
 
+" If 1, uses Neovim's built-in LSP client to integrate with LSP, which
+" improves ALE's integration with built-in Neovim tools and other plugins.
 let g:ale_use_neovim_lsp_api = get(g:, 'ale_use_neovim_lsp_api', has('nvim-0.8'))
 
 " If 1, replaces ALE's use of jobs and channels to connect to language

--- a/run-tests
+++ b/run-tests
@@ -29,6 +29,7 @@ run_neovim_07_tests=1
 run_neovim_08_tests=1
 run_vim_80_tests=1
 run_vim_90_tests=1
+run_lua_tests=1
 run_linters=1
 
 while [ $# -ne 0 ]; do
@@ -46,12 +47,14 @@ while [ $# -ne 0 ]; do
         run_vim_90_tests=0
         run_neovim_07_tests=0
         run_neovim_08_tests=0
+        run_lua_tests=0
         run_linters=0
         shift
     ;;
     --neovim-only)
         run_vim_80_tests=0
         run_vim_90_tests=0
+        run_lua_tests=0
         run_linters=0
         shift
     ;;
@@ -59,6 +62,7 @@ while [ $# -ne 0 ]; do
         run_neovim_08_tests=0
         run_vim_80_tests=0
         run_vim_90_tests=0
+        run_lua_tests=0
         run_linters=0
         shift
     ;;
@@ -66,12 +70,14 @@ while [ $# -ne 0 ]; do
         run_neovim_07_tests=0
         run_vim_80_tests=0
         run_vim_90_tests=0
+        run_lua_tests=0
         run_linters=0
         shift
     ;;
     --vim-only)
         run_neovim_07_tests=0
         run_neovim_08_tests=0
+        run_lua_tests=0
         run_linters=0
         shift
     ;;
@@ -79,6 +85,7 @@ while [ $# -ne 0 ]; do
         run_neovim_07_tests=0
         run_neovim_08_tests=0
         run_vim_90_tests=0
+        run_lua_tests=0
         run_linters=0
         shift
     ;;
@@ -86,6 +93,7 @@ while [ $# -ne 0 ]; do
         run_neovim_07_tests=0
         run_neovim_08_tests=0
         run_vim_80_tests=0
+        run_lua_tests=0
         run_linters=0
         shift
     ;;
@@ -94,6 +102,15 @@ while [ $# -ne 0 ]; do
         run_vim_90_tests=0
         run_neovim_07_tests=0
         run_neovim_08_tests=0
+        run_lua_tests=0
+        shift
+    ;;
+    --lua-only)
+        run_vim_80_tests=0
+        run_vim_90_tests=0
+        run_neovim_07_tests=0
+        run_neovim_08_tests=0
+        run_linters=0
         shift
     ;;
     --fast)
@@ -119,6 +136,7 @@ while [ $# -ne 0 ]; do
         echo '  --vim-only        Run tests only for Vim'
         echo '  --vim-80-only     Run tests only for Vim 8.2'
         echo '  --vim-90-only     Run tests only for Vim 9.0'
+        echo '  --lua-only        Run only Lua tests'
         echo '  --linters-only    Run only Vint and custom checks'
         echo '  --fast            Run only the fastest Vim and custom checks'
         echo '  --help            Show this help text'
@@ -147,6 +165,7 @@ if [ $# -ne 0 ]; then
 
     # Don't run other tools when targeting tests.
     run_linters=0
+    run_lua_tests=0
 fi
 
 # Delete .swp files in the test directory, which cause Vim 8 to hang.
@@ -249,6 +268,13 @@ for vim in $("$DOCKER" run --rm "$DOCKER_RUN_IMAGE" ls /vim-build/bin | grep '^n
         pid_list="$pid_list $!"
     fi
 done
+
+if ((run_lua_tests)); then
+    echo "Starting Lua tests..."
+    file_number=$((file_number+1))
+    test/script/run-lua-tests $quiet_flag > "$output_dir/$file_number" 2>&1 &
+    pid_list="$pid_list $!"
+fi
 
 if ((run_linters)); then
     echo "Starting Vint..."

--- a/test/completion/test_ale_import_command.vader
+++ b/test/completion/test_ale_import_command.vader
@@ -92,6 +92,12 @@ Before:
     call g:LastHandleCallback(a:conn_id, a:message)
     AssertEqual [[0, '']], g:ale_queue_call_list
 
+    let g:ale_lint_on_text_changed = v:true
+
+    let g:ale_queue_call_list = []
+    call g:LastHandleCallback(a:conn_id, a:message)
+    AssertEqual [[0, '']], g:ale_queue_call_list
+
     let g:ale_lint_on_text_changed = 'normal'
 
     let g:ale_queue_call_list = []
@@ -228,7 +234,7 @@ Execute(ALEImport should request imports correctly for tsserver):
   \ [
   \   [0, 'ts@completions', {
   \     'file': expand('%:p'),
-  \     'includeExternalModuleExports': 1,
+  \     'includeExternalModuleExports': v:true,
   \     'offset': 21,
   \     'line': 2,
   \     'prefix': 'missingword',

--- a/test/completion/test_lsp_completion_messages.vader
+++ b/test/completion/test_lsp_completion_messages.vader
@@ -1,11 +1,14 @@
 Before:
   Save g:ale_completion_delay
+  Save g:ale_completion_enabled
   Save g:ale_completion_max_suggestions
   Save g:ale_completion_info
+  Save g:ale_completion_autoimport
   Save &l:omnifunc
   Save &l:completeopt
 
-  let g:ale_completion_enabled = 1
+  let g:ale_completion_enabled = v:true
+  let g:ale_completion_autoimport = v:true
 
   call ale#test#SetDirectory('/testplugin/test/completion')
   call ale#test#SetFilename('dummy.txt')

--- a/test/completion/test_lsp_completion_messages.vader
+++ b/test/completion/test_lsp_completion_messages.vader
@@ -19,7 +19,7 @@ Before:
   let g:init_callback_list = []
 
   function! ale#lsp_linter#StartLSP(buffer, linter, Callback) abort
-    let g:conn_id = ale#lsp#Register('executable', '/foo/bar', {})
+    let g:conn_id = ale#lsp#Register('executable', '/foo/bar', '', {})
     call ale#lsp#MarkDocumentAsOpen(g:conn_id, a:buffer)
 
     let l:details = {

--- a/test/completion/test_tsserver_completion_parsing.vader
+++ b/test/completion/test_tsserver_completion_parsing.vader
@@ -1,7 +1,9 @@
 Before:
+  Save g:ale_completion_autoimport
   Save g:ale_completion_tsserver_remove_warnings
 
-  let g:ale_completion_tsserver_remove_warnings = 0
+  let g:ale_completion_autoimport = v:true
+  let g:ale_completion_tsserver_remove_warnings = v:false
 
 After:
   Restore
@@ -91,7 +93,7 @@ Execute(TypeScript completion details responses should be parsed correctly):
   \     'kind': 'v',
   \     'icase': 1,
   \     'user_data': json_encode({'_ale_completion_item': 1}),
-  \     'dup': g:ale_completion_autoimport,
+  \     'dup': g:ale_completion_autoimport + 0,
   \   },
   \   {
   \     'word': 'def',
@@ -100,7 +102,7 @@ Execute(TypeScript completion details responses should be parsed correctly):
   \     'kind': 'v',
   \     'icase': 1,
   \     'user_data': json_encode({'_ale_completion_item': 1}),
-  \     'dup': g:ale_completion_autoimport,
+  \     'dup': g:ale_completion_autoimport + 0,
   \   },
   \   {
   \     'word': 'ghi',
@@ -109,7 +111,7 @@ Execute(TypeScript completion details responses should be parsed correctly):
   \     'kind': 'v',
   \     'icase': 1,
   \     'user_data': json_encode({'_ale_completion_item': 1}),
-  \     'dup': g:ale_completion_autoimport,
+  \     'dup': g:ale_completion_autoimport + 0,
   \   },
   \ ],
   \ ale#completion#ParseTSServerCompletionEntryDetails({
@@ -188,7 +190,7 @@ Execute(Entries without details should be included in the responses):
   \             'changes': [],
   \         }],
   \     }),
-  \     'dup': g:ale_completion_autoimport,
+  \     'dup': g:ale_completion_autoimport + 0,
   \   },
   \   {
   \     'word': 'def',
@@ -197,7 +199,7 @@ Execute(Entries without details should be included in the responses):
   \     'kind': 'v',
   \     'icase': 1,
   \     'user_data': json_encode({'_ale_completion_item': 1}),
-  \     'dup': g:ale_completion_autoimport,
+  \     'dup': g:ale_completion_autoimport + 0,
   \   },
   \   {
   \     'word': 'xyz',
@@ -272,7 +274,7 @@ Execute(Default imports should be handled correctly):
   \             'changes': [],
   \         }],
   \     }),
-  \     'dup': g:ale_completion_autoimport,
+  \     'dup': g:ale_completion_autoimport + 0,
   \   },
   \ ],
   \ ale#completion#ParseTSServerCompletionEntryDetails({

--- a/test/linter/test_lua_language_server.vader
+++ b/test/linter/test_lua_language_server.vader
@@ -14,3 +14,8 @@ Execute(lua-language-server should be configurable):
 
   AssertLinter 'billy', ale#Escape('billy')
   AssertLSPConfig {'x': 'y'}
+
+Execute(lua-language-server should detect the project root using .luarc.json):
+  call ale#test#SetFilename('../lua/dummy.lua')
+
+  AssertLSPProject ale#path#Simplify(g:dir . '/../lua')

--- a/test/lsp/test_closing_documents.vader
+++ b/test/lsp/test_closing_documents.vader
@@ -37,24 +37,24 @@ After:
   runtime autoload/ale/lsp.vim
 
 Execute(No errors should be thrown if the connection is not initialized):
-  call ale#lsp#Register('command', '/foo', {})
+  call ale#lsp#Register('command', '/foo', '', {})
   call MarkDocumentOpened()
 
   call ale#engine#Cleanup(bufnr(''))
   AssertEqual [], g:message_list
 
 Execute(No messages should be sent if the document wasn't opened):
-  call ale#lsp#Register('command', '/foo', {})
+  call ale#lsp#Register('command', '/foo', '', {})
   call MarkAllConnectionsInitialized()
 
   call ale#engine#Cleanup(bufnr(''))
   AssertEqual [], g:message_list
 
 Execute(A message should be sent if the document was opened):
-  call ale#lsp#Register('command', '/foo', {})
+  call ale#lsp#Register('command', '/foo', 'lang', {})
   call MarkAllConnectionsInitialized()
 
-  call ale#lsp#OpenDocument('command:/foo', bufnr(''), 'lang')
+  call ale#lsp#OpenDocument('command:/foo', bufnr(''))
   call ale#engine#Cleanup(bufnr(''))
   " We should only send the message once.
   call ale#engine#Cleanup(bufnr(''))
@@ -78,10 +78,10 @@ Execute(A message should be sent if the document was opened):
   \ g:message_list
 
 Execute(A message should be sent if the document was opened for tsserver):
-  call ale#lsp#Register('command', '/foo', {})
+  call ale#lsp#Register('command', '/foo', 'lang', {})
   call ale#lsp#MarkConnectionAsTsserver('command:/foo')
 
-  call ale#lsp#OpenDocument('command:/foo', bufnr(''), 'lang')
+  call ale#lsp#OpenDocument('command:/foo', bufnr(''))
   call ale#engine#Cleanup(bufnr(''))
   " We should only send the message once.
   call ale#engine#Cleanup(bufnr(''))
@@ -94,12 +94,12 @@ Execute(A message should be sent if the document was opened for tsserver):
   \ g:message_list
 
 Execute(Re-opening and closing the documents should work):
-  call ale#lsp#Register('command', '/foo', {})
+  call ale#lsp#Register('command', '/foo', 'lang', {})
   call MarkAllConnectionsInitialized()
 
-  call ale#lsp#OpenDocument('command:/foo', bufnr(''), 'lang')
+  call ale#lsp#OpenDocument('command:/foo', bufnr(''))
   call ale#engine#Cleanup(bufnr(''))
-  call ale#lsp#OpenDocument('command:/foo', bufnr(''), 'lang')
+  call ale#lsp#OpenDocument('command:/foo', bufnr(''))
   call ale#engine#Cleanup(bufnr(''))
 
   AssertEqual
@@ -134,12 +134,12 @@ Execute(Re-opening and closing the documents should work):
   \ g:message_list
 
 Execute(Messages for closing documents should be sent to each server):
-  call ale#lsp#Register('command', '/foo', {})
-  call ale#lsp#Register('command', '/bar', {})
+  call ale#lsp#Register('command', '/foo', 'lang', {})
+  call ale#lsp#Register('command', '/bar', 'lang', {})
   call MarkAllConnectionsInitialized()
 
-  call ale#lsp#OpenDocument('command:/foo', bufnr(''), 'lang')
-  call ale#lsp#OpenDocument('command:/bar', bufnr(''), 'lang')
+  call ale#lsp#OpenDocument('command:/foo', bufnr(''))
+  call ale#lsp#OpenDocument('command:/bar', bufnr(''))
   call ale#engine#Cleanup(bufnr(''))
   " We should only send the message once.
   call ale#engine#Cleanup(bufnr(''))

--- a/test/lsp/test_did_save_event.vader
+++ b/test/lsp/test_did_save_event.vader
@@ -39,7 +39,7 @@ Before:
   let g:ale_linters = {'foobar': ['dummy_linter']}
 
   function! ale#lsp_linter#StartLSP(buffer, linter, Callback) abort
-    let g:conn_id = ale#lsp#Register('executable', '/foo/bar', {})
+    let g:conn_id = ale#lsp#Register('executable', '/foo/bar', 'foobar', {})
     call ale#lsp#MarkDocumentAsOpen(g:conn_id, a:buffer)
     let l:details = {
     \ 'command': 'foobar',

--- a/test/lsp/test_engine_lsp_response_handling.vader
+++ b/test/lsp/test_engine_lsp_response_handling.vader
@@ -410,6 +410,130 @@ Execute(LSP errors should mark linters no longer active):
 
   AssertEqual [], g:ale_buffer_info[bufnr('')].active_linter_list
 
+Execute(LSP pull model diagnostic responses should be handled):
+  let b:ale_linters = ['eclipselsp']
+  runtime ale_linters/java/eclipselsp.vim
+
+  if has('win32')
+    call ale#test#SetFilename('filename,[]^$.ts')
+  else
+    call ale#test#SetFilename('filename*?,{}[]^$.java')
+  endif
+
+  call ale#engine#InitBufferInfo(bufnr(''))
+  let g:ale_buffer_info[bufnr('')].active_linter_list = ale#linter#Get('eclipselsp')
+  call ale#lsp_linter#SetLSPLinterMap({'1': {'name': 'eclipselsp', 'aliases': [], 'lsp': 'stdio'}})
+  call ale#lsp_linter#SetDiagnosticURIMap({'347': ale#util#ToURI(expand('%:p'))})
+
+  if has('win32')
+    AssertEqual 'filename,[]^$.ts', expand('%:p:t')
+  else
+    AssertEqual 'filename*?,{}[]^$.java', expand('%:p:t')
+  endif
+
+  call ale#lsp_linter#HandleLSPResponse(1, {
+  \ 'jsonrpc':'2.0',
+  \ 'id': 347,
+  \ 'result': {
+  \   'kind': 'full',
+  \   'items': [
+  \     {
+  \       'range': {
+  \         'start': {
+  \           'line': 0,
+  \           'character':0
+  \         },
+  \         'end': {
+  \           'line': 0,
+  \           'character':0
+  \         }
+  \       },
+  \       'severity': 2,
+  \       'code': "",
+  \       'source': 'Java',
+  \       'message': 'Missing JRE 1-8'
+  \     }
+  \   ]
+  \ },
+  \})
+
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 1,
+  \     'bufnr': bufnr(''),
+  \     'col': 1,
+  \     'pattern': '',
+  \     'valid': 1,
+  \     'vcol': 0,
+  \     'nr': -1,
+  \     'type': 'W',
+  \     'text': 'Missing JRE 1-8'
+  \    }
+  \ ],
+  \ ale#test#GetLoclistWithoutNewerKeys()
+  AssertEqual [], g:ale_buffer_info[bufnr('')].active_linter_list
+
+Execute(LSP pull model diagnostic responses that are 'unchanged' should be handled):
+  let b:ale_linters = ['eclipselsp']
+  runtime ale_linters/java/eclipselsp.vim
+
+  if has('win32')
+    call ale#test#SetFilename('filename,[]^$.ts')
+  else
+    call ale#test#SetFilename('filename*?,{}[]^$.java')
+  endif
+
+  call ale#engine#InitBufferInfo(bufnr(''))
+  let g:ale_buffer_info[bufnr('')].active_linter_list = ale#linter#Get('eclipselsp')
+  let g:ale_buffer_info[bufnr('')].loclist = [
+  \ {
+  \   'lnum': 1,
+  \   'bufnr': bufnr(''),
+  \   'col': 1,
+  \   'pattern': '',
+  \   'valid': 1,
+  \   'vcol': 0,
+  \   'nr': -1,
+  \   'type': 'W',
+  \   'text': 'Missing JRE 1-8'
+  \ },
+  \]
+
+  call ale#lsp_linter#SetLSPLinterMap({'1': {'name': 'eclipselsp', 'aliases': [], 'lsp': 'stdio'}})
+  call ale#lsp_linter#SetDiagnosticURIMap({'347': ale#util#ToURI(expand('%:p'))})
+
+  if has('win32')
+    AssertEqual 'filename,[]^$.ts', expand('%:p:t')
+  else
+    AssertEqual 'filename*?,{}[]^$.java', expand('%:p:t')
+  endif
+
+  call ale#lsp_linter#HandleLSPResponse(1, {
+  \ 'jsonrpc':'2.0',
+  \ 'id': 347,
+  \ 'result': {
+  \     'kind': 'unchanged',
+  \ },
+  \})
+
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 1,
+  \     'bufnr': bufnr(''),
+  \     'col': 1,
+  \     'pattern': '',
+  \     'valid': 1,
+  \     'vcol': 0,
+  \     'nr': -1,
+  \     'type': 'W',
+  \     'text': 'Missing JRE 1-8'
+  \    }
+  \ ],
+  \ g:ale_buffer_info[bufnr('')].loclist
+  AssertEqual [], g:ale_buffer_info[bufnr('')].active_linter_list
+
 Execute(LSP errors should be logged in the history):
   call ale#lsp_linter#SetLSPLinterMap({'347': {'name': 'foobar', 'aliases': [], 'lsp': 'stdio'}})
   call ale#lsp_linter#HandleLSPResponse(347, {

--- a/test/lsp/test_lsp_address_split.vader
+++ b/test/lsp/test_lsp_address_split.vader
@@ -1,0 +1,9 @@
+Execute(Address splitting should function as intended):
+  AssertEqual ['foo', v:null], ale#lsp#SplitAddress('foo')
+  AssertEqual ['foo:', v:null], ale#lsp#SplitAddress('foo:')
+  AssertEqual ['foo', v:null], ale#lsp#SplitAddress('foo:0')
+  AssertEqual ['foo', 123], ale#lsp#SplitAddress('foo:123')
+  AssertEqual ['protocol:/foo:', v:null], ale#lsp#SplitAddress('protocol:/foo:')
+  AssertEqual ['protocol:/foo', v:null], ale#lsp#SplitAddress('protocol:/foo:0')
+  AssertEqual ['protocol:/foo', 123], ale#lsp#SplitAddress('protocol:/foo:123')
+  AssertEqual ['protocol:foo', v:null], ale#lsp#SplitAddress('protocol:foo')

--- a/test/lsp/test_lsp_client_messages.vader
+++ b/test/lsp/test_lsp_client_messages.vader
@@ -248,6 +248,19 @@ Execute(ale#lsp#message#DidChangeConfiguration() should return correct messages)
   \ ],
   \ ale#lsp#message#DidChangeConfiguration(bufnr(''), g:ale_lsp_configuration)
 
+Execute(ale#lsp#message#Diagnostic() should return correct messages):
+  AssertEqual
+  \ [
+  \   0,
+  \   'textDocument/diagnostic',
+  \   {
+  \     'textDocument': {
+  \         'uri': ale#path#ToFileURI(g:dir . '/foo/bar.ts'),
+  \     },
+  \   }
+  \ ],
+  \ ale#lsp#message#Diagnostic(bufnr(''))
+
 Execute(ale#lsp#tsserver_message#Open() should return correct messages):
   AssertEqual
   \ [

--- a/test/lsp/test_lsp_custom_request.vader
+++ b/test/lsp/test_lsp_custom_request.vader
@@ -39,7 +39,7 @@ Before:
 
   " Replace the StartLSP function to mock an LSP linter
   function! ale#lsp_linter#StartLSP(buffer, linter, Callback) abort
-    let g:conn_id = ale#lsp#Register(g:executable_or_address, g:project_root, {})
+    let g:conn_id = ale#lsp#Register(g:executable_or_address, g:project_root, '', {})
     call ale#lsp#MarkDocumentAsOpen(g:conn_id, a:buffer)
     call ale#lsp#HandleMessage(g:conn_id, Encode({'method': 'initialize'}))
 

--- a/test/lsp/test_lsp_startup.vader
+++ b/test/lsp/test_lsp_startup.vader
@@ -193,6 +193,10 @@ Before:
       \             'dynamicRegistration': v:false,
       \             'linkSupport': v:false,
       \           },
+      \           'diagnostic': {
+      \             'dynamicRegistration': v:true,
+      \             'relatedDocumentSupport': v:true,
+      \           },
       \           'publishDiagnostics': {
       \             'relatedInformation': v:true,
       \           },

--- a/test/lsp/test_lsp_startup.vader
+++ b/test/lsp/test_lsp_startup.vader
@@ -441,7 +441,7 @@ Execute(Deferred addresses should be handled correctly):
   call AssertInitSuccess('foo', 'localhost:1234', 'foobar', '/foo/bar', '', bufnr(''))
 
 Execute(Servers that have crashed should be restarted):
-  call ale#lsp#Register('foo', '/foo/bar', {})
+  call ale#lsp#Register('foo', '/foo/bar', '', {})
   call extend(ale#lsp#GetConnections()['foo:/foo/bar'], {'initialized': 1})
 
   " Starting the program again should reset initialized to `0`.

--- a/test/lsp/test_other_initialize_message_handling.vader
+++ b/test/lsp/test_other_initialize_message_handling.vader
@@ -90,6 +90,7 @@ Execute(Capabilities should be set up correctly):
   \   'includeText': 0,
   \   'references': 1,
   \   'rename': 1,
+  \   'pull_model': 0,
   \   'symbol_search': 1,
   \   'typeDefinition': 0,
   \ },
@@ -122,6 +123,7 @@ Execute(Disabled capabilities should be recognised correctly):
   \     'definitionProvider': v:false,
   \     'experimental': {},
   \     'documentHighlightProvider': v:true,
+  \     'diagnosticProvider': {},
   \   },
   \ },
   \})
@@ -140,6 +142,7 @@ Execute(Disabled capabilities should be recognised correctly):
   \   'includeText': 0,
   \   'references': 0,
   \   'rename': 0,
+  \   'pull_model': 0,
   \   'symbol_search': 0,
   \   'typeDefinition': 0,
   \ },
@@ -182,6 +185,9 @@ Execute(Capabilities should be enabled when sent as Dictionaries):
   \     'implementationProvider': {},
   \     'experimental': {},
   \     'documentHighlightProvider': v:true,
+  \     'diagnosticProvider': {
+  \       'interFileDependencies': v:false,
+  \     },
   \     'workspaceSymbolProvider': {}
   \   },
   \ },
@@ -201,6 +207,7 @@ Execute(Capabilities should be enabled when sent as Dictionaries):
   \   'includeText': 1,
   \   'references': 1,
   \   'rename': 1,
+  \   'pull_model': 1,
   \   'symbol_search': 1,
   \   'typeDefinition': 1,
   \ },

--- a/test/lsp/test_other_initialize_message_handling.vader
+++ b/test/lsp/test_other_initialize_message_handling.vader
@@ -2,30 +2,10 @@ Before:
   runtime autoload/ale/lsp.vim
 
   let g:message_list = []
-  let b:conn = {
-  \ 'id': 1,
-  \ 'is_tsserver': 0,
-  \ 'data': '',
-  \ 'root': '/foo/bar',
-  \ 'open_documents': {},
-  \ 'initialized': 0,
-  \ 'init_request_id': 0,
-  \ 'init_options': {},
-  \ 'config': {},
-  \ 'callback_list': [],
-  \ 'message_queue': [],
-  \ 'init_queue': [],
-  \ 'capabilities': {
-  \   'hover': 0,
-  \   'rename': 0,
-  \   'references': 0,
-  \   'completion': 0,
-  \   'completion_trigger_characters': [],
-  \   'definition': 0,
-  \   'symbol_search': 0,
-  \   'code_actions': 0,
-  \ },
-  \}
+
+  " Register a fake connection and get it for tests.
+  call ale#lsp#Register('ale-fake-lsp-server', '/code', {})
+  let b:conn = ale#lsp#GetConnections()['ale-fake-lsp-server:/code']
 
   function! ale#lsp#Send(conn_id, message) abort
     call add(g:message_list, a:message)
@@ -34,6 +14,9 @@ Before:
   endfunction
 
 After:
+  " Remove the connection with the ID.
+  call ale#lsp#RemoveConnectionWithID(b:conn.id)
+
   unlet! b:conn
   unlet! g:message_list
 
@@ -58,7 +41,7 @@ Execute(Other messages should not initialize projects):
   AssertEqual 0, b:conn.initialized
   AssertEqual [], g:message_list
 
-Execute(Capabilities should bet set up correctly):
+Execute(Capabilities should be set up correctly):
   call ale#lsp#HandleInitResponse(b:conn, {
   \ 'jsonrpc': '2.0',
   \ 'id': 1,
@@ -96,14 +79,19 @@ Execute(Capabilities should bet set up correctly):
   AssertEqual 1, b:conn.initialized
   AssertEqual
   \ {
-  \   'completion_trigger_characters': ['.'],
-  \   'completion': 1,
-  \   'references': 1,
-  \   'hover': 1,
-  \   'definition': 1,
-  \   'symbol_search': 1,
-  \   'rename': 1,
   \   'code_actions': 1,
+  \   'completion': 1,
+  \   'completion_trigger_characters': ['.'],
+  \   'definition': 1,
+  \   'did_save': 0,
+  \   'filerename': 0,
+  \   'hover': 1,
+  \   'implementation': 0,
+  \   'includeText': 0,
+  \   'references': 1,
+  \   'rename': 1,
+  \   'symbol_search': 1,
+  \   'typeDefinition': 0,
   \ },
   \ b:conn.capabilities
   AssertEqual [[1, 'initialized', {}]], g:message_list
@@ -141,19 +129,24 @@ Execute(Disabled capabilities should be recognised correctly):
   AssertEqual 1, b:conn.initialized
   AssertEqual
   \ {
-  \   'completion_trigger_characters': [],
-  \   'completion': 0,
-  \   'references': 0,
-  \   'hover': 0,
-  \   'definition': 0,
-  \   'symbol_search': 0,
-  \   'rename': 0,
   \   'code_actions': 0,
+  \   'completion': 0,
+  \   'completion_trigger_characters': [],
+  \   'definition': 0,
+  \   'did_save': 0,
+  \   'filerename': 0,
+  \   'hover': 0,
+  \   'implementation': 0,
+  \   'includeText': 0,
+  \   'references': 0,
+  \   'rename': 0,
+  \   'symbol_search': 0,
+  \   'typeDefinition': 0,
   \ },
   \ b:conn.capabilities
   AssertEqual [[1, 'initialized', {}]], g:message_list
 
-Execute(Capabilities should be enabled when send as Dictionaries):
+Execute(Capabilities should be enabled when sent as Dictionaries):
   call ale#lsp#HandleInitResponse(b:conn, {
   \ 'jsonrpc': '2.0',
   \ 'id': 1,
@@ -174,7 +167,11 @@ Execute(Capabilities should be enabled when send as Dictionaries):
   \       'resolveProvider': v:false
   \     },
   \     'referencesProvider': {},
-  \     'textDocumentSync': 2,
+  \     'textDocumentSync': {
+  \       'save': {
+  \         'includeText': v:true
+  \       }
+  \     },
   \     'documentFormattingProvider': v:true,
   \     'codeActionProvider': v:true,
   \     'signatureHelpProvider': {
@@ -193,16 +190,19 @@ Execute(Capabilities should be enabled when send as Dictionaries):
   AssertEqual 1, b:conn.initialized
   AssertEqual
   \ {
-  \   'completion_trigger_characters': ['.'],
-  \   'completion': 1,
-  \   'references': 1,
-  \   'hover': 1,
-  \   'definition': 1,
-  \   'typeDefinition': 1,
-  \   'implementation': 1,
-  \   'symbol_search': 1,
-  \   'rename': 1,
   \   'code_actions': 1,
+  \   'completion': 1,
+  \   'completion_trigger_characters': ['.'],
+  \   'definition': 1,
+  \   'did_save': 1,
+  \   'filerename': 0,
+  \   'hover': 1,
+  \   'implementation': 1,
+  \   'includeText': 1,
+  \   'references': 1,
+  \   'rename': 1,
+  \   'symbol_search': 1,
+  \   'typeDefinition': 1,
   \ },
   \ b:conn.capabilities
   AssertEqual [[1, 'initialized', {}]], g:message_list

--- a/test/lsp/test_other_initialize_message_handling.vader
+++ b/test/lsp/test_other_initialize_message_handling.vader
@@ -4,7 +4,7 @@ Before:
   let g:message_list = []
 
   " Register a fake connection and get it for tests.
-  call ale#lsp#Register('ale-fake-lsp-server', '/code', {})
+  call ale#lsp#Register('ale-fake-lsp-server', '/code', '', {})
   let b:conn = ale#lsp#GetConnections()['ale-fake-lsp-server:/code']
 
   function! ale#lsp#Send(conn_id, message) abort

--- a/test/lsp/test_read_lsp_diagnostics.vader
+++ b/test/lsp/test_read_lsp_diagnostics.vader
@@ -21,14 +21,14 @@ Execute(ale#lsp#response#ReadDiagnostics() should handle errors):
   \     'code': 'some-error',
   \   }
   \ ],
-  \ ale#lsp#response#ReadDiagnostics({'params': {'uri': 'filename.ts', 'diagnostics': [
+  \ ale#lsp#response#ReadDiagnostics([
   \   {
   \     'severity': 1,
   \     'range': Range(2, 10, 4, 15),
   \     'code': 'some-error',
   \     'message': 'Something went wrong!',
   \   },
-  \ ]}})
+  \ ])
 
 Execute(ale#lsp#response#ReadDiagnostics() should handle warnings):
   AssertEqual [
@@ -42,14 +42,14 @@ Execute(ale#lsp#response#ReadDiagnostics() should handle warnings):
   \     'code': 'some-warning',
   \   }
   \ ],
-  \ ale#lsp#response#ReadDiagnostics({'params': {'uri': 'filename.ts', 'diagnostics': [
+  \ ale#lsp#response#ReadDiagnostics([
   \   {
   \     'severity': 2,
   \     'range': Range(1, 3, 1, 3),
   \     'code': 'some-warning',
   \     'message': 'Something went wrong!',
   \   },
-  \ ]}})
+  \ ])
 
 Execute(ale#lsp#response#ReadDiagnostics() should treat messages with missing severity as errors):
   AssertEqual [
@@ -63,13 +63,13 @@ Execute(ale#lsp#response#ReadDiagnostics() should treat messages with missing se
   \     'code': 'some-error',
   \   }
   \ ],
-  \ ale#lsp#response#ReadDiagnostics({'params': {'uri': 'filename.ts', 'diagnostics': [
+  \ ale#lsp#response#ReadDiagnostics([
   \   {
   \     'range': Range(2, 10, 4, 15),
   \     'code': 'some-error',
   \     'message': 'Something went wrong!',
   \   },
-  \ ]}})
+  \ ])
 
 Execute(ale#lsp#response#ReadDiagnostics() should handle messages without codes):
   AssertEqual [
@@ -82,12 +82,12 @@ Execute(ale#lsp#response#ReadDiagnostics() should handle messages without codes)
   \     'end_col': 15,
   \   }
   \ ],
-  \ ale#lsp#response#ReadDiagnostics({'params': {'uri': 'filename.ts', 'diagnostics': [
+  \ ale#lsp#response#ReadDiagnostics([
   \   {
   \     'range': Range(2, 10, 4, 15),
   \     'message': 'Something went wrong!',
   \   },
-  \ ]}})
+  \ ])
 
 Execute(ale#lsp#response#ReadDiagnostics() should include sources in detail):
   AssertEqual [
@@ -101,13 +101,13 @@ Execute(ale#lsp#response#ReadDiagnostics() should include sources in detail):
   \     'end_col': 22,
   \   }
   \ ],
-  \ ale#lsp#response#ReadDiagnostics({'params': {'uri': 'filename.ts', 'diagnostics': [
+  \ ale#lsp#response#ReadDiagnostics([
   \   {
   \     'range': Range(9, 14, 11, 22),
   \     'message': 'Something went wrong!',
   \     'source': 'tslint',
   \   }
-  \ ]}})
+  \ ])
 
 Execute(ale#lsp#response#ReadDiagnostics() should keep detail with line breaks but replace with spaces in text):
   AssertEqual [
@@ -121,13 +121,13 @@ Execute(ale#lsp#response#ReadDiagnostics() should keep detail with line breaks b
   \     'end_col': 22,
   \   }
   \ ],
-  \ ale#lsp#response#ReadDiagnostics({'params': {'uri': 'filename.ts', 'diagnostics': [
+  \ ale#lsp#response#ReadDiagnostics([
   \   {
   \     'range': Range(9, 14, 11, 22),
   \     'message': "cannot borrow `cap` as mutable\r\nmore than once at a time\n\nmutable borrow starts here\rin previous iteration of loop",
   \     'source': 'rustc',
   \   }
-  \ ]}})
+  \ ])
 
 Execute(ale#lsp#response#ReadDiagnostics() should consider -1 to be a meaningless code):
   AssertEqual [
@@ -140,13 +140,13 @@ Execute(ale#lsp#response#ReadDiagnostics() should consider -1 to be a meaningles
   \     'end_col': 15,
   \   }
   \ ],
-  \ ale#lsp#response#ReadDiagnostics({'params': {'uri': 'filename.ts', 'diagnostics': [
+  \ ale#lsp#response#ReadDiagnostics([
   \   {
   \     'range': Range(2, 10, 4, 15),
   \     'message': 'Something went wrong!',
   \     'code': -1,
   \   },
-  \ ]}})
+  \ ])
 
 Execute(ale#lsp#response#ReadDiagnostics() should handle multiple messages):
   AssertEqual [
@@ -167,7 +167,7 @@ Execute(ale#lsp#response#ReadDiagnostics() should handle multiple messages):
   \     'end_col': 4,
   \   },
   \ ],
-  \ ale#lsp#response#ReadDiagnostics({'params': {'uri': 'filename.ts', 'diagnostics': [
+  \ ale#lsp#response#ReadDiagnostics([
   \   {
   \     'range': Range(0, 2, 0, 2),
   \     'message': 'Something went wrong!',
@@ -177,7 +177,7 @@ Execute(ale#lsp#response#ReadDiagnostics() should handle multiple messages):
   \     'range': Range(1, 4, 1, 4),
   \     'message': 'A warning',
   \   },
-  \ ]}})
+  \ ])
 
 Execute(ale#lsp#response#ReadDiagnostics() should use relatedInformation for detail):
   AssertEqual [
@@ -191,7 +191,7 @@ Execute(ale#lsp#response#ReadDiagnostics() should use relatedInformation for det
   \     'detail': "Something went wrong!\n/tmp/someotherfile.txt:43:80:\n\tmight be this"
   \   }
   \ ],
-  \ ale#lsp#response#ReadDiagnostics({'params': {'uri': 'filename.ts', 'diagnostics': [
+  \ ale#lsp#response#ReadDiagnostics([
   \   {
   \     'range': Range(0, 2, 0, 2),
   \     'message': 'Something went wrong!',
@@ -206,7 +206,7 @@ Execute(ale#lsp#response#ReadDiagnostics() should use relatedInformation for det
   \         }
   \     }]
   \   }
-  \ ]}})
+  \ ])
 
 Execute(ale#lsp#response#ReadTSServerDiagnostics() should handle tsserver responses):
   AssertEqual

--- a/test/lsp/test_update_config.vader
+++ b/test/lsp/test_update_config.vader
@@ -1,7 +1,7 @@
 Before:
   runtime autoload/ale/lsp.vim
 
-  let g:conn_id = ale#lsp#Register('executable', '/foo/bar', {})
+  let g:conn_id = ale#lsp#Register('executable', '/foo/bar', '', {})
 
   " Stub out this function, so we test updating configs.
   function! ale#lsp#Send(conn_id, message) abort

--- a/test/lua/.luarc.json
+++ b/test/lua/.luarc.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://raw.githubusercontent.com/LuaLS/vscode-lua/master/setting/schema.json",
+  "diagnostics.globals": [
+    "vim",
+    "describe",
+    "it",
+    "before_each",
+    "after_each",
+    "setup",
+    "teardown",
+    "pending",
+    "assert"
+  ],
+  "workspace.library": [
+    "../../lua"
+  ],
+  "runtime.version": "LuaJIT",
+  "hint.enable": false
+}

--- a/test/lua/.luarc.json
+++ b/test/lua/.luarc.json
@@ -11,8 +11,29 @@
     "pending",
     "assert"
   ],
+  "workspace.checkThirdParty": false,
   "workspace.library": [
+    "${3rd}/busted/library",
+    "${env:HOME}/.luarocks/share/lua/5.4",
+    "${env:HOME}/.luarocks/share/lua/5.3",
+    "${env:HOME}/.luarocks/share/lua/5.2",
+    "${env:HOME}/.luarocks/share/lua/5.1",
     "../../lua"
+  ],
+  "runtime.pathStrict": true,
+  "runtime.path": [
+    "?.lua",
+    "?/init.lua",
+    "../../lua/?.lua",
+    "../../lua/?/init.lua",
+    "${env:HOME}/.luarocks/share/lua/5.4/?.lua",
+    "${env:HOME}/.luarocks/share/lua/5.4/?/init.lua",
+    "${env:HOME}/.luarocks/share/lua/5.3/?.lua",
+    "${env:HOME}/.luarocks/share/lua/5.3/?/init.lua",
+    "${env:HOME}/.luarocks/share/lua/5.2/?.lua",
+    "${env:HOME}/.luarocks/share/lua/5.2/?/init.lua",
+    "${env:HOME}/.luarocks/share/lua/5.1/?.lua",
+    "${env:HOME}/.luarocks/share/lua/5.1/?/init.lua"
   ],
   "runtime.version": "LuaJIT",
   "hint.enable": false

--- a/test/lua/ale_diagnostics_spec.lua
+++ b/test/lua/ale_diagnostics_spec.lua
@@ -1,0 +1,232 @@
+local eq = assert.are.same
+local diagnostics
+
+describe("ale.diagnostics.send", function()
+    local buffer_map
+    local signs_config
+    local diagnostic_set_calls
+
+    setup(function()
+        _G.vim = {
+            api = {
+                nvim_buf_get_var = function(buffer, key)
+                    local buffer_table = buffer_map[buffer] or {}
+                    local value = buffer_table[key]
+
+                    if value == nil then
+                        error(key .. " is missing")
+                    end
+
+                    return value
+                end,
+                nvim_create_namespace = function()
+                    return 42
+                end,
+            },
+            diagnostic = {
+                severity = {ERROR = 1, WARN = 2, INFO = 3},
+                config = function()
+                    return {signs = signs_config}
+                end,
+                set = function(namespace, bufnr, _diagnostics, opts)
+                    table.insert(diagnostic_set_calls, {
+                        namespace = namespace,
+                        bufnr = bufnr,
+                        diagnostics = _diagnostics,
+                        opts = opts,
+                    })
+                end,
+            },
+            tbl_extend = function(behavior, ...)
+                assert(behavior == "force", "We should only use `force`")
+
+                local merged = {}
+
+                for _, arg in ipairs({...}) do
+                    for key, value in pairs(arg) do
+                        merged[key] = value
+                    end
+                end
+
+                return merged
+            end,
+            g = {},
+        }
+
+        diagnostics = require("ale.diagnostics")
+    end)
+
+    teardown(function()
+        _G.vim = nil
+    end)
+
+    before_each(function()
+        buffer_map = {}
+        diagnostic_set_calls = {}
+        signs_config = false
+        _G.vim.g = {}
+    end)
+
+    it("should set an empty list of diagnostics correctly", function()
+        diagnostics.send(7, {})
+
+        eq(
+            {
+                {
+                    namespace = 42,
+                    bufnr = 7,
+                    diagnostics = {},
+                    opts = {virtual_text = false}
+                },
+            },
+            diagnostic_set_calls
+        )
+    end)
+
+    it("should handle basic case with all fields", function()
+        diagnostics.send(1, {
+            {
+                bufnr = 1,
+                lnum = 2,
+                end_lnum = 3,
+                col = 4,
+                end_col = 5,
+                type = "W",
+                code = "123",
+                text = "Warning message",
+                linter_name = "eslint",
+            },
+        })
+        eq({
+            {
+                lnum = 1,
+                end_lnum = 2,
+                col = 3,
+                end_col = 5,
+                severity = vim.diagnostic.severity.WARN,
+                code = "123",
+                message = "Warning message",
+                source = "eslint",
+            },
+        }, diagnostic_set_calls[1].diagnostics)
+    end)
+
+    it("should default end_lnum to lnum when missing", function()
+        diagnostics.send(1, {
+            {
+                bufnr = 1,
+                lnum = 5,
+                col = 2,
+                end_col = 8,
+                type = "E",
+                text = "Error message",
+                linter_name = "mylinter",
+            },
+        })
+        eq({
+            {
+                lnum = 4,
+                end_lnum = 4,
+                col = 1,
+                end_col = 8,
+                severity = vim.diagnostic.severity.ERROR,
+                code = nil,
+                message = "Error message",
+                source = "mylinter",
+            },
+        }, diagnostic_set_calls[1].diagnostics)
+    end)
+
+    it("should default col to 0 when missing", function()
+        diagnostics.send(1, {
+            {
+                bufnr = 1,
+                lnum = 10,
+                end_lnum = 12,
+                end_col = 6,
+                type = "I",
+                text = "Info message",
+            },
+        })
+        eq({
+            {
+                lnum = 9,
+                end_lnum = 11,
+                col = 0,
+                end_col = 6,
+                severity = vim.diagnostic.severity.INFO,
+                code = nil,
+                message = "Info message",
+                source = nil,
+            },
+        }, diagnostic_set_calls[1].diagnostics)
+    end)
+
+    it("should ignore non-matching buffers", function()
+        diagnostics.send(1, {
+            {
+                bufnr = 2,
+                lnum = 1,
+                end_lnum = 2,
+                col = 1,
+                end_col = 4,
+                type = "W",
+                text = "Message",
+            },
+        })
+        eq({}, diagnostic_set_calls[1].diagnostics)
+    end)
+
+    for _, set_signs_value in ipairs {1, true} do
+        describe("signs with setting set_signs = " .. tostring(set_signs_value), function()
+            before_each(function()
+                _G.vim.g.ale_set_signs = set_signs_value
+                _G.vim.g.ale_sign_priority = 10
+            end)
+
+            it("and global config as `false` should enable signs with the given priority", function()
+                diagnostics.send(7, {})
+                eq({priority = 10}, diagnostic_set_calls[1].opts.signs)
+            end)
+
+            it("and global config as a table should enable signs with the given priority", function()
+                signs_config = {foo = "bar", priority = 5}
+                diagnostics.send(7, {})
+                eq(
+                    {foo = "bar", priority = 10},
+                    diagnostic_set_calls[1].opts.signs
+                )
+            end)
+
+            it("and global config as a function should enable signs with the given priority", function()
+                signs_config = function()
+                    return {foo = "bar", priority = 5}
+                end
+                diagnostics.send(7, {})
+
+                local local_signs = diagnostic_set_calls[1].opts.signs
+
+                eq("function", type(local_signs))
+                eq({foo = "bar", priority = 10}, local_signs())
+            end)
+        end)
+    end
+
+    it("should toggle virtual_text correctly", function()
+        for _, value in ipairs({"all", "2", 2, "current", "1", 1, true}) do
+            diagnostic_set_calls = {}
+            _G.vim.g.ale_virtualtext_cursor = value
+            diagnostics.send(7, {})
+
+            eq({virtual_text = true}, diagnostic_set_calls[1].opts)
+        end
+
+        for _, value in ipairs({"disabled", "0", 0, false, nil}) do
+            diagnostic_set_calls = {}
+            _G.vim.g.ale_virtualtext_cursor = value
+            diagnostics.send(7, {})
+
+            eq({virtual_text = false}, diagnostic_set_calls[1].opts)
+        end
+    end)
+end)

--- a/test/lua/ale_env_spec.lua
+++ b/test/lua/ale_env_spec.lua
@@ -1,0 +1,56 @@
+local eq = assert.are.same
+local ale = require("ale")
+
+describe("ale.env", function()
+    local is_win32 = false
+
+    setup(function()
+        _G.vim = {
+            o = setmetatable({}, {
+                __index = function(_, key)
+                    if key == "shell" then
+                        if is_win32 then
+                            return "cmd.exe"
+                        end
+
+                        return "bash"
+                    end
+
+                    return nil
+                end
+            }),
+            fn = {
+                has = function(feature)
+                    return feature == "win32" and is_win32
+                end,
+                -- Mock a very poor version of shellescape() for Unix
+                -- This shouldn't be called for Windows
+                shellescape = function(str)
+                    return "'" .. str .. "'"
+                end,
+                fnamemodify = function(shell, _)
+                    return shell
+                end
+            }
+        }
+    end)
+
+    teardown(function()
+        _G.vim = nil
+    end)
+
+    before_each(function()
+        is_win32 = false
+    end)
+
+    it("should escape values correctly on Unix", function()
+        eq("name='xxx' ", ale.env('name', 'xxx'))
+        eq("name='foo bar' ", ale.env('name', 'foo bar'))
+    end)
+
+    it("should escape values correctly on Windows", function()
+        is_win32 = true
+        eq('set name=xxx && ', ale.env('name', 'xxx'))
+        eq('set "name=foo bar" && ', ale.env('name', 'foo bar'))
+    end)
+end)

--- a/test/lua/ale_get_filename_mappings_spec.lua
+++ b/test/lua/ale_get_filename_mappings_spec.lua
@@ -1,0 +1,77 @@
+local eq = assert.are.same
+local ale = require("ale")
+
+describe("ale.get_filename_mappings", function()
+    local buffer_map
+
+    setup(function()
+        _G.vim = {
+            api = {
+                nvim_buf_get_var = function(buffer, key)
+                    local buffer_table = buffer_map[buffer] or {}
+                    local value = buffer_table[key]
+
+                    if value == nil then
+                        error(key .. " is missing")
+                    end
+
+                    return value
+                end,
+            },
+            g = {
+            },
+        }
+    end)
+
+    teardown(function()
+        _G.vim = nil
+    end)
+
+    before_each(function()
+        buffer_map = {[42] = {}}
+        _G.vim.g = {}
+    end)
+
+    it("should return the correct mappings for given linters/fixers", function()
+        vim.g.ale_filename_mappings = {
+            a = {{"foo", "bar"}},
+            b = {{"baz", "foo"}},
+        }
+
+        eq({{"foo", "bar"}}, ale.get_filename_mappings(42, "a"))
+        eq({{"baz", "foo"}}, ale.get_filename_mappings(42, "b"))
+        eq({}, ale.get_filename_mappings(42, "c"))
+
+        buffer_map[42].ale_filename_mappings = {b = {{"abc", "xyz"}}}
+
+        eq({}, ale.get_filename_mappings(42, "a"))
+        eq({{"abc", "xyz"}}, ale.get_filename_mappings(42, "b"))
+        eq({}, ale.get_filename_mappings(42, "c"))
+    end)
+
+    it("should return arrays set for use with all tools", function()
+        vim.g.ale_filename_mappings = {{"foo", "bar"}}
+
+        eq({{"foo", "bar"}}, ale.get_filename_mappings(42, "a"))
+        eq({{"foo", "bar"}}, ale.get_filename_mappings(42, ""))
+        eq({{"foo", "bar"}}, ale.get_filename_mappings(42, nil))
+
+        buffer_map[42].ale_filename_mappings = {{"abc", "xyz"}}
+
+        eq({{"abc", "xyz"}}, ale.get_filename_mappings(42, "a"))
+        eq({{"abc", "xyz"}}, ale.get_filename_mappings(42, ""))
+        eq({{"abc", "xyz"}}, ale.get_filename_mappings(42, nil))
+    end)
+
+    it("should let you use * as a fallback", function()
+        vim.g.ale_filename_mappings = {
+            a = {{"foo", "bar"}},
+            ["*"] = {{"abc", "xyz"}},
+        }
+
+        eq({{"foo", "bar"}}, ale.get_filename_mappings(42, "a"))
+        eq({{"abc", "xyz"}}, ale.get_filename_mappings(42, "b"))
+        eq({{"abc", "xyz"}}, ale.get_filename_mappings(42, ""))
+        eq({{"abc", "xyz"}}, ale.get_filename_mappings(42, nil))
+    end)
+end)

--- a/test/lua/ale_has_spec.lua
+++ b/test/lua/ale_has_spec.lua
@@ -1,0 +1,27 @@
+local eq = assert.are.same
+local ale = require("ale")
+
+describe("ale.has", function()
+    setup(function()
+        _G.vim = {
+            fn = {
+                ["ale#Has"] = function(feature)
+                    if feature == "ale-4.0.0" then
+                        return 1
+                    end
+
+                    return 0
+                end,
+            },
+        }
+    end)
+
+    teardown(function()
+        _G.vim = nil
+    end)
+
+    it("should return valuse from ale#Has correctly", function()
+        eq(true, ale.has("ale-4.0.0"))
+        eq(false, ale.has("ale-20.0.0"))
+    end)
+end)

--- a/test/lua/ale_lsp_spec.lua
+++ b/test/lua/ale_lsp_spec.lua
@@ -1,0 +1,224 @@
+local eq = assert.are.same
+local lsp = require("ale.lsp")
+
+describe("ale.lsp.start", function()
+    local start_calls
+    local rpc_connect_calls
+    local vim_fn_calls
+    local defer_calls
+
+    setup(function()
+        _G.vim = {
+            defer_fn = function(func, delay)
+                table.insert(defer_calls, {func, delay})
+            end,
+            fn = setmetatable({}, {
+                __index = function(_, key)
+                    return function(...)
+                        table.insert(vim_fn_calls, {key, ...})
+
+                        if key == "ale#lsp#GetLanguage" then
+                            return "python"
+                        end
+
+                        if key ~= "ale#lsp_linter#HandleLSPResponse"
+                        and key ~= "ale#lsp#UpdateCapabilities"
+                        and key ~= "ale#lsp#CallInitCallbacks"
+                        then
+                            assert(false, "Invalid ALE function: " .. key)
+                        end
+
+                        return nil
+                    end
+                end,
+            }),
+            lsp = {
+                rpc = {
+                    connect = function(host, port)
+                        return function(dispatch)
+                            table.insert(rpc_connect_calls, {
+                                host = host,
+                                port = port,
+                                dispatch = dispatch,
+                            })
+                        end
+                    end,
+                },
+                start = function(...)
+                    table.insert(start_calls, {...})
+
+                    return 42
+                end,
+            },
+        }
+    end)
+
+    teardown(function()
+        _G.vim = nil
+    end)
+
+    before_each(function()
+        start_calls = {}
+        rpc_connect_calls = {}
+        vim_fn_calls = {}
+        defer_calls = {}
+    end)
+
+    it("should start lsp programs with the correct arguments", function()
+        lsp.start({
+            name = "server:/code",
+            cmd = "server",
+            root_dir = "/code",
+            -- This Boolean value somehow ends up in Dictionaries from
+            -- Vim for init_options, and we need to remove it.
+            init_options = {[true] = 123},
+        })
+
+        -- Remove arguments with functions we can't apply equality checks
+        -- for easily.
+        for _, args in pairs(start_calls) do
+            args[1].handlers = nil
+            args[1].on_init = nil
+            args[1].get_language_id = nil
+        end
+
+        eq({
+            {
+                {
+                    cmd = "server",
+                    name = "server:/code",
+                    root_dir = "/code",
+                    init_options = {},
+                },
+                {attach = false, silent = true}
+            }
+        }, start_calls)
+        eq({}, vim_fn_calls)
+    end)
+
+    it("should start lsp socket connections with the correct arguments", function()
+        lsp.start({
+            name = "localhost:1234:/code",
+            host = "localhost",
+            port = 1234,
+            root_dir = "/code",
+            init_options = {foo = "bar"},
+        })
+
+        local cmd
+
+        -- Remove arguments with functions we can't apply equality checks
+        -- for easily.
+        for _, args in pairs(start_calls) do
+            cmd = args[1].cmd
+            args[1].cmd = nil
+            args[1].handlers = nil
+            args[1].on_init = nil
+            args[1].get_language_id = nil
+        end
+
+        eq({
+            {
+                {
+                    name = "localhost:1234:/code",
+                    root_dir = "/code",
+                    init_options = {foo = "bar"},
+                },
+                {attach = false, silent = true}
+            }
+        }, start_calls)
+
+        cmd("dispatch_value")
+
+        eq({
+            {dispatch = "dispatch_value", host = "localhost", port = 1234},
+        }, rpc_connect_calls)
+        eq({}, vim_fn_calls)
+    end)
+
+    it("should return the client_id value from vim.lsp.start", function()
+        eq(42, lsp.start({}))
+    end)
+
+    it("should implement get_language_id correctly", function()
+        lsp.start({name = "server:/code"})
+
+        eq(1, #start_calls)
+        eq("python", start_calls[1][1].get_language_id(347, "ftype"))
+        eq({{"ale#lsp#GetLanguage", "server:/code", 347}}, vim_fn_calls)
+    end)
+
+    it("should initialize clients with ALE correctly", function()
+        lsp.start({name = "server:/code"})
+
+        eq(1, #start_calls)
+
+        start_calls[1][1].on_init({server_capabilities = {cap = 1}})
+
+        eq({
+            {"ale#lsp#UpdateCapabilities", "server:/code", {cap = 1}},
+        }, vim_fn_calls)
+        eq(1, #defer_calls)
+        eq(2, #defer_calls[1])
+        eq("function", type(defer_calls[1][1]))
+        eq(0, defer_calls[1][2])
+
+        defer_calls[1][1]()
+
+        eq({
+            {"ale#lsp#UpdateCapabilities", "server:/code", {cap = 1}},
+            {"ale#lsp#CallInitCallbacks", "server:/code"},
+        }, vim_fn_calls)
+    end)
+
+    it("should configure handlers correctly", function()
+        lsp.start({name = "server:/code"})
+
+        eq(1, #start_calls)
+
+        local handlers = start_calls[1][1].handlers
+        local handler_names = {}
+
+        -- get keys from handlers
+        for key, _ in pairs(handlers) do
+            -- add key to handler_names mapping
+            handler_names[key] = true
+        end
+
+        eq({["textDocument/publishDiagnostics"] = true}, handler_names)
+
+        handlers["textDocument/publishDiagnostics"](nil, {
+            {
+                lnum = 1,
+                end_lnum = 2,
+                col = 3,
+                end_col = 5,
+                severity = 1,
+                code = "123",
+                message = "Warning message",
+            },
+        })
+
+        eq({
+            {
+                "ale#lsp_linter#HandleLSPResponse",
+                "server:/code",
+                {
+                    jsonrpc = "2.0",
+                    method = "textDocument/publishDiagnostics",
+                    params = {
+                        {
+                            lnum = 1,
+                            end_lnum = 2,
+                            col = 3,
+                            end_col = 5,
+                            severity = 1,
+                            code = "123",
+                            message = "Warning message",
+                        },
+                    }
+                }
+            },
+        }, vim_fn_calls)
+    end)
+end)

--- a/test/lua/ale_pad_spec.lua
+++ b/test/lua/ale_pad_spec.lua
@@ -1,0 +1,13 @@
+local eq = assert.are.same
+local ale = require("ale")
+
+describe("ale.pad", function()
+    it("should pad non-empty strings", function()
+        eq(" foo", ale.pad("foo"))
+    end)
+
+    it("should return empty strings for nil or empty strings", function()
+        eq("", ale.pad(nil))
+        eq("", ale.pad(""))
+    end)
+end)

--- a/test/lua/ale_queue_spec.lua
+++ b/test/lua/ale_queue_spec.lua
@@ -1,0 +1,40 @@
+local eq = assert.are.same
+local ale = require("ale")
+
+describe("ale.queue", function()
+    local queue_calls
+
+    setup(function()
+        _G.vim = {
+            fn = {
+                ["ale#Queue"] = function(...)
+                    table.insert(queue_calls, {...})
+                end,
+            },
+        }
+    end)
+
+    teardown(function()
+        _G.vim = nil
+    end)
+
+    before_each(function()
+        queue_calls = {}
+    end)
+
+    it("should call ale#Queue with the right arguments", function()
+        ale.queue(0)
+        ale.queue(0, "")
+        ale.queue(123, "lint_file")
+        ale.queue(0, "", 42)
+        ale.queue(123, "lint_file", 42)
+
+        eq({
+            {0, nil, nil},
+            {0, "", nil},
+            {123, "lint_file", nil},
+            {0, "", 42},
+            {123, "lint_file", 42},
+        }, queue_calls)
+    end)
+end)

--- a/test/lua/ale_var_spec.lua
+++ b/test/lua/ale_var_spec.lua
@@ -1,0 +1,51 @@
+local eq = assert.are.same
+local ale = require("ale")
+
+describe("ale.var", function()
+    local buffer_map
+
+    setup(function()
+        _G.vim = {
+            api = {
+                nvim_buf_get_var = function(buffer, key)
+                    local buffer_table = buffer_map[buffer] or {}
+                    local value = buffer_table[key]
+
+                    if value == nil then
+                        error(key .. " is missing")
+                    end
+
+                    return value
+                end,
+            },
+            g = {
+            },
+        }
+    end)
+
+    teardown(function()
+        _G.vim = nil
+    end)
+
+    before_each(function()
+        buffer_map = {}
+        _G.vim.g = {}
+    end)
+
+    it("should return nil for undefined variables", function()
+        eq(nil, ale.var(1, "foo"))
+    end)
+
+    it("should return buffer-local values, if set", function()
+        _G.vim.g.ale_foo = "global-value"
+        buffer_map[1] = {ale_foo = "buffer-value"}
+
+        eq("buffer-value", ale.var(1, "foo"))
+    end)
+
+    it("should return global values, if set", function()
+        _G.vim.g.ale_foo = "global-value"
+
+        eq("global-value", ale.var(1, "foo"))
+    end)
+end)

--- a/test/lua/windows_escaping_spec.lua
+++ b/test/lua/windows_escaping_spec.lua
@@ -1,0 +1,61 @@
+local eq = assert.are.same
+local ale = require("ale")
+
+describe("ale.escape for cmd.exe", function()
+    setup(function()
+        _G.vim = {
+            o = {
+                shell = "cmd.exe"
+            },
+            fn = {
+                fnamemodify = function(shell, _)
+                    return shell
+                end
+            }
+        }
+    end)
+
+    teardown(function()
+        _G.vim = nil
+    end)
+
+    it("should allow not escape paths without special characters", function()
+        eq("C:", ale.escape("C:"))
+        eq("C:\\", ale.escape("C:\\"))
+        eq("python", ale.escape("python"))
+        eq("C:\\foo\\bar", ale.escape("C:\\foo\\bar"))
+        eq("/bar/baz", ale.escape("/bar/baz"))
+        eq("nul", ale.escape("nul"))
+        eq("'foo'", ale.escape("'foo'"))
+    end)
+
+    it("should escape Windows paths with spaces appropriately", function()
+        eq('"C:\\foo bar\\baz"', ale.escape('C:\\foo bar\\baz'))
+        eq('"^foo bar^"', ale.escape('^foo bar^'))
+        eq('"&foo bar&"', ale.escape('&foo bar&'))
+        eq('"|foo bar|"', ale.escape('|foo bar|'))
+        eq('"<foo bar<"', ale.escape('<foo bar<'))
+        eq('">foo bar>"', ale.escape('>foo bar>'))
+        eq('"^foo bar^"', ale.escape('^foo bar^'))
+        eq('"\'foo\' \'bar\'"', ale.escape('\'foo\' \'bar\''))
+    end)
+
+    it("should use caret escapes on special characters", function()
+        eq('^^foo^^', ale.escape('^foo^'))
+        eq('^&foo^&', ale.escape('&foo&'))
+        eq('^|foo^|', ale.escape('|foo|'))
+        eq('^<foo^<', ale.escape('<foo<'))
+        eq('^>foo^>', ale.escape('>foo>'))
+        eq('^^foo^^', ale.escape('^foo^'))
+        eq('\'foo\'^^\'bar\'', ale.escape('\'foo\'^\'bar\''))
+    end)
+
+    it("should escape percent characters", function()
+        eq('%%foo%%', ale.escape('%foo%'))
+        eq('C:\foo%%\bar\baz%%', ale.escape('C:\foo%\bar\baz%'))
+        eq('"C:\foo bar%%\baz%%"', ale.escape('C:\foo bar%\baz%'))
+        eq('^^%%foo%%', ale.escape('^%foo%'))
+        eq('"^%%foo%% %%bar%%"', ale.escape('^%foo% %bar%'))
+        eq('"^%%foo%% %%bar%% """""', ale.escape('^%foo% %bar% ""'))
+    end)
+end)

--- a/test/script/run-lua-tests
+++ b/test/script/run-lua-tests
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+
+docker_flags=(--rm -v "$PWD:/testplugin" -v "$PWD/test:/home" -w /testplugin/test/lua "$DOCKER_RUN_IMAGE")
+
+quiet=0
+
+while [ $# -ne 0 ]; do
+    case $1 in
+    -q)
+        quiet=1
+        shift
+    ;;
+    --)
+        shift
+        break
+    ;;
+    -?*)
+        echo "Invalid argument: $1" 1>&2
+        exit 1
+    ;;
+    *)
+        break
+    ;;
+    esac
+done
+
+function filter-busted-output() {
+    local hit_failure_line=0
+
+    while read -r; do
+        if ((quiet)); then
+            # If we're using the quiet flag, the filter out lines until we hit
+            # the first line with "Failure" and then print the rest.
+            if ((hit_failure_line)); then
+                echo "$REPLY"
+            elif [[ "$REPLY" = *'Failure'* ]]; then
+                hit_failure_line=1
+                echo "$REPLY"
+            fi
+        else
+            echo "$REPLY"
+        fi
+    done
+}
+
+exit_code=0
+
+set -o pipefail
+"$DOCKER" run -a stdout "${docker_flags[@]}" /usr/bin/busted-5.1 \
+    -m '../../lua/?.lua;../../lua/?/init.lua' . \
+    --output utfTerminal | filter-busted-output || exit_code=$?
+set +o pipefail
+
+exit "$exit_code"

--- a/test/test_codefix.vader
+++ b/test/test_codefix.vader
@@ -23,7 +23,7 @@ Before:
   runtime autoload/ale/code_action.vim
 
   function! ale#lsp_linter#StartLSP(buffer, linter, Callback) abort
-    let g:conn_id = ale#lsp#Register('executable', '/foo/bar', {})
+    let g:conn_id = ale#lsp#Register('executable', '/foo/bar', '', {})
     call ale#lsp#MarkDocumentAsOpen(g:conn_id, a:buffer)
 
     if a:linter.lsp is# 'tsserver'

--- a/test/test_filerename.vader
+++ b/test/test_filerename.vader
@@ -20,7 +20,7 @@ Before:
   runtime autoload/ale/code_action.vim
 
   function! ale#lsp_linter#StartLSP(buffer, linter, Callback) abort
-    let g:conn_id = ale#lsp#Register('executable', '/foo/bar', {})
+    let g:conn_id = ale#lsp#Register('executable', '/foo/bar', '', {})
     call ale#lsp#MarkDocumentAsOpen(g:conn_id, a:buffer)
 
     if a:linter.lsp is# 'tsserver'

--- a/test/test_find_references.vader
+++ b/test/test_find_references.vader
@@ -22,7 +22,7 @@ Before:
   runtime autoload/ale/preview.vim
 
   function! ale#lsp_linter#StartLSP(buffer, linter, Callback) abort
-    let g:conn_id = ale#lsp#Register('executable', '/foo/bar', {})
+    let g:conn_id = ale#lsp#Register('executable', '/foo/bar', '', {})
     call ale#lsp#MarkDocumentAsOpen(g:conn_id, a:buffer)
 
     if a:linter.lsp is# 'tsserver'

--- a/test/test_go_to_definition.vader
+++ b/test/test_go_to_definition.vader
@@ -19,7 +19,7 @@ Before:
   runtime autoload/ale/util.vim
 
   function! ale#lsp_linter#StartLSP(buffer, linter, Callback) abort
-    let g:conn_id = ale#lsp#Register('executable', '/foo/bar', {})
+    let g:conn_id = ale#lsp#Register('executable', '/foo/bar', '', {})
     call ale#lsp#MarkDocumentAsOpen(g:conn_id, a:buffer)
 
     if a:linter.lsp is# 'tsserver'

--- a/test/test_organize_imports.vader
+++ b/test/test_organize_imports.vader
@@ -20,7 +20,7 @@ Before:
   runtime autoload/ale/code_action.vim
 
   function! ale#lsp_linter#StartLSP(buffer, linter, Callback) abort
-    let g:conn_id = ale#lsp#Register('executable', '/foo/bar', {})
+    let g:conn_id = ale#lsp#Register('executable', '/foo/bar', '', {})
     call ale#lsp#MarkDocumentAsOpen(g:conn_id, a:buffer)
 
     if a:linter.lsp is# 'tsserver'

--- a/test/test_rename.vader
+++ b/test/test_rename.vader
@@ -20,7 +20,7 @@ Before:
   runtime autoload/ale/code_action.vim
 
   function! ale#lsp_linter#StartLSP(buffer, linter, Callback) abort
-    let g:conn_id = ale#lsp#Register('executable', '/foo/bar', {})
+    let g:conn_id = ale#lsp#Register('executable', '/foo/bar', '', {})
     call ale#lsp#MarkDocumentAsOpen(g:conn_id, a:buffer)
 
     if a:linter.lsp is# 'tsserver'

--- a/test/test_symbol_search.vader
+++ b/test/test_symbol_search.vader
@@ -18,7 +18,7 @@ Before:
   runtime autoload/ale/preview.vim
 
   function! ale#lsp_linter#StartLSP(buffer, linter, Callback) abort
-    let g:conn_id = ale#lsp#Register('executable', '/foo/bar', {})
+    let g:conn_id = ale#lsp#Register('executable', '/foo/bar', '', {})
     call ale#lsp#MarkDocumentAsOpen(g:conn_id, a:buffer)
     let l:details = {
     \ 'buffer': a:buffer,

--- a/test/vimrc
+++ b/test/vimrc
@@ -4,6 +4,8 @@
 let g:ale_set_lists_synchronously = 1
 " Disable Neovim diagnostics by default for CI tests.
 let g:ale_use_neovim_diagnostics_api = 0
+" Disable Neovim native LSP API by default for CI tests.
+let g:ale_use_neovim_lsp_api = 0
 
 " This lowercase highlight definition is needed for highlight tests.
 hi link aleerrorline spellbad


### PR DESCRIPTION
This pull request is a major move toward goals stated in #4815. The changes here accomplish the following.

1. ALE will use Neovim's LSP client in Neovim 0.8 and up by default.
2. ALE can be configured via `ale.setup` and `ale.setup.buffer` functions in Lua.
3. All ALE settings have documentation updated to describe how to configure ALE easily either in Vim script or in Lua.
4. Various ALE settings have been tweaked so Boolean values work equally well as Numbers, to make configuring ALE easier for Neovim users.
5. Various basic ALE functions have been mirrored in one way or another in Lua for easier configuration in Lua.
6. Cover all new and previous Lua code with tests with [busted](https://lunarmodules.github.io/busted/).

This is a major leap forward for integrating ALE much better with built-in Neovim tools, Neovim plugins, and for making it easy to configure ALE in Neovim user configurations that are purely written in Lua.
