### PR TITLE
Fix option for pymarkdown linter

### DIFF
--- a/ale_linters/markdown/pymarkdown.vim
+++ b/ale_linters/markdown/pymarkdown.vim
@@ -33,9 +33,8 @@ function! ale_linters#markdown#pymarkdown#GetCommand(buffer) abort
     \   : ''
 
     return ale#Escape(l:executable) . l:exec_args
-    \   . ' '
-    \   . ale#Var(a:buffer, 'markdown_pymarkdown_options')
-    \   . 'scan-stdin'
+    \   . ale#Pad(ale#Var(a:buffer, 'markdown_pymarkdown_options'))
+    \   . ' scan-stdin'
 endfunction
 
 function! ale_linters#markdown#pymarkdown#Handle(buffer, lines) abort

--- a/test/linter/test_pymarkdown.vader
+++ b/test/linter/test_pymarkdown.vader
@@ -8,7 +8,10 @@ Execute(The pymarkdown command callback should return default string):
   AssertLinter 'pymarkdown', ale#Escape('pymarkdown') . ' scan-stdin'
 
 Execute(The pycodestyle command callback should allow options):
-  let g:markdown_pymarkdown_options = '--exclude=test*.py'
+  let g:ale_markdown_pymarkdown_options = '--exclude=test*.py'
+
+  AssertLinter 'pymarkdown',
+  \ ale#Escape('pymarkdown') . ' --exclude=test*.py scan-stdin'
 
 Execute(The pymarkdown executable should be configurable):
   let g:ale_markdown_pymarkdown_executable = '~/.local/bin/pymarkdown'
@@ -41,6 +44,12 @@ Execute(Poetry is detected when markdown_pymarkdown_auto_poetry is set):
 
   AssertLinter 'poetry',
   \ ale#Escape('poetry') . ' run pymarkdown scan-stdin'
+
+Execute(Setting executable to 'uv' appends 'run pymarkdown'):
+  let g:ale_markdown_pymarkdown_executable = 'path/to/uv'
+
+  AssertLinter 'path/to/uv',
+  \ ale#Escape('path/to/uv') . ' run pymarkdown scan-stdin' 
 
 Execute(uv is detected when markdown_pymarkdown_auto_uv is set):
   let g:ale_markdown_pymarkdown_auto_uv = 1


### PR DESCRIPTION
This PR improves how **pymarkdown** handles command options by replacing `aleVar()` with `alePad(aleVar())` for better spacing and updating tests to verify the new option formats work correctly.