### PR TITLE
Make phpactor configurable and documented

### DIFF
--- a/ale_linters/php/phpactor.vim
+++ b/ale_linters/php/phpactor.vim
@@ -1,6 +1,9 @@
 " Author: Arizard <https://github.com/Arizard>
 " Description: PHPactor integration for ALE
 
+call ale#Set('php_phpactor_executable', 'phpactor')
+call ale#Set('php_phpactor_init_options', {})
+
 " Copied from langserver.vim
 function! ale_linters#php#phpactor#GetProjectRoot(buffer) abort
     let l:composer_path = ale#path#FindNearestFile(a:buffer, 'composer.json')
@@ -17,7 +20,8 @@ endfunction
 call ale#linter#Define('php', {
 \   'name': 'phpactor',
 \   'lsp': 'stdio',
-\   'executable': 'phpactor',
+\   'executable': {b -> ale#Var(b, 'php_phpactor_executable')},
 \   'command': '%e language-server',
+\   'initialization_options': {b -> ale#Var(b, 'php_phpactor_init_options')},
 \   'project_root': function('ale_linters#php#phpactor#GetProjectRoot'),
 \})

--- a/doc/ale-php.txt
+++ b/doc/ale-php.txt
@@ -79,6 +79,36 @@ g:ale_php_phan_use_client
 
 
 ===============================================================================
+phpactor                                                     *ale-php-phpactor*
+
+                                          *ale-options.php_phpactor_executable*
+                                                *g:ale_php_phpactor_executable*
+                                                *b:ale_php_phpactor_executable*
+php_phpactor_executable
+g:ale_php_phpactor_executable
+  Type: |String|
+  Default: `'phpactor'`
+
+  This variable sets executable used for phpactor.
+
+php_phpactor_init_options
+g:ale_php_phpactor_init_options
+  Type: |Dictionary|
+  Default: `'{}'`
+
+  This variable can be changed to customize the LSP initialization_options.
+  For example: >
+
+  let g:ale_php_phpactor_init_options = {
+  \   'language_server_phpstan.enabled': v:false,
+  \   'language_server_psalm.enabled': v:false,
+  \   'worse_reflection.stub_dir': '%application_root%/.php-stubs'
+  \}
+<
+For all available options and explanations, visit
+https://phpactor.readthedocs.io/en/master/reference/configuration.html
+
+===============================================================================
 phpcbf                                                         *ale-php-phpcbf*
 
                                             *ale-options.php_phpcbf_executable*

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -3760,6 +3760,7 @@ documented in additional help files.
     cspell................................|ale-php-cspell|
     langserver............................|ale-php-langserver|
     phan..................................|ale-php-phan|
+    phpactor..............................|ale-php-phpactor|
     phpcbf................................|ale-php-phpcbf|
     phpcs.................................|ale-php-phpcs|
     phpmd.................................|ale-php-phpmd|

--- a/test/linter/test_phpactor.vader
+++ b/test/linter/test_phpactor.vader
@@ -8,6 +8,12 @@ Execute(The default executable path should be correct):
   AssertLinter 'phpactor',
   \ ale#Escape('phpactor') . ' language-server'
 
+Execute(Overriding the executable should work):
+  let b:ale_php_phpactor_executable = 'my_phpactor'
+
+  AssertLinter 'my_phpactor', ale#Escape('my_phpactor') . ' language-server'
+  unlet b:ale_php_phpactor_executable
+
 Execute(The project path should be correct for .git directories):
   call ale#test#SetFilename('../test-files/php/with-git/test.php')
   silent! call mkdir('../test-files/php/with-git/.git')
@@ -18,3 +24,20 @@ Execute(The project path should be correct for composer.json file):
   call ale#test#SetFilename('../test-files/php/with-composer/test.php')
 
   AssertLSPProject ale#path#Simplify(g:dir . '/../test-files/php/with-composer')
+
+Execute(The LSP values should be set correctly):
+
+  AssertLSPLanguage 'php'
+
+  AssertLSPOptions {}
+
+  AssertLSPConfig {}
+
+Execute(Should accept initialization options):
+  let b:ale_php_phpactor_init_options = {
+  \   'language_server_phpstan.enabled': v:false,
+  \ }
+
+  AssertLSPOptions {
+  \   'language_server_phpstan.enabled': v:false,
+  \ }


### PR DESCRIPTION
Add php_phpactor_executable for phpactor and make it configurable through php_phpactor_config.

When phpactor was first added in 3b8ff65, it had no configuration. Thus the documentation for it could be completely blank. That is why it now seems like an initial addition