### PR TITLE
feat(markdown): add rumdl server and fixer

### DIFF
--- a/ale_linters/markdown/rumdl.vim
+++ b/ale_linters/markdown/rumdl.vim
@@ -6,33 +6,34 @@ call ale#Set('markdown_rumdl_executable', 'rumdl')
 call ale#Set('markdown_rumdl_options', '')
 
 function! ale_linters#markdown#rumdl#GetProjectRoot(buffer) abort
-  let l:dotconfig = ale#path#FindNearestFile(a:buffer, '.rumdl.toml')
-  let l:config = ale#path#FindNearestFile(a:buffer, 'rumdl.toml')
+    let l:dotconfig = ale#path#FindNearestFile(a:buffer, '.rumdl.toml')
+    let l:config = ale#path#FindNearestFile(a:buffer, 'rumdl.toml')
 
-  if !empty(l:dotconfig) && !empty(l:config)
-    let l:nearest = len(l:dotconfig) >= len(l:config) ? l:dotconfig : l:config
-    return fnamemodify(l:nearest, ':h')
-  elseif !empty(l:dotconfig)
-    return fnamemodify(l:dotconfig, ':h')
-  elseif !empty(l:config)
-    return fnamemodify(l:config, ':h')
-  endif
+    if !empty(l:dotconfig) && !empty(l:config)
+        let l:nearest = len(l:dotconfig) >= len(l:config) ? l:dotconfig : l:config
 
-  " Try to find nearest pyproject.toml
-  let l:pyproject_file = ale#path#FindNearestFile(a:buffer, 'pyproject.toml')
+        return fnamemodify(l:nearest, ':h')
+    elseif !empty(l:dotconfig)
+        return fnamemodify(l:dotconfig, ':h')
+    elseif !empty(l:config)
+        return fnamemodify(l:config, ':h')
+    endif
 
-  if !empty(l:pyproject_file)
-      return fnamemodify(l:pyproject_file . '/', ':p:h:h')
-  endif
+    " Try to find nearest pyproject.toml
+    let l:pyproject_file = ale#path#FindNearestFile(a:buffer, 'pyproject.toml')
 
-  " Try to find nearest `git` directory
-  let l:gitdir = ale#path#FindNearestFile(a:buffer, '.git')
+    if !empty(l:pyproject_file)
+        return fnamemodify(l:pyproject_file . '/', ':p:h:h')
+    endif
 
-  if !empty(l:gitdir)
-      return fnamemodify(l:gitdir . '/', ':p:h:h')
-  endif
+    " Try to find nearest `git` directory
+    let l:gitdir = ale#path#FindNearestFile(a:buffer, '.git')
 
-  return fnamemodify(bufname(a:buffer), ':p:h')
+    if !empty(l:gitdir)
+        return fnamemodify(l:gitdir . '/', ':p:h:h')
+    endif
+
+    return fnamemodify(bufname(a:buffer), ':p:h')
 endfunction
 
 call ale#linter#Define('markdown', {

--- a/ale_linters/markdown/rumdl.vim
+++ b/ale_linters/markdown/rumdl.vim
@@ -1,0 +1,32 @@
+" Author: Evan Chen <evan@evanchen.cc>
+" Description: Fast Markdown linter and formatter written in Rust
+
+
+call ale#Set('markdown_rumdl_executable', 'rumdl')
+
+function! ale_linters#markdown#rumdl#GetProjectRoot(buffer) abort
+  let l:dotconfig = ale#path#FindNearestFile(a:buffer, '.rumdl.toml')
+  let l:config = ale#path#FindNearestFile(a:buffer, 'rumdl.toml')
+
+  if !empty(l:dotconfig) || !empty(l:config)
+    let l:nearest = len(l:dotconfig) >= len(l:config) ? l:dotconfig : l:config
+    return fnamemodify(l:nearest, ':h')
+  endif
+
+  let l:project_root = finddir('.git/..', fnamemodify(bufname(a:buffer), ':p:h') . ';')
+
+  if !empty(l:project_root)
+    return l:project_root
+  endif
+
+  return fnamemodify(bufname(a:buffer), ':p:h')
+endfunction
+
+call ale#linter#Define('markdown', {
+\   'name': 'rumdl',
+\   'lsp': 'stdio',
+\   'executable': {b -> ale#Var(b, 'markdown_rumdl_executable')},
+\   'command': '%e server --stdio',
+\   'project_root': function('ale_linters#markdown#rumdl#GetProjectRoot'),
+\   'language': 'markdown',
+\})

--- a/ale_linters/markdown/rumdl.vim
+++ b/ale_linters/markdown/rumdl.vim
@@ -9,9 +9,13 @@ function! ale_linters#markdown#rumdl#GetProjectRoot(buffer) abort
   let l:dotconfig = ale#path#FindNearestFile(a:buffer, '.rumdl.toml')
   let l:config = ale#path#FindNearestFile(a:buffer, 'rumdl.toml')
 
-  if !empty(l:dotconfig) || !empty(l:config)
+  if !empty(l:dotconfig) && !empty(l:config)
     let l:nearest = len(l:dotconfig) >= len(l:config) ? l:dotconfig : l:config
     return fnamemodify(l:nearest, ':h')
+  elseif !empty(l:dotconfig)
+    return fnamemodify(l:dotconfig, ':h')
+  elseif !empty(l:config)
+    return fnamemodify(l:config, ':h')
   endif
 
   let l:project_root = finddir('.git/..', fnamemodify(bufname(a:buffer), ':p:h') . ';')

--- a/ale_linters/markdown/rumdl.vim
+++ b/ale_linters/markdown/rumdl.vim
@@ -3,6 +3,7 @@
 
 
 call ale#Set('markdown_rumdl_executable', 'rumdl')
+call ale#Set('markdown_rumdl_options', '')
 
 function! ale_linters#markdown#rumdl#GetProjectRoot(buffer) abort
   let l:dotconfig = ale#path#FindNearestFile(a:buffer, '.rumdl.toml')
@@ -26,7 +27,9 @@ call ale#linter#Define('markdown', {
 \   'name': 'rumdl',
 \   'lsp': 'stdio',
 \   'executable': {b -> ale#Var(b, 'markdown_rumdl_executable')},
-\   'command': '%e server --stdio',
+\   'command': {b -> ale#Escape(ale#Var(b, 'markdown_rumdl_executable'))
+\       . ' server --stdio'
+\       . ale#Pad(ale#Var(b, 'markdown_rumdl_options'))},
 \   'project_root': function('ale_linters#markdown#rumdl#GetProjectRoot'),
 \   'language': 'markdown',
 \})

--- a/ale_linters/markdown/rumdl.vim
+++ b/ale_linters/markdown/rumdl.vim
@@ -18,10 +18,18 @@ function! ale_linters#markdown#rumdl#GetProjectRoot(buffer) abort
     return fnamemodify(l:config, ':h')
   endif
 
-  let l:project_root = finddir('.git/..', fnamemodify(bufname(a:buffer), ':p:h') . ';')
+  " Try to find nearest pyproject.toml
+  let l:pyproject_file = ale#path#FindNearestFile(a:buffer, 'pyproject.toml')
 
-  if !empty(l:project_root)
-    return l:project_root
+  if !empty(l:pyproject_file)
+      return fnamemodify(l:pyproject_file . '/', ':p:h:h')
+  endif
+
+  " Try to find nearest `git` directory
+  let l:gitdir = ale#path#FindNearestFile(a:buffer, '.git')
+
+  if !empty(l:gitdir)
+      return fnamemodify(l:gitdir . '/', ':p:h:h')
   endif
 
   return fnamemodify(bufname(a:buffer), ':p:h')

--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -767,6 +767,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['markdown'],
 \       'description': 'Fix markdown files with markdownlint.',
 \   },
+\   'rumdl': {
+\       'function': 'ale#fixers#rumdl#Fix',
+\       'suggested_filetypes': ['markdown'],
+\       'description': 'Fix markdown files with rumdl.',
+\   },
 \}
 
 " Reset the function registry to the default entries.

--- a/autoload/ale/fixers/rumdl.vim
+++ b/autoload/ale/fixers/rumdl.vim
@@ -1,0 +1,18 @@
+scriptencoding utf-8
+
+" Author: Evan Chen <evan@evanchen.cc>
+" Description: Fast Markdown linter and formatter written in Rust
+
+
+call ale#Set('markdown_rumdl_executable', 'rumdl')
+call ale#Set('markdown_rumdl_options', '--silent')
+
+function! ale#fixers#rumdl#Fix(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'markdown_rumdl_executable')
+    let l:options = ale#Var(a:buffer, 'markdown_rumdl_options')
+
+    return {
+    \   'command': ale#Escape(l:executable) . ' fmt -'
+    \       . ale#Pad(l:options),
+    \}
+endfunction

--- a/autoload/ale/fixers/rumdl.vim
+++ b/autoload/ale/fixers/rumdl.vim
@@ -5,11 +5,11 @@ scriptencoding utf-8
 
 
 call ale#Set('markdown_rumdl_executable', 'rumdl')
-call ale#Set('markdown_rumdl_options', '--silent')
+call ale#Set('markdown_rumdl_fmt_options', '--silent')
 
 function! ale#fixers#rumdl#Fix(buffer) abort
     let l:executable = ale#Var(a:buffer, 'markdown_rumdl_executable')
-    let l:options = ale#Var(a:buffer, 'markdown_rumdl_options')
+    let l:options = ale#Var(a:buffer, 'markdown_rumdl_fmt_options')
 
     return {
     \   'command': ale#Escape(l:executable) . ' fmt -'

--- a/doc/ale-markdown.txt
+++ b/doc/ale-markdown.txt
@@ -247,9 +247,9 @@ g:ale_markdown_remark_lint_use_global
 ===============================================================================
 rumdl                                                      *ale-markdown-rumdl*
 
-                                       *ale-options.markdown_rumdl_executable*
-                                             *g:ale_markdown_rumdl_executable*
-                                             *b:ale_markdown_rumdl_executable*
+                                        *ale-options.markdown_rumdl_executable*
+                                              *g:ale_markdown_rumdl_executable*
+                                              *b:ale_markdown_rumdl_executable*
 markdown_rumdl_executable
 g:ale_markdown_rumdl_executable
   Type: |String|
@@ -257,9 +257,9 @@ g:ale_markdown_rumdl_executable
 
   Override the invoked `rumdl` binary.
 
-                                          *ale-options.markdown_rumdl_options*
-                                                *g:ale_markdown_rumdl_options*
-                                                *b:ale_markdown_rumdl_options*
+                                           *ale-options.markdown_rumdl_options*
+                                                 *g:ale_markdown_rumdl_options*
+                                                 *b:ale_markdown_rumdl_options*
 markdown_rumdl_options
 g:ale_markdown_rumdl_options
   Type: |String|
@@ -267,9 +267,9 @@ g:ale_markdown_rumdl_options
 
   This variable can be set to pass additional options to `rumdl server`.
 
-                                      *ale-options.markdown_rumdl_fmt_options*
-                                            *g:ale_markdown_rumdl_fmt_options*
-                                            *b:ale_markdown_rumdl_fmt_options*
+                                       *ale-options.markdown_rumdl_fmt_options*
+                                             *g:ale_markdown_rumdl_fmt_options*
+                                             *b:ale_markdown_rumdl_fmt_options*
 markdown_rumdl_fmt_options
 g:ale_markdown_rumdl_fmt_options
   Type: |String|

--- a/doc/ale-markdown.txt
+++ b/doc/ale-markdown.txt
@@ -245,6 +245,30 @@ g:ale_markdown_remark_lint_use_global
 
 
 ===============================================================================
+rumdl                                                      *ale-markdown-rumdl*
+
+                                       *ale-options.markdown_rumdl_executable*
+                                             *g:ale_markdown_rumdl_executable*
+                                             *b:ale_markdown_rumdl_executable*
+markdown_rumdl_executable
+g:ale_markdown_rumdl_executable
+  Type: |String|
+  Default: `'rumdl'`
+
+  Override the invoked `rumdl` binary.
+
+                                          *ale-options.markdown_rumdl_options*
+                                                *g:ale_markdown_rumdl_options*
+                                                *b:ale_markdown_rumdl_options*
+markdown_rumdl_options
+g:ale_markdown_rumdl_options
+  Type: |String|
+  Default: `'--silent'`
+
+  This variable can be set to pass additional options to `rumdl fmt`.
+
+
+===============================================================================
 textlint                                                *ale-markdown-textlint*
 
 See |ale-text-textlint|

--- a/doc/ale-markdown.txt
+++ b/doc/ale-markdown.txt
@@ -263,6 +263,16 @@ g:ale_markdown_rumdl_executable
 markdown_rumdl_options
 g:ale_markdown_rumdl_options
   Type: |String|
+  Default: `''`
+
+  This variable can be set to pass additional options to `rumdl server`.
+
+                                      *ale-options.markdown_rumdl_fmt_options*
+                                            *g:ale_markdown_rumdl_fmt_options*
+                                            *b:ale_markdown_rumdl_fmt_options*
+markdown_rumdl_fmt_options
+g:ale_markdown_rumdl_fmt_options
+  Type: |String|
   Default: `'--silent'`
 
   This variable can be set to pass additional options to `rumdl fmt`.

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -415,6 +415,7 @@ Notes:
   * `pymarkdown`
   * `redpen`
   * `remark-lint`
+  * `rumdl`
   * `textlint`
   * `vale`
   * `write-good`

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -3746,6 +3746,7 @@ documented in additional help files.
     prettier..............................|ale-markdown-prettier|
     pymarkdown............................|ale-markdown-pymarkdown|
     remark-lint...........................|ale-markdown-remark-lint|
+    rumdl.................................|ale-markdown-rumdl|
     textlint..............................|ale-markdown-textlint|
     write-good............................|ale-markdown-write-good|
     redpen................................|ale-markdown-redpen|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -425,6 +425,7 @@ formatting.
   * [pymarkdown](https://github.com/jackdewinter/pymarkdown) :floppy_disk:
   * [redpen](http://redpen.cc/)
   * [remark-lint](https://github.com/wooorm/remark-lint)
+  * [rumdl](https://github.com/rvben/rumdl/issues) :speech_balloon:
   * [textlint](https://textlint.github.io/)
   * [vale](https://github.com/ValeLint/vale)
   * [write-good](https://github.com/btford/write-good)

--- a/test/fixers/test_rumdl_fixer_callback.vader
+++ b/test/fixers/test_rumdl_fixer_callback.vader
@@ -1,0 +1,23 @@
+Before:
+  Save g:ale_markdown_rumdl_executable
+  Save g:ale_markdown_rumdl_options
+
+After:
+  Restore
+
+Execute(The rumdl callback should return the default command):
+  AssertEqual
+  \ {
+  \   'command': ale#Escape('rumdl') . ' fmt - --silent',
+  \ },
+  \ ale#fixers#rumdl#Fix(bufnr(''))
+
+Execute(The rumdl executable and options should be configurable):
+  let g:ale_markdown_rumdl_executable = 'rumdl_custom'
+  let g:ale_markdown_rumdl_options = ''
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape('rumdl_custom') . ' fmt -',
+  \ },
+  \ ale#fixers#rumdl#Fix(bufnr(''))

--- a/test/fixers/test_rumdl_fixer_callback.vader
+++ b/test/fixers/test_rumdl_fixer_callback.vader
@@ -1,6 +1,6 @@
 Before:
   Save g:ale_markdown_rumdl_executable
-  Save g:ale_markdown_rumdl_options
+  Save g:ale_markdown_rumdl_fmt_options
 
 After:
   Restore
@@ -12,9 +12,9 @@ Execute(The rumdl callback should return the default command):
   \ },
   \ ale#fixers#rumdl#Fix(bufnr(''))
 
-Execute(The rumdl executable and options should be configurable):
+Execute(The rumdl executable and fmt options should be configurable):
   let g:ale_markdown_rumdl_executable = 'rumdl_custom'
-  let g:ale_markdown_rumdl_options = ''
+  let g:ale_markdown_rumdl_fmt_options = ''
 
   AssertEqual
   \ {

--- a/test/fixers/test_rumdl_fixer_callback.vader
+++ b/test/fixers/test_rumdl_fixer_callback.vader
@@ -1,23 +1,24 @@
 Before:
-  Save g:ale_markdown_rumdl_executable
-  Save g:ale_markdown_rumdl_fmt_options
+  call ale#assert#SetUpFixerTest('markdown', 'rumdl')
 
 After:
-  Restore
+  call ale#assert#TearDownFixerTest()
 
-Execute(The rumdl callback should return the default command):
-  AssertEqual
-  \ {
-  \   'command': ale#Escape('rumdl') . ' fmt - --silent',
-  \ },
-  \ ale#fixers#rumdl#Fix(bufnr(''))
+Execute:
+  AssertFixer {
+  \ 'command': ale#Escape('rumdl') . ' fmt - --silent',
+  \}
 
-Execute(The rumdl executable and fmt options should be configurable):
+Execute:
   let g:ale_markdown_rumdl_executable = 'rumdl_custom'
+
+  AssertFixer {
+  \ 'command': ale#Escape('rumdl_custom') . ' fmt - --silent',
+  \}
+
+Execute:
   let g:ale_markdown_rumdl_fmt_options = ''
 
-  AssertEqual
-  \ {
-  \   'command': ale#Escape('rumdl_custom') . ' fmt -',
-  \ },
-  \ ale#fixers#rumdl#Fix(bufnr(''))
+  AssertFixer {
+  \ 'command': ale#Escape('rumdl') . ' fmt -',
+  \}

--- a/test/linter/test_markdown_rumdl.vader
+++ b/test/linter/test_markdown_rumdl.vader
@@ -1,0 +1,13 @@
+Before:
+  call ale#assert#SetUpLinterTest('markdown', 'rumdl')
+
+After:
+  call ale#assert#TearDownLinterTest()
+
+Execute(The default command should be correct):
+  AssertLinter 'rumdl', ale#Escape('rumdl') . ' server --stdio'
+
+Execute(The executable should be configurable):
+  let b:ale_markdown_rumdl_executable = 'rumdl_custom'
+
+  AssertLinter 'rumdl_custom', ale#Escape('rumdl_custom') . ' server --stdio'

--- a/test/linter/test_markdown_rumdl.vader
+++ b/test/linter/test_markdown_rumdl.vader
@@ -11,3 +11,8 @@ Execute(The executable should be configurable):
   let b:ale_markdown_rumdl_executable = 'rumdl_custom'
 
   AssertLinter 'rumdl_custom', ale#Escape('rumdl_custom') . ' server --stdio'
+
+Execute(The server options should be configurable):
+  let b:ale_markdown_rumdl_options = '--some-flag'
+
+  AssertLinter 'rumdl', ale#Escape('rumdl') . ' server --stdio --some-flag'


### PR DESCRIPTION
Implements #5064. Some notes:

- I basically copied #4565 and #5066 for the linter and fixer respectively.
- I have configuration options for both the linter and the fixer separately, but I could make them a single option if desired. Although in practice I expect the options list to usually be blank.
- For finding the project root, I look for both `.rumdl.toml` or `rumdl.toml` and take the shorter one if both are found. Otherwise it looks for `pyproject.toml`, else `.git`.
  - I assume it's overkill for ALE to read `pyproject.toml` looking to see if it has a `tool.rumdl` section.
- If no `.git` or `rumdl.toml`/`.rumdl.toml` is found I just set project root as the folder of the buffer.
- Besides the two vader files, I've put the linter and fixer on my own computer in dotfiles (here's [linter](https://github.com/vEnhance/dotfiles/blob/main/vim/ale_linters/markdown/rumdl.vim) and [fixer](https://github.com/vEnhance/dotfiles/blob/main/vim/autoload/ale/fixers/rumdl.vim)) to make sure they pass sanity check.

I hope this is all correct, but it'd be good if someone competent looked over this given I'm first-time contributing and had assistance from an LLM.