### PR TITLE
Fix c build dir name tests

### DIFF
--- a/autoload/ale/c.vim
+++ b/autoload/ale/c.vim
@@ -10,7 +10,7 @@ let s:sep = has('win32') ? '\' : '/'
 " Set just so tests can override it.
 let g:__ale_c_project_filenames = ['.git/HEAD', 'configure', 'Makefile', 'CMakeLists.txt']
 
-let g:ale_c_build_dir_names = get(g:, 'ale_c_build_dir_names', [
+call ale#Set('c_build_dir_names', [
 \   'build',
 \   'build/Debug',
 \   'build/Release',
@@ -18,10 +18,6 @@ let g:ale_c_build_dir_names = get(g:, 'ale_c_build_dir_names', [
 \])
 
 function! s:CanParseMakefile(buffer) abort
-    " Something somewhere seems to delete this setting in tests, so ensure we
-    " always have a default value.
-    call ale#Set('c_parse_makefile', 0)
-
     return ale#Var(a:buffer, 'c_parse_makefile')
 endfunction
 
@@ -245,15 +241,6 @@ function! ale#c#FindCompileCommands(buffer) abort
     if !empty(l:json_file)
         return [fnamemodify(l:json_file, ':h'), l:json_file]
     endif
-
-    " Something somewhere seems to delete this setting in tests, so ensure
-    " we always have a default value.
-    call ale#Set('c_build_dir_names', [
-    \   'build',
-    \   'build/Debug',
-    \   'build/Release',
-    \   'bin',
-    \])
 
     " Search in build directories if we can't find it in the project.
     for l:path in ale#path#Upwards(expand('#' . a:buffer . ':p:h'))

--- a/test/linter/test_c_cc.vader
+++ b/test/linter/test_c_cc.vader
@@ -1,4 +1,6 @@
 Before:
+  call ale#assert#SetUpLinterTest('c', 'cc')
+
   Save g:ale_c_parse_makefile
   Save g:ale_history_enabled
 
@@ -18,8 +20,6 @@ Before:
   function! ale#c#GetCFlags(buffer, output) abort
     return g:get_cflags_return_value
   endfunction
-
-  call ale#assert#SetUpLinterTest('c', 'cc')
 
   let b:command_tail = ' -S -x c'
   \   . ' -o ' . (has('win32') ? 'nul': '/dev/null')

--- a/test/linter/test_c_clang_tidy.vader
+++ b/test/linter/test_c_clang_tidy.vader
@@ -1,9 +1,9 @@
 Before:
-  Save g:ale_c_parse_makefile
-  let g:ale_c_parse_makefile = 0
-
   call ale#assert#SetUpLinterTest('c', 'clangtidy')
   call ale#test#SetFilename('test.c')
+
+  Save g:ale_c_parse_makefile
+  let g:ale_c_parse_makefile = 0
 
 After:
   call ale#assert#TearDownLinterTest()

--- a/test/linter/test_clang_tidy.vader
+++ b/test/linter/test_clang_tidy.vader
@@ -1,9 +1,9 @@
 Before:
-  Save g:ale_c_parse_makefile
-  let g:ale_c_parse_makefile = 0
-
   call ale#assert#SetUpLinterTest('cpp', 'clangtidy')
   call ale#test#SetFilename('test.cpp')
+
+  Save g:ale_c_parse_makefile
+  let g:ale_c_parse_makefile = 0
 
 After:
   call ale#assert#TearDownLinterTest()

--- a/test/linter/test_cpp_cc.vader
+++ b/test/linter/test_cpp_cc.vader
@@ -1,4 +1,6 @@
 Before:
+  call ale#assert#SetUpLinterTest('cpp', 'cc')
+
   Save g:ale_c_parse_makefile
   Save g:ale_history_enabled
 
@@ -8,7 +10,6 @@ Before:
   let g:get_cflags_return_value = ''
   let g:executable_map = {}
 
-  runtime autoload/ale/c.vim
   runtime autoload/ale/engine.vim
 
   function! ale#engine#IsExecutable(buffer, executable) abort
@@ -18,8 +19,6 @@ Before:
   function! ale#c#GetCFlags(buffer, output) abort
     return g:get_cflags_return_value
   endfunction
-
-  call ale#assert#SetUpLinterTest('cpp', 'cc')
 
   let b:command_tail = ' -S -x c++'
   \   . ' -o ' . (has('win32') ? 'nul': '/dev/null')

--- a/test/test_c_find_compile_commands.vader
+++ b/test/test_c_find_compile_commands.vader
@@ -1,4 +1,5 @@
 Before:
+  runtime autoload/ale/c.vim
   Save g:ale_c_build_dir_names
 
   call ale#test#SetDirectory('/testplugin/test')

--- a/test/test_c_flag_parsing.vader
+++ b/test/test_c_flag_parsing.vader
@@ -1,4 +1,7 @@
 Before:
+
+  runtime autoload/ale/c.vim
+
   Save g:ale_c_parse_makefile
   Save g:ale_c_always_make
   Save b:ale_c_always_make


### PR DESCRIPTION
This PR fixes c related tests to work properly without need for the c_build_dir_names workarounds:

- Use ale#Set() to set the ale_c_build_dir_names variable. 
- Ensure SetUpLinterTest() is called before any Save commands in tests.
- Add c.vim to runtime before non-linter tests are executed.
- Remove workarounds in c.vim.

