### PR TITLE
fix expert lsp stdio and register capability

### DIFF
--- a/ale_linters/elixir/expert.vim
+++ b/ale_linters/elixir/expert.vim
@@ -7,6 +7,6 @@ call ale#linter#Define('elixir', {
 \   'name': 'expert',
 \   'lsp': 'stdio',
 \   'executable': {b -> ale#Var(b, 'elixir_expert_executable')},
-\   'command': '%e',
+\   'command': '%e --stdio',
 \   'project_root': function('ale#handlers#elixir#FindMixUmbrellaRoot'),
 \})

--- a/autoload/ale/lsp_linter.vim
+++ b/autoload/ale/lsp_linter.vim
@@ -241,6 +241,8 @@ function! ale#lsp_linter#HandleLSPResponse(conn_id, response) abort
         \   : a:response.result.items
 
         call ale#lsp_linter#HandleLSPDiagnostics(a:conn_id, l:uri, l:diagnostics)
+    elseif l:method is# 'client/registerCapability'
+        call ale#lsp#SendResponse(a:conn_id, a:response.id, v:null)
     elseif l:method is# 'workspace/configuration'
         let l:items = get(get(a:response, 'params', {}), 'items', [])
         let l:config = ale#lsp#GetConnectionConfig(a:conn_id)

--- a/test/linter/test_elixir_expert.vader
+++ b/test/linter/test_elixir_expert.vader
@@ -5,12 +5,12 @@ After:
   call ale#assert#TearDownLinterTest()
 
 Execute(should set correct defaults):
-  AssertLinter 'expert', ale#Escape('expert')
+  AssertLinter 'expert', ale#Escape('expert') . ' --stdio'
 
 Execute(The executable should be configurable):
   let b:ale_elixir_expert_executable = 'foobar'
 
-  AssertLinter 'foobar', ale#Escape('foobar')
+  AssertLinter 'foobar', ale#Escape('foobar') . ' --stdio'
 
 Execute(should set correct LSP values):
   call ale#test#SetFilename('../test-files/elixir/umbrella_project/apps/app1/lib/app.ex')

--- a/test/lsp/test_engine_lsp_response_handling.vader
+++ b/test/lsp/test_engine_lsp_response_handling.vader
@@ -562,6 +562,30 @@ Execute(workspace/configuration requests should be answered with the connection 
   unlet! g:sent_responses
   runtime autoload/ale/lsp.vim
 
+Execute(client/registerCapability requests should be acknowledged):
+  let g:sent_responses = []
+
+  function! ale#lsp#SendResponse(conn_id, id, result) abort
+    call add(g:sent_responses, [a:conn_id, a:id, a:result])
+  endfunction
+
+  call ale#lsp_linter#SetLSPLinterMap({'1': {'name': 'expert', 'aliases': [], 'lsp': 'stdio'}})
+  call ale#lsp_linter#HandleLSPResponse(1, {
+  \ 'jsonrpc': '2.0',
+  \ 'id': 12,
+  \ 'method': 'client/registerCapability',
+  \ 'params': {
+  \   'registrations': [{'id': 'abc', 'method': 'textDocument/didSave'}],
+  \ },
+  \})
+
+  AssertEqual
+  \ [[1, 12, v:null]],
+  \ g:sent_responses
+
+  unlet! g:sent_responses
+  runtime autoload/ale/lsp.vim
+
 Execute(LSP errors should be logged in the history):
   call ale#lsp_linter#SetLSPLinterMap({'347': {'name': 'foobar', 'aliases': [], 'lsp': 'stdio'}})
   call ale#lsp_linter#HandleLSPResponse(347, {


### PR DESCRIPTION
tested with expert v0.1.0 installed via homebrew and ale at `ba8b9cba` (2026-04-01) installed via vim-plug on macos

expert's lsp server requires `--stdio` to use stdio transport (see [expert README](https://github.com/elixir-lang/expert/blob/9de53c22d2a829549356090451a122fa2d0cfd51/README.md?plain=1#L40) and `expert --help`), but the ale linter definition launched it without the flag so the server never entered lsp mode

separately, expert sends a `client/registerCapability` request after initialization to dynamically register capabilities, and ale had no handler for it, i.e., the server blocked waiting for a response and never processed `textDocument/didOpen` or any subsequent messages, making features like go-to-definition non-functional

the first commit adds `--stdio` to the expert launch command, the second adds a handler that acknowledges `client/registerCapability` requests with a null response, matching how ale already handles `workspace/configuration`

note: `client/registerCapability` is part of the lsp spec and other servers may also use it, so this fix is not expert-specific