### PR TITLE
Add 'hint' to supported severities

### DIFF
--- a/autoload/ale.vim
+++ b/autoload/ale.vim
@@ -5,6 +5,7 @@
 " Strings used for severity in the echoed message
 let g:ale_echo_msg_error_str = get(g:, 'ale_echo_msg_error_str', 'Error')
 let g:ale_echo_msg_info_str = get(g:, 'ale_echo_msg_info_str', 'Info')
+let g:ale_echo_msg_hint_str = get(g:, 'ale_echo_msg_hint_str', 'Hint')
 let g:ale_echo_msg_log_str = get(g:, 'ale_echo_msg_log_str', 'Log')
 let g:ale_echo_msg_warning_str = get(g:, 'ale_echo_msg_warning_str', 'Warning')
 

--- a/autoload/ale/engine.vim
+++ b/autoload/ale/engine.vim
@@ -274,6 +274,7 @@ function! s:RemapItemTypes(type_map, loclist) abort
         \|| l:new_key is# 'W'
         \|| l:new_key is# 'WS'
         \|| l:new_key is# 'I'
+        \|| l:new_key is# 'H'
             let l:item.type = l:new_key[0]
 
             if l:new_key is# 'ES' || l:new_key is# 'WS'

--- a/autoload/ale/highlight.vim
+++ b/autoload/ale/highlight.vim
@@ -22,6 +22,10 @@ if !hlexists('ALEInfo')
     highlight link ALEInfo ALEWarning
 endif
 
+if !hlexists('ALEHint')
+    highlight link ALEHint SpellRare
+endif
+
 " The maximum number of items for the second argument of matchaddpos()
 let s:MAX_POS_VALUES = 8
 let s:MAX_COL_SIZE = 1073741824 " pow(2, 30)
@@ -74,7 +78,7 @@ function! ale#highlight#RemoveHighlights() abort
         call ale#highlight#nvim_buf_clear_namespace(bufnr(''), s:ns_id, 0, -1)
     else
         for l:match in getmatches()
-            if l:match.group =~? '\v^ALE(Style)?(Error|Warning|Info)(Line)?$'
+            if l:match.group =~? '\v^ALE(Style)?(Error|Warning|Info|Hint)(Line)?$'
                 call matchdelete(l:match.id)
             endif
         endfor
@@ -149,6 +153,8 @@ function! ale#highlight#UpdateHighlights() abort
             endif
         elseif l:item.type is# 'I'
             let l:group = 'ALEInfo'
+        elseif l:item.type is# 'H'
+            let l:group = 'ALEHint'
         elseif get(l:item, 'sub_type', '') is# 'style'
             let l:group = 'ALEStyleError'
         else
@@ -171,6 +177,7 @@ function! ale#highlight#UpdateHighlights() abort
         let l:available_groups = {
         \   'ALEWarningLine': hlexists('ALEWarningLine'),
         \   'ALEInfoLine': hlexists('ALEInfoLine'),
+        \   'ALEHintLine': hlexists('ALEHintLine'),
         \   'ALEErrorLine': hlexists('ALEErrorLine'),
         \}
 
@@ -179,6 +186,8 @@ function! ale#highlight#UpdateHighlights() abort
                 let l:group = 'ALEWarningLine'
             elseif l:item.type is# 'I'
                 let l:group = 'ALEInfoLine'
+            elseif l:item.type is# 'H'
+                let l:group = 'ALEHintLine'
             else
                 let l:group = 'ALEErrorLine'
             endif

--- a/autoload/ale/sign.vim
+++ b/autoload/ale/sign.vim
@@ -14,6 +14,7 @@ let g:ale_sign_style_error = get(g:, 'ale_sign_style_error', g:ale_sign_error)
 let g:ale_sign_warning = get(g:, 'ale_sign_warning', 'W')
 let g:ale_sign_style_warning = get(g:, 'ale_sign_style_warning', g:ale_sign_warning)
 let g:ale_sign_info = get(g:, 'ale_sign_info', 'I')
+let g:ale_sign_hint = get(g:, 'ale_sign_hint', 'H')
 let g:ale_sign_priority = get(g:, 'ale_sign_priority', 30)
 " This variable sets an offset which can be set for sign IDs.
 " This ID can be changed depending on what IDs are set for other plugins.
@@ -43,6 +44,10 @@ endif
 
 if !hlexists('ALEInfoSign')
     highlight link ALEInfoSign ALEWarningSign
+endif
+
+if !hlexists('ALEHintSign')
+    highlight link ALEHintSign ALEWarningSign
 endif
 
 if !hlexists('ALESignColumnWithErrors')
@@ -85,6 +90,8 @@ execute 'sign define ALEStyleWarningSign text=' . s:EscapeSignText(g:ale_sign_st
 \   . ' texthl=ALEStyleWarningSign linehl=ALEWarningLine'
 execute 'sign define ALEInfoSign text=' . s:EscapeSignText(g:ale_sign_info)
 \   . ' texthl=ALEInfoSign linehl=ALEInfoLine'
+execute 'sign define ALEHintSign text=' . s:EscapeSignText(g:ale_sign_hint)
+\   . ' texthl=ALEHintSign linehl=ALEHintLine'
 sign define ALEDummySign text=\  texthl=SignColumn
 
 if g:ale_sign_highlight_linenrs && (has('nvim-0.3.2') || has('patch-8.2.3874'))
@@ -108,15 +115,20 @@ if g:ale_sign_highlight_linenrs && (has('nvim-0.3.2') || has('patch-8.2.3874'))
         highlight link ALEInfoSignLineNr CursorLineNr
     endif
 
+    if !hlexists('ALEHintSignLineNr')
+        highlight link ALEHintSignLineNr CursorLineNr
+    endif
+
     sign define ALEErrorSign numhl=ALEErrorSignLineNr
     sign define ALEStyleErrorSign numhl=ALEStyleErrorSignLineNr
     sign define ALEWarningSign numhl=ALEWarningSignLineNr
     sign define ALEStyleWarningSign numhl=ALEStyleWarningSignLineNr
     sign define ALEInfoSign numhl=ALEInfoSignLineNr
+    sign define ALEHintSign numhl=ALEHintSignLineNr
 endif
 
 function! ale#sign#GetSignName(sublist) abort
-    let l:priority = g:ale#util#style_warning_priority
+    let l:priority = g:ale#util#hint_priority
 
     " Determine the highest priority item for the line.
     for l:item in a:sublist
@@ -145,6 +157,10 @@ function! ale#sign#GetSignName(sublist) abort
 
     if l:priority is# g:ale#util#info_priority
         return 'ALEInfoSign'
+    endif
+
+    if l:priority is# g:ale#util#hint_priority
+        return 'ALEHintSign'
     endif
 
     " Use the error sign for invalid severities.

--- a/autoload/ale/util.vim
+++ b/autoload/ale/util.vim
@@ -125,8 +125,13 @@ let g:ale#util#warning_priority = 4
 let g:ale#util#info_priority = 3
 let g:ale#util#style_error_priority = 2
 let g:ale#util#style_warning_priority = 1
+let g:ale#util#hint_priority = 0
 
 function! ale#util#GetItemPriority(item) abort
+    if a:item.type is# 'H'
+        return g:ale#util#hint_priority
+    endif
+
     if a:item.type is# 'I'
         return g:ale#util#info_priority
     endif

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2396,6 +2396,7 @@ g:ale_set_highlights
                               `'sub_type': 'style'`    |hl-ALEStyleError|
   ALEStyleWarning  items with `'type': 'W'` and
                               `'sub_type': 'style'`    |hl-ALEStyleWarning|
+  ALEHint          items with `'type': 'H'`            |hl-ALEHint|
 
   When |g:ale_set_signs| is not set to `true` or `1`, the following highlights
   for entire lines will be set.
@@ -2403,6 +2404,7 @@ g:ale_set_highlights
   ALEErrorLine     all items with `'type': 'E'`        |hl-ALEErrorLine|
   ALEWarningLine   all items with `'type': 'W'`        |hl-ALEWarningLine|
   ALEInfoLine      all items with `'type': 'I'`        |hl-ALEInfoLine|
+  ALEHintLine      all items with `'type': 'H'`        |hl-ALEHintLine|
 
   Vim can only highlight the characters up to the last column in a buffer for
   match highlights, whereas the line highlights when signs are enabled will
@@ -2467,6 +2469,7 @@ g:ale_set_signs
                                  `'sub_type': 'style'` |hl-ALEStyleErrorSign|
   ALEStyleWarningSign items with `'type': 'W'` and
                                  `'sub_type': 'style'` |hl-ALEStyleWarningSign|
+  ALEHintSign         items with `'type': 'H'`         |hl-ALEHintSign|
 
   In addition to the style of the signs, the style of lines where signs appear
   can be configured with the following highlights:
@@ -2474,6 +2477,7 @@ g:ale_set_signs
   ALEErrorLine        all items with `'type': 'E'`     |hl-ALEErrorLine|
   ALEWarningLine      all items with `'type': 'W'`     |hl-ALEWarningLine|
   ALEInfoLine         all items with `'type': 'I'`     |hl-ALEInfoLine|
+  ALEHintLine         all items with `'type': 'H'`     |hl-ALEHintLine|
 
   With Neovim 0.3.2 or higher, ALE can use the `numhl` option to highlight the
   'number' column. It uses the following highlight groups.
@@ -2485,6 +2489,7 @@ g:ale_set_signs
                              `'sub_type': 'style'`   |hl-ALEStyleErrorSignLineNr|
   ALEStyleWarningSignLineNr items with `'type': 'W'` and
                              `'sub_type': 'style'`   |hl-ALEStyleWarningSignLineNr|
+  ALEHintSignLineNr         items with `'type': 'H'` |hl-ALEHintSignLineNr|
 
   To enable line number highlighting |g:ale_sign_highlight_linenrs| must be
   set to `true` or `1` before ALE is loaded.
@@ -2496,6 +2501,7 @@ g:ale_set_signs
   |g:ale_sign_info|
   |g:ale_sign_style_error|
   |g:ale_sign_style_warning|
+  |g:ale_sign_hint|
 
   When multiple problems exist on the same line, the signs will take
   precedence in the order above, from highest to lowest.
@@ -2601,6 +2607,17 @@ g:ale_sign_style_warning
   This has no effect when |g:ale_use_neovim_diagnostics_api| is `true` or `1`.
 
   The sign for style warnings in the sign gutter.
+
+                                                  *ale-options.sign_style_hint*
+                                                        *g:ale_sign_style_hint*
+sign_style_hint
+g:ale_sign_style_hint
+  Type: |String|
+  Default: `g:ale_sign_hint`
+
+  This has no effect when |g:ale_use_neovim_diagnostics_api| is `true` or `1`.
+
+  The sign for style hints in the sign gutter.
 
                                                       *ale-options.sign_offset*
                                                             *g:ale_sign_offset*


### PR DESCRIPTION
This appears (in my naivety about the codebase) to be what is needed to support LSP's "Hint" severity so plugins like vim9-lsp and coc.nvim which optionally feed into ALE's diagnostic system can display the full breadth of severity types in the language server protocol. For example, rust-analyzer uses hints extensively in "two-part" diagnostics (e.g. "... due to this" pointing to a related line). I haven't added tests yet and the documentation could be more complete, thus this is in draft mode: @w0rp Is this something you're interested in supporting? I think it makes a lot of sense; I'm content to complete this if so.

Closes #4899.