### PR TITLE
Implement LSP diagnostic pull model

### DIFF
--- a/autoload/ale/lsp.vim
+++ b/autoload/ale/lsp.vim
@@ -47,6 +47,7 @@ function! ale#lsp#Register(executable_or_address, project, language, init_option
         \       'definition': 0,
         \       'typeDefinition': 0,
         \       'implementation': 0,
+        \       'pull_model': 0,
         \       'symbol_search': 0,
         \       'code_actions': 0,
         \       'did_save': 0,
@@ -276,6 +277,13 @@ function! ale#lsp#UpdateCapabilities(conn_id, capabilities) abort
         let l:conn.capabilities.implementation = 1
     endif
 
+    " Check if the language server supports pull model diagnostics.
+    if type(get(a:capabilities, 'diagnosticProvider')) is v:t_dict
+        if type(get(a:capabilities.diagnosticProvider, 'interFileDependencies')) is v:t_bool
+            let l:conn.capabilities.pull_model = 1
+        endif
+    endif
+
     if get(a:capabilities, 'workspaceSymbolProvider') is v:true
         let l:conn.capabilities.symbol_search = 1
     endif
@@ -485,6 +493,10 @@ function! s:SendInitMessage(conn) abort
     \               'implementation': {
     \                   'dynamicRegistration': v:false,
     \                   'linkSupport': v:false,
+    \               },
+    \               'diagnostic': {
+    \                   'dynamicRegistration': v:true,
+    \                   'relatedDocumentSupport': v:true,
     \               },
     \               'publishDiagnostics': {
     \                   'relatedInformation': v:true,

--- a/autoload/ale/lsp/message.vim
+++ b/autoload/ale/lsp/message.vim
@@ -200,6 +200,14 @@ function! ale#lsp#message#CodeAction(buffer, line, column, end_line, end_column,
     \}]
 endfunction
 
+function! ale#lsp#message#Diagnostic(buffer) abort
+    return [0, 'textDocument/diagnostic', {
+    \   'textDocument': {
+    \       'uri': ale#util#ToURI(expand('#' . a:buffer . ':p')),
+    \   },
+    \}]
+endfunction
+
 function! ale#lsp#message#ExecuteCommand(command, arguments) abort
     return [0, 'workspace/executeCommand', {
     \   'command': a:command,

--- a/autoload/ale/lsp/response.vim
+++ b/autoload/ale/lsp/response.vim
@@ -21,11 +21,11 @@ let s:SEVERITY_WARNING = 2
 let s:SEVERITY_INFORMATION = 3
 let s:SEVERITY_HINT = 4
 
-" Parse the message for textDocument/publishDiagnostics
-function! ale#lsp#response#ReadDiagnostics(response) abort
+" Convert Diagnostic[] data from a language server to an ALE loclist.
+function! ale#lsp#response#ReadDiagnostics(diagnostics) abort
     let l:loclist = []
 
-    for l:diagnostic in a:response.params.diagnostics
+    for l:diagnostic in a:diagnostics
         let l:severity = get(l:diagnostic, 'severity', 0)
         let l:loclist_item = {
         \   'text': substitute(l:diagnostic.message, '\(\r\n\|\n\|\r\)', ' ', 'g'),

--- a/autoload/ale/lsp_linter.vim
+++ b/autoload/ale/lsp_linter.vim
@@ -100,7 +100,7 @@ endfunction
 " Handle LSP diagnostics for a given URI.
 " The special value 'unchanged' can be used for diagnostics to indicate
 " that diagnostics haven't changed since we last checked.
-function! s:HandleLSPDiagnostics(conn_id, uri, diagnostics) abort
+function! ale#lsp_linter#HandleLSPDiagnostics(conn_id, uri, diagnostics) abort
     let l:linter = get(s:lsp_linter_map, a:conn_id)
 
     if empty(l:linter)
@@ -233,14 +233,14 @@ function! ale#lsp_linter#HandleLSPResponse(conn_id, response) abort
         let l:uri = a:response.params.uri
         let l:diagnostics = a:response.params.diagnostics
 
-        call s:HandleLSPDiagnostics(a:conn_id, l:uri, l:diagnostics)
+        call ale#lsp_linter#HandleLSPDiagnostics(a:conn_id, l:uri, l:diagnostics)
     elseif has_key(s:diagnostic_uri_map, get(a:response, 'id'))
         let l:uri = remove(s:diagnostic_uri_map, a:response.id)
         let l:diagnostics = a:response.result.kind is# 'unchanged'
         \   ? 'unchanged'
         \   : a:response.result.items
 
-        call s:HandleLSPDiagnostics(a:conn_id, l:uri, l:diagnostics)
+        call ale#lsp_linter#HandleLSPDiagnostics(a:conn_id, l:uri, l:diagnostics)
     elseif l:method is# 'window/showMessage'
         call ale#lsp_window#HandleShowMessage(
         \   s:lsp_linter_map[a:conn_id].name,

--- a/test/lsp/test_engine_lsp_response_handling.vader
+++ b/test/lsp/test_engine_lsp_response_handling.vader
@@ -410,6 +410,130 @@ Execute(LSP errors should mark linters no longer active):
 
   AssertEqual [], g:ale_buffer_info[bufnr('')].active_linter_list
 
+Execute(LSP pull model diagnostic responses should be handled):
+  let b:ale_linters = ['eclipselsp']
+  runtime ale_linters/java/eclipselsp.vim
+
+  if has('win32')
+    call ale#test#SetFilename('filename,[]^$.ts')
+  else
+    call ale#test#SetFilename('filename*?,{}[]^$.java')
+  endif
+
+  call ale#engine#InitBufferInfo(bufnr(''))
+  let g:ale_buffer_info[bufnr('')].active_linter_list = ale#linter#Get('eclipselsp')
+  call ale#lsp_linter#SetLSPLinterMap({'1': {'name': 'eclipselsp', 'aliases': [], 'lsp': 'stdio'}})
+  call ale#lsp_linter#SetDiagnosticURIMap({'347': ale#util#ToURI(expand('%:p'))})
+
+  if has('win32')
+    AssertEqual 'filename,[]^$.ts', expand('%:p:t')
+  else
+    AssertEqual 'filename*?,{}[]^$.java', expand('%:p:t')
+  endif
+
+  call ale#lsp_linter#HandleLSPResponse(1, {
+  \ 'jsonrpc':'2.0',
+  \ 'id': 347,
+  \ 'result': {
+  \   'kind': 'full',
+  \   'items': [
+  \     {
+  \       'range': {
+  \         'start': {
+  \           'line': 0,
+  \           'character':0
+  \         },
+  \         'end': {
+  \           'line': 0,
+  \           'character':0
+  \         }
+  \       },
+  \       'severity': 2,
+  \       'code': "",
+  \       'source': 'Java',
+  \       'message': 'Missing JRE 1-8'
+  \     }
+  \   ]
+  \ },
+  \})
+
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 1,
+  \     'bufnr': bufnr(''),
+  \     'col': 1,
+  \     'pattern': '',
+  \     'valid': 1,
+  \     'vcol': 0,
+  \     'nr': -1,
+  \     'type': 'W',
+  \     'text': 'Missing JRE 1-8'
+  \    }
+  \ ],
+  \ ale#test#GetLoclistWithoutNewerKeys()
+  AssertEqual [], g:ale_buffer_info[bufnr('')].active_linter_list
+
+Execute(LSP pull model diagnostic responses that are 'unchanged' should be handled):
+  let b:ale_linters = ['eclipselsp']
+  runtime ale_linters/java/eclipselsp.vim
+
+  if has('win32')
+    call ale#test#SetFilename('filename,[]^$.ts')
+  else
+    call ale#test#SetFilename('filename*?,{}[]^$.java')
+  endif
+
+  call ale#engine#InitBufferInfo(bufnr(''))
+  let g:ale_buffer_info[bufnr('')].active_linter_list = ale#linter#Get('eclipselsp')
+  let g:ale_buffer_info[bufnr('')].loclist = [
+  \ {
+  \   'lnum': 1,
+  \   'bufnr': bufnr(''),
+  \   'col': 1,
+  \   'pattern': '',
+  \   'valid': 1,
+  \   'vcol': 0,
+  \   'nr': -1,
+  \   'type': 'W',
+  \   'text': 'Missing JRE 1-8'
+  \ },
+  \]
+
+  call ale#lsp_linter#SetLSPLinterMap({'1': {'name': 'eclipselsp', 'aliases': [], 'lsp': 'stdio'}})
+  call ale#lsp_linter#SetDiagnosticURIMap({'347': ale#util#ToURI(expand('%:p'))})
+
+  if has('win32')
+    AssertEqual 'filename,[]^$.ts', expand('%:p:t')
+  else
+    AssertEqual 'filename*?,{}[]^$.java', expand('%:p:t')
+  endif
+
+  call ale#lsp_linter#HandleLSPResponse(1, {
+  \ 'jsonrpc':'2.0',
+  \ 'id': 347,
+  \ 'result': {
+  \     'kind': 'unchanged',
+  \ },
+  \})
+
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 1,
+  \     'bufnr': bufnr(''),
+  \     'col': 1,
+  \     'pattern': '',
+  \     'valid': 1,
+  \     'vcol': 0,
+  \     'nr': -1,
+  \     'type': 'W',
+  \     'text': 'Missing JRE 1-8'
+  \    }
+  \ ],
+  \ g:ale_buffer_info[bufnr('')].loclist
+  AssertEqual [], g:ale_buffer_info[bufnr('')].active_linter_list
+
 Execute(LSP errors should be logged in the history):
   call ale#lsp_linter#SetLSPLinterMap({'347': {'name': 'foobar', 'aliases': [], 'lsp': 'stdio'}})
   call ale#lsp_linter#HandleLSPResponse(347, {

--- a/test/lsp/test_lsp_client_messages.vader
+++ b/test/lsp/test_lsp_client_messages.vader
@@ -248,6 +248,19 @@ Execute(ale#lsp#message#DidChangeConfiguration() should return correct messages)
   \ ],
   \ ale#lsp#message#DidChangeConfiguration(bufnr(''), g:ale_lsp_configuration)
 
+Execute(ale#lsp#message#Diagnostic() should return correct messages):
+  AssertEqual
+  \ [
+  \   0,
+  \   'textDocument/diagnostic',
+  \   {
+  \     'textDocument': {
+  \         'uri': ale#path#ToFileURI(g:dir . '/foo/bar.ts'),
+  \     },
+  \   }
+  \ ],
+  \ ale#lsp#message#Diagnostic(bufnr(''))
+
 Execute(ale#lsp#tsserver_message#Open() should return correct messages):
   AssertEqual
   \ [

--- a/test/lsp/test_lsp_startup.vader
+++ b/test/lsp/test_lsp_startup.vader
@@ -193,6 +193,10 @@ Before:
       \             'dynamicRegistration': v:false,
       \             'linkSupport': v:false,
       \           },
+      \           'diagnostic': {
+      \             'dynamicRegistration': v:true,
+      \             'relatedDocumentSupport': v:true,
+      \           },
       \           'publishDiagnostics': {
       \             'relatedInformation': v:true,
       \           },

--- a/test/lsp/test_other_initialize_message_handling.vader
+++ b/test/lsp/test_other_initialize_message_handling.vader
@@ -90,6 +90,7 @@ Execute(Capabilities should be set up correctly):
   \   'includeText': 0,
   \   'references': 1,
   \   'rename': 1,
+  \   'pull_model': 0,
   \   'symbol_search': 1,
   \   'typeDefinition': 0,
   \ },
@@ -122,6 +123,7 @@ Execute(Disabled capabilities should be recognised correctly):
   \     'definitionProvider': v:false,
   \     'experimental': {},
   \     'documentHighlightProvider': v:true,
+  \     'diagnosticProvider': {},
   \   },
   \ },
   \})
@@ -140,6 +142,7 @@ Execute(Disabled capabilities should be recognised correctly):
   \   'includeText': 0,
   \   'references': 0,
   \   'rename': 0,
+  \   'pull_model': 0,
   \   'symbol_search': 0,
   \   'typeDefinition': 0,
   \ },
@@ -182,6 +185,9 @@ Execute(Capabilities should be enabled when sent as Dictionaries):
   \     'implementationProvider': {},
   \     'experimental': {},
   \     'documentHighlightProvider': v:true,
+  \     'diagnosticProvider': {
+  \       'interFileDependencies': v:false,
+  \     },
   \     'workspaceSymbolProvider': {}
   \   },
   \ },
@@ -201,6 +207,7 @@ Execute(Capabilities should be enabled when sent as Dictionaries):
   \   'includeText': 1,
   \   'references': 1,
   \   'rename': 1,
+  \   'pull_model': 1,
   \   'symbol_search': 1,
   \   'typeDefinition': 1,
   \ },

--- a/test/lsp/test_read_lsp_diagnostics.vader
+++ b/test/lsp/test_read_lsp_diagnostics.vader
@@ -21,14 +21,14 @@ Execute(ale#lsp#response#ReadDiagnostics() should handle errors):
   \     'code': 'some-error',
   \   }
   \ ],
-  \ ale#lsp#response#ReadDiagnostics({'params': {'uri': 'filename.ts', 'diagnostics': [
+  \ ale#lsp#response#ReadDiagnostics([
   \   {
   \     'severity': 1,
   \     'range': Range(2, 10, 4, 15),
   \     'code': 'some-error',
   \     'message': 'Something went wrong!',
   \   },
-  \ ]}})
+  \ ])
 
 Execute(ale#lsp#response#ReadDiagnostics() should handle warnings):
   AssertEqual [
@@ -42,14 +42,14 @@ Execute(ale#lsp#response#ReadDiagnostics() should handle warnings):
   \     'code': 'some-warning',
   \   }
   \ ],
-  \ ale#lsp#response#ReadDiagnostics({'params': {'uri': 'filename.ts', 'diagnostics': [
+  \ ale#lsp#response#ReadDiagnostics([
   \   {
   \     'severity': 2,
   \     'range': Range(1, 3, 1, 3),
   \     'code': 'some-warning',
   \     'message': 'Something went wrong!',
   \   },
-  \ ]}})
+  \ ])
 
 Execute(ale#lsp#response#ReadDiagnostics() should treat messages with missing severity as errors):
   AssertEqual [
@@ -63,13 +63,13 @@ Execute(ale#lsp#response#ReadDiagnostics() should treat messages with missing se
   \     'code': 'some-error',
   \   }
   \ ],
-  \ ale#lsp#response#ReadDiagnostics({'params': {'uri': 'filename.ts', 'diagnostics': [
+  \ ale#lsp#response#ReadDiagnostics([
   \   {
   \     'range': Range(2, 10, 4, 15),
   \     'code': 'some-error',
   \     'message': 'Something went wrong!',
   \   },
-  \ ]}})
+  \ ])
 
 Execute(ale#lsp#response#ReadDiagnostics() should handle messages without codes):
   AssertEqual [
@@ -82,12 +82,12 @@ Execute(ale#lsp#response#ReadDiagnostics() should handle messages without codes)
   \     'end_col': 15,
   \   }
   \ ],
-  \ ale#lsp#response#ReadDiagnostics({'params': {'uri': 'filename.ts', 'diagnostics': [
+  \ ale#lsp#response#ReadDiagnostics([
   \   {
   \     'range': Range(2, 10, 4, 15),
   \     'message': 'Something went wrong!',
   \   },
-  \ ]}})
+  \ ])
 
 Execute(ale#lsp#response#ReadDiagnostics() should include sources in detail):
   AssertEqual [
@@ -101,13 +101,13 @@ Execute(ale#lsp#response#ReadDiagnostics() should include sources in detail):
   \     'end_col': 22,
   \   }
   \ ],
-  \ ale#lsp#response#ReadDiagnostics({'params': {'uri': 'filename.ts', 'diagnostics': [
+  \ ale#lsp#response#ReadDiagnostics([
   \   {
   \     'range': Range(9, 14, 11, 22),
   \     'message': 'Something went wrong!',
   \     'source': 'tslint',
   \   }
-  \ ]}})
+  \ ])
 
 Execute(ale#lsp#response#ReadDiagnostics() should keep detail with line breaks but replace with spaces in text):
   AssertEqual [
@@ -121,13 +121,13 @@ Execute(ale#lsp#response#ReadDiagnostics() should keep detail with line breaks b
   \     'end_col': 22,
   \   }
   \ ],
-  \ ale#lsp#response#ReadDiagnostics({'params': {'uri': 'filename.ts', 'diagnostics': [
+  \ ale#lsp#response#ReadDiagnostics([
   \   {
   \     'range': Range(9, 14, 11, 22),
   \     'message': "cannot borrow `cap` as mutable\r\nmore than once at a time\n\nmutable borrow starts here\rin previous iteration of loop",
   \     'source': 'rustc',
   \   }
-  \ ]}})
+  \ ])
 
 Execute(ale#lsp#response#ReadDiagnostics() should consider -1 to be a meaningless code):
   AssertEqual [
@@ -140,13 +140,13 @@ Execute(ale#lsp#response#ReadDiagnostics() should consider -1 to be a meaningles
   \     'end_col': 15,
   \   }
   \ ],
-  \ ale#lsp#response#ReadDiagnostics({'params': {'uri': 'filename.ts', 'diagnostics': [
+  \ ale#lsp#response#ReadDiagnostics([
   \   {
   \     'range': Range(2, 10, 4, 15),
   \     'message': 'Something went wrong!',
   \     'code': -1,
   \   },
-  \ ]}})
+  \ ])
 
 Execute(ale#lsp#response#ReadDiagnostics() should handle multiple messages):
   AssertEqual [
@@ -167,7 +167,7 @@ Execute(ale#lsp#response#ReadDiagnostics() should handle multiple messages):
   \     'end_col': 4,
   \   },
   \ ],
-  \ ale#lsp#response#ReadDiagnostics({'params': {'uri': 'filename.ts', 'diagnostics': [
+  \ ale#lsp#response#ReadDiagnostics([
   \   {
   \     'range': Range(0, 2, 0, 2),
   \     'message': 'Something went wrong!',
@@ -177,7 +177,7 @@ Execute(ale#lsp#response#ReadDiagnostics() should handle multiple messages):
   \     'range': Range(1, 4, 1, 4),
   \     'message': 'A warning',
   \   },
-  \ ]}})
+  \ ])
 
 Execute(ale#lsp#response#ReadDiagnostics() should use relatedInformation for detail):
   AssertEqual [
@@ -191,7 +191,7 @@ Execute(ale#lsp#response#ReadDiagnostics() should use relatedInformation for det
   \     'detail': "Something went wrong!\n/tmp/someotherfile.txt:43:80:\n\tmight be this"
   \   }
   \ ],
-  \ ale#lsp#response#ReadDiagnostics({'params': {'uri': 'filename.ts', 'diagnostics': [
+  \ ale#lsp#response#ReadDiagnostics([
   \   {
   \     'range': Range(0, 2, 0, 2),
   \     'message': 'Something went wrong!',
@@ -206,7 +206,7 @@ Execute(ale#lsp#response#ReadDiagnostics() should use relatedInformation for det
   \         }
   \     }]
   \   }
-  \ ]}})
+  \ ])
 
 Execute(ale#lsp#response#ReadTSServerDiagnostics() should handle tsserver responses):
   AssertEqual


### PR DESCRIPTION
A follow up to #4932, and finally implements #3600 after all of this time.

Pyright only just implemented pull diagnostics [in the 1.1.397 release](https://github.com/microsoft/pyright/releases/tag/1.1.397) published mere days ago, and I used that language server to test these changes. I tested this with Vim 9, Neovim 0.8, and Neovim 0.10. Neovim 0.10+ is needed for pull diagnostics support. In my tests this seems to work just fine, and ALE seems to receive diagnostics a little bit faster than before.

The biggest plus of this is that when servers implement pull diagnostics support they'll never send diagnostics to ALE until ALE asks for them, and ALE will be able to track when servers are busy checking files.