### PR TITLE
Feat: replace em dash with --

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -207,6 +207,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['puppet'],
 \       'description': 'Run puppet-lint -f on a file.',
 \   },
+\   'replace_emdash': {
+\       'function': 'ale#fixers#generic#ReplaceEmDash',
+\       'suggested_filetypes': [],
+\       'description': 'Replace em dash with -- ASCII characters.',
+\   },
 \   'remove_trailing_lines': {
 \       'function': 'ale#fixers#generic#RemoveTrailingBlankLines',
 \       'suggested_filetypes': [],

--- a/autoload/ale/fixers/generic.vim
+++ b/autoload/ale/fixers/generic.vim
@@ -1,6 +1,10 @@
 " Author: w0rp <devw0rp@gmail.com>
 " Description: Generic functions for fixing files with.
 
+function! ale#fixers#generic#ReplaceEmDash(buffer, lines) abort
+    return map(copy(a:lines), {_, line -> substitute(line, "\u2014", '--', 'g')})
+endfunction
+
 function! ale#fixers#generic#RemoveTrailingBlankLines(buffer, lines) abort
     let l:end_index = len(a:lines) - 1
 

--- a/test/fixers/test_generic_fixers.vader
+++ b/test/fixers/test_generic_fixers.vader
@@ -1,0 +1,29 @@
+Execute(ReplaceEmDash should not change existing dashes):
+  AssertEqual
+  \ ['foo - bar', 'baz -- qux -- end'],
+  \ ale#fixers#generic#ReplaceEmDash(bufnr(''), ["foo - bar", "baz -- qux \u2014 end"])
+
+Execute(ReplaceEmDash should replace em dashes with double hyphens):
+  AssertEqual
+  \ ['foo -- bar', 'baz -- qux -- end'],
+  \ ale#fixers#generic#ReplaceEmDash(bufnr(''), ["foo \u2014 bar", "baz \u2014 qux \u2014 end"])
+
+Execute(ReplaceEmDash should handle lines without em dashes):
+  AssertEqual
+  \ ['no dashes here', 'just -- normal'],
+  \ ale#fixers#generic#ReplaceEmDash(bufnr(''), ['no dashes here', 'just -- normal'])
+
+Execute(ReplaceEmDash should handle empty input):
+  AssertEqual
+  \ [],
+  \ ale#fixers#generic#ReplaceEmDash(bufnr(''), [])
+
+Execute(RemoveTrailingBlankLines should remove trailing empty lines):
+  AssertEqual
+  \ ['foo', 'bar'],
+  \ ale#fixers#generic#RemoveTrailingBlankLines(bufnr(''), ['foo', 'bar', '', ''])
+
+Execute(RemoveTrailingBlankLines should preserve content when no trailing blanks):
+  AssertEqual
+  \ ['foo', 'bar'],
+  \ ale#fixers#generic#RemoveTrailingBlankLines(bufnr(''), ['foo', 'bar'])


### PR DESCRIPTION
LLMs like to use em dash for no reason. I don't like non-ascii character in my text files, so I made a fixer to convert them from em dash to regular old `--` which latex and markdown treat as EM dashes. Added tests. Yes some of this code was was partially created by claude. 

Naming is the hard part, definitely open to renames. `no_emdash` `ascii_emdash` `replace_emdash` `em_dash` or `emdash`? etc.

It might be argued there are quite a few annoying unicodes that could be replaced, who really wants a 🤗 in their C++ code?
