### PR TITLE
Add cargo-fmt fixer for rust

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -387,6 +387,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['rust'],
 \       'description': 'Fix Rust files with Rustfmt.',
 \   },
+\   'cargo-fmt': {
+\       'function': 'ale#fixers#cargo_fmt#Fix',
+\       'suggested_filetypes': ['rust'],
+\       'description': 'Fix Rust files with `cargo-fmt`.',
+\   },
 \   'textlint': {
 \       'function': 'ale#fixers#textlint#Fix',
 \       'suggested_filetypes': ['text','markdown','asciidoc','tex'],

--- a/autoload/ale/fixers/cargo_fmt.vim
+++ b/autoload/ale/fixers/cargo_fmt.vim
@@ -1,0 +1,16 @@
+" Author: Mikhail f. Shiryaev <mr.felixoid@gmail.com
+" Description: Integration of `cargo fmt` with ALE.
+
+call ale#Set('rust_cargo_fmt_executable', 'cargo-fmt')
+call ale#Set('rust_cargo_fmt_options', '')
+
+function! ale#fixers#cargo_fmt#Fix(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'rust_cargo_fmt_executable')
+    let l:options = ale#Var(a:buffer, 'rust_cargo_fmt_options')
+
+    return {
+    \   'command': ale#Escape(l:executable) . ' -- '
+    \       . (empty(l:options) ? '' : ' ' . l:options),
+    \}
+endfunction
+

--- a/doc/ale-rust.txt
+++ b/doc/ale-rust.txt
@@ -30,8 +30,8 @@ Integration Information
      contained in Cargo projects or requires the project to be described in
      the rust-project.json format:
      https://rust-analyzer.github.io/manual.html#non-cargo-based-projects
-  5. rustfmt -- If you have `rustfmt` installed, you can use it as a fixer to
-     consistently reformat your Rust code.
+  5. fixers -- If you have `rustfmt` or `cargo-fmt` installed, you can use one of
+     them as a fixer to consistently reformat your Rust code.
 
   Only cargo and rust-analyzer are enabled by default. To switch to using
   rustc instead of cargo, configure |b:ale_linters| in your ftplugin file
@@ -363,6 +363,30 @@ g:ale_rust_rustfmt_executable
   Default: `'rustfmt'`
 
   This variable can be modified to change the executable path for `rustfmt`.
+
+
+===============================================================================
+cargo-fmt                                                  *ale-rust-cargo-fmt*
+
+                                           *ale-options.rust_cargo_fmt_options*
+                                                 *g:ale_rust_cargo_fmt_options*
+                                                 *b:ale_rust_cargo_fmt_options*
+rust_cargo_fmt_options
+g:ale_rust_cargo_fmt_options
+  Type: |String|
+  Default: `''`
+
+  This variable can be set to pass additional options to the cargo-fmt fixer.
+
+                                        *ale-options.rust_cargo_fmt_executable*
+                                              *g:ale_rust_cargo_fmt_executable*
+                                              *b:ale_rust_cargo_fmt_executable*
+rust_cargo_fmt_executable
+g:ale_rust_cargo_fmt_executable
+  Type: |String|
+  Default: `'cargo-fmt'`
+
+  This variable can be modified to change the executable path for `cargo-fmt`.
 
 
 ===============================================================================

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -623,6 +623,7 @@ Notes:
   * `syntax_tree`
 * Rust
   * `cargo`!!
+  * `cargo-fmt`
   * `cspell`
   * `rls`
   * `rust-analyzer`

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -3900,6 +3900,7 @@ documented in additional help files.
     rls...................................|ale-rust-rls|
     rustc.................................|ale-rust-rustc|
     rustfmt...............................|ale-rust-rustfmt|
+    cargo-fmt.............................|ale-rust-cargo-fmt|
   salt....................................|ale-salt-options|
     salt-lint.............................|ale-salt-salt-lint|
   sass....................................|ale-sass-options|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -633,6 +633,7 @@ formatting.
   * [syntax_tree](https://github.com/ruby-syntax-tree/syntax_tree)
 * Rust
   * [cargo](https://github.com/rust-lang/cargo) :floppy_disk: (see `:help ale-integration-rust` for configuration instructions) :speech_balloon:
+  * [cargo-fmt](https://doc.rust-lang.org/cargo/commands/cargo-fmt.html)
   * [cspell](https://github.com/streetsidesoftware/cspell/tree/main/packages/cspell)
   * [rls](https://github.com/rust-lang-nursery/rls) :warning:
   * [rust-analyzer](https://github.com/rust-analyzer/rust-analyzer) :warning:

--- a/test/fixers/test_cargo_fmt_fixer_callback.vader
+++ b/test/fixers/test_cargo_fmt_fixer_callback.vader
@@ -1,0 +1,17 @@
+Before:
+  call ale#assert#SetUpFixerTest('rust', 'cargo-fmt')
+
+After:
+  call ale#assert#TearDownFixerTest()
+
+Execute(The cargo-fmt callback should return the correct default values):
+  call ale#test#SetFilename('../test-files/rust/testfile.rs')
+
+  AssertFixer {'command': ale#Escape('cargo-fmt') . ' -- '}
+
+Execute(The cargo-fmt callback should include custom cargo-fmt options):
+  let g:ale_rust_cargo_fmt_options = "--skip-children"
+  call ale#test#SetFilename('../test-files/rust/testfile.rs')
+
+  AssertFixer {'command': ale#Escape('cargo-fmt') . ' -- ' . ' ' . g:ale_rust_cargo_fmt_options}
+


### PR DESCRIPTION
<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!

Where are the tests? Have you added tests? Have you updated the tests? Read the
comment above and the documentation referenced in it first. Write tests!

Seriously, read `:help ale-dev` and write tests.

-->

The issue is described in #3814; `rustfmt` produces different output without additional tweaks.

Here, the `cargo-fmt` fixer is added together with tests and docs.