### PR TITLE
Fix multiple lints appearing on the same line.

### DIFF
--- a/autoload/ale/virtualtext.vim
+++ b/autoload/ale/virtualtext.vim
@@ -210,12 +210,18 @@ function! ale#virtualtext#ShowMessage(buffer, item) abort
             call add(s:hl_list, l:hl_group)
         endif
 
+        let l:align = "after"
+        if !empty(prop_list(l:line, { 'bufnr': a:buffer, 'types': s:hl_list }))
+            let l:align = "below"
+        endif
+
         " We ignore all errors from prop_add.
         silent! call prop_add(l:line, 0, {
         \   'type': l:hl_group,
         \   'text': ' ' . l:msg,
         \   'bufnr': a:buffer,
         \   'text_padding_left': l:col_pad,
+        \   'text_align': l:align,
         \})
     endif
 endfunction

--- a/autoload/ale/virtualtext.vim
+++ b/autoload/ale/virtualtext.vim
@@ -323,6 +323,10 @@ function! ale#virtualtext#SetTexts(buffer, loclist) abort
         \   sort(l:buffer_list, function('ale#virtualtext#CompareSeverityPerLine')),
         \   {a, b -> a.lnum - b.lnum}
         \)
+    else
+        " l:buffer_list is sorted in the wrong order from some reason. the
+        " maintiner doesn't know why...
+        call reverse(l:buffer_list)
     endif
 
     for l:item in l:buffer_list

--- a/test/test_virtualtext.vader
+++ b/test/test_virtualtext.vader
@@ -219,3 +219,12 @@ Execute(We should not set cursor messages when Neovim diagnostics are enabled):
 
     AssertEqual '', ale#virtualtext#GetLastMessageForTests()
   endif
+
+Execute(We should add new messages on the next line):
+  if has('patch-9.0.0297')
+    call ale#virtualtext#SetTexts(bufnr(''), g:ale_buffer_info[bufnr('')].loclist)
+
+    let l:line_props = prop_list(2, { 'bufnr': bufnr(''), 'types': [ 'ALEVirtualTextError', 'ALEVirtualTextWarning' ] })
+    AssertEqual get(l:line_props[0] 'text_align', 'below'), 'below'
+    AssertEqual get(l:line_props[1] 'text_align', 'below'), 'after'
+  endif


### PR DESCRIPTION
The [ale demo video](https://github.com/dense-analysis/ale/assets/3518142/8f2ff760-6a87-4704-a11e-c109b8e9ec41) on the main page shows two lints on the same line briefly. the second lint appears on the line below the first one, instead of being concatenated.

vim9 virtualtext support was added to ale, but it was not made to put subsequent lints on following lines - instead they are concatenated to the end of the same line (and so get elided quickly).

this patch fixes it so that it matches the demo video.