### PR TITLE
Add --editor-mode flag when invoking rubocop

### DIFF
--- a/doc/ale-ruby.txt
+++ b/doc/ale-ruby.txt
@@ -187,18 +187,6 @@ g:ale_ruby_rubocop_auto_correct_all
   This variable can be changed to make rubocop to correct all offenses (unsafe).
 
 
-                                         *ale-options.ruby_rubocop_editor_mode*
-                                               *g:ale_ruby_rubocop_editor_mode*
-                                               *b:ale_ruby_rubocop_editor_mode*
-ruby_rubocop_editor_mode
-g:ale_ruby_rubocop_editor_mode
-  Type: |Number|
-  Default: `1`
-
-  This variable can be changed to 0 to run rubocop without the `--editor-mode`
-  flag (if using RuboCop < v1.61.0).
-
-
 ===============================================================================
 ruby                                                            *ale-ruby-ruby*
 

--- a/test/fixers/test_rubocop_fixer_callback.vader
+++ b/test/fixers/test_rubocop_fixer_callback.vader
@@ -1,53 +1,47 @@
 Before:
-  Save g:ale_ruby_rubocop_executable
-  Save g:ale_ruby_rubocop_options
-
-  " Use an invalid global executable, so we don't match it.
-  let g:ale_ruby_rubocop_executable = 'xxxinvalid'
-  let g:ale_ruby_rubocop_options = ''
-
-  call ale#test#SetDirectory('/testplugin/test/fixers')
+  call ale#assert#SetUpFixerTest('ruby', 'rubocop')
 
 After:
-  Restore
-
-  call ale#test#RestoreDirectory()
+  call ale#assert#TearDownFixerTest()
 
 Execute(The rubocop callback should return the correct default values):
   call ale#test#SetFilename('../test-files/ruby/dummy.rb')
 
-  AssertEqual
+  GivenCommandOutput ['1.61.0']
+
+  AssertFixer
   \ {
   \   'process_with': 'ale#fixers#rubocop#PostProcess',
   \   'command': ale#Escape(g:ale_ruby_rubocop_executable)
   \     . ' --auto-correct --editor-mode --force-exclusion --stdin %s',
-  \ },
-  \ ale#fixers#rubocop#Fix(bufnr(''))
+  \ }
 
 Execute(The rubocop callback should include custom rubocop options):
   let g:ale_ruby_rubocop_options = '--except Lint/Debugger'
   call ale#test#SetFilename('../test-files/ruby/with_config/dummy.rb')
 
-  AssertEqual
+  GivenCommandOutput ['1.61.0']
+
+  AssertFixer
   \ {
   \   'process_with': 'ale#fixers#rubocop#PostProcess',
   \   'command': ale#Escape(g:ale_ruby_rubocop_executable)
   \     . ' --except Lint/Debugger'
   \     . ' --auto-correct --editor-mode --force-exclusion --stdin %s',
-  \ },
-  \ ale#fixers#rubocop#Fix(bufnr(''))
+  \ }
 
 Execute(The rubocop callback should use auto-correct-all option when set):
   let g:ale_ruby_rubocop_auto_correct_all = 1
   call ale#test#SetFilename('../test-files/ruby/with_config/dummy.rb')
 
-  AssertEqual
+  GivenCommandOutput ['1.61.0']
+
+  AssertFixer
   \ {
   \   'process_with': 'ale#fixers#rubocop#PostProcess',
   \   'command': ale#Escape(g:ale_ruby_rubocop_executable)
   \     . ' --auto-correct-all --editor-mode --force-exclusion --stdin %s'
-  \ },
-  \ ale#fixers#rubocop#Fix(bufnr(''))
+  \ }
 
 Execute(The rubocop post-processor should remove diagnostics content):
   AssertEqual
@@ -88,14 +82,15 @@ Execute(The rubocop post-processor should remove diagnostics content):
   \   '         ''run'']',
   \ ])
 
-Execute(The rubocop callback should not use editor-mode option when configured not to):
-  let g:ale_ruby_rubocop_editor_mode = 0
+Execute(The rubocop callback should not use editor-mode option with older versions):
   call ale#test#SetFilename('../test-files/ruby/with_config/dummy.rb')
 
-  AssertEqual
+  GivenCommandOutput ['1.59.0']
+
+  AssertFixer
   \ {
   \   'process_with': 'ale#fixers#rubocop#PostProcess',
   \   'command': ale#Escape(g:ale_ruby_rubocop_executable)
-  \     . ' --auto-correct-all --force-exclusion --stdin %s'
-  \ },
-  \ ale#fixers#rubocop#Fix(bufnr(''))
+  \     . ' --auto-correct --force-exclusion --stdin %s'
+  \ }
+


### PR DESCRIPTION
Since RuboCop 1.61 (released in February 2024), RuboCop accepts an `--editor-mode` flag which improves editor integrations like ale.

Some of RuboCop's auto-corrections can be surprising or annoying to run on save. When RuboCop is running via an LSP or when the `--editor-mode` flag is passed, it will understand that it is running in an editor, and it will hold off on making changes that might be surprising or annoying.

For example, if I write

```ruby
def call
  results = some_process
end
```

This has an unused variable, and RuboCop will remove the unused variable when you run it. However, if you're in the middle of editing, you may not want it to remove that unused variable, because you may be about to add a usage of it.

More context:

- PR which introduced it: https://github.com/rubocop/rubocop/pull/12682
- Release notes for 1.61: https://github.com/rubocop/rubocop/releases/tag/v1.61.0
- Docs: https://docs.rubocop.org/rubocop/1.80/configuration.html#contextual
- Issue where I learned about this flag: https://github.com/rubocop/rubocop/issues/14539

In order to make sure this isn't a breaking change for ale users who use an older version of RuboCop, this implementation only enables the `--editor-mode` flag when the version of RuboCop is >= 1.61.0.

In the meantime, I am opting into this behavior by setting this option:

```vim
let g:ale_ruby_rubocop_options = "--editor-mode"
```

So I appreciate that this seam was already introduced.