### PR TITLE
Fix infinite autocompletion loop

### DIFF
--- a/autoload/ale/completion.vim
+++ b/autoload/ale/completion.vim
@@ -952,15 +952,14 @@ function! ale#completion#OmniFunc(findstart, base) abort
         let l:timeout_start = reltime()
 
         while l:result is v:null && !complete_check()
+            sleep 2ms
+            let l:result = ale#completion#GetCompletionResult()
+
             if reltimefloat(reltime(l:timeout_start)) > l:timeout
                 " no-custom-checks
                 echoerr 'no result within timeout (' . l:timeout . 's)'
                 break
             endif
-
-            sleep 2ms
-
-            let l:result = ale#completion#GetCompletionResult()
         endwhile
 
         return l:result isnot v:null ? l:result : []

--- a/autoload/ale/completion.vim
+++ b/autoload/ale/completion.vim
@@ -764,6 +764,9 @@ function! s:OnReady(linter, lsp_details) abort
     let l:id = a:lsp_details.connection_id
 
     if !ale#lsp#HasCapability(l:id, 'completion')
+        " Return at least an empty result to avoid OmniFunc timeout
+        call ale#completion#Show([])
+
         return
     endif
 

--- a/autoload/ale/completion.vim
+++ b/autoload/ale/completion.vim
@@ -945,8 +945,18 @@ function! ale#completion#OmniFunc(findstart, base) abort
     else
         let l:result = ale#completion#GetCompletionResult()
 
+        let l:timeout = get(g:, 'ale_completion_timeout', 3)
+        let l:timeout_start = reltime()
+
         while l:result is v:null && !complete_check()
+            if reltimefloat(reltime(l:timeout_start)) > l:timeout
+                " no-custom-checks
+                echoerr 'no result within timeout (' . l:timeout . 's)'
+                break
+            endif
+
             sleep 2ms
+
             let l:result = ale#completion#GetCompletionResult()
         endwhile
 

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -1143,6 +1143,20 @@ g:ale_completion_max_suggestions
   Adjust this option as needed, depending on the complexity of your codebase
   and your available processing power.
 
+                                               *ale-options.completion_timeout*
+                                                     *g:ale_completion_timeout*
+completion_timeout
+g:ale_completion_timeout
+  Type: |Number|
+  Default: `3`
+
+  The maximum time in seconds ale#completion#OmniFunc() will wait for a
+  completion result from the language server.
+
+  When the timeout is exceeded ale#completion#OmniFunc() will print an error
+  message and return an empty result. Setting a higher value allows longer
+  response times, but it may also keep Vim unresponsible for a longer time.
+
                                                     *ale-options.cursor_detail*
                                                           *g:ale_cursor_detail*
 cursor_detail

--- a/test/completion/test_omnifunc_completion.vader
+++ b/test/completion/test_omnifunc_completion.vader
@@ -59,8 +59,9 @@ Execute(The omnifunc function should parse and return async responses):
     AssertEqual ['foo'], ale#completion#OmniFunc(0, '')
   endif
 
-Execute(The omnifunc function should timeout, if no result is returned):
+Execute (The omnifunc function should timeout with an error, if no result is returned):
   " WARNING: This will lock the whole test-suite, if the timeout does not work!
   let g:ale_completion_timeout = 0.2
 
-  AssertEqual v:null, ale#completion#OmniFunc(0, '')
+  AssertThrows call ale#completion#OmniFunc(0, '')
+  AssertEqual 'Vim(echoerr):no result within timeout (0.2s)', g:vader_exception

--- a/test/completion/test_omnifunc_completion.vader
+++ b/test/completion/test_omnifunc_completion.vader
@@ -58,3 +58,9 @@ Execute(The omnifunc function should parse and return async responses):
 
     AssertEqual ['foo'], ale#completion#OmniFunc(0, '')
   endif
+
+Execute(The omnifunc function should timeout, if no result is returned):
+  " WARNING: This will lock the whole test-suite, if the timeout does not work!
+  let g:ale_completion_timeout = 0.2
+
+  AssertEqual v:null, ale#completion#OmniFunc(0, '')


### PR DESCRIPTION
I stumbled upon an infinite loop while using "pure" omnicompletion with ALE's omnifunction and Vim's native autocompletion:

```
set completeopt=menu,menuone,noselect,noinsert
set autocomplete
autocmd FileType * setlocal omnifunc=ale#completion#OmniFunc
```

Apparently `ale#completion#OmniFunc` does not ever return, if the language server has no completion capabilities. I was able to track the cause down to the while-loop, which waits for the server result. This PR breaks the infinite-loop by introducing a timeout check in the while-loop. The timeout is 3 seconds by default, but can be configured via `g:ale_completion_timeout`, which takes a float value that is interpreted as seconds. 

Additionally, I was able to fix the underlying cause by returning an empty result, if the language server does not have completion capabilities. This fixes the problem, but IMHO the timeout should still be included in order to prevent locks due to other reasons.

A test has also been added, but I am not sure whether it should really be included in the test suite, because it might lock the whole suite, if the timeout does not work as expected.