### PR TITLE
Support for tex-fmt

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -774,7 +774,7 @@ let s:default_registry = {
 \   },
 \   'tex-fmt': {
 \       'function': 'ale#fixers#tex_fmt#Fix',
-\       'suggested_filetypes': ['bib', 'plaintex', 'tex'],
+\       'suggested_filetypes': ['bib', 'tex'],
 \       'description': 'Fix LaTeX and bibliography files with tex-fmt.',
 \   }
 \}

--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -772,6 +772,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['markdown'],
 \       'description': 'Fix markdown files with rumdl.',
 \   },
+\   'tex-fmt': {
+\       'function': 'ale#fixers#tex_fmt#Fix',
+\       'suggested_filetypes': ['bib', 'plaintex', 'tex'],
+\       'description': 'Fix LaTeX and bibliography files with tex-fmt.',
+\   }
 \}
 
 " Reset the function registry to the default entries.

--- a/autoload/ale/fixers/tex_fmt.vim
+++ b/autoload/ale/fixers/tex_fmt.vim
@@ -1,0 +1,20 @@
+" Author: https://github.com/Spixmaster
+" Description: Fix LaTeX and bibliography files with tex-fmt.
+
+call ale#Set('tex_tex_fmt_executable', 'tex-fmt')
+call ale#Set('tex_tex_fmt_use_global', get(g:, 'ale_use_global_executables', 0))
+call ale#Set('tex_tex_fmt_options', '')
+
+function! ale#fixers#tex_fmt#Fix(buffer) abort
+    let l:executable = ale#python#FindExecutable(
+    \   a:buffer,
+    \   'tex_tex_fmt',
+    \   ['tex-fmt']
+    \)
+
+    let l:options = ale#Var(a:buffer, 'tex_tex_fmt_options')
+
+    return {
+    \   'command': ale#Escape(l:executable) . ' ' . l:options . ' -s',
+    \}
+endfunction

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -373,6 +373,7 @@ Notes:
   * `lacheck`
   * `proselint`
   * `redpen`
+  * `tex-fmt`
   * `texlab`
   * `textlint`
   * `vale`

--- a/doc/ale-tex.txt
+++ b/doc/ale-tex.txt
@@ -71,6 +71,30 @@ g:ale_tex_latexindent_options
 
 
 ===============================================================================
+tex-fmt                                                       *ale-tex-tex-fmt*
+
+                                           *ale-options.tex_tex_fmt_executable*
+                                                 *g:ale_tex_tex_fmt_executable*
+                                                 *b:ale_tex_tex_fmt_executable*
+tex_tex_fmt_executable
+g:ale_tex_tex_fmt_executable
+  Type: |String|
+  Default: `'tex-fmt'`
+
+  See |ale-integrations-local-executables|.
+
+                                              *ale-options.tex_tex_fmt_options*
+                                                    *g:ale_tex_tex_fmt_options*
+                                                    *b:ale_tex_tex_fmt_options*
+tex_tex_fmt_options
+g:ale_tex_tex_fmt_options
+  Type: |String|
+  Default: `''`
+
+  This variable can be changed to modify flags given to tex-fmt.
+
+
+===============================================================================
 texlab                                                         *ale-tex-texlab*
 
                                             *ale-options.tex_texlab_executable*

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -4008,6 +4008,7 @@ documented in additional help files.
     cspell................................|ale-tex-cspell|
     lacheck...............................|ale-tex-lacheck|
     latexindent...........................|ale-tex-latexindent|
+    tex-fmt...............................|ale-tex-tex-fmt|
     texlab................................|ale-tex-texlab|
     redpen................................|ale-tex-redpen|
   texinfo.................................|ale-texinfo-options|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -383,6 +383,7 @@ formatting.
   * [lacheck](https://www.ctan.org/pkg/lacheck)
   * [proselint](http://proselint.com/)
   * [redpen](http://redpen.cc/)
+  * [tex-fmt](https://github.com/WGUNDERWOOD/tex-fmt)
   * [texlab](https://texlab.netlify.com) :speech_balloon:
   * [textlint](https://textlint.github.io/)
   * [vale](https://github.com/ValeLint/vale)

--- a/test/fixers/test_tex_fmt_fixer_callback.vader
+++ b/test/fixers/test_tex_fmt_fixer_callback.vader
@@ -1,0 +1,12 @@
+Before:
+  call ale#assert#SetUpFixerTest('tex', 'tex-fmt')
+
+After:
+  Restore
+
+  call ale#assert#TearDownFixerTest()
+
+Execute(The tex-fmt callback should return the correct default command):
+  AssertEqual
+  \ {'command': ale#Escape('tex-fmt') . '  -s'},
+  \ ale#fixers#tex_fmt#Fix(bufnr(''))


### PR DESCRIPTION
Support for tex-fmt, https://github.com/WGUNDERWOOD/tex-fmt.

I added `tex` to autoload/ale/fix/registry.vim but not `plaintex` or the identifier for a ConTeXt file. tex-fmt is only for LaTeX.

I tested this pull request locally. Vim formats correctly with tex-fmt.

Closes https://github.com/dense-analysis/ale/issues/4941.