### PR TITLE
Send JSON-RPC error responses for unknown request methods

### DIFF
--- a/autoload/ale/codefix.vim
+++ b/autoload/ale/codefix.vim
@@ -256,6 +256,7 @@ function! ale#codefix#HandleLSPResponse(conn_id, response) abort
         \   },
         \   {}
         \)
+
         return v:true
     elseif has_key(a:response, 'id')
     \&& has_key(s:codefix_map, a:response.id)

--- a/autoload/ale/lsp.vim
+++ b/autoload/ale/lsp.vim
@@ -396,14 +396,16 @@ function! ale#lsp#HandleMessage(conn_id, message) abort
     if l:conn.initialized
         for l:response in l:response_list
             let l:handled = 0
+
             " Call all of the registered handlers with the response.
             for l:Callback in l:conn.callback_list
                 let l:result = ale#util#GetFunction(l:Callback)(a:conn_id, l:response)
+
                 if l:result is v:true
                     let l:handled = 1
                 endif
             endfor
-            
+
             " If this was a request that no handler processed, send Method Not Found error
             if !l:handled && has_key(l:response, 'method') && has_key(l:response, 'id')
                 call s:SendMethodNotFoundResponse(a:conn_id, l:response.id, l:response.method)
@@ -687,10 +689,11 @@ endfunction
 
 function! s:SendMethodNotFoundResponse(conn_id, request_id, method) abort
     let l:conn = get(s:connections, a:conn_id, {})
+
     if empty(l:conn)
         return
     endif
-    
+
     let l:error_response = {
     \   'jsonrpc': '2.0',
     \   'id': a:request_id,
@@ -700,10 +703,10 @@ function! s:SendMethodNotFoundResponse(conn_id, request_id, method) abort
     \       'data': 'Unknown method: ' . a:method
     \   }
     \}
-    
+
     let l:body = json_encode(l:error_response)
     let l:data = 'Content-Length: ' . strlen(l:body) . "\r\n\r\n" . l:body
-    
+
     call s:SendMessageData(l:conn, l:data)
 endfunction
 

--- a/autoload/ale/lsp_linter.vim
+++ b/autoload/ale/lsp_linter.vim
@@ -234,6 +234,7 @@ function! ale#lsp_linter#HandleLSPResponse(conn_id, response) abort
         let l:diagnostics = a:response.params.diagnostics
 
         call ale#lsp_linter#HandleLSPDiagnostics(a:conn_id, l:uri, l:diagnostics)
+
         return v:true
     elseif has_key(s:diagnostic_uri_map, get(a:response, 'id'))
         let l:uri = remove(s:diagnostic_uri_map, a:response.id)
@@ -248,19 +249,23 @@ function! ale#lsp_linter#HandleLSPResponse(conn_id, response) abort
         \   g:ale_lsp_show_message_format,
         \   a:response.params
         \)
+
         return v:true
     elseif get(a:response, 'type', '') is# 'event'
     \&& get(a:response, 'event', '') is# 'semanticDiag'
         call s:HandleTSServerDiagnostics(a:response, 'semantic')
+
         return v:true
     elseif get(a:response, 'type', '') is# 'event'
     \&& get(a:response, 'event', '') is# 'syntaxDiag'
         call s:HandleTSServerDiagnostics(a:response, 'syntax')
+
         return v:true
     elseif get(a:response, 'type', '') is# 'event'
     \&& get(a:response, 'event', '') is# 'suggestionDiag'
     \&& get(g:, 'ale_lsp_suggestions')
         call s:HandleTSServerDiagnostics(a:response, 'suggestion')
+
         return v:true
     endif
 endfunction


### PR DESCRIPTION
The Language Server Protocol requires that all requests receive responses. Previously, ALE would silently ignore unknown JSON-RPC requests from language servers (like workspace/configuration), violating the LSP specification.

Solution:
- Modified the central message handler in ale#lsp#HandleMessage to track whether any handler processed each message
- Added handler return values: handlers now return v:true when they process server-initiated requests/notifications
- Only 2 handlers needed modification since most handle client request responses:
  * ale#lsp_linter#HandleLSPResponse (textDocument/publishDiagnostics, etc.)
  * ale#codefix#HandleLSPResponse (workspace/applyEdit)
- Unknown requests now receive standard JSON-RPC error responses with code -32601 (Method Not Found)

This ensures ALE is compliant with the LSP specification requirement that "Every processed request must send a response back to the sender."

🤖 Generated with [Claude Code](https://claude.ai/code)


Fixes #4610

I have not added vader test, due to insufficient AI training data. Yet I think this pull request is good enough for an inspiration.