### PR TITLE
cppcheck: don't pass a source file if --project is specified

### DIFF
--- a/ale_linters/c/cppcheck.vim
+++ b/ale_linters/c/cppcheck.vim
@@ -10,13 +10,18 @@ function! ale_linters#c#cppcheck#GetCommand(buffer) abort
     \   ? ale#handlers#cppcheck#GetBufferPathIncludeOptions(a:buffer)
     \   : ''
     let l:template = ' --template=' . ale#Escape('{file}:{line}:{column}: {severity}:{inconclusive:inconclusive:} {message} [{id}]\\n{code}')
+    " Versions >=2.13 don't allow using --project in conjunction with an
+    " explicit source file.
+    let l:source_file = stridx(l:compile_commands_option, '--project=') < 0
+    \   ? ' %t'
+    \   : ''
 
     return '%e -q --language=c'
     \   . l:template
     \   . ale#Pad(l:compile_commands_option)
     \   . ale#Pad(ale#Var(a:buffer, 'c_cppcheck_options'))
     \   . l:buffer_path_include
-    \   . ' %t'
+    \   . l:source_file
 endfunction
 
 call ale#linter#Define('c', {

--- a/ale_linters/cpp/cppcheck.vim
+++ b/ale_linters/cpp/cppcheck.vim
@@ -10,13 +10,18 @@ function! ale_linters#cpp#cppcheck#GetCommand(buffer) abort
     \   ? ale#handlers#cppcheck#GetBufferPathIncludeOptions(a:buffer)
     \   : ''
     let l:template = ' --template=' . ale#Escape('{file}:{line}:{column}: {severity}:{inconclusive:inconclusive:} {message} [{id}]\\n{code}')
+    " Versions >=2.13 don't allow using --project in conjunction with an
+    " explicit source file.
+    let l:source_file = stridx(l:compile_commands_option, '--project=') < 0
+    \   ? ' %t'
+    \   : ''
 
     return '%e -q --language=c++'
     \   . l:template
     \   . ale#Pad(l:compile_commands_option)
     \   . ale#Pad(ale#Var(a:buffer, 'cpp_cppcheck_options'))
     \   . l:buffer_path_include
-    \   . ' %t'
+    \   . l:source_file
 endfunction
 
 call ale#linter#Define('cpp', {

--- a/test/linter/test_c_cppcheck.vader
+++ b/test/linter/test_c_cppcheck.vader
@@ -25,7 +25,7 @@ Execute(cppcheck for C should detect compile_commands.json files):
   \   . ' --template=' . ale#Escape('{file}:{line}:{column}: {severity}:{inconclusive:inconclusive:} {message} [{id}]\\n{code}')
   \   . ' --project=' . ale#Escape('compile_commands.json')
   \   . ' --file-filter=' . ale#Escape(ale#test#GetFilename(b:rel_file_path))
-  \   . ' --enable=style %t'
+  \   . ' --enable=style'
 
 Execute(cppcheck for C should detect compile_commands.json files in build directories):
   let b:rel_file_path = '../test-files/cppcheck/with_build_dir/foo.c'
@@ -37,7 +37,7 @@ Execute(cppcheck for C should detect compile_commands.json files in build direct
   \   . ' --template=' . ale#Escape('{file}:{line}:{column}: {severity}:{inconclusive:inconclusive:} {message} [{id}]\\n{code}')
   \   . ' --project=' . ale#Escape(ale#path#Simplify('build/compile_commands.json'))
   \   . ' --file-filter=' . ale#Escape(ale#test#GetFilename(b:rel_file_path))
-  \   . ' --enable=style %t'
+  \   . ' --enable=style'
 
 Execute(cppcheck for C should include file dir if compile_commands.json file is not found):
   call ale#test#SetFilename('../test-files/cppcheck/foo.c')

--- a/test/linter/test_cpp_cppcheck.vader
+++ b/test/linter/test_cpp_cppcheck.vader
@@ -31,7 +31,7 @@ Execute(cppcheck for C++ should detect compile_commands.json files):
   \   . ' --template=' . ale#Escape('{file}:{line}:{column}: {severity}:{inconclusive:inconclusive:} {message} [{id}]\\n{code}')
   \   . ' --project=' . ale#Escape('compile_commands.json')
   \   . ' --file-filter=' . ale#Escape(ale#test#GetFilename(b:rel_file_path))
-  \   . ' --enable=style %t'
+  \   . ' --enable=style'
 
 Execute(cppcheck for C++ should detect compile_commands.json files in build directories):
   let b:rel_file_path = '../test-files/cppcheck/with_build_dir/foo.cpp'
@@ -43,7 +43,7 @@ Execute(cppcheck for C++ should detect compile_commands.json files in build dire
   \   . ' --template=' . ale#Escape('{file}:{line}:{column}: {severity}:{inconclusive:inconclusive:} {message} [{id}]\\n{code}')
   \   . ' --project=' . ale#Escape(ale#path#Simplify('build/compile_commands.json'))
   \   . ' --file-filter=' . ale#Escape(ale#test#GetFilename(b:rel_file_path))
-  \   . ' --enable=style %t'
+  \   . ' --enable=style'
 
 Execute(cppcheck for C++ should include file dir if compile_commands.json file is not found):
   call ale#test#SetFilename('../test-files/cppcheck/foo.cpp')


### PR DESCRIPTION
This is no longer supported as of version 2.13.0.

Fixes: #4854