### PR TITLE
refactor: use ale#Pad for option padding across the codebase

### DIFF
--- a/ale_linters/cpp/clazy.vim
+++ b/ale_linters/cpp/clazy.vim
@@ -18,7 +18,7 @@ function! ale_linters#cpp#clazy#GetCommand(buffer) abort
     return '%e'
     \   . (!empty(l:checks) ? ' -checks=' . ale#Escape(l:checks) : '')
     \   . (!empty(l:build_dir) ? ' -p ' . ale#Escape(l:build_dir) : '')
-    \   . (!empty(l:options) ? ' ' . l:options : '')
+    \   . ale#Pad(l:options)
     \   . ' %s'
 endfunction
 

--- a/ale_linters/cs/mcs.vim
+++ b/ale_linters/cs/mcs.vim
@@ -4,7 +4,7 @@ function! ale_linters#cs#mcs#GetCommand(buffer) abort
     let l:options = ale#Var(a:buffer, 'cs_mcs_options')
 
     return 'mcs -unsafe --parse'
-    \   . (!empty(l:options) ? ' ' . l:options : '')
+    \   . ale#Pad(l:options)
     \   . ' %t'
 endfunction
 

--- a/ale_linters/go/revive.vim
+++ b/ale_linters/go/revive.vim
@@ -8,7 +8,7 @@ function! ale_linters#go#revive#GetCommand(buffer) abort
     let l:options = ale#Var(a:buffer, 'go_revive_options')
 
     return ale#go#EnvString(a:buffer) . '%e'
-    \   . (!empty(l:options) ? ' ' . l:options : '')
+    \   . ale#Pad(l:options)
     \   . ' %t'
 endfunction
 

--- a/ale_linters/go/staticcheck.vim
+++ b/ale_linters/go/staticcheck.vim
@@ -13,11 +13,11 @@ function! ale_linters#go#staticcheck#GetCommand(buffer) abort
 
     if l:lint_package
         return l:env . '%e'
-        \   . (!empty(l:options) ? ' ' . l:options : '') . ' .'
+        \   . ale#Pad(l:options) . ' .'
     endif
 
     return l:env . '%e'
-    \   . (!empty(l:options) ? ' ' . l:options : '')
+    \   . ale#Pad(l:options)
     \   . ' %s:t'
 endfunction
 

--- a/ale_linters/groovy/npmgroovylint.vim
+++ b/ale_linters/groovy/npmgroovylint.vim
@@ -8,7 +8,7 @@ function! ale_linters#groovy#npmgroovylint#GetCommand(buffer) abort
     let l:options = ale#Var(a:buffer, 'groovy_npmgroovylint_options')
 
     return '%e --failon none --output json'
-    \   . (!empty(l:options) ? ' ' . l:options : '')
+    \   . ale#Pad(l:options)
     \   . ' %t'
 endfunction
 

--- a/ale_linters/html/stylelint.vim
+++ b/ale_linters/html/stylelint.vim
@@ -15,7 +15,7 @@ function! ale_linters#html#stylelint#GetCommand(buffer) abort
     let l:options = ale#Var(a:buffer, 'html_stylelint_options')
 
     return ale#Escape(l:executable)
-    \   . (!empty(l:options) ? ' ' . l:options : '')
+    \   . ale#Pad(l:options)
     \   . ' --no-color --stdin-filename %s'
 endfunction
 

--- a/ale_linters/javascript/standard.vim
+++ b/ale_linters/javascript/standard.vim
@@ -19,7 +19,7 @@ function! ale_linters#javascript#standard#GetCommand(buffer) abort
     let l:options = ale#Var(a:buffer, 'javascript_standard_options')
 
     return ale#node#Executable(a:buffer, l:executable)
-    \   . (!empty(l:options) ? ' ' . l:options : '')
+    \   . ale#Pad(l:options)
     \   . ' --stdin %s'
 endfunction
 

--- a/ale_linters/markdown/markdownlint.vim
+++ b/ale_linters/markdown/markdownlint.vim
@@ -14,7 +14,7 @@ function! ale_linters#markdown#markdownlint#GetCommand(buffer) abort
     let l:options = ale#Var(a:buffer, 'markdown_markdownlint_options')
 
     return ale#Escape(l:executable)
-    \ . (!empty(l:options) ? ' ' . l:options : '') . ' %s'
+    \ . ale#Pad(l:options) . ' %s'
 endfunction
 
 call ale#linter#Define('markdown', {

--- a/ale_linters/markdown/mdl.vim
+++ b/ale_linters/markdown/mdl.vim
@@ -17,7 +17,7 @@ function! ale_linters#markdown#mdl#GetCommand(buffer) abort
     let l:options = ale#Var(a:buffer, 'markdown_mdl_options')
 
     return ale#Escape(l:executable) . l:exec_args
-    \   . ' -j' . (!empty(l:options) ? ' ' . l:options : '')
+    \   . ' -j' . ale#Pad(l:options)
 endfunction
 
 function! ale_linters#markdown#mdl#Handle(buffer, lines) abort

--- a/ale_linters/php/tlint.vim
+++ b/ale_linters/php/tlint.vim
@@ -31,7 +31,7 @@ function! ale_linters#php#tlint#GetCommand(buffer) abort
     let l:options = ale#Var(a:buffer, 'php_tlint_options')
 
     return ale#node#Executable(a:buffer, l:executable)
-    \   . (!empty(l:options) ? ' ' . l:options : '')
+    \   . ale#Pad(l:options)
     \   . ' lint %s'
 endfunction
 

--- a/ale_linters/proto/buf_lint.vim
+++ b/ale_linters/proto/buf_lint.vim
@@ -11,7 +11,7 @@ function! ale_linters#proto#buf_lint#GetCommand(buffer) abort
 
     return '%e lint'
     \ . (!empty(l:config) ? ' --config=' . ale#Escape(l:config) : '')
-    \ . (!empty(l:options) ? ' ' . l:options : '')
+    \ . ale#Pad(l:options)
     \ . ' %s#include_package_files=true'
 endfunction
 

--- a/ale_linters/python/flake8.vim
+++ b/ale_linters/python/flake8.vim
@@ -87,7 +87,7 @@ function! ale_linters#python#flake8#GetCommand(buffer, version) abort
     let l:options = ale#Var(a:buffer, 'python_flake8_options')
 
     return ale#Escape(l:executable) . l:exec_args
-    \   . (!empty(l:options) ? ' ' . l:options : '')
+    \   . ale#Pad(l:options)
     \   . ' --format=default'
     \   . l:display_name_args . ' -'
 endfunction

--- a/ale_linters/rego/opacheck.vim
+++ b/ale_linters/rego/opacheck.vim
@@ -12,7 +12,7 @@ function! ale_linters#rego#opacheck#GetCommand(buffer) abort
 
     return ale#Escape(ale_linters#rego#opacheck#GetExecutable(a:buffer))
     \   . ' check %s:h --format json '
-    \   . (!empty(l:options) ? ' ' . l:options : '')
+    \   . ale#Pad(l:options)
 endfunction
 
 function! ale_linters#rego#opacheck#Handle(buffer, lines) abort

--- a/ale_linters/ruby/sorbet.vim
+++ b/ale_linters/ruby/sorbet.vim
@@ -10,7 +10,7 @@ function! ale_linters#ruby#sorbet#GetCommand(buffer) abort
 
     return ale#ruby#EscapeExecutable(l:executable, 'srb')
     \   . ' tc'
-    \   . (!empty(l:options) ? ' ' . l:options : '')
+    \   . ale#Pad(l:options)
     \   . ' --lsp'
     \   . (l:enable_watchman ? '' : ' --disable-watchman')
 endfunction

--- a/ale_linters/rust/rustc.vim
+++ b/ale_linters/rust/rustc.vim
@@ -20,7 +20,7 @@ function! ale_linters#rust#rustc#RustcCommand(buffer) abort
     let l:options = ale#Var(a:buffer, 'rust_rustc_options')
 
     return 'rustc --error-format=json'
-    \   . (!empty(l:options) ? ' ' . l:options : '')
+    \   . ale#Pad(l:options)
     \   . l:dependencies . ' -'
 endfunction
 

--- a/ale_linters/sass/sasslint.vim
+++ b/ale_linters/sass/sasslint.vim
@@ -16,7 +16,7 @@ function! ale_linters#sass#sasslint#GetCommand(buffer) abort
     let l:options = ale#Var(a:buffer, 'sass_sasslint_options')
 
     return ale#node#Executable(a:buffer, l:executable)
-    \   . (!empty(l:options) ? ' ' . l:options : '')
+    \   . ale#Pad(l:options)
     \   . ' -v -q -f compact %t'
 endfunction
 

--- a/ale_linters/scss/sasslint.vim
+++ b/ale_linters/scss/sasslint.vim
@@ -16,7 +16,7 @@ function! ale_linters#scss#sasslint#GetCommand(buffer) abort
     let l:options = ale#Var(a:buffer, 'scss_sasslint_options')
 
     return ale#node#Executable(a:buffer, l:executable)
-    \   . (!empty(l:options) ? ' ' . l:options : '')
+    \   . ale#Pad(l:options)
     \   . ' -v -q -f compact %t'
 endfunction
 

--- a/ale_linters/text/vale.vim
+++ b/ale_linters/text/vale.vim
@@ -10,7 +10,7 @@ function! ale_linters#text#vale#GetCommand(buffer) abort
     let l:options = ale#Var(a:buffer, 'vale_options')
 
     return ale#Escape(l:executable)
-    \   . (!empty(l:options) ? ' ' . l:options : '')
+    \   . ale#Pad(l:options)
     \   . ' --output=JSON %t'
 endfunction
 

--- a/ale_linters/typescript/standard.vim
+++ b/ale_linters/typescript/standard.vim
@@ -18,7 +18,7 @@ function! ale_linters#typescript#standard#GetCommand(buffer) abort
     let l:options = ale#Var(a:buffer, 'typescript_standard_options')
 
     return ale#node#Executable(a:buffer, l:executable)
-    \   . (!empty(l:options) ? ' ' . l:options : '')
+    \   . ale#Pad(l:options)
     \   . ' --stdin %s'
 endfunction
 

--- a/autoload/ale/fixers/autoflake.vim
+++ b/autoload/ale/fixers/autoflake.vim
@@ -38,7 +38,7 @@ function! ale#fixers#autoflake#Fix(buffer) abort
 
     return {
     \   'command': ale#Escape(l:executable) . l:exec_args
-    \       . (!empty(l:options) ? ' ' . l:options : '')
+    \       . ale#Pad(l:options)
     \       . ' --in-place '
     \       . ' %t',
     \   'read_temporary_file': 1,

--- a/autoload/ale/fixers/autoimport.vim
+++ b/autoload/ale/fixers/autoimport.vim
@@ -39,7 +39,7 @@ function! ale#fixers#autoimport#Fix(buffer) abort
     return {
     \   'cwd': '%s:h',
     \   'command': ale#Escape(l:executable) . l:exec_args
-    \       . (!empty(l:options) ? ' ' . l:options : '')
+    \       . ale#Pad(l:options)
     \       . ' -',
     \}
 endfunction

--- a/autoload/ale/fixers/autopep8.vim
+++ b/autoload/ale/fixers/autopep8.vim
@@ -38,7 +38,7 @@ function! ale#fixers#autopep8#Fix(buffer) abort
 
     return {
     \   'command': ale#Escape(l:executable) . l:exec_args
-    \       . (!empty(l:options) ? ' ' . l:options : '')
+    \       . ale#Pad(l:options)
     \       . ' -',
     \}
 endfunction

--- a/autoload/ale/fixers/biome.vim
+++ b/autoload/ale/fixers/biome.vim
@@ -6,6 +6,6 @@ function! ale#fixers#biome#Fix(buffer) abort
     return {
     \   'command': ale#Escape(l:executable) . ' check '
     \       . '--write --stdin-file-path %s' . l:unsafe
-    \       . (!empty(l:options) ? ' ' . l:options : '')
+    \       . ale#Pad(l:options)
     \}
 endfunction

--- a/autoload/ale/fixers/erblint.vim
+++ b/autoload/ale/fixers/erblint.vim
@@ -28,7 +28,7 @@ function! ale#fixers#erblint#GetCommand(buffer) abort
     let l:options = ale#Var(a:buffer, 'eruby_erblint_options')
 
     return ale#ruby#EscapeExecutable(l:executable, 'erblint')
-    \   . (!empty(l:options) ? ' ' . l:options : '')
+    \   . ale#Pad(l:options)
     \   . ' --autocorrect --stdin %s'
 endfunction
 

--- a/autoload/ale/fixers/gnatpp.vim
+++ b/autoload/ale/fixers/gnatpp.vim
@@ -10,7 +10,7 @@ function! ale#fixers#gnatpp#Fix(buffer) abort
 
     return {
     \   'command': ale#Escape(l:executable)
-    \       . (!empty(l:options) ? ' ' . l:options : '')
+    \       . ale#Pad(l:options)
     \       . ' %t',
     \   'read_temporary_file': 1,
     \}

--- a/autoload/ale/fixers/mix_format.vim
+++ b/autoload/ale/fixers/mix_format.vim
@@ -13,7 +13,7 @@ function! ale#fixers#mix_format#GetCommand(buffer) abort
     let l:options = ale#Var(a:buffer, 'elixir_mix_format_options')
 
     return l:executable . ' format'
-    \   . (!empty(l:options) ? ' ' . l:options : '')
+    \   . ale#Pad(l:options)
     \   . ' %t'
 endfunction
 

--- a/autoload/ale/fixers/npmgroovylint.vim
+++ b/autoload/ale/fixers/npmgroovylint.vim
@@ -9,7 +9,7 @@ function! ale#fixers#npmgroovylint#Fix(buffer) abort
 
     return {
     \   'command': ale#Escape(l:executable)
-    \       . (!empty(l:options) ? ' ' . l:options : '')
+    \       . ale#Pad(l:options)
     \       . ' %t',
     \   'read_temporary_file': 1,
     \}

--- a/autoload/ale/fixers/prettier.vim
+++ b/autoload/ale/fixers/prettier.vim
@@ -99,7 +99,7 @@ function! ale#fixers#prettier#ApplyFixForVersion(buffer, version) abort
         return {
         \   'cwd': '%s:h',
         \   'command':ale#Escape(l:executable)
-        \       . (!empty(l:options) ? ' ' . l:options : '')
+        \       . ale#Pad(l:options)
         \       . ' --stdin-filepath %s --stdin',
         \   'process_with': 'ale#fixers#prettier#ProcessPrettierDOutput',
         \}
@@ -110,7 +110,7 @@ function! ale#fixers#prettier#ApplyFixForVersion(buffer, version) abort
         return {
         \   'cwd': ale#fixers#prettier#GetCwd(a:buffer),
         \   'command': ale#Escape(l:executable)
-        \       . (!empty(l:options) ? ' ' . l:options : '')
+        \       . ale#Pad(l:options)
         \       . ' --stdin-filepath %s --stdin',
         \}
     endif
@@ -118,7 +118,7 @@ function! ale#fixers#prettier#ApplyFixForVersion(buffer, version) abort
     return {
     \   'command': ale#Escape(l:executable)
     \       . ' %t'
-    \       . (!empty(l:options) ? ' ' . l:options : '')
+    \       . ale#Pad(l:options)
     \       . ' --write',
     \   'read_temporary_file': 1,
     \}

--- a/autoload/ale/fixers/prettier_eslint.vim
+++ b/autoload/ale/fixers/prettier_eslint.vim
@@ -40,7 +40,7 @@ function! ale#fixers#prettier_eslint#ApplyFixForVersion(buffer, version) abort
         \   'cwd': '%s:h',
         \   'command': ale#Escape(l:executable)
         \       . l:eslint_config_option
-        \       . (!empty(l:options) ? ' ' . l:options : '')
+        \       . ale#Pad(l:options)
         \       . ' --stdin-filepath %s --stdin',
         \}
     endif
@@ -49,7 +49,7 @@ function! ale#fixers#prettier_eslint#ApplyFixForVersion(buffer, version) abort
     \   'command': ale#Escape(l:executable)
     \       . ' %t'
     \       . l:eslint_config_option
-    \       . (!empty(l:options) ? ' ' . l:options : '')
+    \       . ale#Pad(l:options)
     \       . ' --write',
     \   'read_temporary_file': 1,
     \}

--- a/autoload/ale/fixers/pymarkdown.vim
+++ b/autoload/ale/fixers/pymarkdown.vim
@@ -39,7 +39,7 @@ function! ale#fixers#pymarkdown#Fix(buffer) abort
     return {
     \   'command': ale#Escape(l:executable) . l:exec_args
     \       . ' fix'
-    \       . (!empty(l:options) ? ' ' . l:options : '')
+    \       . ale#Pad(l:options)
     \       . ' %t',
     \   'read_temporary_file': 1,
     \}

--- a/autoload/ale/fixers/remark_lint.vim
+++ b/autoload/ale/fixers/remark_lint.vim
@@ -18,7 +18,7 @@ function! ale#fixers#remark_lint#Fix(buffer) abort
 
     return {
     \   'command': ale#Escape(l:executable)
-    \       . (!empty(l:options) ? ' ' . l:options : ''),
+    \       . ale#Pad(l:options),
     \}
 endfunction
 

--- a/autoload/ale/fixers/reorder_python_imports.vim
+++ b/autoload/ale/fixers/reorder_python_imports.vim
@@ -38,6 +38,6 @@ function! ale#fixers#reorder_python_imports#Fix(buffer) abort
 
     return {
     \   'command': ale#Escape(l:executable) . l:exec_args
-    \       . (!empty(l:options) ? ' ' . l:options : '') . ' -',
+    \       . ale#Pad(l:options) . ' -',
     \}
 endfunction

--- a/autoload/ale/fixers/rubocop.vim
+++ b/autoload/ale/fixers/rubocop.vim
@@ -26,7 +26,7 @@ function! ale#fixers#rubocop#GetCommand(buffer, version) abort
     let l:editor_mode = ale#semver#GTE(a:version, [1, 61, 0])
 
     return ale#ruby#EscapeExecutable(l:executable, 'rubocop')
-    \   . (!empty(l:options) ? ' ' . l:options : '')
+    \   . ale#Pad(l:options)
     \   . (l:auto_correct_all ? ' --auto-correct-all' : ' --auto-correct')
     \   . (l:editor_mode ? ' --editor-mode' : '')
     \   . ' --force-exclusion --stdin %s'

--- a/autoload/ale/fixers/sorbet.vim
+++ b/autoload/ale/fixers/sorbet.vim
@@ -7,7 +7,7 @@ function! ale#fixers#sorbet#GetCommand(buffer) abort
 
     return ale#ruby#EscapeExecutable(l:executable, 'srb')
     \   . ' tc'
-    \   . (!empty(l:options) ? ' ' . l:options : '')
+    \   . ale#Pad(l:options)
     \   . ' --autocorrect --file %t'
 endfunction
 

--- a/autoload/ale/fixers/sqlformat.vim
+++ b/autoload/ale/fixers/sqlformat.vim
@@ -10,7 +10,7 @@ function! ale#fixers#sqlformat#Fix(buffer) abort
 
     return {
     \ 'command': ale#Escape(l:executable)
-    \ . (!empty(l:options) ? ' ' . l:options : '')
+    \ . ale#Pad(l:options)
     \ . ' -'
     \}
 endfunction

--- a/autoload/ale/fixers/standard.vim
+++ b/autoload/ale/fixers/standard.vim
@@ -26,7 +26,7 @@ function! ale#fixers#standard#Fix(buffer) abort
 
     return {
     \   'command': ale#node#Executable(a:buffer, l:executable)
-    \   . (!empty(l:options) ? ' ' . l:options : '')
+    \   . ale#Pad(l:options)
     \       . ' --fix --stdin < %s > %t',
     \   'read_temporary_file': 1,
     \}

--- a/autoload/ale/fixers/standardrb.vim
+++ b/autoload/ale/fixers/standardrb.vim
@@ -11,7 +11,7 @@ function! ale#fixers#standardrb#GetCommand(buffer) abort
 
     return ale#ruby#EscapeExecutable(l:executable, 'standardrb')
     \   . (!empty(l:config) ? ' --config ' . ale#Escape(l:config) : '')
-    \   . (!empty(l:options) ? ' ' . l:options : '')
+    \   . ale#Pad(l:options)
     \   . ' --fix --force-exclusion --stdin %s'
 endfunction
 

--- a/autoload/ale/fixers/syntax_tree.vim
+++ b/autoload/ale/fixers/syntax_tree.vim
@@ -7,7 +7,7 @@ function! ale#fixers#syntax_tree#GetCommand(buffer) abort
 
     return ale#ruby#EscapeExecutable(l:executable, 'stree')
     \   . ' format'
-    \   . (!empty(l:options) ? ' ' . l:options : '')
+    \   . ale#Pad(l:options)
     \   . ' %t'
 endfunction
 

--- a/autoload/ale/fixers/yamlfix.vim
+++ b/autoload/ale/fixers/yamlfix.vim
@@ -20,6 +20,6 @@ function! ale#fixers#yamlfix#Fix(buffer) abort
     return {
     \   'cwd': '%s:h',
     \   'command': ale#Escape(l:executable)
-    \       . (!empty(l:options) ? ' ' . l:options : '') . ' -',
+    \       . ale#Pad(l:options) . ' -',
     \}
 endfunction

--- a/autoload/ale/handlers/djlint.vim
+++ b/autoload/ale/handlers/djlint.vim
@@ -39,7 +39,7 @@ function! ale#handlers#djlint#GetCommand(buffer) abort
     endif
 
     return ale#Escape(l:executable)
-    \ . (!empty(l:options) ? ' ' . l:options : '') . ' %s'
+    \ . ale#Pad(l:options) . ' %s'
 endfunction
 
 function! ale#handlers#djlint#Handle(buffer, lines) abort

--- a/autoload/ale/handlers/eslint.vim
+++ b/autoload/ale/handlers/eslint.vim
@@ -54,7 +54,7 @@ function! ale#handlers#eslint#GetCommand(buffer) abort
     let l:options = ale#Var(a:buffer, 'javascript_eslint_options')
 
     return ale#node#Executable(a:buffer, l:executable)
-    \   . (!empty(l:options) ? ' ' . l:options : '')
+    \   . ale#Pad(l:options)
     \   . ' -f json --stdin --stdin-filename %s'
 endfunction
 

--- a/autoload/ale/handlers/shellcheck.vim
+++ b/autoload/ale/handlers/shellcheck.vim
@@ -57,7 +57,7 @@ function! ale#handlers#shellcheck#GetCommand(buffer, version) abort
 
     return '%e'
     \   . (!empty(l:dialect) ? ' -s ' . l:dialect : '')
-    \   . (!empty(l:options) ? ' ' . l:options : '')
+    \   . ale#Pad(l:options)
     \   . (!empty(l:exclude_option) ? ' -e ' . l:exclude_option : '')
     \   . l:external_option
     \   . ' -f ' . l:format . ' -'

--- a/autoload/ale/handlers/textlint.vim
+++ b/autoload/ale/handlers/textlint.vim
@@ -17,7 +17,7 @@ function! ale#handlers#textlint#GetCommand(buffer) abort
     let l:options = ale#Var(a:buffer, 'textlint_options')
 
     return ale#node#Executable(a:buffer, l:executable)
-    \    . (!empty(l:options) ? ' ' . l:options : '')
+    \    . ale#Pad(l:options)
     \    . ' -f json --stdin --stdin-filename %s'
 endfunction
 

--- a/autoload/ale/handlers/writegood.vim
+++ b/autoload/ale/handlers/writegood.vim
@@ -22,7 +22,7 @@ function! ale#handlers#writegood#GetCommand(buffer) abort
     let l:options = ale#Var(a:buffer, 'writegood_options')
 
     return ale#node#Executable(a:buffer, l:executable)
-    \   . (!empty(l:options) ? ' ' . l:options : '')
+    \   . ale#Pad(l:options)
     \   . ' %t'
 endfunction
 

--- a/autoload/ale/preview.vim
+++ b/autoload/ale/preview.vim
@@ -81,7 +81,7 @@ function! ale#preview#ShowSelection(item_list, ...) abort
         \   l:filename
         \       . ':' . l:item.line
         \       . ':' . l:item.column
-        \       . (!empty(l:match) ? ' ' . l:match : ''),
+        \       . ale#Pad(l:match),
         \)
     endfor
 


### PR DESCRIPTION
Standardize option padding by replacing verbose ternary checks with `ale#Pad()`.

Replaced patterns like:
`. (!empty(l:options) ? ' ' . l:options : '')`

with:
`. ale#Pad(l:options)`