### PR TITLE
Add janet-format fixer for Janet

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -737,6 +737,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['clojure'],
 \       'description': 'formatter and linter for clojure files',
 \   },
+\   'janet-format': {
+\       'function': 'ale#fixers#janet_format#Fix',
+\       'suggested_filetypes': ['janet'],
+\       'description': 'Formatter for janet files',
+\   },
 \   'typstyle': {
 \       'function': 'ale#fixers#typstyle#Fix',
 \       'suggested_filetypes': ['typst'],

--- a/autoload/ale/fixers/janet_format.vim
+++ b/autoload/ale/fixers/janet_format.vim
@@ -1,0 +1,13 @@
+" Author: David Gouch <dgouch@gmail.com>
+" Description: Format with janet-format https://github.com/janet-lang/spork
+
+call ale#Set('janet_janet_format_executable', 'janet-format')
+
+function! ale#fixers#janet_format#Fix(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'janet_janet_format_executable')
+
+    return {
+    \   'command': ale#Escape(l:executable) . ' %t',
+    \   'read_temporary_file': 1,
+    \}
+endfunction

--- a/doc/ale-janet.txt
+++ b/doc/ale-janet.txt
@@ -1,0 +1,19 @@
+===============================================================================
+ALE Janet Integration                                       *ale-janet-options*
+
+
+===============================================================================
+janet-format                                           *ale-janet-janet-format*
+
+                                    *ale-options.janet_janet_format_executable*
+                                          *g:ale_janet_janet_format_executable*
+                                          *b:ale_janet_janet_format_executable*
+janet_janet_format_executable
+g:ale_janet_janet_format_executable
+  Type: |String|
+  Default: `'janet-format'`
+
+  This variable sets the executable used for janet-format.
+
+===============================================================================
+  vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -309,6 +309,8 @@ Notes:
   * `inko` !!
 * ISPC
   * `ispc`!!
+* Janet
+  * `janet-format`
 * Java
   * `PMD`
   * `checkstyle`!!

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -3667,6 +3667,8 @@ documented in additional help files.
     inko..................................|ale-inko-inko|
   ispc....................................|ale-ispc-options|
     ispc..................................|ale-ispc-ispc|
+  janet...................................|ale-janet-options|
+    janet-format..........................|ale-janet-janet-format|
   java....................................|ale-java-options|
     checkstyle............................|ale-java-checkstyle|
     clang-format..........................|ale-java-clangformat|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -319,6 +319,8 @@ formatting.
   * [inko](https://inko-lang.org/) :floppy_disk:
 * ISPC
   * [ispc](https://ispc.github.io/) :floppy_disk:
+* Janet
+  * [janet-format](https://github.com/janet-lang/spork)
 * Java
   * [PMD](https://pmd.github.io/)
   * [checkstyle](http://checkstyle.sourceforge.net) :floppy_disk:

--- a/test/fixers/test_janet_format_fixer_callback.vader
+++ b/test/fixers/test_janet_format_fixer_callback.vader
@@ -1,0 +1,19 @@
+Before:
+  call ale#assert#SetUpFixerTest('janet', 'janet-format')
+
+After:
+  call ale#assert#TearDownFixerTest()
+
+Execute(The janet-format callback should return the correct default values):
+  AssertFixer {
+  \    'command': ale#Escape('janet-format') . ' %t',
+  \    'read_temporary_file': 1,
+  \}
+
+Execute(The janet-format callback should allow a custom executable):
+  let g:ale_janet_janet_format_executable = '/custom/path/to/janet-format'
+
+  AssertFixer {
+  \    'command': ale#Escape('/custom/path/to/janet-format') . ' %t',
+  \    'read_temporary_file': 1,
+  \}


### PR DESCRIPTION
Adds the [janet-format](https://github.com/janet-lang/spork/blob/master/bin/janet-format) fixer for [Janet](https://janet-lang.org/).

`./run-tests` passes locally.