### PR TITLE
feat(nagelfar): Support file name prefix in regex

### DIFF
--- a/ale_linters/tcl/nagelfar.vim
+++ b/ale_linters/tcl/nagelfar.vim
@@ -15,7 +15,13 @@ function! ale_linters#tcl#nagelfar#Handle(buffer, lines) abort
     " Line   5: W Found constant "bepa" which is also a variable.
     " Line  13: E Wrong number of arguments (3) to "set"
     " Line  93: N Close brace not aligned with line 90 (4 0)
-    let l:pattern = '^Line\s\+\([0-9]\+\): \([NEW]\) \(.*\)$'
+    " myfile.tcl: Line   6: W Shortened subcommand for "info", exist -> exists
+
+    " A filename is present when checking multiple files at once.
+    " This can happen if the user provides a header with custom function definitions.
+    " Therefore, we accept the current buffer filename as a prefix.
+    let l:filename = escape(expand('#' . a:buffer . ':p'), '\.^$~[]')
+    let l:pattern = '^\%(' . l:filename . ':\s\+\)\?Line\s\+\([0-9]\+\): \([NEW]\) \(.*\)$'
     let l:output = []
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)

--- a/test/handler/test_nagelfar_handler.vader
+++ b/test/handler/test_nagelfar_handler.vader
@@ -172,3 +172,18 @@ Execute(The nagelfar handler should parse lines correctly):
   \   'Line  90: E Wrong number of arguments (1) to "if"',
   \   'Line  93: N Close brace not aligned with line 90 (4 0)',
   \ ])
+
+Execute(Test with file name prefix):
+  file def.tcl
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 7,
+  \     'type': 'E',
+  \     'text': 'Unknown variable "cep"'
+  \   },
+  \ ],
+  \ ale_linters#tcl#nagelfar#Handle(bufnr(''), [
+  \   'abc.tcl: Line   5: W Found constant "bepa" which is also a variable.',
+  \   expand('%:p') . ': Line   7: E Unknown variable "cep"',
+  \ ])


### PR DESCRIPTION
This allows adding a header file containing custom definitions to tcl_nagelfar_otions.

Nagelfar can generate such headers with:
nagelfar -header file_name <input tcl files>

Note that the file name displayed is the path that is passed as a parameter to nagelfar.

I tested the change, it works both with an extra header and without.

<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!
-->
I have added a test, but:
* I did not run the test (hoping it passes CI)
* I am unsure if I should make a bare call to `file` or use `ale#test#SetFilename('def.tcl')` + `ale#test#GetFilename('def.tcl')`

---
Edit: I only have access to the web GitHub UI right now, and I committed the test to the wrong branch. Fixed, but this cancelled the workflow.