### PR TITLE
Add ale_python_pyright_options variable

### DIFF
--- a/ale_linters/python/pyright.vim
+++ b/ale_linters/python/pyright.vim
@@ -1,5 +1,6 @@
 call ale#Set('python_pyright_use_global', get(g:, 'ale_use_global_executables', 0))
 call ale#Set('python_pyright_executable', 'pyright-langserver')
+call ale#Set('python_pyright_options', '--stdio')
 call ale#Set('python_pyright_config', {})
 call ale#Set('python_pyright_auto_pipenv', 0)
 call ale#Set('python_pyright_auto_poetry', 0)
@@ -79,7 +80,8 @@ function! ale_linters#python#pyright#GetCommand(buffer) abort
         let l:env_string = ale#python#AutoVirtualenvEnvString(a:buffer)
     endif
 
-    return l:env_string . ale#Escape(l:executable) . l:exec_args . ' --stdio'
+    return l:env_string . ale#Escape(l:executable) . l:exec_args .
+    \   ale#Pad(ale#Var(a:buffer, 'python_pyright_options'))
 endfunction
 
 call ale#linter#Define('python', {

--- a/doc/ale-python.txt
+++ b/doc/ale-python.txt
@@ -1721,7 +1721,7 @@ g:ale_python_pyright_config
   Settings for configuring the `pyright` language server.
 
   See pyright's documentation for a full list of options:
-  https://github.com/microsoft/pyright/blob/master/docs/settings.md
+  https://microsoft.github.io/pyright/#/settings
 
   ALE will automatically try to set defaults for `venvPath` and `pythonPath`
   so your project can automatically be checked with the right libraries.
@@ -1780,6 +1780,22 @@ g:ale_python_pyright_auto_uv
 
   Set the executable to `uv` if true. This is overridden by a manually-set
   executable.
+
+                                           *ale-options.python_pyright_options*
+                                                 *g:ale_python_pyright_options*
+                                                 *b:ale_python_pyright_options*
+python_pyright_options
+g:ale_python_pyright_options
+  Type: |String|
+  Default: `'--stdio'`
+
+  This variable can be changed to add command-line arguments to the pyright
+  invocation. Note that this is different from ale_python_pyright_config,
+  which allows configuration of how pyright functions; this is intended to
+  provide flexibility in how the pyright command is invoked.
+
+  For all available options and explanations, visit
+  https://microsoft.github.io/pyright/#/command-line
 
 
 ===============================================================================

--- a/test/linter/test_pyright.vader
+++ b/test/linter/test_pyright.vader
@@ -27,6 +27,13 @@ Execute(The executable should be configurable):
   \ '/bin/foo-bar',
   \ ale#Escape('/bin/foo-bar') . ' --stdio'
 
+Execute(The command invokation arguments should be configurable):
+  let g:ale_python_pyright_options = '--some-option'
+
+  AssertLinter
+  \ 'pyright-langserver',
+  \ ale#Escape('pyright-langserver') . ' --some-option'
+
 Execute(The default configuration should be mostly empty):
   " The default configuration needs to have at least one key in it,
   " or the server won't start up properly.


### PR DESCRIPTION
Add ale_python_pyright_options variable, following the ALE typical configuration pattern.

Commit also replaces link to lsp config doc from its source code to the published rendered page version.