### PR TITLE
Add SuperHTML linter for HTML

### DIFF
--- a/ale_linters/html/superhtml.vim
+++ b/ale_linters/html/superhtml.vim
@@ -1,0 +1,34 @@
+call ale#Set('html_superhtml_executable', 'superhtml')
+call ale#Set('html_superhtml_use_global', get(g:, 'ale_use_global_executables', 0))
+
+function! ale_linters#html#superhtml#GetCommand(buffer) abort
+    return '%e check --stdin'
+endfunction
+
+function! ale_linters#html#superhtml#Handle(buffer, lines) abort
+    let l:output = []
+    let l:pattern = '^\(.*\):\(\d\+\):\(\d\+\): \(.*\)$'
+
+    for l:line in a:lines
+        let l:match = matchlist(l:line, l:pattern)
+
+        if !empty(l:match)
+            call add(l:output, {
+            \ 'lnum': str2nr(l:match[2]),
+            \ 'col': str2nr(l:match[3]),
+            \ 'text': l:match[4],
+            \ 'type': 'E'
+            \})
+        endif
+    endfor
+
+    return l:output
+endfunction
+
+call ale#linter#Define('html', {
+\   'name': 'superhtml',
+\   'executable': {b -> ale#Var(b, 'html_superhtml_executable')},
+\   'command': function('ale_linters#html#superhtml#GetCommand'),
+\   'output_stream': 'stderr',
+\   'callback': 'ale_linters#html#superhtml#Handle',
+\})

--- a/doc/ale-html.txt
+++ b/doc/ale-html.txt
@@ -207,6 +207,24 @@ g:ale_html_stylelint_use_global
 
 
 ===============================================================================
+superhtml                                                  *ale-html-superhtml*
+
+g:ale_html_superhtml_executable               *g:ale_html_superhtml_executable*
+                                              *b:ale_html_superhtml_executable*
+  Type: |String|
+  Default: `'superhtml'`
+
+  This variable can be changed to use a different executable for superhtml.
+
+g:ale_html_superhtml_use_global               *g:ale_html_superhtml_use_global*
+                                              *b:ale_html_superhtml_use_global*
+  Type: |Number|
+  Default: `get(g:, 'ale_use_global_executables', 0)`
+
+  See |ale-integrations-local-executables|
+
+
+===============================================================================
 tidy                                                            *ale-html-tidy*
 
 `tidy` is a console application which corrects and cleans up HTML and XML

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -289,6 +289,7 @@ Notes:
   * `prettier`
   * `proselint`
   * `rustywind`
+  * `superhtml`
   * `tidy`
   * `write-good`
 * HTML Angular

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -3586,6 +3586,7 @@ documented in additional help files.
     prettier..............................|ale-html-prettier|
     rustywind.............................|ale-html-rustywind|
     stylelint.............................|ale-html-stylelint|
+    superhtml.............................|ale-html-superhtml|
     tidy..................................|ale-html-tidy|
     vscodehtml............................|ale-html-vscode|
     write-good............................|ale-html-write-good|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -299,6 +299,7 @@ formatting.
   * [prettier](https://github.com/prettier/prettier)
   * [proselint](http://proselint.com/)
   * [rustywind](https://github.com/avencera/rustywind)
+  * [superhtml](https://github.com/kristoff-it/superhtml)
   * [tidy](http://www.html-tidy.org/)
   * [write-good](https://github.com/btford/write-good)
 * HTML Angular

--- a/test/linter/test_superhtml.vader
+++ b/test/linter/test_superhtml.vader
@@ -1,0 +1,29 @@
+Before:
+  call ale#assert#SetUpLinterTest('html', 'superhtml')
+  call ale#test#SetFilename('test.html')
+
+After:
+  call ale#assert#TearDownLinterTest()
+
+Execute(The default command should be correct):
+  AssertLinter 'superhtml',
+  \ ale#Escape('superhtml') . ' check --stdin'
+
+Execute(The executable should be configurable):
+  let g:ale_html_superhtml_executable = '/usr/local/bin/superhtml'
+
+  AssertLinter '/usr/local/bin/superhtml',
+  \ ale#Escape('/usr/local/bin/superhtml') . ' check --stdin'
+
+Execute(The options should be configurable):
+  let g:ale_html_superhtml_options = '--some-option'
+
+  AssertLinter 'superhtml',
+  \ ale#Escape('superhtml') . ' check --stdin'
+
+Execute(The use_global option should be respected):
+  let g:ale_html_superhtml_executable = 'custom_superhtml'
+  let g:ale_html_superhtml_use_global = 1
+
+  AssertLinter 'custom_superhtml',
+  \ ale#Escape('custom_superhtml') . ' check --stdin'


### PR DESCRIPTION
This pull request adds support for [superhtml](https://github.com/kristoff-it/superhtml) as a linter for html templates in ALE.

Fixes https://github.com/dense-analysis/ale/issues/4850