### PR TITLE
Some absolute paths are not recognized for Windows

### DIFF
--- a/autoload/ale/path.vim
+++ b/autoload/ale/path.vim
@@ -115,12 +115,11 @@ endfunction
 
 " Return 1 if a path is an absolute path.
 function! ale#path#IsAbsolute(filename) abort
-    if has('win32') && a:filename[:0] is# '\'
-        return 1
+    if has('win32')
+        return a:filename[:0] =~# '[\\/]' || a:filename[0:2] =~? '[A-Z]:[/\\]'
+    else
+        return a:filename[:0] is# '/'
     endif
-
-    " Check for /foo and C:\foo, etc.
-    return a:filename[:0] is# '/' || a:filename[1:2] is# ':\'
 endfunction
 
 let s:temp_dir = ale#path#Simplify(fnamemodify(ale#util#Tempname(), ':h:h'))

--- a/test/handler/test_mypy_handler.vader
+++ b/test/handler/test_mypy_handler.vader
@@ -107,7 +107,7 @@ Execute(The mypy handler should handle Windows names with spaces):
   \   {
   \     'lnum': 4,
   \     'col': 0,
-  \     'filename': ale#path#Simplify('C:\something\with spaces.py'),
+  \     'filename': ale#path#GetAbsPath(getcwd(), 'C:\something\with spaces.py'),
   \     'type': 'E',
   \     'text': 'No library stub file for module ''django.db''',
   \   },

--- a/test/test_get_abspath.vader
+++ b/test/test_get_abspath.vader
@@ -13,6 +13,15 @@ Execute(Relative paths should be resolved correctly):
     AssertEqual
     \ 'C:\foo\bar\baz\whatever.txt',
     \ ale#path#GetAbsPath('C:\foo\bar\baz\xyz', '../whatever.txt')
+    AssertEqual
+    \ 'C:\foo\bar\baz\whatever.txt',
+    \ ale#path#GetAbsPath('C:\foo\bar\baz\xyz', '..\whatever.txt')
+    AssertEqual
+    \ 'C:\foo\bar\baz\whatever.txt',
+    \ ale#path#GetAbsPath('C:/foo/bar/baz/xyz', '../whatever.txt')
+    AssertEqual
+    \ 'C:\foo\bar\baz\whatever.txt',
+    \ ale#path#GetAbsPath('C:/foo/bar/baz/xyz', '..\whatever.txt')
   endif
 
 Execute(Absolute paths should be resolved correctly):
@@ -26,4 +35,12 @@ Execute(Absolute paths should be resolved correctly):
 
   if has('win32')
     AssertEqual '\ding', ale#path#GetAbsPath('/foo/bar/xyz', '\\ding')
+    AssertEqual 'c:\ding', ale#path#GetAbsPath('/foo/bar/xyz', 'c:/ding')
+    AssertEqual 'c:\ding', ale#path#GetAbsPath('/foo/bar/xyz', 'c:\ding')
+    AssertEqual 'c:\ding', ale#path#GetAbsPath('\foo\bar\xyz', 'c:/ding')
+    AssertEqual 'c:\ding', ale#path#GetAbsPath('\foo\bar\xyz', 'c:\ding')
+    AssertEqual 'c:\ding', ale#path#GetAbsPath('c:/foo/bar/xyz', 'c:/ding')
+    AssertEqual 'c:\ding', ale#path#GetAbsPath('c:/foo/bar/xyz', 'c:\ding')
+    AssertEqual 'c:\ding', ale#path#GetAbsPath('c:\foo\bar\xyz', 'c:/ding')
+    AssertEqual 'c:\ding', ale#path#GetAbsPath('c:\foo\bar\xyz', 'c:\ding')
   endif


### PR DESCRIPTION
Paths like "c:/abc/def.cpp" were not recognized as absolute on Windows.