### PR TITLE
Add markdownlint fixer for markdown

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -747,6 +747,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['verilog'],
 \       'description': 'Formats verilog files using verible.',
 \   },
+\   'markdownlint': {
+\       'function': 'ale#fixers#markdownlint#Fix',
+\       'suggested_filetypes': ['markdown'],
+\       'description': 'Fix markdown files with markdownlint.',
+\   },
 \}
 
 " Reset the function registry to the default entries.

--- a/autoload/ale/fixers/markdownlint.vim
+++ b/autoload/ale/fixers/markdownlint.vim
@@ -1,0 +1,15 @@
+:scriptencoding utf-8
+
+call ale#Set('markdownlint_executable', 'markdownlint')
+call ale#Set('markdownlint_options', '--fix')
+
+function! ale#fixers#markdownlint#Fix(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'markdownlint_executable')
+    let l:options = ale#Var(a:buffer, 'markdownlint_options')
+
+    return {
+    \   'command': ale#Escape(l:executable)
+    \       . ' ' . l:options,
+    \}
+endfunction
+

--- a/test/fixers/test_markdownlint_fixer_callback.vader
+++ b/test/fixers/test_markdownlint_fixer_callback.vader
@@ -1,0 +1,17 @@
+Before:
+  call ale#assert#SetUpFixerTest('markdown', 'markdownlint')
+
+After:
+  call ale#assert#TearDownFixerTest()
+
+Execute:
+  AssertFixer {
+  \ 'command': ale#Escape('markdownlint') . ' --fix',
+  \}
+
+Execute:
+  let g:ale_markdownlint_executable = 'custom_markdownlint'
+  
+  AssertFixer {
+  \ 'command': ale#Escape('custom_markdownlint') . ' --fix',
+  \}


### PR DESCRIPTION
This pull request adds support for [markdownlint](https://github.com/igorshubovych/markdownlint-cli) as a fixer for markdown templates in ALE.
