### PR TITLE
fix: replace deprecated client.request method call with colon syntax

### DIFF
--- a/lua/ale/lsp.lua
+++ b/lua/ale/lsp.lua
@@ -83,7 +83,7 @@ module.start = function(config)
         -- we can't get a client via get_client_by_id until after `on_init` is
         -- called. By deferring execution of calling the init callbacks we
         -- can only call them after the client becomes available, which
-        -- will make ications for configuration changes work, etc.
+        -- will make notifications for configuration changes work, etc.
         vim.defer_fn(function()
             vim.fn["ale#lsp#CallInitCallbacks"](config.name)
         end, 0)


### PR DESCRIPTION
I don't have much else to say; sorry if this is already being worked on elsewhere (as the deprecation warnings have been present for months now, not just an issue with this project either), but I couldn't find it being discussed anywhere.