### PR TITLE
chktex: always use the right format and grab the error code

### DIFF
--- a/ale_linters/tex/chktex.vim
+++ b/ale_linters/tex/chktex.vim
@@ -12,7 +12,9 @@ function! ale_linters#tex#chktex#GetCommand(buffer, version) abort
     let l:options = ''
 
     " Avoid bug when used without -p (last warning has gibberish for a filename)
-    let l:options .= ' -v0 -p stdin -q'
+    " Do not use -v0 as the meaning of v0 might be modified by the user in
+    " their chktexrc file; instead, use --format to specify the output format.
+    let l:options .= " --format $'%f%b%l%b%c%b%n%b%m\n' -p stdin -q"
 
     " Avoid bug of reporting wrong column when using tabs (issue #723)
     if ale#semver#GTE(a:version, [1, 7, 7])
@@ -43,7 +45,8 @@ function! ale_linters#tex#chktex#Handle(buffer, lines) abort
         call add(l:output, {
         \   'lnum': l:match[1] + 0,
         \   'col': l:match[2] + 0,
-        \   'text': l:match[4] . ' (' . (l:match[3]+0) . ')',
+        \   'text': l:match[4],
+        \   'code': l:match[3] + 0,
         \   'type': 'W',
         \})
     endfor

--- a/test/linter/test_tex_chktex.vader
+++ b/test/linter/test_tex_chktex.vader
@@ -10,7 +10,7 @@ Execute(The default command should be correct):
   AssertLinter 'chktex', [
   \ ale#Escape('chktex') . ' --version',
   \ ale#Escape('chktex')
-  \   . ' -v0 -p stdin -q'
+  \   . " --format $'%f%b%l%b%c%b%n%b%m\n' -p stdin -q"
   \   . ' -I',
   \]
 
@@ -18,7 +18,7 @@ Execute(The default command should be correct):
   GivenCommandOutput []
   AssertLinter 'chktex', [
   \ ale#Escape('chktex')
-  \   . ' -v0 -p stdin -q'
+  \   . " --format $'%f%b%l%b%c%b%n%b%m\n' -p stdin -q"
   \   . ' -I',
   \]
 
@@ -28,7 +28,7 @@ Execute(The default command should be correct):
   AssertLinter 'chktex', [
   \ ale#Escape('chktex') . ' --version',
   \ ale#Escape('chktex')
-  \   . ' -v0 -p stdin -q'
+  \   . " --format $'%f%b%l%b%c%b%n%b%m\n' -p stdin -q"
   \   . ' -S TabSize=1'
   \   . ' -I',
   \]
@@ -38,7 +38,7 @@ Execute(The executable should be configurable):
 
   AssertLinter 'bin/foo',
   \ ale#Escape('bin/foo')
-  \   . ' -v0 -p stdin -q'
+  \   . " --format $'%f%b%l%b%c%b%n%b%m\n' -p stdin -q"
   \   . ' -I'
 
 Execute(The options should be configurable):
@@ -46,5 +46,5 @@ Execute(The options should be configurable):
 
   AssertLinter 'chktex',
   \ ale#Escape('chktex')
-  \   . ' -v0 -p stdin -q'
+  \   . " --format $'%f%b%l%b%c%b%n%b%m\n' -p stdin -q"
   \   . ' --something'


### PR DESCRIPTION
Using -v0 works out of the box, but chktex grabs the "v0 format" from
its configuration file:

    OutFormat
    {
        # -v0; silent mode
        %f%b%l%b%c%b%n%b%m!n
        # -v1; normal mode
        ...
    }

Should the user modify the definition of v0, then the linter would no
longer work. We therefore use "--format" to force the output format.

Also grab the error code so it is correctly displayed.

Closes: #3856
