### PR TITLE
fix(terraform-ls): return current buffer dir when missing .terraform

### DIFF
--- a/ale_linters/terraform/terraform_ls.vim
+++ b/ale_linters/terraform/terraform_ls.vim
@@ -25,6 +25,10 @@ endfunction
 function! ale_linters#terraform#terraform_ls#GetProjectRoot(buffer) abort
     let l:tf_dir = ale#path#FindNearestDirectory(a:buffer, '.terraform')
 
+    if empty(l:tf_dir)
+        let l:tf_dir = ale#path#FindNearestDirectory(a:buffer, '.')
+    endif
+
     return !empty(l:tf_dir) ? fnamemodify(l:tf_dir, ':h:h') : ''
 endfunction
 


### PR DESCRIPTION
while working in some larger repos, the .terraform dir might be missing for one reason or another, terraform-ls will fail to start and return:
```
Failed to find project root, language server won't start
```
check if tf_dir is empty, if so, just return the dir of the file in buffer.
