### PR TITLE
Changed default Project Root when build.zig not found

### DIFF
--- a/ale_linters/zig/zls.vim
+++ b/ale_linters/zig/zls.vim
@@ -7,7 +7,9 @@ call ale#Set('zig_zls_config', {})
 function! ale_linters#zig#zls#GetProjectRoot(buffer) abort
     let l:build_rs = ale#path#FindNearestFile(a:buffer, 'build.zig')
 
-    return !empty(l:build_rs) ? fnamemodify(l:build_rs, ':h') : ''
+    return !empty(l:build_rs) 
+          \ ? fnamemodify(l:build_rs, ':h') 
+          \ : expand('#' . a:buffer . ':p:h')
 endfunction
 
 call ale#linter#Define('zig', {

--- a/test/linter/test_zig_zls.vader
+++ b/test/linter/test_zig_zls.vader
@@ -8,8 +8,11 @@ Execute(The default executable path should be correct):
   AssertLinter 'zls', ale#Escape('zls')
 
 Execute(The project root should be detected correctly):
-  AssertLSPProject ''
-
   call ale#test#SetFilename('../test-files/zig/main.zig')
 
   AssertLSPProject ale#path#Simplify(g:dir . '/../test-files/zig')
+
+Execute(The project root should be detected correctly given no build.zig):
+  call ale#test#SetFilename(g:dir . '../test-files/zig-nobuild/main.zig')
+
+  AssertLSPProject ale#path#Simplify(g:dir . '../test-files/zig-nobuild')


### PR DESCRIPTION
Zig does not need a project root, but when viewing the std library, there is no build.zig. The current directory is fine for these purposes. zls remains quick on my linux machine.

[`Addresses this issue`](https://github.com/dense-analysis/ale/issues/5082)