### PR TITLE
Handle nil result in pull diagnostic handler

### DIFF
--- a/lua/ale/lsp.lua
+++ b/lua/ale/lsp.lua
@@ -77,7 +77,7 @@ module.start = function(config)
         end,
         -- Handle pull model diagnostic data.
         ["textDocument/diagnostic"] = function(err, result, request, _)
-            if err == nil then
+            if err == nil and result ~= nil then
                 local diagnostics
 
                 if result.kind == "unchanged" then

--- a/test/lua/ale_lsp_start_spec.lua
+++ b/test/lua/ale_lsp_start_spec.lua
@@ -444,4 +444,31 @@ describe("ale.lsp.start", function()
             },
         }, vim_fn_calls)
     end)
+
+    it("should ignore pull model diagnostics with a nil result", function()
+        lsp.start({name = "server:/code"})
+
+        eq(1, #start_calls)
+
+        local handlers = start_calls[1][1].handlers
+
+        eq("function", type(handlers["textDocument/diagnostic"]))
+
+        -- A stale request can be answered with a nil result and no error,
+        -- which is valid per the LSP specification. The handler should do
+        -- nothing rather than index the nil result.
+        handlers["textDocument/diagnostic"](
+            nil,
+            nil,
+            {
+                params = {
+                    textDocument = {
+                        uri = "file://code/foo.py",
+                    },
+                },
+            }
+        )
+
+        eq({}, vim_fn_calls)
+    end)
 end)


### PR DESCRIPTION
## Summary

The `textDocument/diagnostic` handler assumed a non-nil `result` whenever no error was returned. A stale or cancelled pull diagnostic request can legitimately be answered with a nil result and no error under the LSP specification, so the handler indexed a nil value and threw `attempt to index local 'result' (a nil value)` inside a scheduled callback.

## Reproduction

- With a language server that supports pull diagnostics, open a file and let a request go stale (for example by reloading the buffer while a request is in flight). The server answers the now-stale request with a nil result and no error, and the handler crashes.

## Changes

- Guard the pull diagnostic handler so a nil result is ignored rather than indexed, matching the existing `err` check.
- Add a test covering a nil result with no error.