### PR TITLE
Fix Vale linter options

### DIFF
--- a/ale_linters/text/vale.vim
+++ b/ale_linters/text/vale.vim
@@ -1,9 +1,22 @@
 " Author: chew-z https://github.com/chew-z
 " Description: vale for text files
 
+call ale#Set('vale_executable', 'vale')
+call ale#Set('vale_options', '')
+
+function! ale_linters#text#vale#GetCommand(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'vale_executable')
+
+    let l:options = ale#Var(a:buffer, 'vale_options')
+
+    return ale#Escape(l:executable)
+    \   . (!empty(l:options) ? ' ' . l:options : '')
+    \   . ' --output=JSON %t'
+endfunction
+
 call ale#linter#Define('text', {
 \   'name': 'vale',
 \   'executable': 'vale',
-\   'command': 'vale --output=JSON %t',
+\   'command': function('ale_linters#text#vale#GetCommand'),
 \   'callback': 'ale#handlers#vale#Handle',
 \})

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -28,10 +28,12 @@ CONTENTS                                                         *ale-contents*
   7. Linter/Fixer Options.................|ale-integration-options|
     7.1 Options for alex..................|ale-alex-options|
     7.2 Options for cspell................|ale-cspell-options|
-    7.3 Options for languagetool..........|ale-languagetool-options|
-    7.4 Options for write-good............|ale-write-good-options|
-    7.5 Options for redpen................|ale-redpen-options|
-    7.6 Other Linter/Fixer Options........|ale-other-integration-options|
+    7.3 Options for dprint................|ale-dprint-options|
+    7.4 Options for languagetool..........|ale-languagetool-options|
+    7.5 Options for write-good............|ale-write-good-options|
+    7.6 Options for redpen................|ale-redpen-options|
+    7.7 Options for vale..................|ale-vale-options|
+    7.8 Other Linter/Fixer Options........|ale-other-integration-options|
   8. Commands/Keybinds....................|ale-commands|
   9. API..................................|ale-api|
   10. Special Thanks......................|ale-special-thanks|
@@ -3359,7 +3361,31 @@ g:ale_redpen_options
 
 
 -------------------------------------------------------------------------------
-7.7. Other Linter/Fixer Options                 *ale-other-integration-options*
+7.7. Options for vale                                        *ale-vale-options*
+
+  The following options can be used to configure the `vale` linter for text
+  files.
+
+g:ale_text_vale_executable                         *g:ale_text_vale_executable*
+  Type: String
+  Default: 'vale'
+
+  This option controls which executable is used for running Vale. Set it to an
+  absolute path or a different command name if needed.
+
+g:ale_text_vale_options                               *g:ale_text_vale_options*
+  Type: String
+  Default: ''
+
+  Extra command-line options to pass to the Vale executable.
+
+  Example:
+
+    let g:ale_text_vale_options = '--minAlertLevel=warning'
+
+
+-------------------------------------------------------------------------------
+7.8. Other Linter/Fixer Options                 *ale-other-integration-options*
 
 ALE supports a very wide variety of tools. Other linter or fixer options are
 documented in additional help files.

--- a/test/linter/test_text_vale.vader
+++ b/test/linter/test_text_vale.vader
@@ -1,0 +1,15 @@
+Before:
+  call ale#assert#SetUpLinterTest('text', 'vale')
+
+After:
+  call ale#assert#TearDownLinterTest()
+
+Execute(The Vale command should include extra options when configured):
+  let g:ale_vale_executable = 'vale'
+  let g:ale_vale_options = '--minAlertLevel=warning'
+  AssertLinter 'vale', ale#Escape('vale') . ' --minAlertLevel=warning --output=JSON %t'
+
+Execute(The Vale command should not include extra options by default):
+  let g:ale_vale_executable = 'vale'
+  let g:ale_vale_options = ''
+  AssertLinter 'vale', ale#Escape('vale') . ' --output=JSON %t'


### PR DESCRIPTION
This pull request adds the ability to configure the Vale linter via the `g:ale_vale_executable` and `g:ale_vale_options` options.

Fixes : #2824 