### PR TITLE
Fix Vint version detection

### DIFF
--- a/ale_linters/vim/vint.vim
+++ b/ale_linters/vim/vint.vim
@@ -58,7 +58,7 @@ call ale#linter#Define('vim', {
 \   'command': {buffer -> ale#semver#RunWithVersionCheck(
 \       buffer,
 \       ale#Var(buffer, 'vim_vint_executable'),
-\       '%e --version',
+\       'PYTHONWARNINGS=ignore %e --version',
 \       function('ale_linters#vim#vint#GetCommand'),
 \   )},
 \   'callback': 'ale_linters#vim#vint#Handle',

--- a/test/linter/test_vint.vader
+++ b/test/linter/test_vint.vader
@@ -10,7 +10,7 @@ After:
 
 Execute(The default command should be correct):
   AssertLinter 'vint', [
-  \ ale#Escape('vint') .' --version',
+  \ 'PYTHONWARNINGS=ignore '. ale#Escape('vint') .' --version',
   \ ale#Escape('vint') .' -s --no-color' . b:common_flags . ' %t',
   \]
 
@@ -18,7 +18,7 @@ Execute(The executable should be configurable):
   let g:ale_vim_vint_executable = 'foobar'
 
   AssertLinter 'foobar', [
-  \ ale#Escape('foobar') .' --version',
+  \ 'PYTHONWARNINGS=ignore '. ale#Escape('foobar') .' --version',
   \ ale#Escape('foobar') .' -s --no-color' . b:common_flags . ' %t',
   \]
 


### PR DESCRIPTION
This PR fixes the broken Vint version detection due to Python warnings that interfere with ALE's version detection algorithm.

I discovered that my Vint based Vim Script linting did not work anymore and was able to track it down to a new Python version (3.14) that has been installed on my system recently. The reason is the `pkg_resources` API, which is still used by the last stable Vint version (0.3.21), but has been declared as obsolete for a longer time now.

This causes `vint --version` to return the following:

```
/usr/lib/python3.14/site-packages/vint/linting/cli.py:4: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources
0.3.21
```

ALE's semver module parses this as `[3, 14, 0]`, possibly due to `python3.14` in the first line. Since ALE assumes that this version of Vint has stdin support, it calls Vint with the `--stdin-display-name` option, which is not yet available in Vint 0.3.21.

This PR changes the call to print Vint's version from just `vint --version` to `PYTHONWARNINGS=ignore vint --version`. This suppresses all Python warnings and thus allows ALE's semver module to detect the correct version. 