### PR TITLE
Use ale#Pad for option padding across the codebase

### DIFF
--- a/autoload/ale/fixers/alejandra.vim
+++ b/autoload/ale/fixers/alejandra.vim
@@ -7,7 +7,7 @@ function! ale#fixers#alejandra#Fix(buffer) abort
 
     return {
     \   'command': ale#Escape(l:executable)
-    \       . (empty(l:options) ? '' : ' ' . l:options)
+    \       . ale#Pad(l:options)
     \       . ' -- -'
     \}
 endfunction

--- a/autoload/ale/fixers/apkbuild_fixer.vim
+++ b/autoload/ale/fixers/apkbuild_fixer.vim
@@ -12,7 +12,7 @@ function! ale#fixers#apkbuild_fixer#Fix(buffer) abort
     return {
     \   'command': ale#Escape(l:executable)
     \       . ' -p ' . ale#Var(a:buffer, 'apkbuild_apkbuild_fixer_lint_executable')
-    \       . (empty(l:options) ? '' : ' ' . l:options)
+    \       . ale#Pad(l:options)
     \       . ' %t',
     \   'read_temporary_file': 1,
     \}

--- a/autoload/ale/fixers/clangtidy.vim
+++ b/autoload/ale/fixers/clangtidy.vim
@@ -36,7 +36,7 @@ function! ale#fixers#clangtidy#GetCommand(buffer) abort
 
     return ' -fix' . (l:fix_errors ? ' -fix-errors' : '')
     \   . (empty(l:checks) ? '' : ' -checks=' . ale#Escape(l:checks))
-    \   . (empty(l:extra_options) ? '' : ' ' . l:extra_options)
+    \   . ale#Pad(l:extra_options)
     \   . (empty(l:build_dir) ? '' : ' -p ' . ale#Escape(l:build_dir))
     \   . ' %t' . (empty(l:options) ? '' : ' -- ' . l:options)
 endfunction

--- a/autoload/ale/fixers/cmakeformat.vim
+++ b/autoload/ale/fixers/cmakeformat.vim
@@ -10,7 +10,7 @@ function! ale#fixers#cmakeformat#Fix(buffer) abort
 
     return {
     \   'command': ale#Escape(l:executable)
-    \       . (empty(l:options) ? '' : ' ' . l:options)
+    \       . ale#Pad(l:options)
     \       . ' -'
     \}
 endfunction

--- a/autoload/ale/fixers/dart_format.vim
+++ b/autoload/ale/fixers/dart_format.vim
@@ -11,7 +11,7 @@ function! ale#fixers#dart_format#Fix(buffer) abort
     return {
     \   'command': ale#Escape(l:executable)
     \       . ' format'
-    \       . (empty(l:options) ? '' : ' ' . l:options)
+    \       . ale#Pad(l:options)
     \       . ' %t',
     \   'read_temporary_file': 1,
     \}

--- a/autoload/ale/fixers/dartfmt.vim
+++ b/autoload/ale/fixers/dartfmt.vim
@@ -11,7 +11,7 @@ function! ale#fixers#dartfmt#Fix(buffer) abort
     return {
     \   'command': ale#Escape(l:executable)
     \       . ' -w'
-    \       . (empty(l:options) ? '' : ' ' . l:options)
+    \       . ale#Pad(l:options)
     \       . ' %t',
     \   'read_temporary_file': 1,
     \}

--- a/autoload/ale/fixers/dfmt.vim
+++ b/autoload/ale/fixers/dfmt.vim
@@ -11,7 +11,7 @@ function! ale#fixers#dfmt#Fix(buffer) abort
     return {
     \   'command': ale#Escape(l:executable)
     \       . ' -i'
-    \       . (empty(l:options) ? '' : ' ' . l:options)
+    \       . ale#Pad(l:options)
     \       . ' %t',
     \   'read_temporary_file': 1,
     \}

--- a/autoload/ale/fixers/dotnet_format.vim
+++ b/autoload/ale/fixers/dotnet_format.vim
@@ -11,7 +11,7 @@ function! ale#fixers#dotnet_format#Fix(buffer) abort
     return {
     \   'command': ale#Escape(l:executable)
     \       . ' format'
-    \       . (empty(l:options) ? '' : ' ' . l:options)
+    \       . ale#Pad(l:options)
     \       . ' --folder --include %t "$(dirname %t)"',
     \   'read_temporary_file': 1,
     \}

--- a/autoload/ale/fixers/dune.vim
+++ b/autoload/ale/fixers/dune.vim
@@ -11,6 +11,6 @@ function! ale#fixers#dune#Fix(buffer) abort
     return {
     \   'command': ale#Escape(l:executable)
     \       . ' format'
-    \       . (empty(l:options) ? '' : ' ' . l:options),
+    \       . ale#Pad(l:options),
     \}
 endfunction

--- a/autoload/ale/fixers/elm_format.vim
+++ b/autoload/ale/fixers/elm_format.vim
@@ -17,7 +17,7 @@ function! ale#fixers#elm_format#Fix(buffer) abort
     return {
     \   'command': ale#Escape(ale#fixers#elm_format#GetExecutable(a:buffer))
     \       . ' %t'
-    \       . (empty(l:options) ? '' : ' ' . l:options),
+    \       . ale#Pad(l:options),
     \   'read_temporary_file': 1,
     \}
 endfunction

--- a/autoload/ale/fixers/fish_indent.vim
+++ b/autoload/ale/fixers/fish_indent.vim
@@ -12,7 +12,7 @@ function! ale#fixers#fish_indent#Fix(buffer) abort
     return {
     \   'command': ale#Escape(l:executable)
     \       . ' -w '
-    \       . (empty(l:options) ? '' : ' ' . l:options)
+    \       . ale#Pad(l:options)
     \       . ' %t',
     \   'read_temporary_file': 1,
     \}

--- a/autoload/ale/fixers/fourmolu.vim
+++ b/autoload/ale/fixers/fourmolu.vim
@@ -13,7 +13,7 @@ function! ale#fixers#fourmolu#Fix(buffer) abort
 
     return {
     \   'command': l:executable
-    \       . (empty(l:options) ? '' : ' ' . l:options)
+    \       . ale#Pad(l:options)
     \       . ' --stdin-input-file '
     \       . ale#Escape(@%),
     \}

--- a/autoload/ale/fixers/gofmt.vim
+++ b/autoload/ale/fixers/gofmt.vim
@@ -11,6 +11,6 @@ function! ale#fixers#gofmt#Fix(buffer) abort
 
     return {
     \   'command': l:env . ale#Escape(l:executable)
-    \       . (empty(l:options) ? '' : ' ' . l:options)
+    \       . ale#Pad(l:options)
     \}
 endfunction

--- a/autoload/ale/fixers/goimports.vim
+++ b/autoload/ale/fixers/goimports.vim
@@ -16,7 +16,7 @@ function! ale#fixers#goimports#Fix(buffer) abort
     return {
     \   'command': l:env . ale#Escape(l:executable)
     \       . ' -l -w -srcdir %s'
-    \       . (empty(l:options) ? '' : ' ' . l:options)
+    \       . ale#Pad(l:options)
     \       . ' %t',
     \   'read_temporary_file': 1,
     \}

--- a/autoload/ale/fixers/golines.vim
+++ b/autoload/ale/fixers/golines.vim
@@ -16,6 +16,6 @@ function! ale#fixers#golines#Fix(buffer) abort
 
     return {
     \   'command': l:env . ale#Escape(l:executable)
-    \       . (empty(l:options) ? '' : ' ' . l:options)
+    \       . ale#Pad(l:options)
     \}
 endfunction

--- a/autoload/ale/fixers/google_java_format.vim
+++ b/autoload/ale/fixers/google_java_format.vim
@@ -15,7 +15,7 @@ function! ale#fixers#google_java_format#Fix(buffer) abort
 
     return {
     \   'command': ale#Escape(l:executable)
-    \       . ' ' . (empty(l:options) ? '' : ' ' . l:options)
+    \       . ' ' . ale#Pad(l:options)
     \       . ' --replace'
     \       . ' %t',
     \   'read_temporary_file': 1,

--- a/autoload/ale/fixers/hackfmt.vim
+++ b/autoload/ale/fixers/hackfmt.vim
@@ -11,7 +11,7 @@ function! ale#fixers#hackfmt#Fix(buffer) abort
     return {
     \   'command': ale#Escape(l:executable)
     \       . ' -i'
-    \       . (empty(l:options) ? '' : ' ' . l:options)
+    \       . ale#Pad(l:options)
     \       . ' %t',
     \   'read_temporary_file': 1,
     \}

--- a/autoload/ale/fixers/latexindent.vim
+++ b/autoload/ale/fixers/latexindent.vim
@@ -11,6 +11,6 @@ function! ale#fixers#latexindent#Fix(buffer) abort
     return {
     \   'command': ale#Escape(l:executable)
     \       . ' -l'
-    \       . (empty(l:options) ? '' : ' ' . l:options)
+    \       . ale#Pad(l:options)
     \}
 endfunction

--- a/autoload/ale/fixers/luafmt.vim
+++ b/autoload/ale/fixers/luafmt.vim
@@ -7,7 +7,7 @@ function! ale#fixers#luafmt#Fix(buffer) abort
 
     return {
     \   'command': ale#Escape(l:executable)
-    \       . (empty(l:options) ? '' : ' ' . l:options)
+    \       . ale#Pad(l:options)
     \       . ' --stdin',
     \}
 endfunction

--- a/autoload/ale/fixers/nickel_format.vim
+++ b/autoload/ale/fixers/nickel_format.vim
@@ -10,7 +10,7 @@ function! ale#fixers#nickel_format#Fix(buffer) abort
 
     return {
     \   'command': ale#Escape(l:executable) . ' format'
-    \       . (empty(l:options) ? '' : ' ' . l:options)
+    \       . ale#Pad(l:options)
     \}
 endfunction
 

--- a/autoload/ale/fixers/nixpkgsfmt.vim
+++ b/autoload/ale/fixers/nixpkgsfmt.vim
@@ -7,6 +7,6 @@ function! ale#fixers#nixpkgsfmt#Fix(buffer) abort
 
     return {
     \   'command': ale#Escape(l:executable)
-    \       . (empty(l:options) ? '' : ' ' . l:options),
+    \       . ale#Pad(l:options),
     \}
 endfunction

--- a/autoload/ale/fixers/ocamlformat.vim
+++ b/autoload/ale/fixers/ocamlformat.vim
@@ -10,7 +10,7 @@ function! ale#fixers#ocamlformat#Fix(buffer) abort
 
     return {
     \   'command': ale#Escape(l:executable)
-    \       . (empty(l:options) ? '' : ' ' . l:options)
+    \       . ale#Pad(l:options)
     \       . ' --name=%s'
     \       . ' -'
     \}

--- a/autoload/ale/fixers/ocp_indent.vim
+++ b/autoload/ale/fixers/ocp_indent.vim
@@ -13,6 +13,6 @@ function! ale#fixers#ocp_indent#Fix(buffer) abort
     return {
     \   'command': ale#Escape(l:executable)
     \       . (empty(l:config) ? '' : ' --config=' . ale#Escape(l:config))
-    \       . (empty(l:options) ? '': ' ' . l:options)
+    \       . ale#Pad(l:options)
     \}
 endfunction

--- a/autoload/ale/fixers/opafmt.vim
+++ b/autoload/ale/fixers/opafmt.vim
@@ -10,6 +10,6 @@ function! ale#fixers#opafmt#Fix(buffer) abort
     return {
     \   'command': ale#Escape(l:executable)
     \       . ' fmt'
-    \       . (empty(l:options) ? '' : ' ' . l:options)
+    \       . ale#Pad(l:options)
     \}
 endfunction

--- a/autoload/ale/fixers/ormolu.vim
+++ b/autoload/ale/fixers/ormolu.vim
@@ -7,6 +7,6 @@ function! ale#fixers#ormolu#Fix(buffer) abort
 
     return {
     \   'command': ale#Escape(l:executable)
-    \       . (empty(l:options) ? '' : ' ' . l:options),
+    \       . ale#Pad(l:options),
     \}
 endfunction

--- a/autoload/ale/fixers/packer.vim
+++ b/autoload/ale/fixers/packer.vim
@@ -11,7 +11,7 @@ function! ale#fixers#packer#Fix(buffer) abort
     return {
     \   'command': ale#Escape(l:executable)
     \       . ' fmt'
-    \       . (empty(l:options) ? '' : ' ' . l:options)
+    \       . ale#Pad(l:options)
     \       . ' -'
     \}
 endfunction

--- a/autoload/ale/fixers/perltidy.vim
+++ b/autoload/ale/fixers/perltidy.vim
@@ -11,7 +11,7 @@ function! ale#fixers#perltidy#Fix(buffer) abort
     return {
     \   'command': ale#Escape(l:executable)
     \       . ' -b'
-    \       . (empty(l:options) ? '' : ' ' . l:options)
+    \       . ale#Pad(l:options)
     \       . ' %t',
     \   'read_temporary_file': 1,
     \}

--- a/autoload/ale/fixers/pgformatter.vim
+++ b/autoload/ale/fixers/pgformatter.vim
@@ -7,6 +7,6 @@ function! ale#fixers#pgformatter#Fix(buffer) abort
 
     return {
     \   'command': ale#Escape(l:executable)
-    \       . (empty(l:options) ? '' : ' ' . l:options),
+    \       . ale#Pad(l:options),
     \}
 endfunction

--- a/autoload/ale/fixers/ptop.vim
+++ b/autoload/ale/fixers/ptop.vim
@@ -10,7 +10,7 @@ function! ale#fixers#ptop#Fix(buffer) abort
 
     return {
     \   'command': ale#Escape(l:executable)
-    \       . (empty(l:options) ? '' : ' ' . l:options)
+    \       . ale#Pad(l:options)
     \       . ' %s %t',
     \   'read_temporary_file': 1,
     \}

--- a/autoload/ale/fixers/raco_fmt.vim
+++ b/autoload/ale/fixers/raco_fmt.vim
@@ -10,6 +10,6 @@ function! ale#fixers#raco_fmt#Fix(buffer) abort
 
     return {
     \   'command': ale#Escape(l:executable) . ' fmt'
-    \       . (empty(l:options) ? '' : ' ' . l:options),
+    \       . ale#Pad(l:options),
     \}
 endfunction

--- a/autoload/ale/fixers/refmt.vim
+++ b/autoload/ale/fixers/refmt.vim
@@ -10,7 +10,7 @@ function! ale#fixers#refmt#Fix(buffer) abort
 
     return {
     \   'command': ale#Escape(l:executable)
-    \       . (empty(l:options) ? '' : ' ' . l:options)
+    \       . ale#Pad(l:options)
     \       . ' --in-place'
     \       . ' %t',
     \   'read_temporary_file': 1,

--- a/autoload/ale/fixers/rubyfmt.vim
+++ b/autoload/ale/fixers/rubyfmt.vim
@@ -10,7 +10,7 @@ function! ale#fixers#rubyfmt#Fix(buffer) abort
 
     return {
     \   'command': ale#Escape(l:executable)
-    \       . (empty(l:options) ? '' : ' ' . l:options)
+    \       . ale#Pad(l:options)
     \}
 endfunction
 

--- a/autoload/ale/fixers/rustfmt.vim
+++ b/autoload/ale/fixers/rustfmt.vim
@@ -10,6 +10,6 @@ function! ale#fixers#rustfmt#Fix(buffer) abort
 
     return {
     \   'command': ale#Escape(l:executable)
-    \       . (empty(l:options) ? '' : ' ' . l:options),
+    \       . ale#Pad(l:options),
     \}
 endfunction

--- a/autoload/ale/fixers/rustywind.vim
+++ b/autoload/ale/fixers/rustywind.vim
@@ -11,7 +11,7 @@ function! ale#fixers#rustywind#Fix(buffer) abort
 
     return {
     \   'command': ale#Escape(l:executable)
-    \       . (empty(l:options) ? '' : ' ' . l:options)
+    \       . ale#Pad(l:options)
     \       . ' --stdin'
     \}
 endfunction

--- a/autoload/ale/fixers/scadformat.vim
+++ b/autoload/ale/fixers/scadformat.vim
@@ -10,6 +10,6 @@ function! ale#fixers#scadformat#Fix(buffer) abort
 
     return {
     \   'command': ale#Escape(l:executable)
-    \       . (empty(l:options) ? '' : ' ' . l:options),
+    \       . ale#Pad(l:options),
     \}
 endfunction

--- a/autoload/ale/fixers/scalafmt.vim
+++ b/autoload/ale/fixers/scalafmt.vim
@@ -13,7 +13,7 @@ function! ale#fixers#scalafmt#GetCommand(buffer) abort
     \   : ''
 
     return ale#Escape(l:executable) . l:exec_args
-    \   . (empty(l:options) ? '' : ' ' . l:options)
+    \   . ale#Pad(l:options)
     \   . ' %t'
 endfunction
 

--- a/autoload/ale/fixers/shfmt.vim
+++ b/autoload/ale/fixers/shfmt.vim
@@ -12,6 +12,6 @@ function! ale#fixers#shfmt#Fix(buffer) abort
     return {
     \   'command': ale#Escape(l:executable)
     \       . ' -filename=%s'
-    \       . (empty(l:options) ? '' : ' ' . l:options)
+    \       . ale#Pad(l:options)
     \}
 endfunction

--- a/autoload/ale/fixers/sqlfmt.vim
+++ b/autoload/ale/fixers/sqlfmt.vim
@@ -8,6 +8,6 @@ function! ale#fixers#sqlfmt#Fix(buffer) abort
     return {
     \   'command': ale#Escape(l:executable)
     \       . ' -w'
-    \       . (empty(l:options) ? '' : ' ' . l:options),
+    \       . ale#Pad(l:options),
     \}
 endfunction

--- a/autoload/ale/fixers/terraform.vim
+++ b/autoload/ale/fixers/terraform.vim
@@ -11,7 +11,7 @@ function! ale#fixers#terraform#Fix(buffer) abort
     return {
     \   'command': ale#Escape(l:executable)
     \       . ' fmt'
-    \       . (empty(l:options) ? '' : ' ' . l:options)
+    \       . ale#Pad(l:options)
     \       . ' -'
     \}
 endfunction

--- a/autoload/ale/fixers/textlint.vim
+++ b/autoload/ale/fixers/textlint.vim
@@ -8,7 +8,7 @@ function! ale#fixers#textlint#Fix(buffer) abort
     return {
     \   'command': ale#Escape(l:executable)
     \       . ' --fix'
-    \       . (empty(l:options) ? '' : ' ' . l:options)
+    \       . ale#Pad(l:options)
     \       . ' %t',
     \   'read_temporary_file': 1,
     \}

--- a/autoload/ale/handlers/ktlint.vim
+++ b/autoload/ale/handlers/ktlint.vim
@@ -11,8 +11,8 @@ function! ale#handlers#ktlint#GetCommand(buffer) abort
     let l:rulesets = ale#handlers#ktlint#GetRulesets(a:buffer)
 
     return ale#Escape(l:executable)
-    \   . (empty(l:options) ? '' : ' ' . l:options)
-    \   . (empty(l:rulesets) ? '' : ' ' . l:rulesets)
+    \   . ale#Pad(l:options)
+    \   . ale#Pad(l:rulesets)
     \   . ' --stdin'
 endfunction
 

--- a/autoload/ale/handlers/languagetool.vim
+++ b/autoload/ale/handlers/languagetool.vim
@@ -13,7 +13,7 @@ function! ale#handlers#languagetool#GetCommand(buffer) abort
     let l:options = ale#Var(a:buffer, 'languagetool_options')
 
     return ale#Escape(l:executable)
-    \ . (empty(l:options) ? '' : ' ' . l:options) . ' %s'
+    \ . ale#Pad(l:options) . ' %s'
 endfunction
 
 function! ale#handlers#languagetool#HandleOutput(buffer, lines) abort


### PR DESCRIPTION
Standardize option padding by replacing verbose ternary checks with ale#Pad()

Replace patterns like:
```vim
(empty(x) ? '' : '' . l:options)
```

with:
```vim
ale#Pad(l:options)
```

Similar to `af5a38c697e0ba062f04347d5165d97d7d1894a3`
